### PR TITLE
Add curated-dlist firmware concept stub

### DIFF
--- a/firmware/versions/v1.0.0/concepts/curated-dlist/concept-header.json
+++ b/firmware/versions/v1.0.0/concepts/curated-dlist/concept-header.json
@@ -1,0 +1,21 @@
+{
+  "word": {
+    "slug": "concept-header-for-the-concept-of-curated-dlists",
+    "name": "concept header for the concept of curated dlists",
+    "title": "Concept Header for the Concept of Curated Dlists",
+    "wordTypes": ["word", "conceptHeader"]
+  },
+  "conceptHeader": {
+    "description": "These are the Decentralized Lists that I am delegating to my community for active curation. Each list requires a Trust Determination method, a publication method, and a publication schedule.",
+    "oNames": { "singular": "curated dlist", "plural": "curated dlists" },
+    "oSlugs": { "singular": "curated-dlist", "plural": "curated-dlists" },
+    "oKeys": { "singular": "curatedDlist", "plural": "curatedDlists" },
+    "oTitles": { "singular": "Curated Dlist", "plural": "Curated Dlist" },
+    "oLabels": { "singular": "CuratedDlist", "plural": "CuratedDlists" },
+    "x-tapestry": {
+      "neo4j": {
+        "nodeLabelRequired": false
+      }
+    }
+  }
+}

--- a/firmware/versions/v1.0.0/concepts/curated-dlist/json-schema.json
+++ b/firmware/versions/v1.0.0/concepts/curated-dlist/json-schema.json
@@ -1,0 +1,75 @@
+{
+    "word": {
+        "slug": "json-schema-for-the-concept-of-curated-dlists",
+        "title": "JSON Schema for the Concept of Curated Dlists",
+        "name": "JSON Schema for the concept of curated dlists",
+        "description": "",
+        "wordTypes": [
+            "word",
+            "jsonSchema"
+        ],
+        "coreMemberOf": [
+            {
+                "slug": "concept-header-for-the-concept-of-curated-dlists",
+                "uuid": "<uuid>"
+            }
+        ]
+    },
+    "jsonSchema": {
+        "name": "curated dlist",
+        "title": "Curated Dlist",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "definitions": {},
+        "type": "object",
+        "required": [
+            "curatedDlist"
+        ],
+        "properties": {
+            "curatedDlist": {
+                "type": "object",
+                "name": "curated dlist",
+                "title": "Curated Dlist",
+                "slug": "curated-dlist",
+                "description": "Metadata about this curated dlist node",
+                "required": [
+                    "slug"
+                ],
+                "properties": {
+                    "slug": {
+                        "type": "string",
+                        "name": "slug",
+                        "title": "Slug",
+                        "slug": "slug",
+                        "description": "Unique identifier for this curated dlist"
+                    },
+                    "trustSource": {
+                        "type": "string",
+                        "name": "trust source",
+                        "title": "Trust Source",
+                        "slug": "trust-source",
+                        "description": "The trust source used in the calculation of the composite score for this dlist (trusted assertions, follows, some other trusted list, etc)"
+                    },
+                    "publicationMethods": {
+                        "type": "string",
+                        "name": "publication methods",
+                        "title": "Publication Methods",
+                        "slug": "publication-methods",
+                        "description": "The methods for publication of the scored dlist (trusted lists vs trusted assertions; include metric or not; selected cutoff; etc)"
+                    },
+                    "publicationSchedule": {
+                        "type": "string",
+                        "name": "publication schedule",
+                        "title": "Publication Schedule",
+                        "slug": "publication-schedule",
+                        "description": "The schedule for publication of the scored dlist (scheduled, event-triggered, etc)"
+                    }
+                },
+                "x-tapestry": {
+                    "unique": [
+                        "slug"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/firmware/versions/v1.0.0/concepts/curated-dlist/manifest.json
+++ b/firmware/versions/v1.0.0/concepts/curated-dlist/manifest.json
@@ -1,0 +1,8 @@
+{
+    "HAS_ELEMENT": [
+        
+    ],
+    "IS_A_SUPERSET_OF": [
+
+    ]
+}


### PR DESCRIPTION
## Summary

- Adds a stub firmware concept for **curated dlists** — Decentralized Lists delegated to a community for active curation. Each requires a Trust Determination method, a publication method, and a publication schedule.
- `concept-header.json` and `json-schema.json` are populated; `manifest.json` is empty (no wired elements or supersets yet).

## Files

- `firmware/versions/v1.0.0/concepts/curated-dlist/concept-header.json`
- `firmware/versions/v1.0.0/concepts/curated-dlist/json-schema.json` — defines `slug`, `trustSource`, `publicationMethods`, `publicationSchedule`
- `firmware/versions/v1.0.0/concepts/curated-dlist/manifest.json` (empty stub)

## Notes

These files were sitting untracked in a local checkout dating back to 2026-03-30. A second untracked directory (`curated-dlist-scoring-method/`) was dropped because its file contents were a stale copy of `dog-breed/`, not actual scoring-method content — worth re-creating fresh later.

## Test plan

- [ ] Confirm firmware install picks up the new concept (`POST /api/firmware/install`)
- [ ] Verify the concept appears in `/tapestry/settings/firmware`
- [ ] Confirm the JSON schema renders correctly in the concept detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)