### PR TITLE
WIP! Feature tapestry discovery

### DIFF
--- a/config/suggested-concept-authors.json
+++ b/config/suggested-concept-authors.json
@@ -1,0 +1,35 @@
+{
+  "_comment": [
+    "Bootstrap list for /kg/concept-discovery. Each entry surfaces as a suggestion",
+    "card when a user opens the page with no recent searches of their own.",
+    "",
+    "Today this file IS the suggestion list. In a future revision we expect to",
+    "swap the backing store for a DCoSL-style 'concept-author' DList on nostr: a",
+    "community-curated DList whose elements are concept-author pubkeys. When that",
+    "lands, only the GET /api/concept-discovery/suggested-authors handler changes",
+    "— the response shape stays identical and the UI is unaffected.",
+    "",
+    "For now, seed with: (1) this instance's own TA so users can self-inspect,",
+    "(2) any trusted 'house' accounts we want new installs to discover by default.",
+    "Production installs can edit this file; demo installs can generate additional",
+    "entries via test-data/mint-foreign-concept.js."
+  ],
+  "authors": [
+    {
+      "pubkey": "82b75e474dda005e912bcbb910391c60c2b89cc7faf5d3c30b7c59a324973833",
+      "name": "This instance (self)",
+      "description": "Our own Tapestry Assistant — every firmware concept installed from this repo.",
+      "relays": [
+        "ws://localhost:7777"
+      ]
+    },
+    {
+      "pubkey": "50562894a151f6be404018d442e4a4af10bc773d27c55e6806561549e9253003",
+      "name": "Demo foreign TA (Magic Mirror)",
+      "description": "Foreign Tapestry Assistant for the Concept Discovery demo — publishes the nostr-relay-v2 concept with country + language fields.",
+      "relays": [
+        "ws://localhost:7777"
+      ]
+    }
+  ]
+}

--- a/public/kg/index.html
+++ b/public/kg/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/kg/brainstorm.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Brainstorm Search</title>
-    <script type="module" crossorigin src="/kg/assets/index-CoYglFcS.js"></script>
-    <link rel="stylesheet" crossorigin href="/kg/assets/index-CG4KiRsK.css">
+    <script type="module" crossorigin src="/kg/assets/index-2laXBC7K.js"></script>
+    <link rel="stylesheet" crossorigin href="/kg/assets/index-BTMwx3Qs.css">
   </head>
   <body>
     <div id="root"></div>

--- a/public/kg/index.html
+++ b/public/kg/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/kg/brainstorm.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Brainstorm Search</title>
-    <script type="module" crossorigin src="/kg/assets/index-Dk8NAAP-.js"></script>
-    <link rel="stylesheet" crossorigin href="/kg/assets/index-EmyVl5Ad.css">
+    <script type="module" crossorigin src="/kg/assets/index-CoYglFcS.js"></script>
+    <link rel="stylesheet" crossorigin href="/kg/assets/index-CG4KiRsK.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/api/concept-discovery/index.js
+++ b/src/api/concept-discovery/index.js
@@ -1,0 +1,501 @@
+/**
+ * Concept Discovery API — cross-instance concept sharing.
+ *
+ * Lets an instance discover and ingest Tapestry concept definitions authored
+ * by some other instance's TA pubkey. Once a foreign concept is imported, it
+ * lives in local Neo4j alongside our own firmware-sourced concepts, and
+ * relay-discovery's aggregated view honours kind-39999 events z-tagged to
+ * either coordinate.
+ *
+ * Endpoints:
+ *   GET  /api/concept-discovery/suggested-authors
+ *        Static bootstrap list, read from config/suggested-concept-authors.json.
+ *        Swap point for a future DCoSL-backed implementation.
+ *
+ *   GET  /api/concept-discovery/concepts-by-pubkey?pubkey=<hex>[&relays=<csv>]
+ *        External + local fetch of the kind-39998 ConceptHeader events
+ *        authored by `pubkey`. Each entry annotated with `alreadyImported`.
+ *
+ *   GET  /api/concept-discovery/concept-preview?pubkey=<hex>&slug=<slug>
+ *        Deep preview of a single foreign concept: schema shape, sets,
+ *        element count. Used by the import confirmation screen.
+ *
+ *   POST /api/concept-discovery/import  body { pubkey, slug, relays? }
+ *        Fetch the concept's full event bundle, land it in local strfry
+ *        (no re-signing — foreign events stay intact), import each event
+ *        to Neo4j via buildImportCypher, then run Pass-3 derivation so
+ *        the concept lights up in the existing Concepts UI.
+ *
+ *   GET  /api/concept-discovery/known-by-slug?slug=<slug>
+ *        List every ConceptHeader currently in Neo4j whose d-tag matches
+ *        `slug`. Used by the informational "other concepts" panels on
+ *        PublishRelayForm / RelayTagPanel.
+ */
+
+const NOSTR_TOOLS_PATH = '/usr/local/lib/node_modules/brainstorm/node_modules/nostr-tools';
+const WS_PATH = '/usr/local/lib/node_modules/brainstorm/node_modules/ws';
+
+if (typeof globalThis.WebSocket === 'undefined') {
+  globalThis.WebSocket = require(WS_PATH);
+}
+
+const { SimplePool } = require(NOSTR_TOOLS_PATH);
+const { exec } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { runCypher } = require('../../lib/neo4j-driver');
+const { buildImportCypher } = require('../neo4j/eventSync');
+const { runPass3 } = require('../../firmware/install');
+const { getDriver } = require('../../lib/neo4j-driver');
+
+const FETCH_TIMEOUT_MS = 8000;
+const SUGGESTED_AUTHORS_PATH = path.resolve(__dirname, '../../../config/suggested-concept-authors.json');
+
+const DEFAULT_RELAYS = [
+  'wss://purplepag.es',
+  'wss://wot.grapevine.network',
+  'wss://relay.primal.net',
+  'wss://nos.lol',
+  'wss://relay.damus.io',
+];
+
+function isHexPubkey(v) {
+  return typeof v === 'string' && /^[0-9a-f]{64}$/.test(v);
+}
+
+function parseRelays(param) {
+  if (!param) return DEFAULT_RELAYS;
+  const list = param
+    .split(',')
+    .map((r) => r.trim())
+    .filter((r) => r.startsWith('wss://') || r.startsWith('ws://'));
+  return list.length > 0 ? list : DEFAULT_RELAYS;
+}
+
+function strfryScan(filter) {
+  return new Promise((resolve) => {
+    const safeFilter = JSON.stringify(filter).replace(/'/g, "'\\''");
+    exec(`strfry scan '${safeFilter}'`, { maxBuffer: 20 * 1024 * 1024, timeout: 15000 }, (err, stdout) => {
+      if (err) return resolve([]);
+      const events = [];
+      for (const line of stdout.split('\n')) {
+        if (!line) continue;
+        try { events.push(JSON.parse(line)); } catch {}
+      }
+      resolve(events);
+    });
+  });
+}
+
+function strfryImport(event) {
+  return new Promise((resolve, reject) => {
+    const child = exec('strfry import --no-verify', { timeout: 10000 }, (err, _stdout, stderr) => {
+      if (err) return reject(new Error(`strfry import: ${err.message} ${stderr || ''}`));
+      resolve();
+    });
+    child.stdin.write(JSON.stringify(event) + '\n');
+    child.stdin.end();
+  });
+}
+
+async function importEventToNeo4j(event) {
+  const statements = buildImportCypher(event);
+  const driver = getDriver();
+  const session = driver.session();
+  try {
+    for (const stmt of statements) {
+      await session.run(stmt);
+    }
+  } finally {
+    await session.close();
+  }
+}
+
+/**
+ * Apply concept-aware Neo4j labels to an imported event based on its JSON
+ * payload shape. `buildImportCypher` only knows about kind→label mapping
+ * (39998 → ListHeader, 39999 → ListItem). Specific labels like
+ * :ConceptHeader / :JSONSchema / :Set / :Superset are assigned by the
+ * firmware install path during Pass 1 — we replicate that here for foreign
+ * imports.
+ */
+async function applyContentLabels(event) {
+  const dTag = (event.tags || []).find((t) => t[0] === 'd')?.[1];
+  if (!dTag) return;
+  const uuid = `${event.kind}:${event.pubkey}:${dTag}`;
+  const payload = parseJsonTag(event) || {};
+  const wordTypes = Array.isArray(payload?.word?.wordTypes) ? payload.word.wordTypes : [];
+  const labels = new Set();
+
+  if (event.kind === 39998 && payload.conceptHeader) labels.add('ConceptHeader');
+  if (event.kind === 39999) {
+    if (payload.jsonSchema) labels.add('JSONSchema');
+    if (payload.set) labels.add('Set');
+    if (wordTypes.includes('superset')) labels.add('Superset');
+    if (payload.primaryProperty) labels.add('Property');
+  }
+  if (labels.size === 0) return;
+
+  const setClause = [...labels].map((l) => `e:${l}`).join(', ');
+  const driver = getDriver();
+  const session = driver.session();
+  try {
+    await session.run(
+      `MATCH (e:NostrEvent {uuid: $uuid}) SET ${setClause}`,
+      { uuid },
+    );
+  } finally {
+    await session.close();
+  }
+}
+
+async function fetchFromPool(relays, filter) {
+  const pool = new SimplePool();
+  try {
+    return await Promise.race([
+      pool.querySync(relays, filter),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), FETCH_TIMEOUT_MS)),
+    ]).catch(() => []);
+  } finally {
+    try { pool.close(relays); } catch {}
+  }
+}
+
+function dedupById(events) {
+  const seen = new Set();
+  const out = [];
+  for (const e of events) {
+    if (!e?.id || seen.has(e.id)) continue;
+    seen.add(e.id);
+    out.push(e);
+  }
+  return out;
+}
+
+function parseJsonTag(event) {
+  const tag = (event.tags || []).find((t) => t[0] === 'json');
+  if (!tag || !tag[1]) return null;
+  try { return JSON.parse(tag[1]); } catch { return null; }
+}
+
+function conceptCoordinate(event) {
+  const dTag = (event.tags || []).find((t) => t[0] === 'd')?.[1];
+  if (!dTag) return null;
+  return `${event.kind}:${event.pubkey}:${dTag}`;
+}
+
+// ── GET /suggested-authors ──────────────────────────────────────────────
+
+function handleSuggestedAuthors(req, res) {
+  try {
+    if (!fs.existsSync(SUGGESTED_AUTHORS_PATH)) {
+      return res.json({ success: true, authors: [] });
+    }
+    const raw = fs.readFileSync(SUGGESTED_AUTHORS_PATH, 'utf8');
+    const data = JSON.parse(raw);
+    const authors = Array.isArray(data.authors) ? data.authors : [];
+    // Pass through only the known keys — keeps the API contract stable across
+    // config additions.
+    res.json({
+      success: true,
+      authors: authors
+        .filter((a) => a && isHexPubkey(a.pubkey))
+        .map((a) => ({
+          pubkey: a.pubkey,
+          name: a.name || a.pubkey.slice(0, 12),
+          description: a.description || '',
+          relays: Array.isArray(a.relays) ? a.relays : [],
+        })),
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+// ── GET /concepts-by-pubkey ─────────────────────────────────────────────
+
+async function handleConceptsByPubkey(req, res) {
+  const { pubkey, relays: relaysParam } = req.query;
+  if (!pubkey || !isHexPubkey(pubkey)) {
+    return res.status(400).json({ success: false, error: 'pubkey query param (64-char hex) is required' });
+  }
+  const relays = parseRelays(relaysParam);
+  try {
+    const [externalEvents, localEvents] = await Promise.all([
+      fetchFromPool(relays, { kinds: [39998], authors: [pubkey] }),
+      strfryScan({ kinds: [39998], authors: [pubkey] }),
+    ]);
+    const merged = dedupById([...externalEvents, ...localEvents]);
+
+    // Collect the coordinates and ask Neo4j which we already have imported.
+    const coordinates = merged.map(conceptCoordinate).filter(Boolean);
+    const installed = new Set();
+    if (coordinates.length > 0) {
+      const rows = await runCypher(
+        'MATCH (c:ConceptHeader) WHERE c.uuid IN $coords RETURN c.uuid AS uuid',
+        { coords: coordinates },
+      );
+      for (const r of rows) installed.add(r.uuid);
+    }
+
+    const concepts = merged.map((e) => {
+      const parsed = parseJsonTag(e);
+      const dTag = (e.tags || []).find((t) => t[0] === 'd')?.[1];
+      const coordinate = conceptCoordinate(e);
+      const header = parsed?.conceptHeader || {};
+      return {
+        coordinate,
+        slug: dTag || null,
+        name: header.oNames?.singular || dTag || null,
+        pluralName: header.oNames?.plural || null,
+        description: header.description || '',
+        pubkey: e.pubkey,
+        eventId: e.id,
+        createdAt: e.created_at,
+        alreadyImported: coordinate ? installed.has(coordinate) : false,
+      };
+    });
+
+    concepts.sort((a, b) => (a.slug || '').localeCompare(b.slug || ''));
+
+    res.json({
+      success: true,
+      pubkey,
+      queriedRelays: relays,
+      concepts,
+      count: concepts.length,
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+// ── GET /concept-preview ────────────────────────────────────────────────
+
+async function fetchConceptBundle(pubkey, slug, relays) {
+  // Header + all addressable supporting 39999s whose d-tag starts with <slug>-.
+  // We can't filter by d-tag prefix server-side on most relays, so we pull all
+  // 39999s authored by pubkey and filter locally.
+  const headerFilter = { kinds: [39998], authors: [pubkey], '#d': [slug] };
+  const supportFilter = { kinds: [39999], authors: [pubkey] };
+
+  const [headerExt, headerLocal, supportExt, supportLocal] = await Promise.all([
+    fetchFromPool(relays, headerFilter),
+    strfryScan(headerFilter),
+    fetchFromPool(relays, supportFilter),
+    strfryScan(supportFilter),
+  ]);
+
+  const header = dedupById([...headerExt, ...headerLocal])[0] || null;
+  const support = dedupById([...supportExt, ...supportLocal]).filter((e) => {
+    const dTag = (e.tags || []).find((t) => t[0] === 'd')?.[1] || '';
+    return dTag === slug || dTag.startsWith(`${slug}-`);
+  });
+
+  return { header, support };
+}
+
+async function handleConceptPreview(req, res) {
+  const { pubkey, slug, relays: relaysParam } = req.query;
+  if (!pubkey || !isHexPubkey(pubkey) || !slug) {
+    return res.status(400).json({ success: false, error: 'pubkey (64-char hex) and slug query params are required' });
+  }
+  const relays = parseRelays(relaysParam);
+  try {
+    const { header, support } = await fetchConceptBundle(pubkey, slug, relays);
+    if (!header) {
+      return res.status(404).json({ success: false, error: `No kind-39998 found for ${pubkey} d-tag=${slug}` });
+    }
+
+    const coordinate = conceptCoordinate(header);
+    const headerJson = parseJsonTag(header)?.conceptHeader || {};
+
+    // Schema event: d-tag = <slug>-schema
+    const schemaEvent = support.find(
+      (e) => (e.tags || []).find((t) => t[0] === 'd')?.[1] === `${slug}-schema`,
+    );
+    const schemaPayload = schemaEvent ? parseJsonTag(schemaEvent)?.jsonSchema : null;
+    const oKeySingular = headerJson.oKeys?.singular || slug;
+    const schemaNode = schemaPayload?.properties?.[oKeySingular] || null;
+    const schemaSummary = schemaNode
+      ? {
+          required: Array.isArray(schemaNode.required) ? schemaNode.required : [],
+          properties: Object.fromEntries(
+            Object.entries(schemaNode.properties || {}).map(([k, v]) => [
+              k,
+              { type: v.type || 'unknown', description: v.description || '' },
+            ]),
+          ),
+          unique: schemaNode['x-tapestry']?.unique || [],
+        }
+      : null;
+
+    // Set events: d-tag does NOT start with <slug>- but their JSON has word.slug
+    // referencing one of the concept's known sets. The firmware pattern pushes
+    // Superset under <slug>-superset though. For preview we list any support
+    // event whose json carries a `set` payload.
+    const sets = support
+      .map((e) => {
+        const payload = parseJsonTag(e);
+        const set = payload?.set;
+        if (!set) return null;
+        return {
+          slug: set.slug || null,
+          name: set.name || set.title || null,
+          description: set.description || '',
+        };
+      })
+      .filter(Boolean);
+
+    // Element count — cheap `strfry --count` on the local relay + SimplePool
+    // count on the external set, deduped by id.
+    const [elemExt, elemLocal] = await Promise.all([
+      fetchFromPool(relays, { kinds: [39999], '#z': [coordinate] }),
+      strfryScan({ kinds: [39999], '#z': [coordinate] }),
+    ]);
+    const elementCount = dedupById([...elemExt, ...elemLocal]).length;
+
+    // Is it already imported?
+    const installedRows = await runCypher(
+      'MATCH (c:ConceptHeader {uuid: $coord}) RETURN c.uuid AS uuid',
+      { coord: coordinate },
+    );
+    const alreadyImported = installedRows.length > 0;
+
+    res.json({
+      success: true,
+      coordinate,
+      header: {
+        name: headerJson.oNames?.singular || slug,
+        pluralName: headerJson.oNames?.plural || null,
+        description: headerJson.description || '',
+        oKeys: headerJson.oKeys || null,
+        pubkey: header.pubkey,
+        eventId: header.id,
+        createdAt: header.created_at,
+      },
+      schema: schemaSummary,
+      sets,
+      elementCount,
+      supportEventIds: support.map((e) => e.id),
+      alreadyImported,
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+// ── POST /import ─────────────────────────────────────────────────────────
+
+async function handleImport(req, res) {
+  const { pubkey, slug, relays: relaysParam } = req.body || {};
+  if (!pubkey || !isHexPubkey(pubkey) || !slug) {
+    return res.status(400).json({ success: false, error: 'pubkey (hex) and slug are required in the body' });
+  }
+  const relays = parseRelays(Array.isArray(relaysParam) ? relaysParam.join(',') : relaysParam);
+
+  try {
+    const { header, support } = await fetchConceptBundle(pubkey, slug, relays);
+    if (!header) {
+      return res.status(404).json({ success: false, error: `No kind-39998 found for ${pubkey} d-tag=${slug}` });
+    }
+    const allEvents = [header, ...support];
+
+    // Land every event in local strfry. strfry dedupes by id; already-imported
+    // events are a no-op.
+    const imported = [];
+    const skipped = [];
+    for (const ev of allEvents) {
+      try {
+        await strfryImport(ev);
+        imported.push(ev.id);
+      } catch (err) {
+        skipped.push({ eventId: ev.id, reason: err.message });
+      }
+    }
+
+    // Import each event's Neo4j nodes + tags + AUTHORS via buildImportCypher.
+    // This is the same path user-published 39999s take via
+    // /api/neo4j/event-update, adapted here so we don't have to re-sign.
+    // Then apply concept-aware labels (:ConceptHeader, :JSONSchema, etc.)
+    // that the firmware install would normally set in Pass 1.
+    for (const ev of allEvents) {
+      try {
+        await importEventToNeo4j(ev);
+        await applyContentLabels(ev);
+      } catch (err) {
+        skipped.push({ eventId: ev.id, reason: `neo4j: ${err.message}` });
+      }
+    }
+
+    // Run Pass 3 to assign labels + wire class threads + derive implicit nodes.
+    // Idempotent; sweeps all currently-present events in Neo4j.
+    const pass3 = await runPass3(req.app);
+
+    const coordinate = conceptCoordinate(header);
+    res.json({
+      success: true,
+      coordinate,
+      imported,
+      skipped,
+      eventCount: allEvents.length,
+      pass3,
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+// ── GET /known-by-slug ───────────────────────────────────────────────────
+
+async function handleKnownBySlug(req, res) {
+  const { slug } = req.query;
+  if (!slug) {
+    return res.status(400).json({ success: false, error: 'slug query param is required' });
+  }
+  try {
+    // Strict slug-coordinate match. A different slug (even one that's
+    // semantically related, like nostr-relay-v2) is a different concept by
+    // definition — surfacing it here would conflate "alternative
+    // interpretations of the same coordinate" with "things that are
+    // vaguely about the same idea." Plurality across slugs lives on the
+    // dedicated Concepts and Concept Discovery pages, not in publish UIs.
+    const rows = await runCypher(
+      `MATCH (c:ConceptHeader)
+       WHERE c.uuid ENDS WITH $suffix
+       RETURN c.uuid AS coordinate, c.pubkey AS pubkey, c.created_at AS createdAt, c.name AS name
+       ORDER BY c.created_at ASC`,
+      { suffix: `:${slug}` },
+    );
+    res.json({
+      success: true,
+      slug,
+      concepts: rows.map((r) => ({
+        coordinate: r.coordinate,
+        pubkey: r.pubkey,
+        name: r.name || slug,
+        createdAt: r.createdAt,
+      })),
+      count: rows.length,
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+function registerConceptDiscoveryRoutes(app) {
+  app.get('/api/concept-discovery/suggested-authors', handleSuggestedAuthors);
+  app.get('/api/concept-discovery/concepts-by-pubkey', handleConceptsByPubkey);
+  app.get('/api/concept-discovery/concept-preview', handleConceptPreview);
+  app.post('/api/concept-discovery/import', handleImport);
+  app.get('/api/concept-discovery/known-by-slug', handleKnownBySlug);
+}
+
+module.exports = {
+  registerConceptDiscoveryRoutes,
+  handleSuggestedAuthors,
+  handleConceptsByPubkey,
+  handleConceptPreview,
+  handleImport,
+  handleKnownBySlug,
+};

--- a/src/api/concept-discovery/index.js
+++ b/src/api/concept-discovery/index.js
@@ -47,6 +47,11 @@ const { runCypher } = require('../../lib/neo4j-driver');
 const { buildImportCypher } = require('../neo4j/eventSync');
 const { runPass3 } = require('../../firmware/install');
 const { getDriver } = require('../../lib/neo4j-driver');
+const firmware = require('../normalize/firmware');
+
+// Resolve canonical relationship-type slugs to the Neo4j edge labels this
+// install actually uses (e.g. CLASS_THREAD_INITIATION → IS_THE_CONCEPT_FOR).
+function rel(name) { return firmware.relAlias(name); }
 
 const FETCH_TIMEOUT_MS = 8000;
 const SUGGESTED_AUTHORS_PATH = path.resolve(__dirname, '../../../config/suggested-concept-authors.json');
@@ -115,9 +120,9 @@ async function importEventToNeo4j(event) {
  * Apply concept-aware Neo4j labels to an imported event based on its JSON
  * payload shape. `buildImportCypher` only knows about kind→label mapping
  * (39998 → ListHeader, 39999 → ListItem). Specific labels like
- * :ConceptHeader / :JSONSchema / :Set / :Superset are assigned by the
- * firmware install path during Pass 1 — we replicate that here for foreign
- * imports.
+ * :ConceptHeader / :JSONSchema / :Set / :Superset / :Property are assigned
+ * by the firmware install path during Pass 1; we replicate that here for
+ * foreign imports.
  */
 async function applyContentLabels(event) {
   const dTag = (event.tags || []).find((t) => t[0] === 'd')?.[1];
@@ -132,7 +137,7 @@ async function applyContentLabels(event) {
     if (payload.jsonSchema) labels.add('JSONSchema');
     if (payload.set) labels.add('Set');
     if (wordTypes.includes('superset')) labels.add('Superset');
-    if (payload.primaryProperty) labels.add('Property');
+    if (payload.primaryProperty || wordTypes.includes('property')) labels.add('Property');
   }
   if (labels.size === 0) return;
 
@@ -143,6 +148,56 @@ async function applyContentLabels(event) {
     await session.run(
       `MATCH (e:NostrEvent {uuid: $uuid}) SET ${setClause}`,
       { uuid },
+    );
+  } finally {
+    await session.close();
+  }
+}
+
+/**
+ * Wire structural relationships from a foreign concept's ConceptHeader to
+ * its supporting events, mirroring the edges firmware install creates in
+ * Pass 1 / Pass 2. Without these edges, `wire-implicit-elements` can't
+ * traverse from header → superset → element to attach HAS_ELEMENT, and
+ * the imported concept appears empty in the existing Concepts UI.
+ *
+ * The mapping from wordType → Neo4j relationship type follows the
+ * `relAlias` mapping (CLASS_THREAD_INITIATION → IS_THE_CONCEPT_FOR, etc.).
+ *
+ * Each support event's `word.coreMemberOf[].uuid` already names the
+ * parent ConceptHeader's coordinate, so we can wire from that pointer
+ * without any guess-the-coord logic.
+ */
+async function wireStructuralEdges(event) {
+  if (event.kind !== 39999) return;
+  const payload = parseJsonTag(event);
+  const headerUuid = payload?.word?.coreMemberOf?.[0]?.uuid;
+  if (!headerUuid) return;
+  const wordTypes = Array.isArray(payload?.word?.wordTypes) ? payload.word.wordTypes : [];
+  const dTag = (event.tags || []).find((t) => t[0] === 'd')?.[1];
+  if (!dTag) return;
+  const childUuid = `${event.kind}:${event.pubkey}:${dTag}`;
+
+  // wordType → REL slug. Both are properties of the support event's role.
+  // (Superset → IS_THE_CONCEPT_FOR is the critical one for element wiring.)
+  let relSlug = null;
+  if (wordTypes.includes('superset')) relSlug = 'CLASS_THREAD_INITIATION';
+  else if (wordTypes.includes('jsonSchema')) relSlug = 'CORE_NODE_JSON_SCHEMA';
+  else if (wordTypes.includes('primaryProperty')) relSlug = 'CORE_NODE_PRIMARY_PROPERTY';
+  else if (wordTypes.includes('propertiesSet')) relSlug = 'CORE_NODE_PROPERTIES';
+  else if (wordTypes.includes('propertyTreeGraph')) relSlug = 'CORE_NODE_PROPERTY_TREE_GRAPH';
+  else if (wordTypes.includes('coreNodesGraph')) relSlug = 'CORE_NODE_CORE_GRAPH';
+  else if (wordTypes.includes('conceptGraph')) relSlug = 'CORE_NODE_CONCEPT_GRAPH';
+  if (!relSlug) return;
+
+  const edgeName = rel(relSlug);
+  const driver = getDriver();
+  const session = driver.session();
+  try {
+    await session.run(
+      `MATCH (h:NostrEvent {uuid: $headerUuid}), (c:NostrEvent {uuid: $childUuid})
+       MERGE (h)-[:${edgeName}]->(c)`,
+      { headerUuid, childUuid },
     );
   } finally {
     await session.close();
@@ -423,6 +478,7 @@ async function handleImport(req, res) {
       try {
         await importEventToNeo4j(ev);
         await applyContentLabels(ev);
+        await wireStructuralEdges(ev);
       } catch (err) {
         skipped.push({ eventId: ev.id, reason: `neo4j: ${err.message}` });
       }
@@ -483,12 +539,48 @@ async function handleKnownBySlug(req, res) {
   }
 }
 
+// ── GET /api/concept-discovery/installed-concepts ───────────────────────
+// Lists every ConceptHeader currently in Neo4j. Used by the relay-discovery
+// "view through concept" picker so the user can scope the aggregated view
+// to any installed concept (ours, foreign — anything). Generic on purpose:
+// the UI is what knows about relay-shape semantics, not this endpoint.
+
+const OUR_TA_PUBKEY = '82b75e474dda005e912bcbb910391c60c2b89cc7faf5d3c30b7c59a324973833';
+
+async function handleInstalledConcepts(req, res) {
+  try {
+    const rows = await runCypher(
+      `MATCH (c:ConceptHeader)
+       RETURN c.uuid AS coordinate, c.pubkey AS pubkey, c.name AS name, c.created_at AS createdAt
+       ORDER BY c.name ASC`,
+    );
+    res.json({
+      success: true,
+      concepts: rows.map((r) => {
+        const slug = (r.coordinate || '').split(':').pop();
+        return {
+          coordinate: r.coordinate,
+          pubkey: r.pubkey,
+          slug,
+          name: r.name || slug,
+          createdAt: r.createdAt,
+          isOurs: r.pubkey === OUR_TA_PUBKEY,
+        };
+      }),
+      count: rows.length,
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
 function registerConceptDiscoveryRoutes(app) {
   app.get('/api/concept-discovery/suggested-authors', handleSuggestedAuthors);
   app.get('/api/concept-discovery/concepts-by-pubkey', handleConceptsByPubkey);
   app.get('/api/concept-discovery/concept-preview', handleConceptPreview);
   app.post('/api/concept-discovery/import', handleImport);
   app.get('/api/concept-discovery/known-by-slug', handleKnownBySlug);
+  app.get('/api/concept-discovery/installed-concepts', handleInstalledConcepts);
 }
 
 module.exports = {
@@ -498,4 +590,5 @@ module.exports = {
   handleConceptPreview,
   handleImport,
   handleKnownBySlug,
+  handleInstalledConcepts,
 };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -460,6 +460,10 @@ async function register(app) {
     const { registerRelayDiscoveryRoutes } = require('./relay-discovery');
     registerRelayDiscoveryRoutes(app);
 
+    // ── Concept Discovery API (cross-instance concept sharing) ──
+    const { registerConceptDiscoveryRoutes } = require('./concept-discovery');
+    registerConceptDiscoveryRoutes(app);
+
     // Initialize router state (presets → state file → strfry config)
     await initRouter();
 

--- a/src/api/relay-discovery/index.js
+++ b/src/api/relay-discovery/index.js
@@ -352,17 +352,27 @@ async function handleTagsForRelay(req, res) {
 //   limit    — optional, cap on rows returned (default 100).
 
 async function handleAggregated(req, res) {
-  const { tagSlug, limit: limitRaw } = req.query;
+  const { tagSlug, limit: limitRaw, conceptCoord } = req.query;
   const limit = Math.max(1, Math.min(500, parseInt(limitRaw, 10) || 100));
 
   try {
     // Resolve every installed concept coordinate per slug. Any TA's
     // nostr-relay / nostr-relay-tag / tag concept contributes.
-    const [relayCoords, tagAppCoords, tagCoords] = await Promise.all([
+    //
+    // When `conceptCoord` is provided, the picker has scoped the view to
+    // a single coordinate — could be a nostr-relay slug, could be
+    // anything else (`dog`, `nostr-relay-v2`, etc.). We use it for the
+    // relay-row filter only; tag aggregation continues across all known
+    // tag/tag-application coordinates so existing tags still annotate
+    // the filtered rows.
+    const [allRelayCoords, tagAppCoords, tagCoords] = await Promise.all([
       resolveConceptCoordinates('nostr-relay', NOSTR_RELAY_Z_TAG),
       resolveConceptCoordinates('nostr-relay-tag', NOSTR_RELAY_TAG_Z_TAG),
       resolveConceptCoordinates('tag', TAG_Z_TAG),
     ]);
+    // If the caller pinned a specific concept coordinate, use only that.
+    // Otherwise default to "every nostr-relay coordinate we know about."
+    const relayCoords = conceptCoord ? [conceptCoord] : allRelayCoords;
 
     // All imported kind 39999 relay items, with authors and JSON payload.
     const relayRows = await runCypher(
@@ -428,12 +438,21 @@ async function handleAggregated(req, res) {
       if (row.author) bySlug.get(slug).add(row.author);
     }
 
+    // Standard fields the relay UI knows how to render. Anything else in
+    // the relay event's JSON payload becomes "extras" — stuff a foreign
+    // concept may define that this UI doesn't natively render.
+    const STANDARD_FIELDS = new Set(['slug', 'websocketUrl', 'httpUrl']);
+
     // Group relay events by websocket URL.
     const byUrl = new Map();
     for (const row of relayRows) {
       if (!row.json) continue;
       let parsed;
       try { parsed = JSON.parse(row.json); } catch { continue; }
+      // Some foreign schemas may use a different top-level key, but for
+      // now we only know how to extract `nostrRelay`. (Other shapes will
+      // simply yield no rows here, which is the correct "this UI is a
+      // relay UI" behavior.)
       const nr = parsed?.nostrRelay;
       if (!nr?.websocketUrl) continue;
       const url = String(nr.websocketUrl).trim().replace(/\/+$/, '').toLowerCase();
@@ -447,11 +466,21 @@ async function handleAggregated(req, res) {
           endorsers: new Set(),           // distinct authors who published a 39999 for this relay
           relayEventIds: new Set(),       // all 39999 event IDs referencing this relay (by url)
           tagApplications: {},            // tagSlug → { authors: Set, count }
+          extras: {},                     // unmapped JSON keys — schema-divergence surface
+          appearsUnder: new Set(),        // concept coordinates this URL appears under
         });
       }
       const entry = byUrl.get(url);
       if (row.author) entry.endorsers.add(row.author);
       if (row.eventId) entry.relayEventIds.add(row.eventId);
+      if (row.concept) entry.appearsUnder.add(row.concept);
+      // Union extras across every event for this URL — last writer wins
+      // per key, but in practice schemas converge on the same shape.
+      for (const [k, v] of Object.entries(nr)) {
+        if (STANDARD_FIELDS.has(k)) continue;
+        if (v == null) continue;
+        entry.extras[k] = v;
+      }
     }
 
     // Merge tag applications into entries.
@@ -486,6 +515,8 @@ async function handleAggregated(req, res) {
         endorserCount: entry.endorsers.size,
         relayEventIds: [...entry.relayEventIds],
         tagApplications: tagApps,
+        extras: entry.extras,
+        appearsUnder: [...entry.appearsUnder],
       });
     }
 
@@ -509,7 +540,8 @@ async function handleAggregated(req, res) {
       count: entries.length,
       relays: entries,
       tagMeta,
-      filters: { tagSlug: tagSlug || null, limit },
+      filters: { tagSlug: tagSlug || null, conceptCoord: conceptCoord || null, limit },
+      knownConcepts: allRelayCoords,
     });
   } catch (err) {
     res.status(500).json({ success: false, error: err.message });

--- a/src/api/relay-discovery/index.js
+++ b/src/api/relay-discovery/index.js
@@ -27,10 +27,33 @@ const FETCH_TIMEOUT_MS = 8000;
 // Firmware TA pubkey (publishes all kind 39998 concept headers).
 const TA_PUBKEY = '82b75e474dda005e912bcbb910391c60c2b89cc7faf5d3c30b7c59a324973833';
 
-// Coordinate for the nostr-relay firmware concept (TA pubkey + d-tag).
+// Coordinate for our own TA's firmware concepts. Retained for fallback: if
+// Neo4j has no ConceptHeader matching a slug (e.g. because a stale install
+// or a prune wiped the firmware), the resolver below falls back to the
+// hardcoded coordinate so the app keeps working.
 const NOSTR_RELAY_Z_TAG = `39998:${TA_PUBKEY}:nostr-relay`;
 const TAG_Z_TAG = `39998:${TA_PUBKEY}:tag`;
 const NOSTR_RELAY_TAG_Z_TAG = `39998:${TA_PUBKEY}:nostr-relay-tag`;
+
+// Runtime resolution of every ConceptHeader coordinate whose d-tag matches
+// `slug`. Returns an array of `39998:<pubkey>:<slug>` strings. Used to make
+// every downstream query (tag lookup, tag-application scan, aggregated
+// ranking) multi-TA aware — any concept imported via /api/concept-discovery
+// automatically contributes to the relay-discovery experience.
+//
+// The `ENDS WITH $suffix` clause matches exactly on the ":<slug>" suffix,
+// regardless of which TA pubkey is in the middle.
+async function resolveConceptCoordinates(slug, fallback) {
+  try {
+    const rows = await runCypher(
+      'MATCH (c:ConceptHeader) WHERE c.uuid ENDS WITH $suffix RETURN c.uuid AS uuid',
+      { suffix: `:${slug}` },
+    );
+    const coords = rows.map((r) => r.uuid).filter(Boolean);
+    if (coords.length > 0) return coords;
+  } catch {}
+  return fallback ? [fallback] : [];
+}
 
 // Default relays used when the client does not specify. Mirrors
 // ui/src/utils/nostrPublish.js PUBLISH_RELAYS so the server query sees the same
@@ -231,10 +254,12 @@ function strfryScan(filter) {
 
 async function handleAvailableTags(req, res) {
   try {
+    // Every imported `tag` ConceptHeader contributes to the tag vocabulary —
+    // we no longer filter by a single author.
+    const tagCoords = await resolveConceptCoordinates('tag', TAG_Z_TAG);
     const events = await strfryScan({
       kinds: [39999],
-      '#z': [TAG_Z_TAG],
-      authors: [TA_PUBKEY],
+      '#z': tagCoords,
     });
 
     const tags = [];
@@ -275,11 +300,12 @@ async function handleTagsForRelay(req, res) {
 
   try {
     // We can't index into the JSON payload from strfry, so scan all
-    // nostr-relay-tag events and filter client-side. This list grows slowly
-    // in the MVP; Phase 4 will move aggregation into Neo4j.
+    // nostr-relay-tag events and filter client-side. Multi-TA aware:
+    // every imported `nostr-relay-tag` coordinate contributes.
+    const tagAppCoords = await resolveConceptCoordinates('nostr-relay-tag', NOSTR_RELAY_TAG_Z_TAG);
     const events = await strfryScan({
       kinds: [39999],
-      '#z': [NOSTR_RELAY_TAG_Z_TAG],
+      '#z': tagAppCoords,
     });
 
     const applications = [];
@@ -330,34 +356,44 @@ async function handleAggregated(req, res) {
   const limit = Math.max(1, Math.min(500, parseInt(limitRaw, 10) || 100));
 
   try {
+    // Resolve every installed concept coordinate per slug. Any TA's
+    // nostr-relay / nostr-relay-tag / tag concept contributes.
+    const [relayCoords, tagAppCoords, tagCoords] = await Promise.all([
+      resolveConceptCoordinates('nostr-relay', NOSTR_RELAY_Z_TAG),
+      resolveConceptCoordinates('nostr-relay-tag', NOSTR_RELAY_TAG_Z_TAG),
+      resolveConceptCoordinates('tag', TAG_Z_TAG),
+    ]);
+
     // All imported kind 39999 relay items, with authors and JSON payload.
     const relayRows = await runCypher(
       `MATCH (e:NostrEvent {kind: 39999})-[:HAS_TAG]->(zt:NostrEventTag {type: 'z'})
-       WHERE zt.value = $zTag
+       WHERE zt.value IN $zTags
        OPTIONAL MATCH (u:NostrUser)-[:AUTHORS]->(e)
        OPTIONAL MATCH (e)-[:HAS_TAG]->(jt:NostrEventTag {type: 'json'})
-       RETURN e.id AS eventId, e.uuid AS uuid, u.pubkey AS author, jt.value AS json`,
-      { zTag: NOSTR_RELAY_Z_TAG }
+       RETURN e.id AS eventId, e.uuid AS uuid, u.pubkey AS author, jt.value AS json, zt.value AS concept`,
+      { zTags: relayCoords }
     );
 
     // All imported nostr-relay-tag applications with authors and JSON.
     const tagAppRows = await runCypher(
       `MATCH (e:NostrEvent {kind: 39999})-[:HAS_TAG]->(zt:NostrEventTag {type: 'z'})
-       WHERE zt.value = $zTag
+       WHERE zt.value IN $zTags
        OPTIONAL MATCH (u:NostrUser)-[:AUTHORS]->(e)
        OPTIONAL MATCH (e)-[:HAS_TAG]->(jt:NostrEventTag {type: 'json'})
        RETURN e.id AS eventId, u.pubkey AS author, jt.value AS json`,
-      { zTag: NOSTR_RELAY_TAG_Z_TAG }
+      { zTags: tagAppCoords }
     );
 
-    // All imported tag elements (authored by the TA), so we can resolve
-    // tagEventId → tag slug.
+    // All imported tag elements across every `tag` concept coordinate. No
+    // author filter — each concept-author publishes their own tag elements
+    // and we want to resolve every tagEventId our tag applications might
+    // reference.
     const tagRows = await runCypher(
-      `MATCH (e:NostrEvent {kind: 39999, pubkey: $ta})-[:HAS_TAG]->(zt:NostrEventTag {type: 'z'})
-       WHERE zt.value = $zTag
+      `MATCH (e:NostrEvent {kind: 39999})-[:HAS_TAG]->(zt:NostrEventTag {type: 'z'})
+       WHERE zt.value IN $zTags
        OPTIONAL MATCH (e)-[:HAS_TAG]->(jt:NostrEventTag {type: 'json'})
        RETURN e.id AS eventId, jt.value AS json`,
-      { ta: TA_PUBKEY, zTag: TAG_Z_TAG }
+      { zTags: tagCoords }
     );
 
     const tagSlugByEventId = new Map();

--- a/src/firmware/install.js
+++ b/src/firmware/install.js
@@ -1176,4 +1176,56 @@ if (require.main === module) {
   });
 }
 
-module.exports = { install, pass1_bootstrap, pass2_enrich, handleFirmwareInstall };
+/**
+ * Pass-3 only: derive labels + apply enumerations + wire implicit elements.
+ *
+ * Extracted so callers that land foreign-authored events in Neo4j (e.g.
+ * /api/concept-discovery/import) can trigger the same derivation pipeline
+ * without going through Pass-1 / Pass-2 (which re-sign with our TA key and
+ * would destroy foreign events).
+ *
+ * Requires an `app` (Express instance, usually `req.app`) so the helper can
+ * make internal route calls without looping back through HTTP.
+ */
+async function runPass3(app) {
+  if (!app) throw new Error('runPass3 requires an Express app (pass req.app)');
+  const bridge = createInternalBridge(app);
+  const wasInternal = _internalMode;
+  const prevHandlers = _internalHandlers;
+  enableInternalMode(bridge);
+  try {
+    const result = { derived: 0, enumerationsApplied: 0, implicitWired: 0, errors: [] };
+    const deriveLabels = ['ListItem', 'ListHeader', 'ConceptHeader', 'JSONSchema', 'Property', 'Set', 'Superset'];
+    for (const label of deriveLabels) {
+      try {
+        await bridge.post(`/api/tapestry-key/derive-all/${label}`, {});
+      } catch (err) {
+        result.errors.push(`derive ${label}: ${err.message}`);
+      }
+    }
+    try {
+      const statusRes = await bridge.get('/api/tapestry-key/derive-status');
+      if (statusRes?.success) {
+        result.derived = (statusRes.data || []).reduce((s, l) => s + (l.derived || 0), 0);
+      }
+    } catch {}
+    try {
+      const enumRes = await bridge.post('/api/normalize/apply-enumerations', {});
+      result.enumerationsApplied = enumRes?.updated || 0;
+    } catch (err) {
+      result.errors.push(`apply-enumerations: ${err.message}`);
+    }
+    try {
+      const wireRes = await bridge.post('/api/normalize/wire-implicit-elements', {});
+      result.implicitWired = wireRes?.wired || 0;
+    } catch (err) {
+      result.errors.push(`wire-implicit-elements: ${err.message}`);
+    }
+    return result;
+  } finally {
+    _internalMode = wasInternal;
+    _internalHandlers = prevHandlers;
+  }
+}
+
+module.exports = { install, pass1_bootstrap, pass2_enrich, handleFirmwareInstall, runPass3, createInternalBridge };

--- a/test-data/demo-foreign-concept.json
+++ b/test-data/demo-foreign-concept.json
@@ -1,0 +1,9 @@
+{
+  "taName": "Magic Mirror",
+  "taPubkey": "50562894a151f6be404018d442e4a4af10bc773d27c55e6806561549e9253003",
+  "taNpub": "npub12ptz399p28mtuszqrr2y9e9y4ugtcaeaylz4u6qx2c25n6f9xqps8lac3x",
+  "conceptSlug": "nostr-relay-v2",
+  "conceptCoordinate": "39998:50562894a151f6be404018d442e4a4af10bc773d27c55e6806561549e9253003:nostr-relay-v2",
+  "headerEventId": "a9f11cae41e556c6aa4b1041d094e5090774bbafe823650a2c487520920583d8",
+  "schemaEventId": "7d1c512399346f25bbb23c129c3842e2a6599e57716128c2b967c399171c5417"
+}

--- a/test-data/demo-foreign-concept.json
+++ b/test-data/demo-foreign-concept.json
@@ -4,6 +4,74 @@
   "taNpub": "npub12ptz399p28mtuszqrr2y9e9y4ugtcaeaylz4u6qx2c25n6f9xqps8lac3x",
   "conceptSlug": "nostr-relay-v2",
   "conceptCoordinate": "39998:50562894a151f6be404018d442e4a4af10bc773d27c55e6806561549e9253003:nostr-relay-v2",
-  "headerEventId": "a9f11cae41e556c6aa4b1041d094e5090774bbafe823650a2c487520920583d8",
-  "schemaEventId": "7d1c512399346f25bbb23c129c3842e2a6599e57716128c2b967c399171c5417"
+  "headerEventId": "951edbeabc628cb50946227839c0f49c66e65a7a2949647401bd39b5f98b8d18",
+  "supports": [
+    {
+      "role": "JSONSchema",
+      "uuid": "39999:50562894a151f6be404018d442e4a4af10bc773d27c55e6806561549e9253003:nostr-relay-v2-schema",
+      "eventId": "668d6082ef4a8bd3e8d193df27a2512c0cb492538174ff502e56439186f81d64"
+    },
+    {
+      "role": "PrimaryProperty",
+      "uuid": "39999:50562894a151f6be404018d442e4a4af10bc773d27c55e6806561549e9253003:nostr-relay-v2-primary-property",
+      "eventId": "069d5696a7462dcf014868c915da01bd3b01608ad2727b844d5a8ccb01728507"
+    },
+    {
+      "role": "PropertiesSet",
+      "uuid": "39999:50562894a151f6be404018d442e4a4af10bc773d27c55e6806561549e9253003:nostr-relay-v2-properties",
+      "eventId": "9af73f074f2aeb9fce4b85cc5498d7d99d3181d67e4b4b0e480216ea1b45a875"
+    },
+    {
+      "role": "Superset",
+      "uuid": "39999:50562894a151f6be404018d442e4a4af10bc773d27c55e6806561549e9253003:nostr-relay-v2-superset",
+      "eventId": "1db6fc76064b2a613c664559d7d4cf7eb191e7b0773ec5ae12fc3f30233a5ca9"
+    },
+    {
+      "role": "CoreNodesGraph",
+      "uuid": "39999:50562894a151f6be404018d442e4a4af10bc773d27c55e6806561549e9253003:nostr-relay-v2-core-nodes-graph",
+      "eventId": "f1da8f715bfc8fe5722aa357c42a533fe4934d973ba91491f2d60bd2a01ee217"
+    },
+    {
+      "role": "ConceptGraph",
+      "uuid": "39999:50562894a151f6be404018d442e4a4af10bc773d27c55e6806561549e9253003:nostr-relay-v2-concept-graph",
+      "eventId": "fbc120892cde01d19de29f21e374cb2d89a48889705be62fc6c0c15e2c4dc8ed"
+    },
+    {
+      "role": "PropertyTreeGraph",
+      "uuid": "39999:50562894a151f6be404018d442e4a4af10bc773d27c55e6806561549e9253003:nostr-relay-v2-property-tree-graph",
+      "eventId": "44095fbdec118b878acc5b61c3b027e35f950914911c978196f869747f3457bf"
+    }
+  ],
+  "elements": [
+    {
+      "publisher": "Snow White",
+      "slug": "relay-tokyo",
+      "websocketUrl": "wss://relay-tokyo.example.com",
+      "httpUrl": "https://relay-tokyo.example.com",
+      "country": "JP",
+      "language": "ja",
+      "eventId": "31ec3ef986af5c169a48c7d57cba5924273eac4ba26be9bec4224dc844474c9f",
+      "publisherPubkey": "a19ffd86e1c5bad3f9f3934ab689c2be4dea2d07e04ff3df9864da1c6a7b8eec"
+    },
+    {
+      "publisher": "Huntsman",
+      "slug": "relay-berlin",
+      "websocketUrl": "wss://relay-berlin.example.com",
+      "httpUrl": "https://relay-berlin.example.com",
+      "country": "DE",
+      "language": "de",
+      "eventId": "b683bf3e381c734365a506773f1825f4a25a067a5310fe705f4e4aaea9635e37",
+      "publisherPubkey": "957bc98b30ce9b13545bfabb1052713de292123a5ab78f40e442010c541b31bc"
+    },
+    {
+      "publisher": "Magic Mirror",
+      "slug": "relay-mirror",
+      "websocketUrl": "wss://relay-mirror.example.com",
+      "httpUrl": "https://relay-mirror.example.com",
+      "country": "US",
+      "language": "en",
+      "eventId": "f0a5f4b591ebcef107963951a270dd9bd21560094d2e1818c7a1661ce0fae428",
+      "publisherPubkey": "50562894a151f6be404018d442e4a4af10bc773d27c55e6806561549e9253003"
+    }
+  ]
 }

--- a/test-data/mint-foreign-concept.js
+++ b/test-data/mint-foreign-concept.js
@@ -1,27 +1,35 @@
 #!/usr/bin/env node
 /**
- * Mint a "foreign" Tapestry concept for the Concept Discovery demo.
+ * Mint a fully-formed "foreign" Tapestry concept for the Concept Discovery
+ * demo.
  *
- * Uses one of the dwarves keypairs as the foreign Tapestry Assistant (TA)
- * pubkey and publishes a minimal but realistic `nostr-relay-v2` concept
- * bundle (kind-39998 ConceptHeader + kind-39999 JSONSchema) to local
- * strfry. The schema deliberately differs from our own `nostr-relay`
- * concept — it adds `country` and `language` fields — so importing it
- * produces a second installed concept under the same abstract idea,
- * demonstrating schema-level divergence between instances.
+ * Uses a dwarves keypair as the foreign Tapestry Assistant (TA) and
+ * publishes a complete `nostr-relay-v2` concept to local strfry, matching
+ * the 8-event shape our own firmware install produces for any concept:
  *
- * After running this script:
- *   1. /api/concept-discovery/suggested-authors lists the foreign TA
- *      (appended to config/suggested-concept-authors.json if --seed-config
- *      is passed).
- *   2. /api/concept-discovery/concepts-by-pubkey?pubkey=<foreign-TA>
- *      returns the nostr-relay-v2 ConceptHeader.
- *   3. A user can preview + import it via the /kg/concept-discovery UI.
+ *   1. ConceptHeader            (kind 39998, d-tag = <slug>)
+ *   2. JSONSchema               (kind 39999, d-tag = <slug>-schema)
+ *   3. Primary Property         (kind 39999, d-tag = <slug>-primary-property)
+ *   4. Properties Set           (kind 39999, d-tag = <slug>-properties)
+ *   5. Superset                 (kind 39999, d-tag = <slug>-superset)
+ *   6. Core Nodes Graph         (kind 39999, d-tag = <slug>-core-nodes-graph)
+ *   7. Concept Graph            (kind 39999, d-tag = <slug>-concept-graph)
+ *   8. Property Tree Graph      (kind 39999, d-tag = <slug>-property-tree-graph)
+ *
+ * Plus 3 seed relay elements published by various dwarves keypairs, each
+ * carrying the v2-only fields (`country`, `language`) so the Concept
+ * Discovery demo has visible schema-divergence content to render.
+ *
+ * The foreign TA's z-tags reference its OWN pubkey for the firmware-level
+ * concepts (`word`, `set`, `json-schema`, etc.). Those references are
+ * dangling on this install — that's correct; in the real world the
+ * foreign TA would have its own full firmware. Locally, derive Pass 3
+ * just leaves those edges unresolved, which is the realistic "I see your
+ * concept's shape but not your full ontology" behavior we want to model.
  *
  * Usage:
  *   node mint-foreign-concept.js               # publish only
- *   node mint-foreign-concept.js --seed-config # also add to the
- *                                              # suggested-authors config
+ *   node mint-foreign-concept.js --seed-config # also add to suggested-authors
  */
 
 const fs = require('fs');
@@ -29,18 +37,10 @@ const path = require('path');
 const http = require('http');
 const { execSync } = require('child_process');
 
-// nostr-tools isn't reliably available on the host (lives only inside the
-// container's named volume). For the npub encoding we shell out to `nak`
-// which the dev environment already requires.
 function encodeNpub(hex) {
-  try {
-    return execSync(`nak encode npub ${hex}`, { encoding: 'utf8' }).trim();
-  } catch {
-    return null;
-  }
+  try { return execSync(`nak encode npub ${hex}`, { encoding: 'utf8' }).trim(); }
+  catch { return null; }
 }
-
-// ── Port resolution (matches mint-demo-relays.js) ────────────
 
 function resolveApi() {
   if (process.env.BRAINSTORM_API) return process.env.BRAINSTORM_API;
@@ -58,91 +58,58 @@ function resolveApi() {
 
 const API = resolveApi();
 const SEED_CONFIG = process.argv.includes('--seed-config');
-const FOREIGN_TA_NAME = 'Magic Mirror'; // arbitrary good-actor keypair from dwarves-test-data.json
-
-// ── Concept definition — nostr-relay-v2 ──────────────────────
+const FOREIGN_TA_NAME = 'Magic Mirror';
 
 const CONCEPT_SLUG = 'nostr-relay-v2';
-const CONCEPT_HUMAN = 'Nostr Relay (v2)';
-
-// Note: `oKeys.singular` is used as the top-level property key in the schema.
-// For cross-concept compatibility with user-published kind-39999s we keep it
-// as `nostrRelay` (same key our canonical concept uses). Only the SHAPE
-// inside that object diverges — new optional `country` and `language`.
-const CONCEPT_HEADER_PAYLOAD = {
-  word: {
-    slug: `concept-header-for-the-concept-of-${CONCEPT_SLUG}`,
-    name: `concept header for the concept of ${CONCEPT_HUMAN}`,
-    title: `Concept Header for the Concept of ${CONCEPT_HUMAN}`,
-    wordTypes: ['word', 'conceptHeader'],
-  },
-  conceptHeader: {
-    description:
-      'A Nostr relay (v2). Same idea as the canonical nostr-relay concept but with optional geographic + language metadata. Minted by a foreign TA for the Concept Discovery demo.',
-    oNames: { singular: 'nostr relay v2', plural: 'nostr relays v2' },
-    oSlugs: { singular: CONCEPT_SLUG, plural: `${CONCEPT_SLUG}s` },
-    oKeys: { singular: 'nostrRelay', plural: 'nostrRelays' },
-    oTitles: { singular: CONCEPT_HUMAN, plural: `${CONCEPT_HUMAN}s` },
-    oLabels: { singular: 'NostrRelay', plural: 'NostrRelays' },
-    'x-tapestry': { neo4j: { nodeLabelRequired: true } },
-  },
+const CONCEPT_PLURAL = `${CONCEPT_SLUG}s`;
+const NAMES = {
+  singular: 'nostr relay v2',
+  plural: 'nostr relays v2',
+};
+const TITLES = {
+  singular: 'Nostr Relay v2',
+  plural: 'Nostr Relays v2',
+};
+const KEYS = {
+  singular: 'nostrRelay',
+  plural: 'nostrRelays',
+};
+const LABELS = {
+  singular: 'NostrRelay',
+  plural: 'NostrRelays',
 };
 
-const SCHEMA_PAYLOAD = {
-  word: {
-    slug: `json-schema-for-the-concept-of-${CONCEPT_SLUG}`,
-    name: `JSON schema for the concept of ${CONCEPT_HUMAN}`,
-    title: `JSON Schema for the Concept of ${CONCEPT_HUMAN}`,
-    description: `JSON schema for the concept of ${CONCEPT_HUMAN}`,
-    wordTypes: ['word', 'jsonSchema'],
-    // coreMemberOf uuid is filled in after we know the foreign-TA-keyed header coordinate
+// Three seed elements: each from a different dwarves account so the
+// aggregated relay-discovery view sees distinct endorsers under the v2
+// coordinate.
+const SEED_ELEMENTS = [
+  {
+    publisher: 'Snow White',
+    slug: 'relay-tokyo',
+    websocketUrl: 'wss://relay-tokyo.example.com',
+    httpUrl: 'https://relay-tokyo.example.com',
+    country: 'JP',
+    language: 'ja',
   },
-  jsonSchema: {
-    $schema: 'https://json-schema.org/draft/2020-12/schema',
-    type: 'object',
-    name: CONCEPT_HUMAN.toLowerCase(),
-    title: CONCEPT_HUMAN,
-    description: `JSON Schema for ${CONCEPT_HUMAN}`,
-    required: ['nostrRelay'],
-    definitions: {},
-    properties: {
-      nostrRelay: {
-        type: 'object',
-        name: CONCEPT_HUMAN.toLowerCase(),
-        title: CONCEPT_HUMAN,
-        slug: CONCEPT_SLUG,
-        description: `data about this ${CONCEPT_HUMAN}`,
-        required: ['slug', 'websocketUrl'],
-        properties: {
-          slug: {
-            type: 'string', name: 'slug', title: 'Slug', slug: 'slug',
-            description: 'A unique kebab-case identifier for this relay',
-          },
-          websocketUrl: {
-            type: 'string', name: 'websocketUrl', title: 'Websocket URL', slug: 'websocket-url',
-            description: 'The websocket URL',
-          },
-          httpUrl: {
-            type: 'string', name: 'httpUrl', title: 'HTTP URL', slug: 'http-url',
-            description: 'The HTTP URL (optional)',
-          },
-          // NEW FIELDS — the visible "schema divergence" for the demo
-          country: {
-            type: 'string', name: 'country', title: 'Country', slug: 'country',
-            description: 'ISO 3166-1 alpha-2 country code where this relay is hosted',
-          },
-          language: {
-            type: 'string', name: 'language', title: 'Language', slug: 'language',
-            description: 'BCP 47 language tag for the relay\'s primary community',
-          },
-        },
-        'x-tapestry': { unique: ['slug', 'websocketUrl'] },
-      },
-    },
+  {
+    publisher: 'Huntsman',
+    slug: 'relay-berlin',
+    websocketUrl: 'wss://relay-berlin.example.com',
+    httpUrl: 'https://relay-berlin.example.com',
+    country: 'DE',
+    language: 'de',
   },
-};
+  {
+    publisher: FOREIGN_TA_NAME, // self-endorsement from the foreign TA
+    slug: 'relay-mirror',
+    websocketUrl: 'wss://relay-mirror.example.com',
+    httpUrl: 'https://relay-mirror.example.com',
+    country: 'US',
+    language: 'en',
+  },
+];
 
-// ── Helpers ──────────────────────────────────────────────────
+// ── HTTP / nak helpers ───────────────────────────────────────
 
 function httpPost(pathname, body) {
   return new Promise((resolve, reject) => {
@@ -173,14 +140,245 @@ function signEvent(sk, eventJson) {
   return JSON.parse(result);
 }
 
-async function publish(event) {
-  return httpPost('/api/strfry/publish', { event, signAs: 'client' });
+async function publish(event) { return httpPost('/api/strfry/publish', { event, signAs: 'client' }); }
+async function importToNeo4j(uuid) { return httpPost('/api/neo4j/event-update', { uuid }); }
+
+// ── Concept event builders ───────────────────────────────────
+
+const NOW = () => Math.floor(Date.now() / 1000);
+
+function mintHeader(taPk, taSk) {
+  const description = `A Nostr relay (v2). Same shape as the canonical nostr-relay concept but with optional country + language metadata. Authored by foreign TA ${FOREIGN_TA_NAME} for the Concept Discovery demo.`;
+  const json = {
+    word: {
+      slug: `concept-header-for-the-concept-of-${CONCEPT_SLUG}`,
+      name: `concept header for the concept of ${NAMES.singular}`,
+      title: `Concept Header for the Concept of ${TITLES.singular}`,
+      wordTypes: ['word', 'conceptHeader'],
+    },
+    conceptHeader: {
+      description,
+      oNames: NAMES,
+      oSlugs: { singular: CONCEPT_SLUG, plural: CONCEPT_PLURAL },
+      oKeys: KEYS,
+      oTitles: TITLES,
+      oLabels: LABELS,
+      'x-tapestry': { neo4j: { nodeLabelRequired: true } },
+    },
+  };
+  const event = signEvent(taSk, {
+    kind: 39998,
+    pubkey: taPk,
+    created_at: NOW(),
+    content: '',
+    tags: [
+      ['d', CONCEPT_SLUG],
+      ['names', NAMES.singular, NAMES.plural],
+      ['slug', CONCEPT_SLUG],
+      ['json', JSON.stringify(json)],
+      ['description', description],
+    ],
+  });
+  return { event, uuid: `39998:${taPk}:${CONCEPT_SLUG}` };
 }
 
-// ── Main ─────────────────────────────────────────────────────
+/**
+ * Generic builder for the 7 supporting kind-39999 events. Each one
+ * z-tags its conceptual parents under the FOREIGN TA's pubkey so this
+ * looks like a fully-formed concept from the foreign instance's
+ * perspective. Locally, those z-tag references are dangling — that's
+ * realistic.
+ */
+function mintSupport({ taPk, taSk, headerUuid, role, parentSlugs, wordTypes, payloadKey, payload, description }) {
+  const dTag = `${CONCEPT_SLUG}-${role}`;
+  const wordSlug = `${role.replace(/-/g, '-')}-for-the-concept-of-${CONCEPT_SLUG}`;
+  const json = {
+    word: {
+      slug: wordSlug,
+      name: `${role.replace(/-/g, ' ')} for the concept of ${NAMES.singular}`,
+      title: `${role.replace(/(^|-)\w/g, (m) => m.toUpperCase()).replace(/-/g, ' ')} for the Concept of ${TITLES.singular}`,
+      wordTypes: ['word', ...wordTypes],
+      coreMemberOf: [{ slug: `concept-header-for-the-concept-of-${CONCEPT_SLUG}`, uuid: headerUuid }],
+    },
+    [payloadKey]: payload,
+  };
+  const tags = [
+    ['d', dTag],
+    ['name', `${role.replace(/-/g, ' ')} for the concept of ${NAMES.singular}`],
+  ];
+  for (const ps of parentSlugs) {
+    tags.push(['z', `39998:${taPk}:${ps}`]);
+  }
+  if (description) tags.push(['description', description]);
+  tags.push(['json', JSON.stringify(json)]);
+
+  const event = signEvent(taSk, {
+    kind: 39999,
+    pubkey: taPk,
+    created_at: NOW(),
+    content: '',
+    tags,
+  });
+  return { event, uuid: `39999:${taPk}:${dTag}` };
+}
+
+function mintSchema(taPk, taSk, headerUuid) {
+  return mintSupport({
+    taPk, taSk, headerUuid,
+    role: 'schema',
+    parentSlugs: ['json-schema', 'word'],
+    wordTypes: ['jsonSchema'],
+    payloadKey: 'jsonSchema',
+    description: `the json schema for the concept of ${NAMES.singular}`,
+    payload: {
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      type: 'object',
+      name: NAMES.singular,
+      title: TITLES.singular,
+      description: `JSON Schema for the concept of ${NAMES.singular}`,
+      required: [KEYS.singular],
+      definitions: {},
+      properties: {
+        [KEYS.singular]: {
+          type: 'object',
+          name: NAMES.singular,
+          title: TITLES.singular,
+          slug: CONCEPT_SLUG,
+          description: `data about this ${NAMES.singular}`,
+          required: ['slug', 'websocketUrl'],
+          properties: {
+            slug: { type: 'string', name: 'slug', title: 'Slug', slug: 'slug', description: 'A unique kebab-case identifier for this relay' },
+            websocketUrl: { type: 'string', name: 'websocketUrl', title: 'Websocket URL', slug: 'websocket-url', description: 'The websocket URL' },
+            httpUrl: { type: 'string', name: 'httpUrl', title: 'HTTP URL', slug: 'http-url', description: 'The HTTP URL (optional)' },
+            country: { type: 'string', name: 'country', title: 'Country', slug: 'country', description: 'ISO 3166-1 alpha-2 country code where this relay is hosted' },
+            language: { type: 'string', name: 'language', title: 'Language', slug: 'language', description: "BCP 47 language tag for the relay's primary community" },
+          },
+          'x-tapestry': { unique: ['slug', 'websocketUrl'] },
+        },
+      },
+    },
+  });
+}
+
+function mintPrimaryProperty(taPk, taSk, headerUuid) {
+  return mintSupport({
+    taPk, taSk, headerUuid,
+    role: 'primary-property',
+    parentSlugs: ['primary-property', 'property', 'word'],
+    wordTypes: ['property', 'primaryProperty'],
+    payloadKey: 'primaryProperty',
+    description: `the primary property for the concept of ${NAMES.singular}`,
+    payload: {
+      slug: KEYS.singular,
+      name: KEYS.singular,
+      title: TITLES.singular,
+      type: 'object',
+      description: `the primary property for the concept of ${NAMES.singular}`,
+    },
+  });
+}
+
+function mintPropertiesSet(taPk, taSk, headerUuid) {
+  return mintSupport({
+    taPk, taSk, headerUuid,
+    role: 'properties',
+    parentSlugs: ['properties-set', 'set', 'word'],
+    wordTypes: ['set', 'propertiesSet'],
+    payloadKey: 'set',
+    payload: {
+      slug: `properties-for-the-concept-of-${CONCEPT_SLUG}`,
+      name: `the set of properties for the concept of ${NAMES.singular}`,
+      title: `The Set of Properties for the Concept of ${TITLES.singular}`,
+    },
+  });
+}
+
+function mintSuperset(taPk, taSk, headerUuid) {
+  return mintSupport({
+    taPk, taSk, headerUuid,
+    role: 'superset',
+    parentSlugs: ['superset', 'set', 'word'],
+    wordTypes: ['set', 'superset'],
+    payloadKey: 'set',
+    description: `This is the superset of all known ${NAMES.plural}.`,
+    payload: {
+      slug: CONCEPT_PLURAL,
+      name: NAMES.plural,
+      title: TITLES.plural,
+    },
+  });
+}
+
+function mintCoreNodesGraph(taPk, taSk, headerUuid) {
+  return mintSupport({
+    taPk, taSk, headerUuid,
+    role: 'core-nodes-graph',
+    parentSlugs: ['core-nodes-graph', 'graph', 'word'],
+    wordTypes: ['graph', 'coreNodesGraph'],
+    payloadKey: 'graph',
+    description: `the set of core nodes for the concept of ${NAMES.singular}`,
+    payload: { slug: `core-nodes-graph-for-the-concept-of-${CONCEPT_SLUG}` },
+  });
+}
+
+function mintConceptGraph(taPk, taSk, headerUuid) {
+  return mintSupport({
+    taPk, taSk, headerUuid,
+    role: 'concept-graph',
+    parentSlugs: ['concept-graph', 'graph', 'word'],
+    wordTypes: ['graph', 'conceptGraph'],
+    payloadKey: 'graph',
+    description: `The concept graph for the concept of ${NAMES.singular}`,
+    payload: { slug: `concept-graph-for-the-concept-of-${CONCEPT_SLUG}` },
+  });
+}
+
+function mintPropertyTreeGraph(taPk, taSk, headerUuid) {
+  return mintSupport({
+    taPk, taSk, headerUuid,
+    role: 'property-tree-graph',
+    parentSlugs: ['property-tree-graph', 'graph', 'word'],
+    wordTypes: ['graph', 'propertyTreeGraph'],
+    payloadKey: 'graph',
+    description: `the collection of the JSON schema node, all property nodes and all of their connections for the concept of ${NAMES.singular}`,
+    payload: { slug: `property-tree-graph-for-the-concept-of-${CONCEPT_SLUG}` },
+  });
+}
+
+// ── Element minting ────────────────────────────────────────
+
+function mintElement(elem, accounts, headerUuid) {
+  const acc = accounts[elem.publisher];
+  if (!acc) throw new Error(`No keypair for ${elem.publisher}`);
+  const dTag = `${elem.slug}-${acc.pk.slice(0, 8)}`;
+  const payload = {
+    nostrRelay: {
+      slug: elem.slug,
+      websocketUrl: elem.websocketUrl,
+      httpUrl: elem.httpUrl,
+      country: elem.country,
+      language: elem.language,
+    },
+  };
+  const event = signEvent(acc.sk, {
+    kind: 39999,
+    pubkey: acc.pk,
+    created_at: NOW(),
+    content: '',
+    tags: [
+      ['d', dTag],
+      ['name', elem.slug],
+      ['z', headerUuid],
+      ['json', JSON.stringify(payload)],
+    ],
+  });
+  return { event, uuid: `39999:${acc.pk}:${dTag}`, publisher: elem.publisher };
+}
+
+// ── Main ────────────────────────────────────────────────────
 
 async function main() {
-  console.log('🧪  Minting a foreign Tapestry concept for Concept Discovery demo\n');
+  console.log('🧪  Minting a fully-formed foreign Tapestry concept\n');
 
   const seedPath = path.join(__dirname, 'dwarves-test-data.json');
   if (!fs.existsSync(seedPath)) {
@@ -188,7 +386,8 @@ async function main() {
     process.exit(1);
   }
   const seed = JSON.parse(fs.readFileSync(seedPath, 'utf8'));
-  const ta = seed.accounts?.[FOREIGN_TA_NAME];
+  const accounts = seed.accounts;
+  const ta = accounts?.[FOREIGN_TA_NAME];
   if (!ta) {
     console.error(`❌  Missing account "${FOREIGN_TA_NAME}" in dwarves-test-data.json`);
     process.exit(1);
@@ -199,56 +398,47 @@ async function main() {
   console.log(`  Foreign pubkey: ${ta.pk}`);
   console.log(`  Concept slug:  ${CONCEPT_SLUG}\n`);
 
-  // 1. ConceptHeader — kind 39998 ────────────────────────────
-  console.log('── Step 1: publishing ConceptHeader (kind 39998) ──');
-  const headerEvent = signEvent(ta.sk, {
-    kind: 39998,
-    pubkey: ta.pk,
-    created_at: Math.floor(Date.now() / 1000),
-    content: '',
-    tags: [
-      ['d', CONCEPT_SLUG],
-      ['names', 'nostr relay v2', 'nostr relays v2'],
-      ['slug', CONCEPT_SLUG],
-      ['json', JSON.stringify(CONCEPT_HEADER_PAYLOAD)],
-      ['description', CONCEPT_HEADER_PAYLOAD.conceptHeader.description],
-    ],
-  });
-  const headerResp = await publish(headerEvent);
-  const headerCoordinate = `39998:${ta.pk}:${CONCEPT_SLUG}`;
-  console.log(`   ${headerResp.success ? '✅' : '❌'} ${headerCoordinate} (event ${headerEvent.id.slice(0, 16)}…)\n`);
+  // 1. ConceptHeader
+  console.log('── Step 1/3: Publishing 8-event concept bundle ──');
+  const header = mintHeader(ta.pk, ta.sk);
+  let r = await publish(header.event);
+  await importToNeo4j(header.uuid);
+  console.log(`   ${r.success ? '✅' : '❌'} ConceptHeader        ${header.uuid}`);
 
-  // 2. JSONSchema — kind 39999 z-tagged to the header ─────────
-  console.log('── Step 2: publishing JSONSchema (kind 39999) ──');
-  // Fill in the coreMemberOf reference now that we know the header coord.
-  SCHEMA_PAYLOAD.word.coreMemberOf = [
-    { slug: `concept-header-for-the-concept-of-${CONCEPT_SLUG}`, uuid: headerCoordinate },
+  // 2-8. Supporting events
+  const supports = [
+    { fn: mintSchema,            label: 'JSONSchema' },
+    { fn: mintPrimaryProperty,   label: 'PrimaryProperty' },
+    { fn: mintPropertiesSet,     label: 'PropertiesSet' },
+    { fn: mintSuperset,          label: 'Superset' },
+    { fn: mintCoreNodesGraph,    label: 'CoreNodesGraph' },
+    { fn: mintConceptGraph,      label: 'ConceptGraph' },
+    { fn: mintPropertyTreeGraph, label: 'PropertyTreeGraph' },
   ];
-  const schemaEvent = signEvent(ta.sk, {
-    kind: 39999,
-    pubkey: ta.pk,
-    created_at: Math.floor(Date.now() / 1000),
-    content: '',
-    tags: [
-      ['d', `${CONCEPT_SLUG}-schema`],
-      ['name', `JSON schema for the concept of ${CONCEPT_HUMAN}`],
-      ['description', `the json schema for the concept of ${CONCEPT_HUMAN}`],
-      // z-tag points at the foreign TA's own json-schema concept. On this
-      // install that won't resolve (we only have it under our own TA), so
-      // Neo4j's derive pass will leave the edge unresolved. That's
-      // acceptable for the demo — the schema still imports as a standalone
-      // node with JSONSchema label.
-      ['z', `39998:${ta.pk}:json-schema`],
-      ['z', `39998:${ta.pk}:word`],
-      ['json', JSON.stringify(SCHEMA_PAYLOAD)],
-    ],
-  });
-  const schemaResp = await publish(schemaEvent);
-  console.log(`   ${schemaResp.success ? '✅' : '❌'} ${CONCEPT_SLUG}-schema (event ${schemaEvent.id.slice(0, 16)}…)\n`);
+  const supportRefs = [];
+  for (const { fn, label } of supports) {
+    const built = fn(ta.pk, ta.sk, header.uuid);
+    const pubResp = await publish(built.event);
+    const impResp = await importToNeo4j(built.uuid);
+    console.log(`   ${pubResp.success && impResp.success ? '✅' : '❌'} ${label.padEnd(20)} ${built.uuid}`);
+    supportRefs.push({ role: label, uuid: built.uuid, eventId: built.event.id });
+  }
 
-  // 3. Optional — seed the suggested-authors config so the UI shows this TA
+  // 3. Seed elements
+  console.log('\n── Step 2/3: Publishing 3 seed relay elements (v2-shape) ──');
+  const elementRefs = [];
+  for (const elem of SEED_ELEMENTS) {
+    const built = mintElement(elem, accounts, header.uuid);
+    const pubResp = await publish(built.event);
+    const impResp = await importToNeo4j(built.uuid);
+    const ok = pubResp.success && impResp.success;
+    console.log(`   ${ok ? '✅' : '❌'} ${built.publisher.padEnd(16)} → ${elem.slug.padEnd(14)} (${elem.country}/${elem.language})`);
+    elementRefs.push({ ...elem, eventId: built.event.id, publisherPubkey: accounts[elem.publisher].pk });
+  }
+
+  // 4. Optionally seed config
   if (SEED_CONFIG) {
-    console.log('── Step 3: seeding config/suggested-concept-authors.json ──');
+    console.log('\n── Step 3/3: Seeding config/suggested-concept-authors.json ──');
     const configPath = path.resolve(__dirname, '../config/suggested-concept-authors.json');
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
     config.authors = Array.isArray(config.authors) ? config.authors : [];
@@ -256,42 +446,44 @@ async function main() {
       config.authors.push({
         pubkey: ta.pk,
         name: `Demo foreign TA (${FOREIGN_TA_NAME})`,
-        description: `Foreign Tapestry Assistant for the Concept Discovery demo — publishes the ${CONCEPT_SLUG} concept with country + language fields.`,
+        description: `Foreign Tapestry Assistant for the Concept Discovery demo — publishes the ${CONCEPT_SLUG} concept with country + language fields and 3 seed relays.`,
         relays: ['ws://localhost:7777'],
       });
       fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-      console.log(`   ✅ appended ${ta.pk.slice(0, 12)}… to authors\n`);
+      console.log(`   ✅ appended ${ta.pk.slice(0, 12)}… to authors`);
     } else {
-      console.log(`   ⏭  ${ta.pk.slice(0, 12)}… already in config\n`);
+      console.log(`   ⏭  ${ta.pk.slice(0, 12)}… already in config`);
     }
+  } else {
+    console.log('\n── Step 3/3: skipped (pass --seed-config to update suggested-authors)');
   }
 
-  // 4. Persist demo metadata
+  // 5. Persist demo metadata
   const outPath = path.join(__dirname, 'demo-foreign-concept.json');
   fs.writeFileSync(outPath, JSON.stringify({
     taName: FOREIGN_TA_NAME,
     taPubkey: ta.pk,
     taNpub: encodeNpub(ta.pk),
     conceptSlug: CONCEPT_SLUG,
-    conceptCoordinate: headerCoordinate,
-    headerEventId: headerEvent.id,
-    schemaEventId: schemaEvent.id,
+    conceptCoordinate: header.uuid,
+    headerEventId: header.event.id,
+    supports: supportRefs,
+    elements: elementRefs,
   }, null, 2));
-  console.log(`  📄 Wrote demo metadata to ${outPath}`);
 
   console.log('\n══════════════════════════════════════════════════════');
   console.log('  ✨  FOREIGN CONCEPT MINTED');
-  console.log('══════════════════════════════════════════════════════\n');
+  console.log('══════════════════════════════════════════════════════');
+  console.log();
   console.log(`  Foreign TA pubkey: ${ta.pk}`);
-  console.log(`  Coordinate:        ${headerCoordinate}`);
+  console.log(`  Coordinate:        ${header.uuid}`);
+  console.log(`  Bundle:            8 events  (header + 7 supports)`);
+  console.log(`  Seed elements:     ${SEED_ELEMENTS.length} (Tokyo, Berlin, US Mirror)`);
   console.log();
   console.log('  Next:');
-  console.log('    curl "$API/api/concept-discovery/concepts-by-pubkey?pubkey=' + ta.pk + '&relays=ws://localhost:7777"');
-  console.log('    Navigate to /kg/concept-discovery and click the card to import.');
+  console.log('    Visit /kg/concept-discovery → import the foreign concept');
+  console.log('    Then /kg/concepts/<uuid>/elements should show the 3 seeds');
   console.log();
 }
 
-main().catch((err) => {
-  console.error('Fatal error:', err);
-  process.exit(1);
-});
+main().catch((err) => { console.error('Fatal error:', err); process.exit(1); });

--- a/test-data/mint-foreign-concept.js
+++ b/test-data/mint-foreign-concept.js
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+/**
+ * Mint a "foreign" Tapestry concept for the Concept Discovery demo.
+ *
+ * Uses one of the dwarves keypairs as the foreign Tapestry Assistant (TA)
+ * pubkey and publishes a minimal but realistic `nostr-relay-v2` concept
+ * bundle (kind-39998 ConceptHeader + kind-39999 JSONSchema) to local
+ * strfry. The schema deliberately differs from our own `nostr-relay`
+ * concept — it adds `country` and `language` fields — so importing it
+ * produces a second installed concept under the same abstract idea,
+ * demonstrating schema-level divergence between instances.
+ *
+ * After running this script:
+ *   1. /api/concept-discovery/suggested-authors lists the foreign TA
+ *      (appended to config/suggested-concept-authors.json if --seed-config
+ *      is passed).
+ *   2. /api/concept-discovery/concepts-by-pubkey?pubkey=<foreign-TA>
+ *      returns the nostr-relay-v2 ConceptHeader.
+ *   3. A user can preview + import it via the /kg/concept-discovery UI.
+ *
+ * Usage:
+ *   node mint-foreign-concept.js               # publish only
+ *   node mint-foreign-concept.js --seed-config # also add to the
+ *                                              # suggested-authors config
+ */
+
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const { execSync } = require('child_process');
+
+// nostr-tools isn't reliably available on the host (lives only inside the
+// container's named volume). For the npub encoding we shell out to `nak`
+// which the dev environment already requires.
+function encodeNpub(hex) {
+  try {
+    return execSync(`nak encode npub ${hex}`, { encoding: 'utf8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// ── Port resolution (matches mint-demo-relays.js) ────────────
+
+function resolveApi() {
+  if (process.env.BRAINSTORM_API) return process.env.BRAINSTORM_API;
+  const argPort = process.argv.find((a) => /^\d+$/.test(a));
+  if (argPort) return `http://localhost:${argPort}`;
+  try {
+    const raw = execSync(
+      "docker inspect tapestry --format '{{(index (index .NetworkSettings.Ports \"7778/tcp\") 0).HostPort}}'",
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    ).trim();
+    if (/^\d+$/.test(raw)) return `http://localhost:${raw}`;
+  } catch {}
+  return 'http://localhost:7778';
+}
+
+const API = resolveApi();
+const SEED_CONFIG = process.argv.includes('--seed-config');
+const FOREIGN_TA_NAME = 'Magic Mirror'; // arbitrary good-actor keypair from dwarves-test-data.json
+
+// ── Concept definition — nostr-relay-v2 ──────────────────────
+
+const CONCEPT_SLUG = 'nostr-relay-v2';
+const CONCEPT_HUMAN = 'Nostr Relay (v2)';
+
+// Note: `oKeys.singular` is used as the top-level property key in the schema.
+// For cross-concept compatibility with user-published kind-39999s we keep it
+// as `nostrRelay` (same key our canonical concept uses). Only the SHAPE
+// inside that object diverges — new optional `country` and `language`.
+const CONCEPT_HEADER_PAYLOAD = {
+  word: {
+    slug: `concept-header-for-the-concept-of-${CONCEPT_SLUG}`,
+    name: `concept header for the concept of ${CONCEPT_HUMAN}`,
+    title: `Concept Header for the Concept of ${CONCEPT_HUMAN}`,
+    wordTypes: ['word', 'conceptHeader'],
+  },
+  conceptHeader: {
+    description:
+      'A Nostr relay (v2). Same idea as the canonical nostr-relay concept but with optional geographic + language metadata. Minted by a foreign TA for the Concept Discovery demo.',
+    oNames: { singular: 'nostr relay v2', plural: 'nostr relays v2' },
+    oSlugs: { singular: CONCEPT_SLUG, plural: `${CONCEPT_SLUG}s` },
+    oKeys: { singular: 'nostrRelay', plural: 'nostrRelays' },
+    oTitles: { singular: CONCEPT_HUMAN, plural: `${CONCEPT_HUMAN}s` },
+    oLabels: { singular: 'NostrRelay', plural: 'NostrRelays' },
+    'x-tapestry': { neo4j: { nodeLabelRequired: true } },
+  },
+};
+
+const SCHEMA_PAYLOAD = {
+  word: {
+    slug: `json-schema-for-the-concept-of-${CONCEPT_SLUG}`,
+    name: `JSON schema for the concept of ${CONCEPT_HUMAN}`,
+    title: `JSON Schema for the Concept of ${CONCEPT_HUMAN}`,
+    description: `JSON schema for the concept of ${CONCEPT_HUMAN}`,
+    wordTypes: ['word', 'jsonSchema'],
+    // coreMemberOf uuid is filled in after we know the foreign-TA-keyed header coordinate
+  },
+  jsonSchema: {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    name: CONCEPT_HUMAN.toLowerCase(),
+    title: CONCEPT_HUMAN,
+    description: `JSON Schema for ${CONCEPT_HUMAN}`,
+    required: ['nostrRelay'],
+    definitions: {},
+    properties: {
+      nostrRelay: {
+        type: 'object',
+        name: CONCEPT_HUMAN.toLowerCase(),
+        title: CONCEPT_HUMAN,
+        slug: CONCEPT_SLUG,
+        description: `data about this ${CONCEPT_HUMAN}`,
+        required: ['slug', 'websocketUrl'],
+        properties: {
+          slug: {
+            type: 'string', name: 'slug', title: 'Slug', slug: 'slug',
+            description: 'A unique kebab-case identifier for this relay',
+          },
+          websocketUrl: {
+            type: 'string', name: 'websocketUrl', title: 'Websocket URL', slug: 'websocket-url',
+            description: 'The websocket URL',
+          },
+          httpUrl: {
+            type: 'string', name: 'httpUrl', title: 'HTTP URL', slug: 'http-url',
+            description: 'The HTTP URL (optional)',
+          },
+          // NEW FIELDS — the visible "schema divergence" for the demo
+          country: {
+            type: 'string', name: 'country', title: 'Country', slug: 'country',
+            description: 'ISO 3166-1 alpha-2 country code where this relay is hosted',
+          },
+          language: {
+            type: 'string', name: 'language', title: 'Language', slug: 'language',
+            description: 'BCP 47 language tag for the relay\'s primary community',
+          },
+        },
+        'x-tapestry': { unique: ['slug', 'websocketUrl'] },
+      },
+    },
+  },
+};
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function httpPost(pathname, body) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(pathname, API);
+    const data = JSON.stringify(body);
+    const req = http.request(
+      url,
+      { method: 'POST', headers: { 'Content-Type': 'application/json', 'Content-Length': data.length } },
+      (res) => {
+        let buf = '';
+        res.on('data', (c) => (buf += c));
+        res.on('end', () => {
+          try { resolve(JSON.parse(buf)); } catch { resolve({ raw: buf, status: res.statusCode }); }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+function signEvent(sk, eventJson) {
+  const result = execSync(
+    `echo '${JSON.stringify(eventJson).replace(/'/g, "'\\''")}' | nak event --sec ${sk}`,
+    { encoding: 'utf8' },
+  ).trim();
+  return JSON.parse(result);
+}
+
+async function publish(event) {
+  return httpPost('/api/strfry/publish', { event, signAs: 'client' });
+}
+
+// ── Main ─────────────────────────────────────────────────────
+
+async function main() {
+  console.log('🧪  Minting a foreign Tapestry concept for Concept Discovery demo\n');
+
+  const seedPath = path.join(__dirname, 'dwarves-test-data.json');
+  if (!fs.existsSync(seedPath)) {
+    console.error(`❌  ${seedPath} not found. Run mint-dwarves.js first.`);
+    process.exit(1);
+  }
+  const seed = JSON.parse(fs.readFileSync(seedPath, 'utf8'));
+  const ta = seed.accounts?.[FOREIGN_TA_NAME];
+  if (!ta) {
+    console.error(`❌  Missing account "${FOREIGN_TA_NAME}" in dwarves-test-data.json`);
+    process.exit(1);
+  }
+
+  console.log(`  API:           ${API}`);
+  console.log(`  Foreign TA:    ${FOREIGN_TA_NAME}`);
+  console.log(`  Foreign pubkey: ${ta.pk}`);
+  console.log(`  Concept slug:  ${CONCEPT_SLUG}\n`);
+
+  // 1. ConceptHeader — kind 39998 ────────────────────────────
+  console.log('── Step 1: publishing ConceptHeader (kind 39998) ──');
+  const headerEvent = signEvent(ta.sk, {
+    kind: 39998,
+    pubkey: ta.pk,
+    created_at: Math.floor(Date.now() / 1000),
+    content: '',
+    tags: [
+      ['d', CONCEPT_SLUG],
+      ['names', 'nostr relay v2', 'nostr relays v2'],
+      ['slug', CONCEPT_SLUG],
+      ['json', JSON.stringify(CONCEPT_HEADER_PAYLOAD)],
+      ['description', CONCEPT_HEADER_PAYLOAD.conceptHeader.description],
+    ],
+  });
+  const headerResp = await publish(headerEvent);
+  const headerCoordinate = `39998:${ta.pk}:${CONCEPT_SLUG}`;
+  console.log(`   ${headerResp.success ? '✅' : '❌'} ${headerCoordinate} (event ${headerEvent.id.slice(0, 16)}…)\n`);
+
+  // 2. JSONSchema — kind 39999 z-tagged to the header ─────────
+  console.log('── Step 2: publishing JSONSchema (kind 39999) ──');
+  // Fill in the coreMemberOf reference now that we know the header coord.
+  SCHEMA_PAYLOAD.word.coreMemberOf = [
+    { slug: `concept-header-for-the-concept-of-${CONCEPT_SLUG}`, uuid: headerCoordinate },
+  ];
+  const schemaEvent = signEvent(ta.sk, {
+    kind: 39999,
+    pubkey: ta.pk,
+    created_at: Math.floor(Date.now() / 1000),
+    content: '',
+    tags: [
+      ['d', `${CONCEPT_SLUG}-schema`],
+      ['name', `JSON schema for the concept of ${CONCEPT_HUMAN}`],
+      ['description', `the json schema for the concept of ${CONCEPT_HUMAN}`],
+      // z-tag points at the foreign TA's own json-schema concept. On this
+      // install that won't resolve (we only have it under our own TA), so
+      // Neo4j's derive pass will leave the edge unresolved. That's
+      // acceptable for the demo — the schema still imports as a standalone
+      // node with JSONSchema label.
+      ['z', `39998:${ta.pk}:json-schema`],
+      ['z', `39998:${ta.pk}:word`],
+      ['json', JSON.stringify(SCHEMA_PAYLOAD)],
+    ],
+  });
+  const schemaResp = await publish(schemaEvent);
+  console.log(`   ${schemaResp.success ? '✅' : '❌'} ${CONCEPT_SLUG}-schema (event ${schemaEvent.id.slice(0, 16)}…)\n`);
+
+  // 3. Optional — seed the suggested-authors config so the UI shows this TA
+  if (SEED_CONFIG) {
+    console.log('── Step 3: seeding config/suggested-concept-authors.json ──');
+    const configPath = path.resolve(__dirname, '../config/suggested-concept-authors.json');
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    config.authors = Array.isArray(config.authors) ? config.authors : [];
+    if (!config.authors.some((a) => a.pubkey === ta.pk)) {
+      config.authors.push({
+        pubkey: ta.pk,
+        name: `Demo foreign TA (${FOREIGN_TA_NAME})`,
+        description: `Foreign Tapestry Assistant for the Concept Discovery demo — publishes the ${CONCEPT_SLUG} concept with country + language fields.`,
+        relays: ['ws://localhost:7777'],
+      });
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      console.log(`   ✅ appended ${ta.pk.slice(0, 12)}… to authors\n`);
+    } else {
+      console.log(`   ⏭  ${ta.pk.slice(0, 12)}… already in config\n`);
+    }
+  }
+
+  // 4. Persist demo metadata
+  const outPath = path.join(__dirname, 'demo-foreign-concept.json');
+  fs.writeFileSync(outPath, JSON.stringify({
+    taName: FOREIGN_TA_NAME,
+    taPubkey: ta.pk,
+    taNpub: encodeNpub(ta.pk),
+    conceptSlug: CONCEPT_SLUG,
+    conceptCoordinate: headerCoordinate,
+    headerEventId: headerEvent.id,
+    schemaEventId: schemaEvent.id,
+  }, null, 2));
+  console.log(`  📄 Wrote demo metadata to ${outPath}`);
+
+  console.log('\n══════════════════════════════════════════════════════');
+  console.log('  ✨  FOREIGN CONCEPT MINTED');
+  console.log('══════════════════════════════════════════════════════\n');
+  console.log(`  Foreign TA pubkey: ${ta.pk}`);
+  console.log(`  Coordinate:        ${headerCoordinate}`);
+  console.log();
+  console.log('  Next:');
+  console.log('    curl "$API/api/concept-discovery/concepts-by-pubkey?pubkey=' + ta.pk + '&relays=ws://localhost:7777"');
+  console.log('    Navigate to /kg/concept-discovery and click the card to import.');
+  console.log();
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -69,6 +69,7 @@ import BrainstormSettings from './pages/BrainstormSettings';
 import BrainstormPersonalization from './pages/BrainstormPersonalization';
 import BrainstormDevelopers from './pages/BrainstormDevelopers';
 import RelayDiscovery from './pages/relay-discovery/RelayDiscovery';
+import ConceptDiscovery from './pages/concept-discovery/ConceptDiscovery';
 const router = createBrowserRouter([
   {
     path: '/kg/brainstorm-search',
@@ -97,6 +98,7 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <Dashboard /> },
       { path: 'relay-discovery', element: <RelayDiscovery />, handle: { crumb: 'Relay Discovery' } },
+      { path: 'concept-discovery', element: <ConceptDiscovery />, handle: { crumb: 'Concept Discovery' } },
       {
         path: 'concepts',
         handle: { crumb: 'Concepts' },

--- a/ui/src/components/KnownConceptsPanel.jsx
+++ b/ui/src/components/KnownConceptsPanel.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+
+const OUR_TA = '82b75e474dda005e912bcbb910391c60c2b89cc7faf5d3c30b7c59a324973833';
+
+/**
+ * Read-only summary of every ConceptHeader currently in Neo4j whose
+ * d-tag matches `slug`. Used on PublishRelayForm and RelayTagPanel to
+ * communicate that this instance may know about multiple concepts under
+ * the same abstract idea — but currently publishes only to its own.
+ *
+ * No picker, no behavior change. Pure information.
+ */
+export default function KnownConceptsPanel({ slug }) {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await fetch(`/api/concept-discovery/known-by-slug?slug=${encodeURIComponent(slug)}`);
+        const body = await resp.json();
+        if (cancelled) return;
+        if (!body.success) throw new Error(body.error || `HTTP ${resp.status}`);
+        setData(body);
+      } catch (err) {
+        if (!cancelled) setError(err.message);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [slug]);
+
+  if (error) {
+    return <div className="known-concepts-panel known-concepts-error">⚠️ {error}</div>;
+  }
+  if (!data) return null;
+
+  const ours = data.concepts.find((c) => c.pubkey === OUR_TA);
+  const others = data.concepts.filter((c) => c.pubkey !== OUR_TA);
+
+  return (
+    <div className="known-concepts-panel">
+      <div className="known-concepts-row">
+        <span className="known-concepts-label">Publishing to:</span>{' '}
+        {ours ? (
+          <code className="known-concepts-coord">{ours.coordinate}</code>
+        ) : (
+          <em>our <code>{slug}</code> concept (not yet installed)</em>
+        )}
+      </div>
+      {others.length > 0 && (
+        <>
+          <div className="known-concepts-divider" />
+          <div className="known-concepts-row">
+            <span className="known-concepts-label">
+              Other <code>{slug}</code> concepts you've imported:
+            </span>
+          </div>
+          <ul className="known-concepts-list">
+            {others.map((c) => (
+              <li key={c.coordinate}>
+                <code className="known-concepts-coord-small">{c.coordinate}</code>
+              </li>
+            ))}
+          </ul>
+          <div className="known-concepts-hint">
+            Each defines &ldquo;what a <code>{slug}</code> is&rdquo; slightly differently.
+            This instance publishes to its own concept for now; user-published events
+            against any imported coordinate are surfaced in the aggregated discovery view.
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -48,6 +48,7 @@ const mainNavItems = [
     ],
   },
   { to: '/kg/relay-discovery', label: '📡 Relay Discovery' },
+  { to: '/kg/concept-discovery', label: '🔭 Concept Discovery' },
 ];
 
 const managementNavItems = [

--- a/ui/src/pages/concept-discovery/ConceptDiscovery.jsx
+++ b/ui/src/pages/concept-discovery/ConceptDiscovery.jsx
@@ -1,0 +1,223 @@
+import { useState, useEffect, useMemo } from 'react';
+import { nip19 } from 'nostr-tools';
+import ConceptPreview from './ConceptPreview';
+
+/**
+ * Concept Discovery page.
+ *
+ * Top: bootstrap "suggested concept authors" cards (config-driven today,
+ * DList-driven tomorrow). Click a card to populate the search and fetch.
+ *
+ * Middle: free-form pubkey search.
+ *
+ * Bottom: results — one card per ConceptHeader the searched pubkey has
+ * published. Click a card to open the preview/import drawer.
+ */
+
+function decodePubkey(input) {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (/^[0-9a-f]{64}$/i.test(trimmed)) return trimmed.toLowerCase();
+  try {
+    const d = nip19.decode(trimmed);
+    if (d.type === 'npub') return d.data;
+    if (d.type === 'nprofile') return d.data.pubkey;
+  } catch {}
+  return null;
+}
+
+function shortPk(pk) {
+  if (!pk) return '';
+  return `${pk.slice(0, 8)}…${pk.slice(-4)}`;
+}
+
+export default function ConceptDiscovery() {
+  const [suggested, setSuggested] = useState([]);
+  const [input, setInput] = useState('');
+  const [relayInput, setRelayInput] = useState('');
+  const [pubkey, setPubkey] = useState(null);
+  const [authorMeta, setAuthorMeta] = useState(null); // { name, description } when sourced from suggested cards
+  const [results, setResults] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [previewOpen, setPreviewOpen] = useState(null); // { pubkey, slug, name } or null
+
+  // Load bootstrap suggestions
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await fetch('/api/concept-discovery/suggested-authors');
+        const body = await resp.json();
+        if (cancelled) return;
+        if (body.success) setSuggested(body.authors || []);
+      } catch {}
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const relays = useMemo(() => {
+    return relayInput
+      .split(',')
+      .map((r) => r.trim())
+      .filter((r) => r.startsWith('wss://') || r.startsWith('ws://'));
+  }, [relayInput]);
+
+  async function search(targetPubkey, targetRelays, meta) {
+    setError(null);
+    setResults(null);
+    setLoading(true);
+    setPubkey(targetPubkey);
+    setAuthorMeta(meta || null);
+    try {
+      const params = new URLSearchParams({ pubkey: targetPubkey });
+      if (targetRelays && targetRelays.length > 0) {
+        params.set('relays', targetRelays.join(','));
+      }
+      const resp = await fetch(`/api/concept-discovery/concepts-by-pubkey?${params}`);
+      const body = await resp.json();
+      if (!body.success) throw new Error(body.error || `HTTP ${resp.status}`);
+      setResults(body);
+    } catch (err) {
+      setError(err.message);
+      setResults({ concepts: [], count: 0 });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleSubmit(e) {
+    e?.preventDefault();
+    const hex = decodePubkey(input);
+    if (!hex) {
+      setError('Enter a 64-char hex pubkey, npub, or nprofile.');
+      return;
+    }
+    search(hex, relays);
+  }
+
+  function handleSuggestedClick(author) {
+    setInput(author.pubkey);
+    setRelayInput((author.relays || []).join(', '));
+    search(author.pubkey, author.relays || [], { name: author.name, description: author.description });
+  }
+
+  function handleImported() {
+    // Re-run the current search so `alreadyImported` flips on the
+    // freshly-imported concept.
+    if (pubkey) search(pubkey, relays, authorMeta);
+  }
+
+  return (
+    <div className="cdisc-page">
+      <div className="page-header">
+        <h1>🔭 Concept Discovery</h1>
+        <p className="page-description">
+          Different Brainstorm instances may define the same abstract idea
+          (a nostr relay, a tag taxonomy, anything else) with slightly
+          different schemas. To <em>interoperate</em> with another instance
+          you need to recognize the coordinate they author concepts under
+          — that's what an import does. Schema only; their elements remain
+          decentralized and flow in via shared coordinate matching.
+        </p>
+      </div>
+
+      {suggested.length > 0 && (
+        <section className="cdisc-section">
+          <div className="cdisc-section-title">Suggested concept authors</div>
+          <div className="cdisc-suggestions">
+            {suggested.map((a) => (
+              <button
+                key={a.pubkey}
+                type="button"
+                className="cdisc-suggestion"
+                onClick={() => handleSuggestedClick(a)}
+                title={a.pubkey}
+              >
+                <div className="cdisc-suggestion-name">{a.name}</div>
+                <div className="cdisc-suggestion-pk"><code>{shortPk(a.pubkey)}</code></div>
+                {a.description && <div className="cdisc-suggestion-desc">{a.description}</div>}
+              </button>
+            ))}
+          </div>
+          <div className="cdisc-section-hint">
+            These come from <code>tapestry/config/suggested-concept-authors.json</code>.
+            In a future revision we'll source them from a community-curated
+            DList on nostr — same UX, different backing store.
+          </div>
+        </section>
+      )}
+
+      <section className="cdisc-section">
+        <div className="cdisc-section-title">Search by pubkey</div>
+        <form onSubmit={handleSubmit} className="cdisc-search-form">
+          <input
+            type="text"
+            placeholder="npub1… / nprofile1… / 64-char hex pubkey"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            className="cdisc-search-input"
+          />
+          <input
+            type="text"
+            placeholder="wss://relay1, wss://relay2 (optional)"
+            value={relayInput}
+            onChange={(e) => setRelayInput(e.target.value)}
+            className="cdisc-relay-input"
+          />
+          <button type="submit" disabled={loading} className="cdisc-search-btn">
+            {loading ? 'Searching…' : 'Search'}
+          </button>
+        </form>
+        {error && <div className="rtp-error" style={{ marginTop: '0.5rem' }}>⚠️ {error}</div>}
+      </section>
+
+      {pubkey && results && (
+        <section className="cdisc-section">
+          <div className="cdisc-section-title">
+            {results.count} concept{results.count === 1 ? '' : 's'}
+            {' '}published by{' '}
+            <code>{shortPk(pubkey)}</code>
+            {authorMeta && <em style={{ marginLeft: '0.5rem', opacity: 0.7 }}>({authorMeta.name})</em>}
+          </div>
+          {results.count === 0 ? (
+            <div className="rtp-empty">
+              No kind-39998 ConceptHeader events found for this pubkey on the queried relays.
+            </div>
+          ) : (
+            <div className="cdisc-results">
+              {results.concepts.map((c) => (
+                <button
+                  key={c.coordinate}
+                  type="button"
+                  className={`cdisc-concept ${c.alreadyImported ? 'cdisc-concept-imported' : ''}`}
+                  onClick={() => setPreviewOpen({ pubkey: c.pubkey, slug: c.slug, name: c.name })}
+                >
+                  <div className="cdisc-concept-header">
+                    <span className="cdisc-concept-slug">{c.slug}</span>
+                    {c.alreadyImported && (
+                      <span className="cdisc-concept-badge">✓ imported</span>
+                    )}
+                  </div>
+                  <div className="cdisc-concept-name">{c.name}</div>
+                  {c.description && <div className="cdisc-concept-desc">{c.description}</div>}
+                  <div className="cdisc-concept-coordinate"><code>{c.coordinate}</code></div>
+                </button>
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+
+      {previewOpen && (
+        <ConceptPreview
+          pubkey={previewOpen.pubkey}
+          slug={previewOpen.slug}
+          relays={relays}
+          onClose={() => setPreviewOpen(null)}
+          onImported={() => { setPreviewOpen(null); handleImported(); }}
+        />
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/concept-discovery/ConceptPreview.jsx
+++ b/ui/src/pages/concept-discovery/ConceptPreview.jsx
@@ -1,0 +1,156 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Modal that fetches a deep preview of a foreign concept (schema shape, sets,
+ * element count) and offers a one-click import button.
+ */
+export default function ConceptPreview({ pubkey, slug, relays, onClose, onImported }) {
+  const [preview, setPreview] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [importing, setImporting] = useState(false);
+  const [importMessage, setImportMessage] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setPreview(null);
+    (async () => {
+      try {
+        const params = new URLSearchParams({ pubkey, slug });
+        if (relays && relays.length > 0) params.set('relays', relays.join(','));
+        const resp = await fetch(`/api/concept-discovery/concept-preview?${params}`);
+        const body = await resp.json();
+        if (cancelled) return;
+        if (!body.success) throw new Error(body.error || `HTTP ${resp.status}`);
+        setPreview(body);
+      } catch (err) {
+        if (!cancelled) setError(err.message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [pubkey, slug, relays.join(',')]);
+
+  async function doImport() {
+    setImporting(true);
+    setImportMessage(null);
+    try {
+      const resp = await fetch('/api/concept-discovery/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pubkey, slug, relays }),
+      });
+      const body = await resp.json();
+      if (!resp.ok || !body.success) throw new Error(body.error || `HTTP ${resp.status}`);
+      setImportMessage(`✅ Imported ${body.eventCount} events. Pass-3 derived ${body.pass3?.derived || 0} nodes.`);
+      // Brief pause so the user sees the success message, then close.
+      setTimeout(() => onImported?.(body), 1200);
+    } catch (err) {
+      setImportMessage(`⚠️ ${err.message}`);
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  return (
+    <div className="cdisc-modal-backdrop" onClick={onClose}>
+      <div className="cdisc-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="cdisc-modal-header">
+          <span className="cdisc-modal-title">Concept Preview</span>
+          <button type="button" onClick={onClose} className="cdisc-modal-close">×</button>
+        </div>
+
+        {loading && <div className="rtp-loading">Loading preview…</div>}
+        {error && <div className="rtp-error">⚠️ {error}</div>}
+
+        {preview && (
+          <div className="cdisc-preview-body">
+            <div className="cdisc-preview-section">
+              <div className="cdisc-preview-label">Coordinate</div>
+              <div><code className="cdisc-preview-coord">{preview.coordinate}</code></div>
+            </div>
+
+            <div className="cdisc-preview-section">
+              <div className="cdisc-preview-label">Name</div>
+              <div className="cdisc-preview-name">
+                {preview.header.name}
+                {preview.header.pluralName && (
+                  <span className="cdisc-preview-plural"> · {preview.header.pluralName}</span>
+                )}
+              </div>
+              {preview.header.description && (
+                <div className="cdisc-preview-desc">{preview.header.description}</div>
+              )}
+            </div>
+
+            {preview.schema && (
+              <div className="cdisc-preview-section">
+                <div className="cdisc-preview-label">Schema shape</div>
+                <table className="cdisc-schema-table">
+                  <thead>
+                    <tr><th>Field</th><th>Type</th><th>Req?</th><th>Description</th></tr>
+                  </thead>
+                  <tbody>
+                    {Object.entries(preview.schema.properties).map(([name, prop]) => (
+                      <tr key={name}>
+                        <td><code>{name}</code></td>
+                        <td>{prop.type}</td>
+                        <td>{preview.schema.required.includes(name) ? '✓' : ''}</td>
+                        <td className="cdisc-schema-desc">{prop.description}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            {preview.sets && preview.sets.length > 0 && (
+              <div className="cdisc-preview-section">
+                <div className="cdisc-preview-label">Sets ({preview.sets.length})</div>
+                <ul className="cdisc-sets-list">
+                  {preview.sets.map((s, i) => (
+                    <li key={i}>
+                      <strong>{s.name || s.slug}</strong>
+                      {s.description && <span className="cdisc-set-desc"> — {s.description}</span>}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <div className="cdisc-preview-section">
+              <div className="cdisc-preview-label">User-published instances ({preview.elementCount})</div>
+              <div className="cdisc-preview-hint">
+                Once imported, your relay-discovery aggregated view will start surfacing every
+                kind-39999 anywhere on nostr that is z-tagged to this concept's coordinate.
+              </div>
+            </div>
+
+            {importMessage && (
+              <div className="cdisc-import-msg">{importMessage}</div>
+            )}
+
+            <div className="cdisc-modal-actions">
+              <button type="button" onClick={onClose} className="cdisc-btn">
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={doImport}
+                disabled={importing || preview.alreadyImported}
+                className="cdisc-btn cdisc-btn-primary"
+              >
+                {preview.alreadyImported
+                  ? '✓ Already imported'
+                  : importing ? 'Importing…' : 'Import this concept'}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/relay-discovery/PublishRelayForm.jsx
+++ b/ui/src/pages/relay-discovery/PublishRelayForm.jsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { publishEverywhere, importAddressableToNeo4j } from '../../utils/nostrPublish';
+import KnownConceptsPanel from '../../components/KnownConceptsPanel';
 
 const NOSTR_RELAY_Z_TAG =
   '39998:82b75e474dda005e912bcbb910391c60c2b89cc7faf5d3c30b7c59a324973833:nostr-relay';
@@ -149,6 +150,8 @@ export default function PublishRelayForm({ open, onClose, onPublished }) {
           </label>
 
           {error && <div className="bsp-form-error">{error}</div>}
+
+          <KnownConceptsPanel slug="nostr-relay" />
 
           <div className="bsp-form-actions">
             <button type="button" onClick={onClose} disabled={submitting}>

--- a/ui/src/pages/relay-discovery/RelayDiscovery.jsx
+++ b/ui/src/pages/relay-discovery/RelayDiscovery.jsx
@@ -474,15 +474,62 @@ function EndorserList({ pubkeys, weights, profiles }) {
   );
 }
 
+// "Standard" relay fields the UI knows how to render natively. Anything
+// else surfaced by the aggregated endpoint's per-row `extras` is a
+// schema-divergence signal — fields a foreign concept defines that this
+// UI doesn't have a column for.
+const KNOWN_RELAY_FIELDS = new Set(['slug', 'websocketUrl', 'httpUrl']);
+
 function AggregatedTab() {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [tagFilter, setTagFilter] = useState('');
   const [expandedUrl, setExpandedUrl] = useState(null);
+  const [installedConcepts, setInstalledConcepts] = useState(null);
+  const [conceptCoord, setConceptCoord] = useState('');           // '' = default (canonical nostr-relay)
+  const [conceptSchema, setConceptSchema] = useState(null);       // schema preview for the selected concept
 
   const { povPubkey, scoringMethod } = useTrust();
   const scoringLabel = SCORING_METHODS.find((m) => m.id === scoringMethod)?.label || scoringMethod;
+
+  // Load the full installed-concepts catalogue once for the picker.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await fetch('/api/concept-discovery/installed-concepts');
+        const body = await resp.json();
+        if (!cancelled && body.success) setInstalledConcepts(body.concepts || []);
+      } catch {}
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // When the user picks a concept (other than default), fetch its schema
+  // so we can show the divergence banner ("this concept also defines …").
+  useEffect(() => {
+    if (!conceptCoord) {
+      setConceptSchema(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        // coordinate format: 39998:<pubkey>:<slug>
+        const parts = conceptCoord.split(':');
+        const pubkey = parts[1];
+        const slug = parts.slice(2).join(':');
+        const params = new URLSearchParams({ pubkey, slug, relays: 'ws://localhost:7777' });
+        const resp = await fetch(`/api/concept-discovery/concept-preview?${params}`);
+        const body = await resp.json();
+        if (!cancelled && body.success) setConceptSchema(body);
+      } catch {
+        if (!cancelled) setConceptSchema(null);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [conceptCoord]);
 
   useEffect(() => {
     let cancelled = false;
@@ -490,8 +537,11 @@ function AggregatedTab() {
     setError(null);
     (async () => {
       try {
-        const qs = tagFilter ? `?tagSlug=${encodeURIComponent(tagFilter)}` : '';
-        const resp = await fetch(`/api/relay-discovery/aggregated${qs}`);
+        const params = new URLSearchParams();
+        if (tagFilter) params.set('tagSlug', tagFilter);
+        if (conceptCoord) params.set('conceptCoord', conceptCoord);
+        const qs = params.toString();
+        const resp = await fetch(`/api/relay-discovery/aggregated${qs ? '?' + qs : ''}`);
         const body = await resp.json();
         if (cancelled) return;
         if (!body.success) throw new Error(body.error || 'Failed to fetch');
@@ -503,7 +553,25 @@ function AggregatedTab() {
       }
     })();
     return () => { cancelled = true; };
-  }, [tagFilter]);
+  }, [tagFilter, conceptCoord]);
+
+  // Compute the "extra" field set across the currently visible rows.
+  // Drives the dynamic Extras column header.
+  const extraFieldKeys = useMemo(() => {
+    const set = new Set();
+    for (const r of data?.relays || []) {
+      for (const k of Object.keys(r.extras || {})) set.add(k);
+    }
+    return Array.from(set).sort();
+  }, [data]);
+
+  // What the SCHEMA says vs what the UI knows how to render natively.
+  // Anything in schema but not in KNOWN_RELAY_FIELDS becomes the
+  // "this concept also defines" banner.
+  const schemaExtras = useMemo(() => {
+    if (!conceptSchema?.schema?.properties) return [];
+    return Object.keys(conceptSchema.schema.properties).filter((k) => !KNOWN_RELAY_FIELDS.has(k));
+  }, [conceptSchema]);
 
   const tagMeta = data?.tagMeta || {};
   const tagSlugs = useMemo(() => Object.keys(tagMeta).sort(), [tagMeta]);
@@ -570,10 +638,93 @@ function AggregatedTab() {
 
   const weightsAvailable = weights && Object.keys(weights).length > 0;
 
+  // Group installed concepts (self / foreign) for the picker.
+  const conceptGroups = useMemo(() => {
+    const ours = [];
+    const foreign = [];
+    for (const c of installedConcepts || []) {
+      (c.isOurs ? ours : foreign).push(c);
+    }
+    return { ours, foreign };
+  }, [installedConcepts]);
+
+  const selectedConceptMeta = useMemo(() => {
+    if (!conceptCoord) return null;
+    return (installedConcepts || []).find((c) => c.coordinate === conceptCoord) || null;
+  }, [conceptCoord, installedConcepts]);
+
+  const tableColCount = 5 + (extraFieldKeys.length > 0 ? 1 : 0);
+
   return (
     <div className="rdisc-tab">
-      <DemoPanel />
-      <PipelinePanel />
+      {/* Concept-lens picker */}
+      <div className="rdisc-concept-bar">
+        <span className="rtp-label" style={{ marginRight: '0.5rem' }}>View through concept</span>
+        <select
+          className="rdisc-concept-select"
+          value={conceptCoord}
+          onChange={(e) => setConceptCoord(e.target.value)}
+        >
+          <option value="">Default — canonical nostr-relay (all matching)</option>
+          {conceptGroups.ours.length > 0 && (
+            <optgroup label="Ours (this instance)">
+              {conceptGroups.ours.map((c) => (
+                <option key={c.coordinate} value={c.coordinate}>{c.name} ({c.slug})</option>
+              ))}
+            </optgroup>
+          )}
+          {conceptGroups.foreign.length > 0 && (
+            <optgroup label="Foreign (imported)">
+              {conceptGroups.foreign.map((c) => (
+                <option key={c.coordinate} value={c.coordinate}>
+                  {c.name} ({c.slug}) — by {c.pubkey.slice(0, 8)}…
+                </option>
+              ))}
+            </optgroup>
+          )}
+        </select>
+        {conceptCoord && (
+          <button
+            type="button"
+            className="rdisc-concept-clear"
+            onClick={() => setConceptCoord('')}
+            title="Back to default view"
+          >reset</button>
+        )}
+      </div>
+
+      {/* Schema-divergence banner: visible only when a specific concept
+          is selected and its schema declares fields the relay UI doesn't
+          natively render. */}
+      {selectedConceptMeta && (
+        <div className="rdisc-schema-banner">
+          <div className="rdisc-schema-banner-title">
+            🔍 Viewing through{' '}
+            <code>{selectedConceptMeta.coordinate}</code>{' '}
+            ({selectedConceptMeta.isOurs ? 'ours' : 'foreign — imported'})
+          </div>
+          {conceptSchema?.schema?.properties ? (
+            schemaExtras.length > 0 ? (
+              <div className="rdisc-schema-banner-body">
+                This concept's schema additionally defines{' '}
+                {schemaExtras.map((k) => <code key={k} className="rdisc-extra-key">{k}</code>).reduce((a, b) => [a, ', ', b])}.
+                {extraFieldKeys.length > 0
+                  ? ' These flow through to the rightmost "Extras" column when published events provide values.'
+                  : ' No published events under this coordinate carry values for them yet.'}
+              </div>
+            ) : (
+              <div className="rdisc-schema-banner-body">
+                This concept's schema covers exactly the fields this UI knows about. No
+                schema divergence to surface.
+              </div>
+            )
+          ) : (
+            <div className="rdisc-schema-banner-body">
+              <em>No JSONSchema event found for this concept — extras column may not populate.</em>
+            </div>
+          )}
+        </div>
+      )}
 
       <div className="rdisc-trust-bar">
         <span className="rtp-label" style={{ marginRight: '0.5rem' }}>Trust mode</span>
@@ -617,7 +768,7 @@ function AggregatedTab() {
       {!loading && data && (
         <>
           <div className="rdisc-results-header">
-            {data.count} relay{data.count === 1 ? '' : 's'} imported into Neo4j
+            {data.count} relay{data.count === 1 ? '' : 's'} in view
             {tagFilter && ` — filtered to "${tagMeta[tagFilter]?.name || tagFilter}"`}
             {' — ranked by '}
             {weightsAvailable ? <strong>trust-weighted endorser score</strong> : 'raw endorser count'}
@@ -625,8 +776,9 @@ function AggregatedTab() {
 
           {rankedRelays.length === 0 ? (
             <div className="rtp-empty" style={{ marginTop: '0.8rem' }}>
-              No relays match. User-published relays only appear here after they land in Neo4j
-              (happens automatically on publish via BrainstormProfile → Relays → Publish).
+              {selectedConceptMeta
+                ? <>No relay-shaped events under <code>{selectedConceptMeta.coordinate}</code>. This may not be a relay-shaped concept (e.g. dog), or no one has published instances yet.</>
+                : 'No relays match. User-published relays only appear here after they land in Neo4j (happens automatically on publish via BrainstormProfile → Relays → Publish).'}
             </div>
           ) : (
             <table className="data-table">
@@ -637,6 +789,7 @@ function AggregatedTab() {
                   <th>Endorsers</th>
                   <th>Weighted score</th>
                   <th>Tag applications</th>
+                  {extraFieldKeys.length > 0 && <th>Extras</th>}
                 </tr>
               </thead>
               <tbody>
@@ -690,13 +843,41 @@ function AggregatedTab() {
                             )}
                           </div>
                         </td>
+                        {extraFieldKeys.length > 0 && (
+                          <td>
+                            <div className="rdisc-extras-cell">
+                              {extraFieldKeys.map((k) => {
+                                const v = r.extras?.[k];
+                                if (v == null || v === '') {
+                                  return <span key={k} className="rdisc-extras-empty" title={`${k}: (not set)`}>—</span>;
+                                }
+                                return (
+                                  <span key={k} className="rdisc-extras-pill" title={k}>
+                                    <span className="rdisc-extras-key">{k}</span>{' '}
+                                    <span className="rdisc-extras-val">{String(v)}</span>
+                                  </span>
+                                );
+                              })}
+                            </div>
+                          </td>
+                        )}
                       </tr>
                       {isOpen && (
                         <tr className="rtp-row">
-                          <td colSpan={5}>
+                          <td colSpan={tableColCount}>
                             <div className="rdisc-endorsers-block">
                               <div className="rtp-label">Endorsers ({r.endorserCount})</div>
                               <EndorserList pubkeys={r.endorsers} weights={weights} profiles={profiles} />
+                              {r.appearsUnder && r.appearsUnder.length > 0 && (
+                                <div style={{ marginTop: '0.6rem' }}>
+                                  <div className="rtp-label">Appears under</div>
+                                  <div className="rdisc-appears-list">
+                                    {r.appearsUnder.map((coord) => (
+                                      <code key={coord} className="rdisc-appears-coord">{coord}</code>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
                             </div>
                           </td>
                         </tr>
@@ -710,12 +891,17 @@ function AggregatedTab() {
 
           <div className="rdisc-footer-note">
             Weight per endorser depends on your Trust Determination (POV + scoring method).
-            Click a relay row to see each endorser and their individual weight. An unknown
-            weight (<code>—</code>) means the hook couldn't resolve a number for that pubkey
-            under the current method.
+            Click a relay row to see each endorser, their weight, and which concept
+            coordinate(s) the row appears under.
           </div>
         </>
       )}
+
+      {/* Operational panels — push to bottom now that the demo is set up. */}
+      <div className="rdisc-ops-panels">
+        <DemoPanel />
+        <PipelinePanel />
+      </div>
     </div>
   );
 }

--- a/ui/src/pages/relay-discovery/RelayTagPanel.jsx
+++ b/ui/src/pages/relay-discovery/RelayTagPanel.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { publishEverywhere, importAddressableToNeo4j } from '../../utils/nostrPublish';
+import KnownConceptsPanel from '../../components/KnownConceptsPanel';
 
 const NOSTR_RELAY_TAG_Z_TAG =
   '39998:82b75e474dda005e912bcbb910391c60c2b89cc7faf5d3c30b7c59a324973833:nostr-relay-tag';
@@ -114,6 +115,8 @@ export default function RelayTagPanel({ relayEventId, relaySlug, user }) {
 
   return (
     <div className="rtp">
+      <KnownConceptsPanel slug="nostr-relay-tag" />
+
       <div className="rtp-section">
         <div className="rtp-label">Applied tags</div>
         {(applications || []).length === 0 ? (

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -5109,3 +5109,121 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   padding: 0.02rem 0.25rem;
   border-radius: 2px;
 }
+
+/* ── Concept-lens picker on RelayDiscovery ──────────────── */
+.rdisc-concept-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(168,85,247,0.05);
+  border: 1px solid rgba(168,85,247,0.18);
+  border-radius: 5px;
+  margin-bottom: 0.7rem;
+  font-size: 0.82rem;
+}
+.rdisc-concept-select {
+  flex: 1;
+  padding: 0.4rem 0.55rem;
+  background: rgba(0,0,0,0.3);
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 5px;
+  color: inherit;
+  font-family: inherit;
+  font-size: 0.82rem;
+}
+.rdisc-concept-select:focus { outline: none; border-color: #a855f7; }
+.rdisc-concept-clear {
+  padding: 0.35rem 0.7rem;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 5px;
+  color: inherit;
+  font-family: inherit;
+  font-size: 0.74rem;
+  cursor: pointer;
+}
+.rdisc-concept-clear:hover { background: rgba(255,255,255,0.12); }
+
+.rdisc-schema-banner {
+  background: rgba(168,85,247,0.06);
+  border: 1px solid rgba(168,85,247,0.25);
+  border-radius: 5px;
+  padding: 0.6rem 0.8rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.82rem;
+  color: rgba(255,255,255,0.85);
+}
+.rdisc-schema-banner-title {
+  font-weight: 600;
+  color: #e9d5ff;
+  margin-bottom: 0.3rem;
+}
+.rdisc-schema-banner-title code {
+  background: rgba(0,0,0,0.3);
+  padding: 0.05rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.76rem;
+  font-weight: 400;
+}
+.rdisc-schema-banner-body { color: rgba(255,255,255,0.7); line-height: 1.5; }
+.rdisc-extra-key {
+  background: rgba(168,85,247,0.18);
+  color: #e9d5ff;
+  padding: 0.05rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.78rem;
+  margin: 0 0.05rem;
+}
+
+.rdisc-extras-cell {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+.rdisc-extras-pill {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(168,85,247,0.12);
+  border: 1px solid rgba(168,85,247,0.3);
+  font-size: 0.74rem;
+}
+.rdisc-extras-key {
+  color: rgba(255,255,255,0.55);
+  font-size: 0.7rem;
+}
+.rdisc-extras-val {
+  color: #e9d5ff;
+  font-weight: 500;
+}
+.rdisc-extras-empty {
+  font-size: 0.74rem;
+  color: rgba(255,255,255,0.25);
+}
+
+.rdisc-appears-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.25rem;
+}
+.rdisc-appears-coord {
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.1);
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.7rem;
+  color: rgba(255,255,255,0.6);
+  word-break: break-all;
+}
+
+/* Operational panels (Demo Setup + Pipeline) move below the table once
+   the user has configured them. */
+.rdisc-ops-panels {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255,255,255,0.06);
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -4774,3 +4774,338 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   color: rgba(255,255,255,0.5);
   line-height: 1.4;
 }
+
+/* ── Concept Discovery page ─────────────────────────────── */
+.cdisc-page { padding: 1rem 0; }
+.cdisc-section { margin-bottom: 1.5rem; }
+.cdisc-section-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(255,255,255,0.85);
+  margin-bottom: 0.6rem;
+}
+.cdisc-section-hint {
+  margin-top: 0.6rem;
+  font-size: 0.74rem;
+  color: rgba(255,255,255,0.5);
+  font-style: italic;
+}
+.cdisc-section-hint code {
+  background: rgba(255,255,255,0.06);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+}
+
+.cdisc-suggestions {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 0.75rem;
+}
+.cdisc-suggestion {
+  text-align: left;
+  background: rgba(99,102,241,0.07);
+  border: 1px solid rgba(99,102,241,0.2);
+  border-radius: 6px;
+  padding: 0.75rem 0.9rem;
+  color: inherit;
+  cursor: pointer;
+  font-family: inherit;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.cdisc-suggestion:hover {
+  background: rgba(99,102,241,0.12);
+  border-color: rgba(99,102,241,0.4);
+}
+.cdisc-suggestion-name { font-weight: 600; color: #c7d2fe; font-size: 0.86rem; }
+.cdisc-suggestion-pk code {
+  background: rgba(0,0,0,0.3);
+  padding: 0.05rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.74rem;
+  color: rgba(255,255,255,0.7);
+}
+.cdisc-suggestion-desc {
+  font-size: 0.78rem;
+  color: rgba(255,255,255,0.65);
+  line-height: 1.4;
+}
+
+.cdisc-search-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.cdisc-search-input { flex: 2; min-width: 240px; }
+.cdisc-relay-input { flex: 2; min-width: 240px; }
+.cdisc-search-input,
+.cdisc-relay-input {
+  padding: 0.55rem 0.75rem;
+  background: rgba(0,0,0,0.3);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 5px;
+  color: inherit;
+  font-family: inherit;
+  font-size: 0.88rem;
+}
+.cdisc-search-input:focus,
+.cdisc-relay-input:focus {
+  outline: none;
+  border-color: #6366f1;
+}
+.cdisc-search-btn {
+  padding: 0.55rem 1.1rem;
+  background: #6366f1;
+  border: 1px solid #6366f1;
+  border-radius: 5px;
+  color: white;
+  font-family: inherit;
+  font-size: 0.88rem;
+  cursor: pointer;
+}
+.cdisc-search-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.cdisc-results {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 0.75rem;
+}
+.cdisc-concept {
+  text-align: left;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 6px;
+  padding: 0.85rem 1rem;
+  color: inherit;
+  font-family: inherit;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.cdisc-concept:hover {
+  background: rgba(255,255,255,0.08);
+  border-color: rgba(255,255,255,0.25);
+}
+.cdisc-concept-imported {
+  border-color: rgba(16,185,129,0.4);
+  background: rgba(16,185,129,0.05);
+}
+.cdisc-concept-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+.cdisc-concept-slug {
+  font-family: ui-monospace, monospace;
+  font-size: 0.78rem;
+  color: rgba(255,255,255,0.55);
+}
+.cdisc-concept-badge {
+  font-size: 0.68rem;
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  background: rgba(16,185,129,0.2);
+  color: #6ee7b7;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+.cdisc-concept-name { font-weight: 600; font-size: 0.95rem; color: rgba(255,255,255,0.95); }
+.cdisc-concept-desc { font-size: 0.8rem; color: rgba(255,255,255,0.7); line-height: 1.4; }
+.cdisc-concept-coordinate code {
+  background: rgba(0,0,0,0.3);
+  padding: 0.05rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.7rem;
+  color: rgba(255,255,255,0.45);
+  word-break: break-all;
+}
+
+/* ── Concept Preview modal ──────────────────────────────── */
+.cdisc-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+  padding: 1rem;
+}
+.cdisc-modal {
+  background: #18181d;
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 8px;
+  padding: 1.2rem 1.3rem;
+  max-width: 640px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 12px 40px rgba(0,0,0,0.55);
+}
+.cdisc-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.6rem;
+  padding-bottom: 0.55rem;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+.cdisc-modal-title {
+  font-weight: 600;
+  font-size: 1rem;
+  color: #e0e7ff;
+}
+.cdisc-modal-close {
+  background: transparent;
+  border: none;
+  color: rgba(255,255,255,0.55);
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.25rem;
+}
+.cdisc-modal-close:hover { color: rgba(255,255,255,0.9); }
+
+.cdisc-preview-body { display: flex; flex-direction: column; gap: 0.85rem; }
+.cdisc-preview-section { display: flex; flex-direction: column; gap: 0.3rem; }
+.cdisc-preview-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(255,255,255,0.55);
+}
+.cdisc-preview-coord {
+  background: rgba(255,255,255,0.06);
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.78rem;
+  word-break: break-all;
+}
+.cdisc-preview-name { font-weight: 600; font-size: 0.92rem; }
+.cdisc-preview-plural { font-weight: 400; opacity: 0.7; }
+.cdisc-preview-desc { font-size: 0.84rem; color: rgba(255,255,255,0.75); line-height: 1.5; }
+.cdisc-preview-hint { font-size: 0.78rem; color: rgba(255,255,255,0.55); font-style: italic; }
+
+.cdisc-schema-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+}
+.cdisc-schema-table th {
+  text-align: left;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(255,255,255,0.55);
+  font-weight: 500;
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid rgba(255,255,255,0.1);
+}
+.cdisc-schema-table td {
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+  vertical-align: top;
+}
+.cdisc-schema-table code {
+  background: transparent;
+  font-size: 0.82rem;
+  color: #c7d2fe;
+}
+.cdisc-schema-desc { color: rgba(255,255,255,0.65); font-size: 0.78rem; }
+
+.cdisc-sets-list { margin: 0; padding-left: 1rem; font-size: 0.84rem; }
+.cdisc-sets-list li { margin-bottom: 0.3rem; }
+.cdisc-set-desc { color: rgba(255,255,255,0.6); }
+
+.cdisc-import-msg {
+  padding: 0.55rem 0.7rem;
+  border-radius: 5px;
+  background: rgba(16,185,129,0.08);
+  border: 1px solid rgba(16,185,129,0.25);
+  font-size: 0.82rem;
+  color: #6ee7b7;
+}
+
+.cdisc-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  padding-top: 0.6rem;
+  border-top: 1px solid rgba(255,255,255,0.06);
+}
+.cdisc-btn {
+  padding: 0.5rem 1rem;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 5px;
+  color: inherit;
+  font-family: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+.cdisc-btn:hover:not(:disabled) { background: rgba(255,255,255,0.15); }
+.cdisc-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.cdisc-btn-primary { background: #6366f1; border-color: #6366f1; color: white; }
+.cdisc-btn-primary:hover:not(:disabled) { background: #7780ff; }
+
+/* ── KnownConceptsPanel ─────────────────────────────────── */
+.known-concepts-panel {
+  background: rgba(99,102,241,0.05);
+  border: 1px solid rgba(99,102,241,0.18);
+  border-radius: 5px;
+  padding: 0.55rem 0.7rem;
+  font-size: 0.78rem;
+  color: rgba(255,255,255,0.7);
+  margin: 0.3rem 0 0.5rem;
+}
+.known-concepts-error {
+  background: rgba(239,68,68,0.05);
+  border-color: rgba(239,68,68,0.25);
+  color: #fca5a5;
+}
+.known-concepts-row { line-height: 1.5; }
+.known-concepts-label { color: rgba(255,255,255,0.55); }
+.known-concepts-coord {
+  background: rgba(255,255,255,0.08);
+  padding: 0.05rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.74rem;
+  word-break: break-all;
+}
+.known-concepts-coord-small {
+  background: rgba(255,255,255,0.06);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  font-size: 0.7rem;
+  word-break: break-all;
+}
+.known-concepts-divider {
+  height: 1px;
+  background: rgba(255,255,255,0.06);
+  margin: 0.45rem 0;
+}
+.known-concepts-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.3rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.known-concepts-hint {
+  margin-top: 0.4rem;
+  font-size: 0.72rem;
+  color: rgba(255,255,255,0.5);
+  font-style: italic;
+  line-height: 1.45;
+}
+.known-concepts-hint code {
+  background: rgba(255,255,255,0.06);
+  padding: 0.02rem 0.25rem;
+  border-radius: 2px;
+}


### PR DESCRIPTION
## local relay concept:

<img width="937" height="836" alt="image" src="https://github.com/user-attachments/assets/d3779313-305b-4646-b9a6-5999f8d944f3" />

## foreign relay concept:

<img width="939" height="829" alt="image" src="https://github.com/user-attachments/assets/ac80d2d8-de0b-4eba-889b-433c363cbf95" />

## relay discovery UI when selecting the "dog" concept:

<img width="933" height="526" alt="image" src="https://github.com/user-attachments/assets/fa283eea-0466-40ec-afc2-3fcf27b914fa" />

---

## foreign concept Element: 

<img width="935" height="914" alt="image" src="https://github.com/user-attachments/assets/8fbc4ba6-1f81-4bbe-a941-e6c143892b42" />

## local concept Element:

<img width="936" height="923" alt="image" src="https://github.com/user-attachments/assets/2e52fe84-72a5-4302-a68a-06b56480c010" />

---

## Concept Discovery (This instance):

<img width="1171" height="983" alt="image" src="https://github.com/user-attachments/assets/2f581066-1afc-49fa-bce6-a8b8e3c607ff" />

<img width="678" height="727" alt="image" src="https://github.com/user-attachments/assets/2275125e-3eb4-459d-8d80-ede8df4b900b" />


## Concept Discovery foreign concept:

<img width="1182" height="838" alt="image" src="https://github.com/user-attachments/assets/83102e57-7167-495f-96ed-45ae2d3e6c47" />

<img width="671" height="759" alt="image" src="https://github.com/user-attachments/assets/46e7f28e-7dca-4472-9a58-0a25e6dbac35" />


---

# **Concept Discovery: cross-instance schema sharing**

Adds a "View through concept" picker on `/kg/relay-discovery` so the canonical relay view can be re-scoped to any installed ConceptHeader — including foreign concepts imported from another instance's TA. Picking a foreign concept narrows the table to events under that coordinate, surfaces a banner naming the schema fields this UI doesn't natively render (e.g. `country`, `language` from `nostr-relay-v2`), and adds an "Extras" column that pills out their values per row. Picking a non-relay concept (like `dog`) yields an empty state that explains the mismatch — making the schema-as-contract relationship visible.

New `src/api/concept-discovery/` module wires the import path: `suggested-authors` (config-backed today, DCoSL-backed later), `concepts-by-pubkey`, `concept-preview`, `import` (lands foreign events in strfry, runs `buildImportCypher`, applies content-aware Neo4j labels, wires the 7 structural ConceptHeader edges via `coreMemberOf`, then triggers the existing Pass-3 derive pipeline). `installed-concepts` exposes the catalogue for the picker. New `/kg/concept-discovery` page provides the import UX with bootstrap suggestion cards + free-form pubkey search + schema preview modal.

`relay-discovery/aggregated` is now multi-TA aware — it resolves every installed concept coordinate matching a slug instead of hardcoding our TA, and accepts `conceptCoord` to scope the view. `extras` and `appearsUnder` are exposed per row so the UI can render schema divergence and which concept(s) each row is published under. Demo panels (Demo Setup + GrapeRank Pipeline) move below the table — operational, not primary.

`mint-foreign-concept.js` now mints the full 8-event firmware-shaped bundle plus 3 seed relay elements with the v2-only fields, so the foreign concept appears properly populated in the existing Concepts UI and has real demo data to render.

## Concept Discovery caveats

The "suggested concept authors" comes from `tapestry/config/suggested-concept-authors.json` — the bootstrap config file we set up. Concretely:

1. **Seeded by the demo script.** When you run `node mint-foreign-concept.js --seed-config`, the script appends Magic Mirror's pubkey + name + description to that JSON file (alongside the self-referencing entry that ships by default).

2. **Served by the API.** `GET /api/concept-discovery/suggested-authors` reads the file at request time, filters out malformed entries, and returns `{ success: true, authors: [...] }`.

3. **Rendered by the UI.** `ConceptDiscovery.jsx` fetches that endpoint on mount and renders one card per author in the "Suggested concept authors" section. Click → it pre-fills the search input and triggers a `concepts-by-pubkey` fetch.


The TODO item below changes only step 2: the same endpoint stops reading the file and instead resolves a DCoSL "concept-author" DList from Neo4j. UI and config-file consumers are unchanged because the response shape stays the same.

# TODO (at least)

- [ ] Migrate `suggested-concept-authors` to a DCoSL `concept-author` DList; make the canonical DList coordinate configurable in `brainstorm.conf`

....also....

- [ ] Allow per-import override of which DList to consult, so users can subscribe to multiple curators (and rank their suggestions by GR)
- [ ] Surface concept-author trust scores on suggestion cards (use `useTrustWeights` against the configured POV)
- [ ] Concept "uninstall" / "unsubscribe" flow — today removing an imported concept requires direct Cypher
- [ ] Concept "refresh" / re-import — re-pull when the foreign TA updates schema or supports
- [ ] Exempt any pubkey that has authored a `:ConceptHeader` from reconciliation pruning, so imported foreign TAs aren't repeatedly dropped + their concepts orphaned
- [ ] Verify event signatures on import (currently uses `strfry import --no-verify`)
- [ ] Persist provenance ("imported from relay X on date Y") on each ConceptHeader node and surface it in the Concepts UI
- [ ] Diff-view: when re-importing or comparing two concepts, highlight schema changes (added/removed/renamed fields)
- [ ] Detect schema-shape compatibility for the relay-discovery picker so non-relay concepts can be visually grouped or down-ranked rather than mixed in
- [ ] Allow the concept-lens picker to scope to multiple coordinates simultaneously (multi-select for "show me v1 + v2 together")
- [ ] Expose `appearsUnder` on collapsed rows (icon or tooltip) so users can see at a glance which concepts a relay is endorsed under without expanding
- [ ] Concept-author profile cards: render kind-0 metadata (name, picture, NIP-05) on suggestion cards so foreign TAs are visually identifiable
- [ ] Per-publish concept picker on `PublishRelayForm` (and `RelayTagPanel`) once a real "publish to a foreign concept" use case emerges
- [ ] Bulk-import: "import all concepts from this TA" action when a user trusts an entire instance's ontology
- [ ] Conflict resolution UI when an imported concept's schema differs from another concept with the same slug — currently coexist silently under different coordinates
- [ ] Auto-discover concept authors from kind-3 follows + their published 39998s (passive discovery via your existing WoT)
- [ ] Versioning + supersedes: a TA publishing `nostr-relay-v2` could declare it supersedes `nostr-relay-v1` via a tag, and the UI could suggest migration
- [ ] Element migration: when adopting a new schema version, offer to convert your existing kind-39999 publishes from old coord to new coord
- [ ] Concept "explorer" page that visualizes the multi-TA graph: which slugs exist across which authors, who imported what, schema-overlap heatmap
- [ ] Negentropy-style sync of concept events from external relays so concept import works without the foreign TA having to be online
- [ ] Schema validation on user publishes: when publishing under a coordinate, validate the payload against that concept's JSONSchema before signing
- [ ] Test data for concepts other than relays — e.g. a foreign `tag` concept with different vocabulary — to demonstrate plurality across the whole feature surface
- [ ] Documentation page describing the conceptual model (decentralized concepts, coordinates, schema-as-contract) for users encountering this feature for the first time