### PR TITLE
Magic Carpet v2: bounty system on tapestry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,12 @@ lerna-debug.log*
 .env.test
 .env.production
 
+# Local SQLite bounty store (not shared; production uses the tapestry-data volume)
+/data/bounties.db
+/data/bounties.db-journal
+/data/bounties.db-wal
+/data/bounties.db-shm
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/BIBLE.md
+++ b/BIBLE.md
@@ -1391,4 +1391,37 @@ docker compose exec tapestry strfry sync wss://dcosl.brainstorm.world \
 
 ---
 
+## 22. Bounties (Magic Carpet v2)
+
+The bounties subsystem lets a list curator (Alice) offer Lightning sats to any trusted contributor (Bob) who adds items to her list.
+
+### Model
+
+- **Bounty = a row in SQLite**, not a nostr event. Bounties are app-level metadata (no cross-client coordination needed for a PoC). Schema lives in `src/db/bounties.js`; table is `bounties(id, issuer_pubkey, list_coordinate, amount_sats, criteria, expiration, created_at, status)`. DB file is `/var/lib/brainstorm/bounties.db` in prod (tapestry-data volume) or `./data/bounties.db` in dev.
+- **Claim = an ordinary kind-39999 ListItem** on the bountied list, published through tapestry's existing `/tapestry/lists/:id/items/new` flow. No new event kind, no new submission endpoint. Correlation is implicit: claims are items on `bounty.list_coordinate` by pubkeys trusted by the issuer (rank ≥ 2), created after `bounty.created_at`.
+- **Payment = NIP-57 zap** tagging the claim's event id. Client signs kind-9734, posts to the recipient's LNURL callback, gets back an invoice. Kind-9735 receipt (published by the LNURL provider) is the proof of payment.
+- **Fulfilled status = derived**: the bounty is considered `fulfilled` when any kind-9735 receipt exists whose embedded zap request pubkey (parsed from the receipt's `description` tag per NIP-57) equals `bounty.issuer_pubkey`, targeting the bounty's list coordinate.
+
+### Trust check
+
+The `/api/bounties/eligible` endpoint uses `src/lib/trust-rank.js`, a **provider-agnostic** wrapper that reads `rank(observer, subject)` from Trusted Assertions. It looks up `wot_rank_<povSuffix>` on the subject's Meilisearch profile document (where `povSuffix = observer.rankAuthor.slice(0,8)` read from the user-prefs file), falling back to a direct strfry scan for kind-30382 events if Meilisearch hasn't indexed the suffix yet. No GrapeRank-specific code paths — any WoT service provider whose assertions conform to the `rank` tag convention will work.
+
+Set `DEV_SKIP_TRUST_CHECK=true` in `.env` to bypass the rank gate for local development; returns `100` for every pair.
+
+### API
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/bounties` | Create a bounty (session required). Body: `{ listCoordinate, amountSats, criteria, expiration? }`. |
+| GET | `/api/bounties` | List bounties (`?status=open\|all`). Each includes a derived status. |
+| GET | `/api/bounties/eligible?viewer=<hex>` | Bounties whose issuer trusts the viewer at rank ≥ 2. |
+| GET | `/api/bounties/:id` | Single bounty + derived claims + zap receipts. |
+| GET | `/api/bounties/mine/payments-due` | Current user's bounties with unpaid claims. |
+
+### UI
+
+Routes live under `/tapestry/bounties/*`: `BountyList`, `BountyNew`, `BountyDetail`, `Eligibility`, `PaymentsDue`. The list-detail Actions tab has an "Incentivize" button that deeplinks into `BountyNew` with the list's a-tag coordinate pre-filled. The `items/new` page renders a claim banner when arrived at via `?bounty=<id>`.
+
+---
+
 *This document is maintained by the development team. When making significant architectural changes, update this file.*

--- a/docs/magic-carpet-v2-pivot/meetings/2026-04-14-david-streyhorn.md
+++ b/docs/magic-carpet-v2-pivot/meetings/2026-04-14-david-streyhorn.md
@@ -1,0 +1,92 @@
+# Meeting: David Streyhorn — 2026-04-14
+
+## Participants
+- **Matthias** (md)
+- **David Streyhorn**
+
+## Key Decision
+
+**Pivot from Dioxus/Rust to forking Tapestry.** The Dioxus-based Magic Carpet site (c.brainstorm.org) works but is too slow to compile and deploy for rapid prototyping. David proposed forking Tapestry (Vite-based, already has NIP-07 login and list creation working) and building the bounty system there instead. Matthias agreed.
+
+> "Let's not do any technology that's cool, but not needed."
+
+**Assumption: whatever we build now is going to get rebuilt.** This is a proof of concept.
+
+## Source Branch
+
+Fork from: `nous-clawds4/tapestry`, branch `refactor-paths`
+
+David will text the exact branch name. (Update: he sent "refactor-paths".)
+
+Create a PR back to Tapestry — David is okay with that.
+
+## What Tapestry Already Has (no need to rebuild)
+
+- **NIP-07 Nostr login** — sign in / sign out works across the whole site
+- **List creation** — at `tapestry/lists/new` (title, description, items)
+- **List publishing** — publishes to local relay (stir fry), good enough for now
+- **Router** — works, just extend it
+- **Legacy pages** — David moved old Brainstorm front page content to `/legacy` on the refactor-paths branch
+
+## Tasks for Thursday (2026-04-17)
+
+### 1. Bounty Creation
+- Any logged-in user can attach a bounty (sats) to a list, incentivizing others to add items
+- UI: button on a list like "Incentivize" or "Pay people to add"
+- Could be on the list page itself or link to a Magic Carpet subpage
+
+### 2. Eligibility Dashboard
+- When logged in, show a dashboard of bounties you're eligible to claim
+- Eligibility is based on **Trusted Assertions** (Nostr web of trust)
+- Default trust cutoff: **rank 2** (make adjustable later)
+- Ask Claude: "How did Alice find out if Bob trusts her in Tapestry using Trusted Assertions?"
+- Display: issuer name, trust rank (0-100), bounty amount in sats
+- Filter out untrusted issuers (likely spam)
+
+### 3. Claiming Bounties
+- From the eligibility view, user can choose to claim a bounty
+- Claiming = submitting content (list items) to fulfill the request
+- Example: Alice posts bounty for "dog breeds" list → Bob (trusted by Alice) submits entries
+
+### 4. Payments / Zap Integration
+- Issuer sees submissions and can zap (pay) contributors they like
+- Anyone can zap, not just the issuer — if others are interested in the same list, they can zap contributors too
+- Issuer needs a "Payments Due" page showing who submitted what
+- Sort bounties by most-paid (highest signal of demand)
+
+### 5. Broadcast / Advertising Bounties
+- Ability to broadcast/advertise that a bounty exists
+- For now, local relay is fine; broadcasting to wider network comes later
+
+## Architecture Notes
+
+- **Tapestry uses Vite** (not React, not Dioxus)
+- Extend the existing router — ask Claude how it's implemented
+- NIP-07 for login (browser extension wallets like Alby, nos2x)
+- Trusted Assertions for web-of-trust eligibility checks
+- Zaps for payment mechanism
+
+## Future / Parking Lot
+
+- **Dioxus Magic Carpet**: shelved, not abandoned. Good framework (one codebase for web + desktop + mobile), Rust type safety eliminates whole classes of bugs, fast by default. Worth revisiting when scaling.
+- **Issuer trust track record**: show whether an issuer actually pays out bounties (not just rank score)
+- **Adjustable trust cutoff**: let users set their own threshold beyond rank 2
+- **Broadcast to wider relays**: currently local stir fry only
+- **LLM Wiki**: David recommends creating one for Nostr Fabrica / Tapestry / decentralized lists concepts using Hermes agent's LLM Wiki skill. Knowledge graph of linked markdown files, better for agents than a single Bible file. Eventually expose as an API other agents can query. Goes on the to-do list, not this sprint.
+- **Tapestry Bible**: exists at top level of Tapestry repo (`bible.md`), possibly also in Tapestry CLI repo. Use as reference for now.
+
+## Workflow
+
+1. Read Tapestry YouTube video transcript + Tapestry repo (especially the Bible)
+2. Use the Sleepy Dwarfs example as canonical test vector
+3. Fork `refactor-paths` branch
+4. Implement bounty system in the router
+5. PR back to Tapestry
+6. Review with David on Thursday 2026-04-17
+
+## Tooling Discussion
+
+- David uses Claude Code with Max Plan, finds it effective
+- Hermes (by Nous Research) is more capable as an agent harness (self-improving, mistake logging) but can't use Max Plan with it
+- Rust's `cargo check`, `cargo clippy`, `machete`, `mutants`, prop tests give Claude "extra eyes" via static analysis — JS/TS lacks this
+- For now, Claude Code is the primary tool

--- a/docs/magic-carpet-v2-pivot/solutions/build-errors/dioxus-dx-build-target-triple-autodetect-failure-2026-04-13.md
+++ b/docs/magic-carpet-v2-pivot/solutions/build-errors/dioxus-dx-build-target-triple-autodetect-failure-2026-04-13.md
@@ -1,0 +1,136 @@
+---
+title: "Dioxus dx build fails with 'Could not automatically detect target triple' when multiple renderer features present"
+date: 2026-04-13
+category: build-errors
+module: carpet-ui
+problem_type: build_error
+component: tooling
+severity: high
+symptoms:
+  - "dx build fails with 'Could not automatically detect target triple'"
+  - "dx build fails with 'Could not automatically detect bundle format'"
+  - "dx build panics at workspace.rs:325 when run from crate subdirectory"
+root_cause: config_error
+resolution_type: code_fix
+tags:
+  - dioxus
+  - dx-build
+  - platform-detection
+  - cargo-features
+  - fullstack
+  - docker
+  - target-triple
+  - bundle-format
+---
+
+# Dioxus dx build fails with "Could not automatically detect target triple" when multiple renderer features present
+
+## Problem
+
+`dx build -p carpet-ui --release` fails during Docker image build with "Could not automatically detect target triple" because the crate declares multiple non-server renderer features (`web` and `desktop`), and dioxus-cli 0.7.5's auto-detection algorithm requires exactly one.
+
+## Symptoms
+
+- `dx build` inside Docker buildx fails with:
+  ```
+  ERROR dx build: Could not automatically detect target triple
+  ```
+- Earlier flag combinations produced a different error:
+  ```
+  ERROR dx build: Could not automatically detect bundle format
+  ```
+- Running `dx build` from a workspace member subdirectory (`WORKDIR /app/crates/carpet-ui`) causes a panic:
+  ```
+  panicked at workspace.rs:325: called `Result::unwrap()` on an `Err` value:
+  Os { code: 2, kind: NotFound, message: "No such file or directory" }
+  ```
+
+## What Didn't Work
+
+Seven approaches were tried across five sessions before the root cause was found by reading the dioxus-cli source code:
+
+1. **WORKDIR to crate directory, drop `-p` flag** (session history): Set `WORKDIR /app/crates/carpet-ui` and ran `dx build --release`. dx panicked at `workspace.rs:325` — running dx from inside a workspace member subdirectory is broken.
+
+2. **Remove `--target` flag** (still in crate dir): Same `workspace.rs:325` panic. The panic was caused by the WORKDIR location, not `--target`.
+
+3. **Copy `Dioxus.toml` to workspace root, use `-p` from `/app`**: Changed the error to "Could not automatically detect target triple" — progress. Bundle format was now detected from the copied `Dioxus.toml`, but triple detection still failed.
+
+4. **Copy `Dioxus.toml` + explicit `--target x86_64-unknown-linux-gnu`**: Regressed to "Could not automatically detect bundle format". The `--target` flag breaks bundle format detection even when `Dioxus.toml` is present — it overrides the detection pipeline in clap parsing.
+
+5. **`--fullstack` flag + `@server --target`**: "Could not automatically detect target triple". `--fullstack` fixed bundle format but `@server --target` does not propagate to the top-level triple resolution.
+
+6. **`--fullstack --target` at top level**: "Could not automatically detect bundle format". The `--target` flag at the top level overrides `--fullstack` — these two flags are mutually destructive.
+
+7. **Cargo config `[build] target` in `.cargo/config.toml`**: "Could not automatically detect target triple". dx does not read Cargo's build config for its own platform detection.
+
+## Solution
+
+Remove the unused `desktop` feature from `crates/carpet-ui/Cargo.toml`.
+
+**Before:**
+```toml
+[features]
+default = []
+web = ["dioxus/web"]
+server = ["dioxus/server", "dep:axum", "dep:tokio", "dep:nostr-lib", "dep:phoenixd-lib"]
+desktop = ["dioxus/desktop"]
+```
+
+**After:**
+```toml
+[features]
+default = []
+web = ["dioxus/web"]
+server = ["dioxus/server", "dep:axum", "dep:tokio", "dep:nostr-lib", "dep:phoenixd-lib"]
+```
+
+**Dockerfile** simplified to a plain build command with no workarounds:
+```dockerfile
+RUN dx build -p carpet-ui --release
+```
+
+## Why This Works
+
+The dx CLI 0.7.5 platform auto-detection in `request.rs:633-833` follows this sequence:
+
+1. **`renderer_enabled_by_dioxus_dependency()`** checks the dioxus dependency's feature list. Both `"fullstack"` and `"router"` return `None` from `autodetect_from_cargo_feature()` (it only recognizes: `web`, `desktop`, `mobile`, `native`, `liveview`, `server`). Since no single renderer is found, returns `None`.
+
+2. **`enabled_cargo_toml_default_features_renderers()`** checks `default = []` — empty, returns empty vec.
+
+3. **`features_that_enable_renderers()`** iterates all `[features]` keys. Maps: `web` -> `Web`, `server` -> `Server`, `desktop` -> `Webview`. Returns 3 entries.
+
+4. **Fallback logic** filters out server-type features, then checks `non_server_features.len() == 1`. With both `web` and `desktop`, length is 2 — **fails**.
+
+5. `platform` stays `Platform::Unknown`. The match arm for `Unknown` does nothing, so `triple` remains `None`.
+
+6. Because `using_dioxus_explicitly == true`, the code hits:
+   ```rust
+   triple.context("Could not automatically detect target triple")?
+   ```
+   and errors out.
+
+After removing `desktop`, step 3 finds only `web` and `server`. Step 4 filters to one non-server feature (`web`), sets `platform = Platform::Web`, which resolves `triple` to `wasm32-unknown-unknown` for the client and `Triple::host()` for the server in fullstack mode.
+
+### Additional dx bugs discovered
+
+- **`--target` breaks `--fullstack`**: The `--target` flag at the top level of `dx build` silently overrides `--fullstack`'s bundle format setting in clap argument parsing. These flags cannot be used together.
+- **`autodetect_from_cargo_feature("fullstack")` returns `None`**: The `"fullstack"` dioxus feature is not recognized during auto-detection, even though it's a primary dioxus feature.
+- **Workspace subdirectory panic**: Running `dx build` from a workspace member crate directory panics at `workspace.rs:325`.
+
+## Prevention
+
+1. **One non-server renderer per crate**: In any Dioxus 0.7 crate built with `dx build`, define exactly one non-server renderer feature (e.g., `web` OR `desktop`, not both). If you genuinely need both, use separate crates or pass `--platform` explicitly via the `@server`/`@client` subcommands.
+
+2. **Do not combine `--target` with `--fullstack`**: These flags are mutually destructive in dioxus-cli 0.7.5. If your environment can auto-detect the host triple (i.e., not Docker buildx cross-compiling), omit `--target` entirely.
+
+3. **Always run `dx` from the workspace root**: Use `-p <crate>` to specify the build target. Running from a workspace member subdirectory triggers a panic.
+
+4. **Treat `fullstack` and `router` as invisible to auto-detection**: These Cargo features are not recognized by dx's feature scanner. Platform detection depends on your own `[features]` table keys, not the dioxus dependency features.
+
+5. **Read the dx source when debugging**: The auto-detection logic in `request.rs` is undocumented. When `dx build` fails with vague target/bundle errors, the source at `~/.cargo/registry/src/*/dioxus-cli-*/src/build/request.rs` is the only reliable reference.
+
+## Related Issues
+
+- [DioxusLabs/dioxus#3867](https://github.com/DioxusLabs/dioxus/issues/3867) — Closely related: `desktop` feature in Cargo.toml confuses dx's platform auto-detection
+- [DioxusLabs/dioxus#3916](https://github.com/DioxusLabs/dioxus/issues/3916) — Docker + fullstack dx build issues (different root cause: read-only filesystem)
+- [DioxusLabs/dioxus#3594](https://github.com/DioxusLabs/dioxus/issues/3594) — `--target` not forwarded to cargo for server builds

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "adm-zip": "^0.5.16",
         "ajv": "^8.18.0",
         "archiver": "^7.0.1",
+        "better-sqlite3": "^12.9.0",
         "chart.js": "^4.4.1",
         "chartjs-adapter-date-fns": "^3.0.0",
         "cors": "^2.8.5",
@@ -33,6 +34,7 @@
         "proper-lockfile": "^4.1.2",
         "swagger-ui-express": "^5.0.1",
         "typescript": "^5.8.2",
+        "uuid": "^13.0.0",
         "websocket": "^1.0.35",
         "websocket-polyfill": "^0.0.3",
         "ws": "^8.18.1"
@@ -678,6 +680,78 @@
       ],
       "license": "MIT"
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -848,6 +922,12 @@
         "chart.js": ">=2.8.0",
         "date-fns": ">=2.0.0"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
@@ -1506,6 +1586,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/delaunator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
@@ -1766,6 +1870,15 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/express": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
@@ -1942,6 +2055,12 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -2043,6 +2162,12 @@
       "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==",
       "license": "ISC"
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -2118,6 +2243,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.4.5",
@@ -2248,6 +2379,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/internmap": {
@@ -2547,6 +2684,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -2591,6 +2740,12 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2648,6 +2803,12 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -2690,6 +2851,18 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "license": "ISC"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/node-addon-api": {
       "version": "6.1.0",
@@ -2952,6 +3125,33 @@
         "node": ">=18"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -3047,6 +3247,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
       }
     },
     "node_modules/readable-stream": {
@@ -3171,6 +3386,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "0.19.0",
@@ -3340,6 +3567,51 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
@@ -3481,6 +3753,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/swagger-ui-dist": {
       "version": "5.32.2",
       "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.2.tgz",
@@ -3503,6 +3784,48 @@
       },
       "peerDependencies": {
         "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tar-fs/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tar-stream": {
@@ -3551,6 +3874,18 @@
       "resolved": "https://registry.npmjs.org/tstl/-/tstl-2.5.16.tgz",
       "integrity": "sha512-+O2ybLVLKcBwKm4HymCEwZIT0PpwS3gCYnxfSDEjJEKADvIFruaQjd3m7CAKNU1c7N3X3WjVz87re7TA2A5FUw==",
       "license": "MIT"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type": {
       "version": "2.7.3",
@@ -3668,6 +4003,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "adm-zip": "^0.5.16",
     "ajv": "^8.18.0",
     "archiver": "^7.0.1",
+    "better-sqlite3": "^12.9.0",
     "chart.js": "^4.4.1",
     "chartjs-adapter-date-fns": "^3.0.0",
     "cors": "^2.8.5",
@@ -75,6 +76,7 @@
     "proper-lockfile": "^4.1.2",
     "swagger-ui-express": "^5.0.1",
     "typescript": "^5.8.2",
+    "uuid": "^13.0.0",
     "websocket": "^1.0.35",
     "websocket-polyfill": "^0.0.3",
     "ws": "^8.18.1"

--- a/src/api/bounties.js
+++ b/src/api/bounties.js
@@ -1,0 +1,182 @@
+const { exec } = require('child_process');
+const { promisify } = require('util');
+const execAsync = promisify(exec);
+
+const {
+  createBounty,
+  listOpenBounties,
+  listAllBounties,
+  getBounty,
+  bountiesByIssuer,
+  markFulfilled,
+} = require('../db/bounties');
+const { rank } = require('../lib/trust-rank');
+
+const COORDINATE_RE = /^(\d+):([0-9a-f]{64}):(.+)$/;
+
+function requireAuthed(req, res, next) {
+  if (!req.session?.authenticated || !req.session?.pubkey) {
+    return res.status(401).json({ success: false, error: 'Not authenticated' });
+  }
+  next();
+}
+
+async function scanStrfry(filter) {
+  try {
+    const safe = JSON.stringify(filter).replace(/'/g, "'\\''");
+    const { stdout } = await execAsync(`strfry scan '${safe}'`, { maxBuffer: 32 * 1024 * 1024 });
+    return stdout.trim().split('\n').filter(Boolean).flatMap(line => {
+      try { return [JSON.parse(line)]; } catch { return []; }
+    });
+  } catch (err) {
+    console.error('[bounties] strfry scan failed:', err.message);
+    return [];
+  }
+}
+
+function getTag(event, name, index = 1) {
+  const tag = event.tags?.find(t => t[0] === name);
+  return tag ? tag[index] : null;
+}
+
+function parseZapRequestPubkey(receipt) {
+  const description = getTag(receipt, 'description');
+  if (!description) return null;
+  try { return JSON.parse(description).pubkey ?? null; } catch { return null; }
+}
+
+async function isBountyFulfilled(bounty) {
+  const receipts = await scanStrfry({
+    kinds: [9735],
+    '#a': [bounty.list_coordinate],
+  });
+  return receipts.some(r => parseZapRequestPubkey(r) === bounty.issuer_pubkey);
+}
+
+function deriveStatus(bounty, { fulfilled = false, now = Math.floor(Date.now() / 1000) } = {}) {
+  if (fulfilled) return 'fulfilled';
+  if (bounty.expiration && bounty.expiration < now) return 'expired';
+  return bounty.status;
+}
+
+async function listClaimsFor(bounty, { trustFilter = true } = {}) {
+  const items = await scanStrfry({
+    kinds: [39999],
+    '#z': [bounty.list_coordinate],
+    since: bounty.created_at,
+  });
+
+  const results = [];
+  for (const item of items) {
+    if (trustFilter) {
+      const r = await rank(bounty.issuer_pubkey, item.pubkey);
+      if (r < 2) continue;
+    }
+    const receipts = await scanStrfry({ kinds: [9735], '#e': [item.id] });
+    const zapReceipt = receipts.find(r => parseZapRequestPubkey(r) === bounty.issuer_pubkey) ?? receipts[0] ?? null;
+    results.push({ event: item, zapReceipt });
+  }
+  return results;
+}
+
+async function handleCreateBounty(req, res) {
+  const { listCoordinate, amountSats, criteria, expiration } = req.body || {};
+
+  if (!listCoordinate || !COORDINATE_RE.test(listCoordinate)) {
+    return res.status(400).json({ success: false, error: 'listCoordinate must be <kind>:<pubkey>:<dtag>' });
+  }
+  const amt = Number(amountSats);
+  if (!Number.isInteger(amt) || amt <= 0) {
+    return res.status(400).json({ success: false, error: 'amountSats must be a positive integer' });
+  }
+  if (typeof criteria !== 'string' || !criteria.trim()) {
+    return res.status(400).json({ success: false, error: 'criteria is required' });
+  }
+  let exp = null;
+  if (expiration !== undefined && expiration !== null && expiration !== '') {
+    exp = Number(expiration);
+    if (!Number.isInteger(exp) || exp <= 0) {
+      return res.status(400).json({ success: false, error: 'expiration must be a unix timestamp' });
+    }
+  }
+
+  const row = createBounty({
+    issuerPubkey: req.session.pubkey,
+    listCoordinate,
+    amountSats: amt,
+    criteria: criteria.trim(),
+    expiration: exp,
+  });
+  res.json({ success: true, bounty: row });
+}
+
+async function handleListBounties(req, res) {
+  const statusFilter = (req.query.status || 'open').toLowerCase();
+  const limit = Math.min(Number(req.query.limit) || 100, 500);
+  const rows = statusFilter === 'all' ? listAllBounties({ limit }) : listOpenBounties({ limit });
+  const now = Math.floor(Date.now() / 1000);
+
+  const enriched = await Promise.all(rows.map(async b => {
+    const fulfilled = await isBountyFulfilled(b);
+    return { ...b, derivedStatus: deriveStatus(b, { fulfilled, now }) };
+  }));
+  res.json({ success: true, bounties: enriched });
+}
+
+async function handleEligibleBounties(req, res) {
+  const viewer = (req.query.viewer || req.session.pubkey || '').toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(viewer)) {
+    return res.status(400).json({ success: false, error: 'viewer must be a 64-char hex pubkey' });
+  }
+  if (viewer !== req.session.pubkey) {
+    return res.status(403).json({ success: false, error: 'viewer must match session pubkey' });
+  }
+
+  const open = listOpenBounties({ limit: 500 });
+  const checked = await Promise.all(open.map(async b => {
+    const issuerRank = await rank(b.issuer_pubkey, viewer);
+    return { bounty: b, issuerRank };
+  }));
+  const eligible = checked
+    .filter(({ issuerRank }) => issuerRank >= 2)
+    .map(({ bounty, issuerRank }) => ({ ...bounty, issuerRank }));
+  res.json({ success: true, bounties: eligible });
+}
+
+async function handleGetBounty(req, res) {
+  const b = getBounty(req.params.id);
+  if (!b) return res.status(404).json({ success: false, error: 'bounty not found' });
+
+  const fulfilled = await isBountyFulfilled(b);
+  if (fulfilled && b.status !== 'fulfilled') markFulfilled(b.id);
+  const claims = await listClaimsFor(b, { trustFilter: true });
+  res.json({
+    success: true,
+    bounty: { ...b, derivedStatus: deriveStatus(b, { fulfilled }) },
+    claims,
+  });
+}
+
+async function handlePaymentsDue(req, res) {
+  const mine = bountiesByIssuer(req.session.pubkey);
+  const open = mine.filter(b => b.status !== 'expired');
+  const result = [];
+  for (const b of open) {
+    const claims = await listClaimsFor(b, { trustFilter: true });
+    const pending = claims.filter(c => !c.zapReceipt);
+    if (pending.length > 0) result.push({ bounty: b, pendingClaims: pending });
+  }
+  res.json({ success: true, items: result });
+}
+
+function register(app) {
+  // Eligible route MUST be registered before GET /:id so Express doesn't treat
+  // "eligible" and "mine" as bounty ids.
+  app.get('/api/bounties/eligible', requireAuthed, handleEligibleBounties);
+  app.get('/api/bounties/mine/payments-due', requireAuthed, handlePaymentsDue);
+  app.post('/api/bounties', requireAuthed, handleCreateBounty);
+  app.get('/api/bounties', handleListBounties);
+  app.get('/api/bounties/:id', handleGetBounty);
+}
+
+module.exports = { register };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -487,6 +487,10 @@ async function register(app) {
     const { registerTapestryKeyRoutes } = require('./tapestry-key');
     registerTapestryKeyRoutes(app);
 
+    // ── Bounties API (Magic Carpet v2) ──
+    const bountiesApi = require('./bounties');
+    bountiesApi.register(app);
+
     // Initialize router state (presets → state file → strfry config)
     await initRouter();
 

--- a/src/db/bounties.js
+++ b/src/db/bounties.js
@@ -1,0 +1,101 @@
+const fs = require('fs');
+const path = require('path');
+const Database = require('better-sqlite3');
+const { v4: uuidv4 } = require('uuid');
+
+const DEFAULT_PROD_DIR = '/var/lib/brainstorm';
+const DEFAULT_DEV_DIR = path.join(__dirname, '..', '..', 'data');
+
+function resolveDbPath() {
+  if (process.env.BOUNTIES_DB_PATH) return process.env.BOUNTIES_DB_PATH;
+  const prodDir = DEFAULT_PROD_DIR;
+  try {
+    fs.accessSync(prodDir, fs.constants.W_OK);
+    return path.join(prodDir, 'bounties.db');
+  } catch {
+    fs.mkdirSync(DEFAULT_DEV_DIR, { recursive: true });
+    return path.join(DEFAULT_DEV_DIR, 'bounties.db');
+  }
+}
+
+const dbPath = resolveDbPath();
+const db = new Database(dbPath);
+db.pragma('journal_mode = WAL');
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS bounties (
+    id              TEXT PRIMARY KEY,
+    issuer_pubkey   TEXT NOT NULL,
+    list_coordinate TEXT NOT NULL,
+    amount_sats     INTEGER NOT NULL CHECK (amount_sats > 0),
+    criteria        TEXT NOT NULL,
+    expiration      INTEGER,
+    created_at      INTEGER NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open','fulfilled','expired'))
+  );
+  CREATE INDEX IF NOT EXISTS idx_bounties_list   ON bounties(list_coordinate);
+  CREATE INDEX IF NOT EXISTS idx_bounties_issuer ON bounties(issuer_pubkey);
+  CREATE INDEX IF NOT EXISTS idx_bounties_status ON bounties(status);
+`);
+
+const insertStmt = db.prepare(`
+  INSERT INTO bounties (id, issuer_pubkey, list_coordinate, amount_sats, criteria, expiration, created_at, status)
+  VALUES (@id, @issuer_pubkey, @list_coordinate, @amount_sats, @criteria, @expiration, @created_at, 'open')
+`);
+const selectOpenStmt = db.prepare(`
+  SELECT * FROM bounties
+  WHERE status = 'open' AND (expiration IS NULL OR expiration > @now)
+  ORDER BY amount_sats DESC
+  LIMIT @limit
+`);
+const selectAllStmt = db.prepare(`SELECT * FROM bounties ORDER BY amount_sats DESC LIMIT @limit`);
+const selectByIdStmt = db.prepare(`SELECT * FROM bounties WHERE id = ?`);
+const selectByIssuerStmt = db.prepare(`SELECT * FROM bounties WHERE issuer_pubkey = ? ORDER BY created_at DESC`);
+const markFulfilledStmt = db.prepare(`UPDATE bounties SET status = 'fulfilled' WHERE id = ?`);
+
+function createBounty({ issuerPubkey, listCoordinate, amountSats, criteria, expiration }) {
+  const id = uuidv4();
+  const row = {
+    id,
+    issuer_pubkey: issuerPubkey,
+    list_coordinate: listCoordinate,
+    amount_sats: amountSats,
+    criteria,
+    expiration: expiration ?? null,
+    created_at: Math.floor(Date.now() / 1000),
+  };
+  insertStmt.run(row);
+  return { ...row, status: 'open' };
+}
+
+function listOpenBounties({ limit = 100 } = {}) {
+  const now = Math.floor(Date.now() / 1000);
+  return selectOpenStmt.all({ now, limit });
+}
+
+function listAllBounties({ limit = 100 } = {}) {
+  return selectAllStmt.all({ limit });
+}
+
+function getBounty(id) {
+  return selectByIdStmt.get(id) ?? null;
+}
+
+function bountiesByIssuer(pubkey) {
+  return selectByIssuerStmt.all(pubkey);
+}
+
+function markFulfilled(id) {
+  markFulfilledStmt.run(id);
+}
+
+module.exports = {
+  db,
+  dbPath,
+  createBounty,
+  listOpenBounties,
+  listAllBounties,
+  getBounty,
+  bountiesByIssuer,
+  markFulfilled,
+};

--- a/src/lib/trust-rank.js
+++ b/src/lib/trust-rank.js
@@ -1,0 +1,86 @@
+const fs = require('fs');
+const path = require('path');
+
+const MEILI_URL = process.env.MEILI_URL || 'http://nostr-search-meili:7700';
+const MEILI_INDEX = process.env.MEILI_INDEX || 'profiles';
+const USER_PREFS_DIR = process.env.USER_PREFS_DIR || '/var/lib/brainstorm/user-prefs';
+const STRFRY_SCAN_URL = process.env.STRFRY_SCAN_URL || 'http://localhost:7778';
+const DEV_SKIP = process.env.DEV_SKIP_TRUST_CHECK === 'true';
+
+function readUserPrefs(pubkey) {
+  if (!pubkey || !/^[0-9a-f]{64}$/i.test(pubkey)) return {};
+  const filePath = path.join(USER_PREFS_DIR, `${pubkey.toLowerCase()}.json`);
+  try {
+    if (fs.existsSync(filePath)) {
+      return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    }
+  } catch { /* ignore */ }
+  return {};
+}
+
+function resolveRankAuthor(observerPubkey) {
+  const userPrefs = readUserPrefs(observerPubkey);
+  if (userPrefs.rankAuthor && /^[0-9a-f]{64}$/i.test(userPrefs.rankAuthor)) {
+    return userPrefs.rankAuthor.toLowerCase();
+  }
+  const housePrefs = readUserPrefs(process.env.OWNER_PUBKEY || '');
+  if (housePrefs.rankAuthor) return housePrefs.rankAuthor.toLowerCase();
+  return (process.env.OWNER_PUBKEY || '').toLowerCase();
+}
+
+async function fetchMeiliRank(subjectPubkey, povSuffix) {
+  try {
+    const resp = await fetch(`${MEILI_URL}/indexes/${MEILI_INDEX}/documents/${subjectPubkey}`);
+    if (!resp.ok) return null;
+    const doc = await resp.json();
+    const val = doc?.[`wot_rank_${povSuffix}`];
+    return typeof val === 'number' ? val : null;
+  } catch { return null; }
+}
+
+async function fetchStrfryTaRank(rankAuthor, subjectPubkey) {
+  try {
+    const filter = { kinds: [30382], authors: [rankAuthor], '#p': [subjectPubkey], limit: 1 };
+    const url = `${STRFRY_SCAN_URL}/api/strfry/scan?filter=${encodeURIComponent(JSON.stringify(filter))}`;
+    const resp = await fetch(url);
+    if (!resp.ok) return null;
+    const events = await resp.json();
+    const ev = Array.isArray(events) ? events[0] : null;
+    if (!ev) return null;
+    for (const tag of ev.tags || []) {
+      if (tag[0] === 'rank') {
+        const n = Number(tag[1]);
+        if (Number.isFinite(n)) return n;
+      }
+    }
+    return null;
+  } catch { return null; }
+}
+
+/**
+ * rank(observer, subject) -> number in [0, 100].
+ * Returns 0 when no rank can be found (caller filters on >= threshold).
+ * Provider-agnostic: reads whatever rank number the observer's configured
+ * rankAuthor has published in Trusted Assertions (kind 30382), regardless
+ * of which algorithm produced it.
+ */
+async function rank(observerPubkey, subjectPubkey) {
+  if (DEV_SKIP) return 100;
+  if (!observerPubkey || !subjectPubkey) return 0;
+  if (observerPubkey === subjectPubkey) return 100;
+
+  const rankAuthor = resolveRankAuthor(observerPubkey);
+  if (!rankAuthor) return 0;
+
+  const povSuffix = rankAuthor.slice(0, 8);
+
+  const cached = await fetchMeiliRank(subjectPubkey, povSuffix);
+  if (cached !== null) return cached;
+
+  const direct = await fetchStrfryTaRank(rankAuthor, subjectPubkey);
+  if (direct !== null) return direct;
+
+  return 0;
+}
+
+module.exports = { rank, resolveRankAuthor };

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -27,6 +27,11 @@ import DListActions from './pages/lists/DListActions';
 import DListRatings from './pages/lists/DListRatings';
 import NewDList from './pages/lists/NewDList';
 import NewDListItem from './pages/lists/NewDListItem';
+import BountyList from './pages/bounties/BountyList';
+import BountyNew from './pages/bounties/BountyNew';
+import BountyDetail from './pages/bounties/BountyDetail';
+import Eligibility from './pages/bounties/Eligibility';
+import PaymentsDue from './pages/bounties/PaymentsDue';
 import NodesIndex from './pages/nodes/Index';
 import NodeDetail from './pages/nodes/NodeDetail';
 import NodeOverview from './pages/nodes/NodeOverview';
@@ -123,6 +128,17 @@ const router = createBrowserRouter([
               { path: 'schema', element: <ConceptSchema />, handle: { crumb: 'Schema' } },
             ],
           },
+        ],
+      },
+      {
+        path: 'bounties',
+        handle: { crumb: 'Bounties' },
+        children: [
+          { index: true, element: <BountyList /> },
+          { path: 'new', element: <BountyNew />, handle: { crumb: 'New Bounty' } },
+          { path: 'eligible', element: <Eligibility />, handle: { crumb: 'Eligibility' } },
+          { path: 'payments-due', element: <PaymentsDue />, handle: { crumb: 'Payments Due' } },
+          { path: ':id', element: <BountyDetail />, handle: { crumb: 'Detail' } },
         ],
       },
       {

--- a/ui/src/api/bounties.js
+++ b/ui/src/api/bounties.js
@@ -1,0 +1,39 @@
+async function parseJsonOrThrow(resp) {
+  const body = await resp.json().catch(() => ({}));
+  if (!resp.ok || body.success === false) {
+    throw new Error(body.error || `HTTP ${resp.status}`);
+  }
+  return body;
+}
+
+export async function listBounties({ status = 'open' } = {}) {
+  const resp = await fetch(`/api/bounties?status=${encodeURIComponent(status)}`);
+  return (await parseJsonOrThrow(resp)).bounties ?? [];
+}
+
+export async function getBounty(id) {
+  const resp = await fetch(`/api/bounties/${encodeURIComponent(id)}`);
+  return parseJsonOrThrow(resp);
+}
+
+export async function createBounty({ listCoordinate, amountSats, criteria, expiration }) {
+  const resp = await fetch('/api/bounties', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ listCoordinate, amountSats, criteria, expiration }),
+  });
+  return (await parseJsonOrThrow(resp)).bounty;
+}
+
+export async function getEligible(viewerPubkeyHex) {
+  const resp = await fetch(`/api/bounties/eligible?viewer=${encodeURIComponent(viewerPubkeyHex)}`, {
+    credentials: 'include',
+  });
+  return (await parseJsonOrThrow(resp)).bounties ?? [];
+}
+
+export async function getPaymentsDue() {
+  const resp = await fetch('/api/bounties/mine/payments-due', { credentials: 'include' });
+  return (await parseJsonOrThrow(resp)).items ?? [];
+}

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -20,6 +20,16 @@ const mainNavItems = [
     ],
   },
   {
+    label: '💰 Bounties',
+    prefix: '/tapestry/bounties',
+    children: [
+      { to: '/tapestry/bounties', label: 'All Bounties', end: true },
+      { to: '/tapestry/bounties/eligible', label: 'Eligibility' },
+      { to: '/tapestry/bounties/payments-due', label: 'Payments Due' },
+      { to: '/tapestry/bounties/new', label: 'New Bounty' },
+    ],
+  },
+  {
     label: '🧩 Concepts',
     prefix: '/tapestry/concepts',
     children: [

--- a/ui/src/pages/bounties/BountyDetail.jsx
+++ b/ui/src/pages/bounties/BountyDetail.jsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import { getBounty } from '../../api/bounties';
+import { zapContributor } from '../../utils/zap';
+
+function short(pk) { return pk ? pk.slice(0, 8) + '…' : '—'; }
+function age(ts) {
+  if (!ts) return '—';
+  const d = Date.now() / 1000 - ts;
+  if (d < 60) return `${Math.floor(d)}s ago`;
+  if (d < 3600) return `${Math.floor(d / 60)}m ago`;
+  if (d < 86400) return `${Math.floor(d / 3600)}h ago`;
+  return `${Math.floor(d / 86400)}d ago`;
+}
+
+function getTag(event, name) {
+  const tag = event.tags?.find(t => t[0] === name);
+  return tag ? tag[1] : null;
+}
+
+function titleFromClaim(event) {
+  const names = event.tags?.find(t => t[0] === 'names');
+  if (names && names[1]) return names[1];
+  return getTag(event, 'name') || event.id?.slice(0, 12) || '(untitled)';
+}
+
+function ClaimRow({ claim, bountyAmount, onZap }) {
+  const [busy, setBusy] = useState(false);
+  const [invoice, setInvoice] = useState(null);
+  const [error, setError] = useState(null);
+
+  const paid = !!claim.zapReceipt;
+
+  async function handleZap() {
+    if (paid) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const inv = await onZap(claim.event.pubkey, claim.event.id);
+      setInvoice(inv);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div style={{ padding: '0.9rem', background: '#161b22', border: '1px solid #30363d', borderRadius: 6, marginBottom: '0.5rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '1rem' }}>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontWeight: 600 }}>{titleFromClaim(claim.event)}</div>
+          <div style={{ fontSize: '0.8rem', opacity: 0.6 }}>
+            by <code>{short(claim.event.pubkey)}</code> · {age(claim.event.created_at)}
+          </div>
+          {claim.event.content && (
+            <div style={{ marginTop: '0.4rem', fontSize: '0.9rem', opacity: 0.85 }}>{claim.event.content}</div>
+          )}
+        </div>
+        <div style={{ textAlign: 'right' }}>
+          {paid ? (
+            <span style={{ background: '#2ea043', color: '#fff', padding: '0.2rem 0.5rem', borderRadius: 3, fontSize: '0.75rem' }}>
+              Paid
+            </span>
+          ) : (
+            <button
+              onClick={handleZap}
+              disabled={busy}
+              style={{ padding: '0.4rem 0.9rem', background: '#f2a134', color: '#0d1117', border: 'none', borderRadius: 4, fontWeight: 700, cursor: busy ? 'wait' : 'pointer' }}
+            >
+              {busy ? 'Zapping…' : `Zap ${bountyAmount} sats`}
+            </button>
+          )}
+        </div>
+      </div>
+      {invoice && (
+        <div style={{ marginTop: '0.6rem', padding: '0.6rem', background: '#0d1117', borderRadius: 4 }}>
+          <div style={{ fontSize: '0.75rem', opacity: 0.6, marginBottom: 4 }}>Lightning invoice (pay with your wallet):</div>
+          <textarea readOnly value={invoice} rows={3} style={{ width: '100%', fontFamily: 'monospace', fontSize: '0.75rem', background: '#010409', color: '#c9d1d9', border: '1px solid #30363d', borderRadius: 3 }} />
+        </div>
+      )}
+      {error && <div style={{ color: '#f85149', marginTop: '0.4rem', fontSize: '0.85rem' }}>{error}</div>}
+    </div>
+  );
+}
+
+export default function BountyDetail() {
+  const { id } = useParams();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  async function refresh() {
+    try {
+      setLoading(true);
+      setError(null);
+      const payload = await getBounty(id);
+      setData(payload);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { refresh(); }, [id]);
+
+  if (loading) return <div className="page"><Breadcrumbs /><p>Loading bounty…</p></div>;
+  if (error) return <div className="page"><Breadcrumbs /><p className="error">Error: {error}</p></div>;
+  if (!data?.bounty) return <div className="page"><Breadcrumbs /><p>Bounty not found.</p></div>;
+
+  const { bounty, claims = [] } = data;
+  const derived = bounty.derivedStatus || bounty.status;
+
+  async function onZap(recipientPubkeyHex, claimEventId) {
+    return zapContributor({ recipientPubkeyHex, amountSats: bounty.amount_sats, claimEventId });
+  }
+
+  const listHref = `/tapestry/lists/${encodeURIComponent(bounty.list_coordinate)}`;
+
+  return (
+    <div className="page">
+      <Breadcrumbs />
+      <div style={{ marginBottom: '1.5rem' }}>
+        <div style={{ fontSize: '0.8rem', opacity: 0.55, letterSpacing: '0.08em', textTransform: 'uppercase' }}>Bounty</div>
+        <h1 style={{ margin: '0.2rem 0 0.4rem', color: '#f2a134' }}>
+          {bounty.amount_sats.toLocaleString()} sats
+          <span style={{ fontSize: '0.8rem', marginLeft: '0.8rem', padding: '0.2rem 0.5rem', background: derived === 'open' ? '#2ea043' : '#8b949e', color: '#fff', borderRadius: 3, verticalAlign: 'middle' }}>
+            {derived}
+          </span>
+        </h1>
+        <div style={{ fontSize: '0.9rem', opacity: 0.85 }}>{bounty.criteria}</div>
+        <div style={{ fontSize: '0.8rem', opacity: 0.6, marginTop: '0.4rem' }}>
+          issued by <code>{short(bounty.issuer_pubkey)}</code> · {age(bounty.created_at)}
+        </div>
+        <div style={{ fontSize: '0.85rem', marginTop: '0.3rem' }}>
+          target list: <Link to={listHref} style={{ fontFamily: 'monospace' }}>{bounty.list_coordinate}</Link>
+        </div>
+      </div>
+
+      <h2 style={{ fontSize: '1.2rem', marginTop: '1.5rem' }}>Claims ({claims.length})</h2>
+      {claims.length === 0 && (
+        <p style={{ opacity: 0.6 }}>No claims yet. Trusted contributors submitting list items will appear here.</p>
+      )}
+      {claims.map(c => (
+        <ClaimRow key={c.event.id} claim={c} bountyAmount={bounty.amount_sats} onZap={onZap} />
+      ))}
+    </div>
+  );
+}

--- a/ui/src/pages/bounties/BountyList.jsx
+++ b/ui/src/pages/bounties/BountyList.jsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import { listBounties } from '../../api/bounties';
+
+function short(pk) { return pk ? pk.slice(0, 8) + '…' : '—'; }
+function age(ts) {
+  if (!ts) return '—';
+  const d = Date.now() / 1000 - ts;
+  if (d < 60) return `${Math.floor(d)}s ago`;
+  if (d < 3600) return `${Math.floor(d / 60)}m ago`;
+  if (d < 86400) return `${Math.floor(d / 3600)}h ago`;
+  return `${Math.floor(d / 86400)}d ago`;
+}
+
+function StatusBadge({ status }) {
+  const color = status === 'open' ? '#2ea043' : status === 'fulfilled' ? '#58a6ff' : '#8b949e';
+  return (
+    <span style={{ background: color, color: '#fff', padding: '0.15rem 0.5rem', borderRadius: 3, fontSize: '0.75rem', textTransform: 'uppercase' }}>
+      {status}
+    </span>
+  );
+}
+
+export default function BountyList() {
+  const [bounties, setBounties] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listBounties({ status: 'open' })
+      .then(bs => { if (!cancelled) setBounties(bs); })
+      .catch(e => { if (!cancelled) setError(e.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <div className="page">
+      <Breadcrumbs />
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+        <h1>Bounties</h1>
+        <Link to="new" className="button" style={{ background: '#1f6feb', color: '#fff', padding: '0.5rem 1rem', borderRadius: 4, textDecoration: 'none' }}>
+          + New Bounty
+        </Link>
+      </div>
+
+      {loading && <p>Loading bounties…</p>}
+      {error && <p className="error">Error: {error}</p>}
+      {!loading && !error && bounties.length === 0 && (
+        <p style={{ opacity: 0.6 }}>No open bounties yet. Be the first to incentivize a list!</p>
+      )}
+
+      <div style={{ display: 'grid', gap: '0.75rem' }}>
+        {bounties.map(b => (
+          <Link
+            key={b.id}
+            to={b.id}
+            style={{ display: 'block', padding: '1rem', background: '#161b22', border: '1px solid #30363d', borderRadius: 6, textDecoration: 'none', color: 'inherit' }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+              <div>
+                <div style={{ fontSize: '0.85rem', opacity: 0.55 }}>List</div>
+                <div style={{ fontFamily: 'monospace', fontSize: '0.85rem', marginBottom: '0.4rem' }}>{b.list_coordinate}</div>
+                <div style={{ marginBottom: '0.2rem' }}>{b.criteria}</div>
+                <div style={{ fontSize: '0.8rem', opacity: 0.6 }}>
+                  issued by <code>{short(b.issuer_pubkey)}</code> · {age(b.created_at)}
+                </div>
+              </div>
+              <div style={{ textAlign: 'right' }}>
+                <div style={{ color: '#f2a134', fontSize: '1.4rem', fontWeight: 700 }}>{b.amount_sats.toLocaleString()}</div>
+                <div style={{ fontSize: '0.7rem', opacity: 0.6, letterSpacing: '0.05em' }}>SATS</div>
+                <div style={{ marginTop: '0.4rem' }}>
+                  <StatusBadge status={b.derivedStatus || b.status} />
+                </div>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/bounties/BountyNew.jsx
+++ b/ui/src/pages/bounties/BountyNew.jsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import { useAuth } from '../../context/AuthContext';
+import { createBounty } from '../../api/bounties';
+
+const COORDINATE_RE = /^\d+:[0-9a-f]{64}:.+$/;
+
+export default function BountyNew() {
+  const { user, loading: authLoading } = useAuth();
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+
+  const [listCoordinate, setListCoordinate] = useState(params.get('concept') || '');
+  const [amountSats, setAmountSats] = useState(1000);
+  const [criteria, setCriteria] = useState('');
+  const [expiration, setExpiration] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!authLoading && !user?.pubkey) {
+      navigate('/', { replace: true });
+    }
+  }, [authLoading, user, navigate]);
+
+  const valid = COORDINATE_RE.test(listCoordinate)
+    && Number.isInteger(Number(amountSats)) && Number(amountSats) > 0
+    && criteria.trim().length > 0;
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (!valid) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const row = await createBounty({
+        listCoordinate,
+        amountSats: Number(amountSats),
+        criteria: criteria.trim(),
+        expiration: expiration ? Math.floor(new Date(expiration).getTime() / 1000) : undefined,
+      });
+      navigate(`/tapestry/bounties/${row.id}`);
+    } catch (err) {
+      setError(err.message);
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="page">
+      <Breadcrumbs />
+      <h1>New Bounty</h1>
+      <p style={{ opacity: 0.7 }}>
+        Attach a bounty to a list — anyone Alice trusts (rank ≥ 2) will see it on their eligibility dashboard
+        and can submit items to earn sats.
+      </p>
+
+      <form onSubmit={handleSubmit} style={{ display: 'grid', gap: '1rem', maxWidth: 600 }}>
+        <label>
+          <div style={{ marginBottom: 4, fontWeight: 600 }}>Target list coordinate</div>
+          <input
+            type="text"
+            value={listCoordinate}
+            onChange={e => setListCoordinate(e.target.value)}
+            placeholder="39998:&lt;curator-pubkey&gt;:&lt;d-tag&gt;"
+            required
+            style={{ width: '100%', padding: '0.5rem', fontFamily: 'monospace', background: '#0d1117', border: '1px solid #30363d', borderRadius: 4, color: '#c9d1d9' }}
+          />
+          <small style={{ opacity: 0.6 }}>a-tag format: kind:pubkey:d-tag</small>
+        </label>
+
+        <label>
+          <div style={{ marginBottom: 4, fontWeight: 600 }}>Reward (sats)</div>
+          <input
+            type="number"
+            min={1}
+            step={1}
+            value={amountSats}
+            onChange={e => setAmountSats(e.target.value)}
+            required
+            style={{ width: '100%', padding: '0.5rem', background: '#0d1117', border: '1px solid #30363d', borderRadius: 4, color: '#c9d1d9' }}
+          />
+        </label>
+
+        <label>
+          <div style={{ marginBottom: 4, fontWeight: 600 }}>Criteria</div>
+          <textarea
+            rows={4}
+            value={criteria}
+            onChange={e => setCriteria(e.target.value)}
+            placeholder="What kind of contributions earn the bounty? e.g. 'Names of sleepy dwarfs in English folklore.'"
+            required
+            style={{ width: '100%', padding: '0.5rem', background: '#0d1117', border: '1px solid #30363d', borderRadius: 4, color: '#c9d1d9' }}
+          />
+        </label>
+
+        <label>
+          <div style={{ marginBottom: 4, fontWeight: 600 }}>Expiration (optional)</div>
+          <input
+            type="datetime-local"
+            value={expiration}
+            onChange={e => setExpiration(e.target.value)}
+            style={{ padding: '0.5rem', background: '#0d1117', border: '1px solid #30363d', borderRadius: 4, color: '#c9d1d9' }}
+          />
+        </label>
+
+        {error && <div className="error" style={{ color: '#f85149' }}>{error}</div>}
+
+        <div>
+          <button
+            type="submit"
+            disabled={!valid || submitting}
+            style={{ padding: '0.6rem 1.2rem', background: valid && !submitting ? '#1f6feb' : '#30363d', color: '#fff', border: 'none', borderRadius: 4, cursor: valid && !submitting ? 'pointer' : 'not-allowed' }}
+          >
+            {submitting ? 'Publishing…' : 'Publish Bounty'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/ui/src/pages/bounties/Eligibility.jsx
+++ b/ui/src/pages/bounties/Eligibility.jsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import { useAuth } from '../../context/AuthContext';
+import { getEligible } from '../../api/bounties';
+
+function short(pk) { return pk ? pk.slice(0, 8) + '…' : '—'; }
+function age(ts) {
+  if (!ts) return '—';
+  const d = Date.now() / 1000 - ts;
+  if (d < 60) return `${Math.floor(d)}s ago`;
+  if (d < 3600) return `${Math.floor(d / 60)}m ago`;
+  if (d < 86400) return `${Math.floor(d / 3600)}h ago`;
+  return `${Math.floor(d / 86400)}d ago`;
+}
+
+export default function Eligibility() {
+  const { user, loading: authLoading } = useAuth();
+  const [bounties, setBounties] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user?.pubkey) { setLoading(false); return; }
+    let cancelled = false;
+    getEligible(user.pubkey)
+      .then(bs => { if (!cancelled) setBounties(bs); })
+      .catch(e => { if (!cancelled) setError(e.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [authLoading, user?.pubkey]);
+
+  if (authLoading) return <div className="page"><Breadcrumbs /><p>Loading…</p></div>;
+  if (!user?.pubkey) {
+    return (
+      <div className="page">
+        <Breadcrumbs />
+        <h1>Eligibility</h1>
+        <p style={{ opacity: 0.7 }}>Sign in with a Nostr extension to see bounties you're eligible to claim.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page">
+      <Breadcrumbs />
+      <h1>Eligibility</h1>
+      <p style={{ opacity: 0.7 }}>
+        Bounties issued by people whose web of trust says you're trustworthy enough to contribute
+        (Trusted Assertion rank ≥ 2).
+      </p>
+
+      {loading && <p>Checking eligibility…</p>}
+      {error && <p className="error" style={{ color: '#f85149' }}>Error: {error}</p>}
+      {!loading && !error && bounties.length === 0 && (
+        <p style={{ opacity: 0.6 }}>
+          No bounties are visible to you yet. This can mean (a) no open bounties exist, or
+          (b) no bounty issuer has your pubkey at rank ≥ 2 in their WoT.
+        </p>
+      )}
+
+      <div style={{ display: 'grid', gap: '0.75rem' }}>
+        {bounties.map(b => {
+          const claimHref = `/tapestry/lists/${encodeURIComponent(b.list_coordinate)}/items/new?bounty=${encodeURIComponent(b.id)}`;
+          return (
+            <div key={b.id} style={{ padding: '1rem', background: '#161b22', border: '1px solid #30363d', borderRadius: 6 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '1rem' }}>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: '0.85rem', opacity: 0.55 }}>List</div>
+                  <div style={{ fontFamily: 'monospace', fontSize: '0.85rem', marginBottom: '0.4rem' }}>{b.list_coordinate}</div>
+                  <div style={{ marginBottom: '0.3rem' }}>{b.criteria}</div>
+                  <div style={{ fontSize: '0.8rem', opacity: 0.7 }}>
+                    issued by <code>{short(b.issuer_pubkey)}</code>
+                    <span style={{ marginLeft: '0.6rem', background: '#1f6feb', color: '#fff', padding: '0.1rem 0.4rem', borderRadius: 3 }}>
+                      rank {b.issuerRank}
+                    </span>
+                    <span style={{ marginLeft: '0.5rem' }}>· {age(b.created_at)}</span>
+                  </div>
+                </div>
+                <div style={{ textAlign: 'right', minWidth: 140 }}>
+                  <div style={{ color: '#f2a134', fontSize: '1.4rem', fontWeight: 700 }}>{b.amount_sats.toLocaleString()}</div>
+                  <div style={{ fontSize: '0.7rem', opacity: 0.6, letterSpacing: '0.05em', marginBottom: '0.5rem' }}>SATS</div>
+                  <Link
+                    to={claimHref}
+                    style={{ display: 'inline-block', padding: '0.4rem 0.9rem', background: '#2ea043', color: '#fff', borderRadius: 4, textDecoration: 'none', fontWeight: 600 }}
+                  >
+                    Claim →
+                  </Link>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/bounties/PaymentsDue.jsx
+++ b/ui/src/pages/bounties/PaymentsDue.jsx
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import { useAuth } from '../../context/AuthContext';
+import { getPaymentsDue } from '../../api/bounties';
+import { zapContributor } from '../../utils/zap';
+
+function short(pk) { return pk ? pk.slice(0, 8) + '…' : '—'; }
+
+function PendingClaimRow({ claim, bountyAmount }) {
+  const [busy, setBusy] = useState(false);
+  const [invoice, setInvoice] = useState(null);
+  const [error, setError] = useState(null);
+
+  async function handleZap() {
+    setBusy(true);
+    setError(null);
+    try {
+      const inv = await zapContributor({
+        recipientPubkeyHex: claim.event.pubkey,
+        amountSats: bountyAmount,
+        claimEventId: claim.event.id,
+      });
+      setInvoice(inv);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div style={{ padding: '0.75rem', background: '#0d1117', border: '1px solid #30363d', borderRadius: 4, marginBottom: '0.4rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '1rem' }}>
+        <div style={{ flex: 1, fontFamily: 'monospace', fontSize: '0.85rem' }}>
+          <div><code>{short(claim.event.pubkey)}</code></div>
+          <div style={{ opacity: 0.8 }}>{claim.event.content?.slice(0, 80) || claim.event.id?.slice(0, 16)}</div>
+        </div>
+        <button
+          onClick={handleZap}
+          disabled={busy}
+          style={{ padding: '0.35rem 0.8rem', background: '#f2a134', color: '#0d1117', border: 'none', borderRadius: 4, fontWeight: 700, cursor: busy ? 'wait' : 'pointer' }}
+        >
+          {busy ? 'Zapping…' : `Zap ${bountyAmount}`}
+        </button>
+      </div>
+      {invoice && (
+        <textarea readOnly value={invoice} rows={2} style={{ width: '100%', marginTop: 6, fontFamily: 'monospace', fontSize: '0.7rem', background: '#010409', color: '#c9d1d9', border: '1px solid #30363d' }} />
+      )}
+      {error && <div style={{ color: '#f85149', fontSize: '0.8rem', marginTop: 4 }}>{error}</div>}
+    </div>
+  );
+}
+
+export default function PaymentsDue() {
+  const { user, loading: authLoading } = useAuth();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    getPaymentsDue()
+      .then(setItems)
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (authLoading || !user?.pubkey) return;
+    refresh();
+  }, [authLoading, user?.pubkey, refresh]);
+
+  if (authLoading) return <div className="page"><Breadcrumbs /><p>Loading…</p></div>;
+  if (!user?.pubkey) {
+    return <div className="page"><Breadcrumbs /><h1>Payments Due</h1><p style={{ opacity: 0.7 }}>Sign in to see claims on your bounties.</p></div>;
+  }
+
+  return (
+    <div className="page">
+      <Breadcrumbs />
+      <h1>Payments Due</h1>
+      <p style={{ opacity: 0.7 }}>Claims on your bounties that haven't been zapped yet. Click Zap to pay.</p>
+
+      {loading && <p>Loading…</p>}
+      {error && <p className="error" style={{ color: '#f85149' }}>Error: {error}</p>}
+      {!loading && !error && items.length === 0 && (
+        <p style={{ opacity: 0.6 }}>All caught up. No pending claims on your bounties.</p>
+      )}
+
+      {items.map(({ bounty, pendingClaims }) => (
+        <div key={bounty.id} style={{ marginBottom: '1.25rem', padding: '0.9rem', background: '#161b22', border: '1px solid #30363d', borderRadius: 6 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '0.6rem' }}>
+            <div>
+              <Link to={`/tapestry/bounties/${bounty.id}`} style={{ fontWeight: 700, color: '#58a6ff' }}>
+                {bounty.criteria.slice(0, 60)}
+              </Link>
+              <div style={{ fontSize: '0.8rem', opacity: 0.6, fontFamily: 'monospace' }}>{bounty.list_coordinate}</div>
+            </div>
+            <div style={{ color: '#f2a134', fontWeight: 700 }}>{bounty.amount_sats.toLocaleString()} sats</div>
+          </div>
+          {pendingClaims.map(c => (
+            <PendingClaimRow key={c.event.id} claim={c} bountyAmount={bounty.amount_sats} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/pages/lists/DListActions.jsx
+++ b/ui/src/pages/lists/DListActions.jsx
@@ -1,8 +1,36 @@
+import { Link, useOutletContext } from 'react-router-dom';
+
+function getTag(event, name, index = 1) {
+  const tag = event.tags?.find(t => t[0] === name);
+  return tag ? tag[index] : null;
+}
+
 export default function DListActions() {
+  const { event } = useOutletContext() || {};
+  const dTag = event && getTag(event, 'd');
+  const coordinate = event && dTag ? `${event.kind}:${event.pubkey}:${dTag}` : null;
+
   return (
     <div className="dlist-actions">
       <h2>Actions</h2>
-      <p className="placeholder">Coming soon — import to Neo4j, sync to remote relay, add items, and more.</p>
+
+      {coordinate && (
+        <div style={{ padding: '1rem', background: '#161b22', border: '1px solid #30363d', borderRadius: 6, marginBottom: '1rem' }}>
+          <div style={{ fontSize: '0.85rem', opacity: 0.6, marginBottom: '0.3rem' }}>Incentivize contributions</div>
+          <div style={{ marginBottom: '0.6rem' }}>
+            Attach a Lightning bounty to this list. People you trust (rank ≥ 2) will see it on their
+            eligibility dashboard and can submit items to earn sats.
+          </div>
+          <Link
+            to={`/tapestry/bounties/new?concept=${encodeURIComponent(coordinate)}`}
+            style={{ display: 'inline-block', padding: '0.55rem 1.1rem', background: '#f2a134', color: '#0d1117', borderRadius: 4, textDecoration: 'none', fontWeight: 700 }}
+          >
+            💰 Incentivize — pay people to add items
+          </Link>
+        </div>
+      )}
+
+      <p className="placeholder">More actions coming soon — import to Neo4j, sync to remote relay, etc.</p>
     </div>
   );
 }

--- a/ui/src/pages/lists/NewDListItem.jsx
+++ b/ui/src/pages/lists/NewDListItem.jsx
@@ -1,8 +1,9 @@
 import { useState, useMemo, useEffect } from 'react';
-import { useNavigate, useOutletContext } from 'react-router-dom';
+import { useNavigate, useOutletContext, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import { childDTag, randomDTag } from '../../utils/dtag';
+import { getBounty } from '../../api/bounties';
 
 function getTag(event, name, index = 1) {
   const tag = event.tags?.find(t => t[0] === name);
@@ -17,6 +18,18 @@ export default function NewDListItem() {
   const navigate = useNavigate();
   const { user } = useAuth();
   const { event: parentEvent } = useOutletContext();
+  const [searchParams] = useSearchParams();
+  const bountyId = searchParams.get('bounty');
+  const [bountyInfo, setBountyInfo] = useState(null);
+
+  useEffect(() => {
+    if (!bountyId) return;
+    let cancelled = false;
+    getBounty(bountyId)
+      .then(payload => { if (!cancelled) setBountyInfo(payload); })
+      .catch(() => { /* silent; banner just won't render */ });
+    return () => { cancelled = true; };
+  }, [bountyId]);
 
   // Derive parent list info
   const parentName = getTag(parentEvent, 'names', 1) || getTag(parentEvent, 'name', 1) || '(unnamed)';
@@ -194,6 +207,23 @@ export default function NewDListItem() {
 
   return (
     <div className="new-dlist-item">
+      {bountyInfo?.bounty && (
+        <div style={{ padding: '0.9rem 1rem', background: '#1f3a55', border: '1px solid #1f6feb', borderRadius: 6, marginBottom: '1rem' }}>
+          <div style={{ fontSize: '0.85rem', opacity: 0.85, marginBottom: '0.25rem' }}>
+            💰 You're fulfilling a bounty
+          </div>
+          <div style={{ fontWeight: 600, marginBottom: '0.2rem' }}>
+            {bountyInfo.bounty.criteria}
+          </div>
+          <div style={{ fontSize: '0.85rem', opacity: 0.8 }}>
+            Issuer: <code>{bountyInfo.bounty.issuer_pubkey.slice(0, 8)}…</code>
+            {' · '}
+            Reward: <strong style={{ color: '#f2a134' }}>{bountyInfo.bounty.amount_sats.toLocaleString()} sats</strong>
+            {' · '}
+            The issuer (or anyone) may zap you if they approve your submission.
+          </div>
+        </div>
+      )}
       <h2>Add Item to "{parentName}"</h2>
 
       <div className="form-section">

--- a/ui/src/utils/zap.js
+++ b/ui/src/utils/zap.js
@@ -1,0 +1,89 @@
+/**
+ * Client-side NIP-57 zap flow.
+ *
+ * zapContributor({ recipientPubkeyHex, amountSats, claimEventId })
+ *   -> Lightning invoice string
+ *
+ * Callers must catch errors and show a friendly message (e.g. "This
+ * contributor hasn't set up Lightning receiving — you can't zap them yet")
+ * when the recipient has no lud16 or the LNURL endpoint doesn't support
+ * Nostr zaps. We deliberately throw instead of silently failing so the UI
+ * can't send an invoice to the wrong place.
+ */
+
+async function fetchRecipientLud16(pubkeyHex) {
+  const resp = await fetch(`/api/profiles?pubkeys=${pubkeyHex}`);
+  if (!resp.ok) throw new Error(`profile fetch failed (${resp.status})`);
+  const payload = await resp.json();
+  const profiles = payload?.profiles ?? payload;
+  const entry = Array.isArray(profiles) ? profiles[0] : profiles?.[pubkeyHex] ?? null;
+  const lud16 = entry?.lud16 ?? entry?.lud06 ?? null;
+  if (!lud16) throw new Error('Recipient has no Lightning address');
+  return lud16;
+}
+
+async function fetchLnurlPayData(lud16) {
+  const [user, domain] = lud16.split('@');
+  if (!user || !domain) throw new Error(`Malformed lud16: ${lud16}`);
+  const resp = await fetch(`https://${domain}/.well-known/lnurlp/${user}`);
+  if (!resp.ok) throw new Error(`LNURL endpoint returned ${resp.status}`);
+  const data = await resp.json();
+  if (!data?.allowsNostr) throw new Error("Recipient's LNURL does not support Nostr zaps");
+  return data;
+}
+
+async function fetchRelayList(recipientPubkeyHex) {
+  const filter = { kinds: [10002], authors: [recipientPubkeyHex], limit: 1 };
+  try {
+    const resp = await fetch(`/api/strfry/scan?filter=${encodeURIComponent(JSON.stringify(filter))}`);
+    if (!resp.ok) return [];
+    const payload = await resp.json();
+    const events = payload?.events ?? (Array.isArray(payload) ? payload : []);
+    const tags = events[0]?.tags ?? [];
+    return tags.filter(t => t[0] === 'r').map(t => t[1]);
+  } catch { return []; }
+}
+
+export async function zapContributor({ recipientPubkeyHex, amountSats, claimEventId }) {
+  if (!window.nostr) throw new Error('No NIP-07 signer (nos2x / Alby) detected');
+  if (!/^[0-9a-f]{64}$/i.test(recipientPubkeyHex)) throw new Error('recipientPubkeyHex must be hex');
+  if (!Number.isInteger(amountSats) || amountSats <= 0) throw new Error('amountSats must be a positive integer');
+  if (!claimEventId) throw new Error('claimEventId is required');
+
+  const lud16 = await fetchRecipientLud16(recipientPubkeyHex);
+  const lnurlData = await fetchLnurlPayData(lud16);
+
+  const amountMsats = amountSats * 1000;
+  if (lnurlData.minSendable && amountMsats < lnurlData.minSendable) {
+    throw new Error(`Amount below recipient minimum (${Math.ceil(lnurlData.minSendable / 1000)} sats)`);
+  }
+  if (lnurlData.maxSendable && amountMsats > lnurlData.maxSendable) {
+    throw new Error(`Amount above recipient maximum (${Math.floor(lnurlData.maxSendable / 1000)} sats)`);
+  }
+
+  const relays = await fetchRelayList(recipientPubkeyHex);
+  const relayTag = ['relays', ...(relays.length > 0 ? relays : ['wss://localhost:7777'])];
+
+  const zapRequest = {
+    kind: 9734,
+    created_at: Math.floor(Date.now() / 1000),
+    content: '',
+    tags: [
+      ['p', recipientPubkeyHex],
+      ['e', claimEventId],
+      ['amount', String(amountMsats)],
+      relayTag,
+    ],
+  };
+  const signed = await window.nostr.signEvent(zapRequest);
+
+  const callbackUrl = new URL(lnurlData.callback);
+  callbackUrl.searchParams.set('amount', String(amountMsats));
+  callbackUrl.searchParams.set('nostr', JSON.stringify(signed));
+
+  const invoiceResp = await fetch(callbackUrl.toString());
+  if (!invoiceResp.ok) throw new Error(`LNURL callback returned ${invoiceResp.status}`);
+  const invoiceData = await invoiceResp.json();
+  if (!invoiceData?.pr) throw new Error('LNURL callback did not return an invoice');
+  return invoiceData.pr;
+}


### PR DESCRIPTION
## Summary

Adds a bounty system to tapestry: a list curator (Alice) offers Lightning sats to trusted contributors (Bob) who add items to her list. The loop works entirely on existing tapestry primitives — no new event kinds, no new submission endpoint.

- **Bounty = SQLite row** (app-level metadata; not broadcast to relays). Schema in `src/db/bounties.js`. DB file at `/var/lib/brainstorm/bounties.db` (prod, on the existing `tapestry-data` volume) or `./data/bounties.db` (dev).
- **Claim = ordinary kind-39999 ListItem** published through tapestry's existing `/tapestry/lists/:id/items/new` flow. Correlation is implicit: items on the bountied list by trusted pubkeys after `bounty.created_at`.
- **Payment = NIP-57 zap** tagging the claim's event id. Client signs kind-9734 → LNURL callback → invoice. kind-9735 receipt is proof-of-payment.
- **Trust check = Trusted Assertions** (kind-30382), provider-agnostic. Reads `wot_rank_<povSuffix>` on the viewer's Meilisearch profile; falls back to strfry scan. No GrapeRank-specific code paths — any WoT service provider works.

Full design in `BIBLE.md §22`.

## New files

| File | Role |
|---|---|
| `src/db/bounties.js` | better-sqlite3 module + schema + CRUD helpers |
| `src/api/bounties.js` | 5 endpoints (POST/GET `/api/bounties`, `/:id`, `/eligible`, `/mine/payments-due`) |
| `src/lib/trust-rank.js` | Provider-agnostic `rank(observer, subject)` reader |
| `ui/src/api/bounties.js` | Frontend fetch wrappers |
| `ui/src/utils/zap.js` | Client-side NIP-57 zap flow |
| `ui/src/pages/bounties/{BountyList,BountyNew,BountyDetail,Eligibility,PaymentsDue}.jsx` | 5 React pages under `/tapestry/bounties/*` |
| `docs/magic-carpet-v2-pivot/` | Preserved 2026-04-14 meeting notes from David Streyhorn |

## Modifications

- `src/api/index.js` — mount bounties router
- `ui/src/App.jsx` — 5 new routes under `/tapestry/bounties/*`
- `ui/src/components/Layout.jsx` — sidebar entry
- `ui/src/pages/lists/DListActions.jsx` — "Incentivize" button
- `ui/src/pages/lists/NewDListItem.jsx` — claim banner when arrived via `?bounty=<id>`
- `BIBLE.md` — adds §22 documenting the design
- `package.json` — adds `better-sqlite3` and `uuid`
- `.gitignore` — excludes `/data/bounties.db*`

## Test plan

Walk through the Sleepy Dwarfs test vector from the meeting notes:

### Pre-demo setup
- [ ] Boot the stack: `cp .env.example .env && npm install && docker compose up -d && npm run dev`
- [ ] `sqlite3 data/bounties.db '.schema'` confirms the `bounties` table is created on server boot
- [ ] Set `DEV_SKIP_TRUST_CHECK=true` in `.env` for local testing (bypasses the TA rank gate; remove before prod)
- [ ] Alice + Bob both need a `lud16` in their kind-0 profiles for zaps to flow

### Walkthrough
- [ ] Sign in as Alice via NIP-07 (`GET /api/auth/status` returns `{ authenticated: true, pubkey: <alice-hex> }`)
- [ ] Alice creates a "Sleepy Dwarfs" list via existing `/tapestry/lists/new` flow
- [ ] `/tapestry/lists/<coord>` → **Actions** tab → **Incentivize** button → lands on `/tapestry/bounties/new?concept=<coord>` with the list pre-filled
- [ ] Amount 1000, criteria "Names of sleepy dwarfs in English folklore" → submit → redirected to `/tapestry/bounties/<id>`
- [ ] `sqlite3 data/bounties.db 'SELECT * FROM bounties'` shows the row
- [ ] `/tapestry/bounties` shows the bounty at the top
- [ ] Second browser as Bob. Sign in. `/tapestry/bounties/eligible` shows Alice's bounty (rank ≥ 2 required; dev skip grants 100)
- [ ] Click **Claim** → deeplinks to `/tapestry/lists/<coord>/items/new?bounty=<id>` with banner "You're fulfilling Alice's bounty..."
- [ ] Bob adds "Dozy" via the unchanged item-add flow → kind-39999 event published
- [ ] Back on Alice's `/tapestry/bounties/<id>` — "Dozy" appears under Claims
- [ ] Click **Zap** on Dozy → signs kind-9734 → LNURL callback returns an invoice
- [ ] (Optional) pay the invoice from a wallet → kind-9735 receipt propagates → bounty derivedStatus transitions to `fulfilled`

### Smoke tests (already passing)
- [x] `npm run build` in `ui/` — Vite build succeeds (~7s)
- [x] `node --check` on all new/modified server files
- [x] better-sqlite3 native module loads + basic CRUD via the `bounties` module

## Out of scope (PoC)

- Broadcasting bounties externally (SQLite-only by design)
- Adjustable trust threshold (hardcoded `rank ≥ 2`)
- Issuer pay-out reputation / history
- Migrations framework (schema is idempotent via `CREATE IF NOT EXISTS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)