### PR TITLE
Add deploy-magic-carpet.yml workflow

### DIFF
--- a/.github/workflows/deploy-magic-carpet.yml
+++ b/.github/workflows/deploy-magic-carpet.yml
@@ -1,0 +1,28 @@
+name: Deploy to Magic Carpet
+
+on:
+  push:
+    branches: [feature-magic-carpet]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        timeout-minutes: 60
+        with:
+          host: ${{ secrets.DEPLOY_HOST_MAGIC_CARPET }}
+          username: ${{ secrets.DEPLOY_USER_MAGIC_CARPET }}
+          key: ${{ secrets.DEPLOY_SSH_KEY_MAGIC_CARPET }}
+          command_timeout: 25m
+          script: |
+            cd /opt/tapestry
+            git checkout -- docker-compose.yml 2>/dev/null
+            git checkout feature-magic-carpet 2>/dev/null || git checkout -b feature-magic-carpet origin/feature-magic-carpet
+            git pull origin feature-magic-carpet
+            # Magic Carpet droplet uses host nginx on port 80, so Docker must bind to 8080 on localhost only
+            sed -i 's/"80:80"/"127.0.0.1:8080:80"/' docker-compose.yml
+            docker compose up -d --build
+            docker image prune -f


### PR DESCRIPTION
## Summary

Adds a CI/CD workflow that deploys pushes on `feature-magic-carpet` to the magic-carpet.brainstorm.world droplet (Matthias's sandbox env for the bounty-system work).

Mirrors `deploy-brainstorm.yml` exactly — same SSH-action, same `cd /opt/tapestry`, `git pull`, `sed` port remap, `docker compose up -d --build`, image prune. Just swapped:
- Trigger branch: `main` → `feature-magic-carpet`
- Secret names: `*_BRAINSTORM` → `*_MAGIC_CARPET`
- Branch checked out on droplet: `main` → `feature-magic-carpet`

## Required GitHub repo secrets (already configured by David)

- `DEPLOY_HOST_MAGIC_CARPET` — magic-carpet droplet IP/hostname
- `DEPLOY_USER_MAGIC_CARPET` — SSH username
- `DEPLOY_SSH_KEY_MAGIC_CARPET` — private key

## Side effect on merge

Merging this triggers a `deploy-brainstorm.yml` run (because it's a push to `main`). That deploy is idempotent — same code, just a rebuild — and takes ~80s. No production impact.

## What happens after merge

1. Merge → main has the workflow file
2. (Next step, not in this PR) Fast-forward `feature-magic-carpet` to main's HEAD
3. That push triggers the first magic-carpet deploy
4. magic-carpet.brainstorm.world serves a clean tapestry instance — Matthias can then rebase his PR #33 onto the new feature-magic-carpet HEAD and merge it to land his bounty-system code

## Test plan

- [ ] PR merge triggers a brainstorm.world deploy (✅ expected, idempotent)
- [ ] After main → feature-magic-carpet sync, push triggers `Deploy to Magic Carpet` workflow
- [ ] Workflow SSHes successfully (validates the 3 new secrets work)
- [ ] magic-carpet.brainstorm.world stops returning 502 and serves the tapestry UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)