### PR TITLE
Add deploy-staging.yml workflow

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,28 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches: [staging]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        timeout-minutes: 60
+        with:
+          host: ${{ secrets.DEPLOY_HOST_STAGING }}
+          username: ${{ secrets.DEPLOY_USER_STAGING }}
+          key: ${{ secrets.DEPLOY_SSH_KEY_STAGING }}
+          command_timeout: 25m
+          script: |
+            cd /opt/tapestry
+            git checkout -- docker-compose.yml 2>/dev/null
+            git checkout staging 2>/dev/null || git checkout -b staging origin/staging
+            git pull origin staging
+            # Staging droplet uses host nginx on port 80, so Docker must bind to 8080 on localhost only
+            sed -i 's/"80:80"/"127.0.0.1:8080:80"/' docker-compose.yml
+            docker compose up -d --build
+            docker image prune -f


### PR DESCRIPTION
## Summary

Adds the third and final deploy workflow for the reorg: pushes on \`staging\` → staging.brainstorm.world droplet. Completes the trio alongside \`deploy-brainstorm.yml\` (main → prod) and \`deploy-magic-carpet.yml\` (feature-magic-carpet → Matthias's sandbox).

Mirrors the existing patterns exactly — same SSH-action, same \`cd /opt/tapestry\`, \`git pull\`, \`sed\` port remap, \`docker compose up -d --build\`, image prune. Just swapped the trigger branch, secret names, and checkout target.

## Required GitHub repo secrets (already configured by David)

- \`DEPLOY_HOST_STAGING\`
- \`DEPLOY_USER_STAGING\`
- \`DEPLOY_SSH_KEY_STAGING\`

## Side effect on merge

Merging triggers a \`deploy-brainstorm.yml\` run (because it's a push to \`main\`). That deploy is idempotent — same code, just a rebuild — and takes ~80s. No production impact.

## What happens after merge

1. Merge → main has the workflow file
2. (Next step, not in this PR) Fast-forward \`staging\` to main's HEAD
3. That push triggers the first staging deploy
4. staging.brainstorm.world stops returning 502 and serves a clean tapestry instance

## Test plan

- [ ] PR merge triggers brainstorm.world redeploy (expected, idempotent)
- [ ] After main → staging sync, push triggers \`Deploy to Staging\` workflow
- [ ] Workflow SSHes successfully (validates the 3 new secrets)
- [ ] staging.brainstorm.world returns 200 with \`<title>Brainstorm Search</title>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)