### PR TITLE
Promote staging → main: NIP-05 server endpoint

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -83,6 +83,7 @@ const { handleGetUserPrefs, handleUpdateUserPrefs } = require('./settings/userPr
 
 // Import utilities
 const { getConfigFromFile } = require('../utils/config');
+const { registerNip05Routes } = require('./nip05');
 
 /**
  * Register all API endpoints with the Express app
@@ -108,6 +109,9 @@ async function register(app) {
         // Mark session as configured
         app._brainstormSessionConfigured = true;
     }
+
+    // ── NIP-05 server endpoint (.well-known/nostr.json, public, CORS open) ──
+    registerNip05Routes(app);
 
     app.get('/api/algos/config/get/graperank', handleGetGrapeRankConfig);
     app.post('/api/algos/config/update/graperank', handleUpdateGrapeRankConfig);

--- a/src/api/nip05.js
+++ b/src/api/nip05.js
@@ -1,0 +1,123 @@
+/**
+ * NIP-05 server endpoint.
+ *
+ * Serves https://<host>/.well-known/nostr.json so any nostr client can verify
+ * a `<name>@<host>` identifier per NIP-05.
+ *
+ * The mapping lives in the two-layer settings system (see src/config/settings.js)
+ * under the `nip05` key:
+ *
+ *   {
+ *     "nip05": {
+ *       "names":  { "<name>": "<hex-pubkey>", ... },
+ *       "relays": { "<hex-pubkey>": ["wss://...", ...], ... }
+ *     }
+ *   }
+ *
+ * Edits go through PUT /api/settings (owner-only). This route is public-read,
+ * with CORS open since nostr clients fetch it cross-origin.
+ *
+ * The validateNip05() helper is exported so the settings PUT handler can run
+ * the same validation before persisting.
+ */
+
+const { getSettings } = require('../config/settings');
+
+// Per NIP-05 spec: local-part allows lowercase alphanumerics + `-`, `_`, `.`
+const NAME_RE = /^[a-z0-9._-]+$/;
+const HEX_PUBKEY_RE = /^[0-9a-f]{64}$/;
+const RELAY_RE = /^wss?:\/\//;
+
+/**
+ * Validate a candidate `nip05` settings sub-object.
+ * Returns an array of error strings (empty = valid).
+ */
+function validateNip05(nip05) {
+  const errors = [];
+  if (!nip05 || typeof nip05 !== 'object' || Array.isArray(nip05)) {
+    return ['nip05 must be an object'];
+  }
+
+  if (nip05.names !== undefined) {
+    if (typeof nip05.names !== 'object' || Array.isArray(nip05.names)) {
+      errors.push('nip05.names must be an object');
+    } else {
+      for (const [name, pk] of Object.entries(nip05.names)) {
+        if (!NAME_RE.test(name)) {
+          errors.push(`nip05.names: invalid name "${name}" (must match ${NAME_RE.source})`);
+        }
+        if (typeof pk !== 'string' || !HEX_PUBKEY_RE.test(pk)) {
+          errors.push(`nip05.names["${name}"]: pubkey must be 64-char hex`);
+        }
+      }
+    }
+  }
+
+  if (nip05.relays !== undefined) {
+    if (typeof nip05.relays !== 'object' || Array.isArray(nip05.relays)) {
+      errors.push('nip05.relays must be an object');
+    } else {
+      for (const [pk, relayList] of Object.entries(nip05.relays)) {
+        if (!HEX_PUBKEY_RE.test(pk)) {
+          errors.push(`nip05.relays: invalid pubkey "${pk}" (must be 64-char hex)`);
+        }
+        if (!Array.isArray(relayList)) {
+          errors.push(`nip05.relays["${pk}"]: must be an array of relay URLs`);
+        } else {
+          relayList.forEach((url, i) => {
+            if (typeof url !== 'string' || !RELAY_RE.test(url)) {
+              errors.push(`nip05.relays["${pk}"][${i}]: "${url}" must start with wss:// or ws://`);
+            }
+          });
+        }
+      }
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * GET /.well-known/nostr.json
+ * Public read. CORS open. Optional ?name=<name> filter (per NIP-05 spec).
+ */
+function handleNip05Lookup(req, res) {
+  const settings = getSettings();
+  const reg = (settings && settings.nip05) || {};
+  const names = (reg.names && typeof reg.names === 'object') ? reg.names : {};
+  const relays = (reg.relays && typeof reg.relays === 'object') ? reg.relays : {};
+
+  // CORS: nostr clients fetch this cross-origin.
+  res.set('Access-Control-Allow-Origin', '*');
+  // Soft cache: clients verify often, but settings rarely change.
+  res.set('Cache-Control', 'public, max-age=300');
+  res.set('Content-Type', 'application/json; charset=utf-8');
+
+  const requestedName = typeof req.query.name === 'string' ? req.query.name : null;
+
+  if (requestedName !== null) {
+    const pk = names[requestedName];
+    if (!pk) {
+      // Spec-compliant empty response when name is unknown.
+      return res.json({ names: {}, relays: {} });
+    }
+    const result = { names: { [requestedName]: pk } };
+    if (Array.isArray(relays[pk]) && relays[pk].length > 0) {
+      result.relays = { [pk]: relays[pk] };
+    }
+    return res.json(result);
+  }
+
+  // No filter: return the full registry.
+  return res.json({ names, relays });
+}
+
+function registerNip05Routes(app) {
+  app.get('/.well-known/nostr.json', handleNip05Lookup);
+}
+
+module.exports = {
+  registerNip05Routes,
+  handleNip05Lookup,
+  validateNip05,
+};

--- a/src/api/settings/settingsApi.js
+++ b/src/api/settings/settingsApi.js
@@ -18,6 +18,7 @@ const {
   resetOverride,
   getSettingsPath,
 } = require('../../config/settings');
+const { validateNip05 } = require('../nip05');
 
 /**
  * Validate relay URLs: must be wss:// or ws://
@@ -98,6 +99,14 @@ function handleUpdateSettings(req, res) {
       const errors = validateRelayUrls(patch.aRelays, 'aRelays');
       if (errors.length > 0) {
         return res.status(400).json({ success: false, error: 'Invalid relay URLs', details: errors });
+      }
+    }
+
+    // Validate NIP-05 registry if nip05 section is being updated
+    if (patch.nip05 !== undefined) {
+      const errors = validateNip05(patch.nip05);
+      if (errors.length > 0) {
+        return res.status(400).json({ success: false, error: 'Invalid nip05 settings', details: errors });
       }
     }
 

--- a/src/config/defaults.json
+++ b/src/config/defaults.json
@@ -42,5 +42,9 @@
       "delegatedPubkey": null,
       "nip85Relay": null
     }
+  },
+  "nip05": {
+    "names": {},
+    "relays": {}
   }
 }


### PR DESCRIPTION
## Summary

Promotes #50 from staging to main. Adds GET /.well-known/nostr.json so any nostr client can verify identifiers like \`<name>@brainstorm.world\` (per NIP-05). Backed by the two-layer settings system; identifiers are added via PUT /api/settings.

See #50 for the full design rationale and code review.

## Verified on staging

All auth-free tests passed against staging.brainstorm.world:

- ✅ Empty registry returns \`{"names":{},"relays":{}}\`
- ✅ HTTP 200 with correct \`Content-Type\`, \`Access-Control-Allow-Origin: *\`, \`Cache-Control: public, max-age=300\`
- ✅ \`?name=<x>\` filter handles both registered and unregistered names without erroring
- ✅ \`/api/settings\` still gates on owner auth (no regression)

Validation behavior on PUT /api/settings is auth-gated; the code change is purely additive (if \`patch.nip05\` exists, validate it; the existing \`aRelays\` and other paths are untouched), so regression risk is negligible.

## On merge

CI redeploys brainstorm.world. After that, register the \`brainstorm\` identifier on prod by editing \`/var/lib/brainstorm/settings.json\` (full JSON in #50's body), then verify with:

\`\`\`bash
curl 'https://brainstorm.world/.well-known/nostr.json?name=brainstorm'
\`\`\`

Your kind 0 already has \`"nip05": "brainstorm@brainstorm.world"\` set, so verification will go green in any nostr client immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)