### PR TITLE
Fix /kg/ URLs in Relay Discovery feature

### DIFF
--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -47,7 +47,7 @@ const mainNavItems = [
       { to: '/tapestry/users/search', label: 'Search' },
     ],
   },
-  { to: '/kg/relay-discovery', label: '📡 Relay Discovery' },
+  { to: '/tapestry/relay-discovery', label: '📡 Relay Discovery' },
 ];
 
 const managementNavItems = [

--- a/ui/src/components/TrustWidget.jsx
+++ b/ui/src/components/TrustWidget.jsx
@@ -161,7 +161,7 @@ export default function TrustWidget() {
 
           <div className="trust-widget-footer">
             Changes apply live across the app via TrustContext.{' '}
-            <a href="/kg/grapevine/trust-determination" className="bsp-id-link">Full settings →</a>
+            <a href="/tapestry/grapevine/trust-determination" className="bsp-id-link">Full settings →</a>
           </div>
         </div>
       )}

--- a/ui/src/pages/relay-discovery/RelayDiscovery.jsx
+++ b/ui/src/pages/relay-discovery/RelayDiscovery.jsx
@@ -358,7 +358,7 @@ function PipelinePanel() {
 
         <div className="rdisc-pipeline-footer">
           After all five steps complete, go to{' '}
-          <a href="/kg/grapevine/trust-determination" className="rdisc-trust-link" style={{ marginLeft: 0 }}>
+          <a href="/tapestry/grapevine/trust-determination" className="rdisc-trust-link" style={{ marginLeft: 0 }}>
             Trust Determination
           </a>
           {' '}and switch scoring to <em>Trusted Assertions (rank)</em>. The aggregated
@@ -445,7 +445,7 @@ function EndorserList({ pubkeys, weights, profiles }) {
         return (
           <a
             key={pk}
-            href={`/kg/brainstorm-search/user/${pk}`}
+            href={`/user/${pk}`}
             target="_blank"
             rel="noopener noreferrer"
             className={`rdisc-endorser ${cls}`}
@@ -584,7 +584,7 @@ function AggregatedTab() {
             ? <code>{povPubkey.slice(0, 12)}…{povPubkey.slice(-8)}</code>
             : <em>(none — defaulting to owner)</em>}
         </span>
-        <a href="/kg/grapevine/trust-determination" className="rdisc-trust-link">change →</a>
+        <a href="/tapestry/grapevine/trust-determination" className="rdisc-trust-link">change →</a>
         {trustLoading && <span className="rdisc-trust-status">resolving weights…</span>}
         {trustError && <span className="rdisc-trust-status rdisc-trust-error" title={trustError}>⚠ weights unavailable</span>}
       </div>
@@ -730,7 +730,7 @@ export default function RelayDiscovery() {
         <p className="page-description">
           Relays imported into Neo4j, ranked by your trust-weighted endorser score.
           Looking for the relays <em>a specific account</em> has published? Use{' '}
-          <a href="/kg/brainstorm-search" className="bsp-id-link">brainstorm-search</a>{' '}
+          <a href="/" className="bsp-id-link">brainstorm-search</a>{' '}
           to find the account — each profile's page has a Relays section.
         </p>
       </div>


### PR DESCRIPTION
## Summary

Vinney's relay-discovery feature (merged via #35) was authored before the URL refactor. The refactor promoted Brainstorm Search to root `/` and moved the dashboard to `/tapestry/`. His code still had 6 stale `/kg/` URL references which 404 on the current site.

## Changes (6 URLs across 3 files)

| File:Line | Before | After |
|-----------|--------|-------|
| `ui/src/components/Layout.jsx:50` | `/kg/relay-discovery` | `/tapestry/relay-discovery` |
| `ui/src/pages/relay-discovery/RelayDiscovery.jsx:361` | `/kg/grapevine/trust-determination` | `/tapestry/grapevine/trust-determination` |
| `ui/src/pages/relay-discovery/RelayDiscovery.jsx:448` | `/kg/brainstorm-search/user/${pk}` | `/user/${pk}` |
| `ui/src/pages/relay-discovery/RelayDiscovery.jsx:587` | `/kg/grapevine/trust-determination` | `/tapestry/grapevine/trust-determination` |
| `ui/src/pages/relay-discovery/RelayDiscovery.jsx:733` | `/kg/brainstorm-search` | `/` |
| `ui/src/components/TrustWidget.jsx:164` | `/kg/grapevine/trust-determination` | `/tapestry/grapevine/trust-determination` |

Two of these aren't simple `kg → tapestry` swaps — the ones under `/kg/brainstorm-search/...` reference the old URL structure before Brainstorm Search was promoted to root. Those become root-relative paths.

## Verification

- Text-level: `grep -E "/kg/" ui/src/components/Layout.jsx ui/src/components/TrustWidget.jsx ui/src/pages/relay-discovery/*.jsx` → no matches
- Route existence: confirmed against BIBLE §13 — `/tapestry/relay-discovery`, `/tapestry/grapevine/trust-determination`, `/user/:pubkey`, and `/` all exist
- Browser: not verified in this branch (the running local dev server serves different code). Recommended to verify on staging after that deploy target lands, or pull this branch locally.

## Test plan

- [ ] `/tapestry/relay-discovery` renders the Relay Discovery page (sidebar link works)
- [ ] Sidebar "📡 Relay Discovery" link navigates correctly
- [ ] "Trust Determination" links (3 spots) navigate to `/tapestry/grapevine/trust-determination`
- [ ] Endorser avatar links on aggregated table open `/user/<pubkey>` (new tab)
- [ ] "brainstorm-search" label link at top of Relay Discovery goes to `/`
- [ ] TrustWidget "Full settings →" link goes to `/tapestry/grapevine/trust-determination`

🤖 Generated with [Claude Code](https://claude.com/claude-code)