### PR TITLE
Promote staging → main: cosmetic tweaks (6 stages)

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -68,6 +68,7 @@ import BrainstormProfile from './pages/BrainstormProfile';
 import BrainstormSettings from './pages/BrainstormSettings';
 import BrainstormPersonalization from './pages/BrainstormPersonalization';
 import BrainstormHowSearchWorks from './pages/BrainstormHowSearchWorks';
+import BrainstormAbout from './pages/BrainstormAbout';
 import BrainstormDevelopers from './pages/BrainstormDevelopers';
 const router = createBrowserRouter([
   {
@@ -89,6 +90,10 @@ const router = createBrowserRouter([
   {
     path: '/how-search-works',
     element: <BrainstormHowSearchWorks />,
+  },
+  {
+    path: '/about',
+    element: <BrainstormAbout />,
   },
   {
     path: '/developers',

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -67,6 +67,7 @@ import BrainstormSearch from './pages/BrainstormSearch';
 import BrainstormProfile from './pages/BrainstormProfile';
 import BrainstormSettings from './pages/BrainstormSettings';
 import BrainstormPersonalization from './pages/BrainstormPersonalization';
+import BrainstormHowSearchWorks from './pages/BrainstormHowSearchWorks';
 import BrainstormDevelopers from './pages/BrainstormDevelopers';
 const router = createBrowserRouter([
   {
@@ -84,6 +85,10 @@ const router = createBrowserRouter([
   {
     path: '/personalization',
     element: <BrainstormPersonalization />,
+  },
+  {
+    path: '/how-search-works',
+    element: <BrainstormHowSearchWorks />,
   },
   {
     path: '/developers',

--- a/ui/src/pages/BrainstormAbout.jsx
+++ b/ui/src/pages/BrainstormAbout.jsx
@@ -1,0 +1,45 @@
+import { useAuth } from '../context/AuthContext';
+import BrainstormUserMenu from '../components/BrainstormUserMenu';
+
+export default function BrainstormAbout() {
+  const { user, login, logout } = useAuth();
+
+  return (
+    <div className="bsp-page">
+      {/* Top bar */}
+      <div className="bsp-top-bar">
+        <a href="/" className="bsp-logo">
+          <img src="/brainstorm.svg" alt="" className="bsp-logo-img" />
+        </a>
+        <div className="bsp-auth">
+          <BrainstormUserMenu user={user} login={login} logout={logout} />
+        </div>
+      </div>
+
+      <div className="bsp-content" style={{ maxWidth: 680, margin: '0 auto', padding: '2rem 1.5rem' }}>
+        <h1 style={{ fontSize: '1.5rem', marginBottom: '1.5rem' }}>About Brainstorm</h1>
+
+        <div style={{ lineHeight: 1.7, fontSize: '0.95rem', opacity: 0.85, display: 'flex', flexDirection: 'column', gap: '14px' }}>
+          <p>
+            Brainstorm is a search engine for <a href="https://github.com/nostr" target="_blank" rel="noopener noreferrer">nostr</a>,
+            the open social-media protocol. It indexes millions of profiles and ranks them through a trust-based filter —
+            by default using a community-curated perspective, or optionally one personalized to your own trust network.
+          </p>
+
+          <p>
+            Brainstorm is a project of{' '}
+            <a href="https://nosfabrica.com" target="_blank" rel="noopener noreferrer">NosFabrica</a>,
+            which builds sovereign-data infrastructure on nostr and Bitcoin.
+          </p>
+
+          <p>
+            Brainstorm is open source. See <a href="/developers" style={{ color: '#a5b4fc' }}>Developers</a> for
+            repository links and integration docs, <a href="/how-search-works" style={{ color: '#a5b4fc' }}>How Search Works</a> for
+            the underlying mechanics, and <a href="/personalization" style={{ color: '#a5b4fc' }}>How Personalization Works</a> for
+            an explanation of the trust filter.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/BrainstormDevelopers.jsx
+++ b/ui/src/pages/BrainstormDevelopers.jsx
@@ -1,8 +1,4 @@
-import { useNavigate } from 'react-router-dom';
-
 export default function BrainstormDevelopers() {
-  const navigate = useNavigate();
-
   // Derive relay URL from current host
   const relayUrl = typeof window !== 'undefined'
     ? `wss://${window.location.host}/relay`
@@ -23,12 +19,8 @@ export default function BrainstormDevelopers() {
     <div className="bsp-page">
       {/* Top bar — reuses bsp- styles from BrainstormPersonalization */}
       <div className="bsp-top-bar">
-        <button className="bsp-back-btn" onClick={() => navigate(-1)}>
-          &larr; Back
-        </button>
         <a href="/" className="bsp-logo">
           <img src="/brainstorm.svg" alt="" className="bsp-logo-img" />
-          Brainstorm
         </a>
         <div className="bsp-auth" />
       </div>

--- a/ui/src/pages/BrainstormDevelopers.jsx
+++ b/ui/src/pages/BrainstormDevelopers.jsx
@@ -36,7 +36,8 @@ export default function BrainstormDevelopers() {
       <div className="bsp-content" style={{ maxWidth: 720, margin: '0 auto', padding: '2rem 1.5rem' }}>
         <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>Add Brainstorm Search to Your Nostr Client</h1>
         <p style={{ opacity: 0.6, marginBottom: '2rem', fontSize: '0.9rem' }}>
-          This relay supports NIP-50 full-text profile search.
+          This relay supports <a href="https://github.com/nostr-protocol/nips/blob/master/50.md" target="_blank" >NIP-50</a>{' '}
+          full-text profile search.
           Any nostr client can query it over a standard WebSocket connection.
         </p>
 
@@ -139,9 +140,18 @@ export default function BrainstormDevelopers() {
           Once loaded, subsequent searches will return results that are fully personalized.
         </p>
 
+        {/* Open source */}
+        <h2 style={{ fontSize: '1.1rem', marginTop: '2rem' }}>Open-source</h2>
+        <ul>
+          <a href="https://github.com/nous-clawds4/tapestry" target="_blank">Brainstorm Search</a> (this website)
+        </ul>
+        <ul>
+          <a href="https://github.com/nosfabrica" target="_blank">My Brainstorm</a> (personalization service)
+        </ul>
+
         {/* Footer */}
         <div style={{ marginTop: '3rem', paddingTop: '1.5rem', borderTop: '1px solid rgba(255,255,255,0.1)', opacity: 0.5, fontSize: '0.85rem', textAlign: 'center' }}>
-          <a href="https://brainstorm.nosfabrica.com/" target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'underline' }}>My Brainstorm</a>
+          <a href="https://brainstorm.nosfabrica.com/" target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'underline' }}>Personalize my Search</a>
         </div>
       </div>
     </div>

--- a/ui/src/pages/BrainstormHowSearchWorks.jsx
+++ b/ui/src/pages/BrainstormHowSearchWorks.jsx
@@ -1,21 +1,15 @@
-import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu from '../components/BrainstormUserMenu';
 
 export default function BrainstormHowSearchWorks() {
-  const navigate = useNavigate();
   const { user, login, logout } = useAuth();
 
   return (
     <div className="bsp-page">
       {/* Top bar */}
       <div className="bsp-top-bar">
-        <button className="bsp-back-btn" onClick={() => navigate(-1)}>
-          ← Back
-        </button>
         <a href="/" className="bsp-logo">
           <img src="/brainstorm.svg" alt="" className="bsp-logo-img" />
-          Brainstorm
         </a>
         <div className="bsp-auth">
           <BrainstormUserMenu user={user} login={login} logout={logout} />

--- a/ui/src/pages/BrainstormHowSearchWorks.jsx
+++ b/ui/src/pages/BrainstormHowSearchWorks.jsx
@@ -1,0 +1,64 @@
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import BrainstormUserMenu from '../components/BrainstormUserMenu';
+
+export default function BrainstormHowSearchWorks() {
+  const navigate = useNavigate();
+  const { user, login, logout } = useAuth();
+
+  return (
+    <div className="bsp-page">
+      {/* Top bar */}
+      <div className="bsp-top-bar">
+        <button className="bsp-back-btn" onClick={() => navigate(-1)}>
+          ← Back
+        </button>
+        <a href="/" className="bsp-logo">
+          <img src="/brainstorm.svg" alt="" className="bsp-logo-img" />
+          Brainstorm
+        </a>
+        <div className="bsp-auth">
+          <BrainstormUserMenu user={user} login={login} logout={logout} />
+        </div>
+      </div>
+
+      <div className="bsp-content" style={{ maxWidth: 680, margin: '0 auto', padding: '2rem 1.5rem' }}>
+        <h1 style={{ fontSize: '1.5rem', marginBottom: '1.5rem' }}>How Search Works</h1>
+
+        <div style={{ lineHeight: 1.7, fontSize: '0.95rem', opacity: 0.85, display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <h2 style={{ fontSize: '1.1rem', marginTop: '1.5rem' }}>Search</h2>
+          <p>
+            Brainstorm indexes millions of nostr profiles (and growing) and lets you search them by name,
+            bio, NIP-05, or website. Under the hood we are using <a href="https://meilisearch.com" target="_blank">Meilisearch</a>,
+            a lightning-fast, open-source, and developer-friendly search engine designed to provide instant,
+            typo-tolerant full-text and hybrid (semantic) search.
+          </p>
+
+          <h2 style={{ fontSize: '1.1rem', marginTop: '1.5rem' }}>Verification</h2>
+          <p>
+            Brainstorm harnesses organic signals from your community to distinguish "legitimate" nostr accounts from spam,
+            impersonators, bots, and other bad actors seeking to weasel their way onto the screen in front of your eyes.
+          </p>
+
+          <p>
+            Currently we rely upon follows, mutes, and reports, processed
+            using a method called <a href="https://primal.net/straycat/graperank">GrapeRank</a> to come up with a
+            verification score between 0 and 100. When one profile (whose score is above 0) follows another, that profile's score gets a bump up,
+            leveling out at the max score of 100. Mutes and reports push a score down. But have no fear: if an
+            unverified account follows, mutes, or reports someone, that follow, mute, or report is <i>completely ignored</i>{' '}
+            by virtue of having a verification score of 0.
+          </p>
+
+          <p>
+            So it doesn't matter how many spambots are spun up. A thousand, a million. Without social proof, they will all be ignored.
+          </p>
+
+          <p style={{ marginTop: '2rem', opacity: 0.7, fontSize: '0.9rem' }}>
+            Curious how your point of view affects what you see?
+            See <a href="/personalization" style={{ color: '#a5b4fc' }}>How Personalization Works</a>.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/BrainstormPersonalization.jsx
+++ b/ui/src/pages/BrainstormPersonalization.jsx
@@ -1,21 +1,15 @@
-import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu from '../components/BrainstormUserMenu';
 
 export default function BrainstormPersonalization() {
-  const navigate = useNavigate();
   const { user, login, logout } = useAuth();
 
   return (
     <div className="bsp-page">
       {/* Top bar */}
       <div className="bsp-top-bar">
-        <button className="bsp-back-btn" onClick={() => navigate(-1)}>
-          ← Back
-        </button>
         <a href="/" className="bsp-logo">
           <img src="/brainstorm.svg" alt="" className="bsp-logo-img" />
-          Brainstorm
         </a>
         <div className="bsp-auth">
           <BrainstormUserMenu user={user} login={login} logout={logout} />

--- a/ui/src/pages/BrainstormPersonalization.jsx
+++ b/ui/src/pages/BrainstormPersonalization.jsx
@@ -23,36 +23,9 @@ export default function BrainstormPersonalization() {
       </div>
 
       <div className="bsp-content" style={{ maxWidth: 680, margin: '0 auto', padding: '2rem 1.5rem' }}>
-        <h1 style={{ fontSize: '1.5rem', marginBottom: '1.5rem' }}>How Personalized Search Works</h1>
+        <h1 style={{ fontSize: '1.5rem', marginBottom: '1.5rem' }}>How Personalization Works</h1>
 
         <div style={{ lineHeight: 1.7, fontSize: '0.95rem', opacity: 0.85, display: 'flex', flexDirection: 'column', gap: '10px' }}>
-          <h2 style={{ fontSize: '1.1rem', marginTop: '1.5rem' }}>Search</h2>
-          <p>
-            Brainstorm indexes millions of nostr profiles (and growing) and lets you search them by name,
-            bio, NIP-05, or website. Under the hood we are using <a href="https://meilisearch.com" target="_blank" >Meilisearch</a>,
-            a lightning-fast, open-source, and developer-friendly search engine designed to provide instant, 
-            typo-tolerant full-text and hybrid (semantic) search.
-          </p>
-
-          <h2 style={{ fontSize: '1.1rem', marginTop: '1.5rem' }}>Verification</h2>
-          <p>
-            Brainstorm harnesses organic signals from your community to distinguish "legitimate" nostr accounts from spam, 
-            impersonators, bots, and other bad actors seeking to weasel their way onto the screen in front of your eyes.
-          </p>
-
-          <p>  
-            Currently we rely upon follows, mutes, and reports, processed
-            using a method called <a href="https://primal.net/straycat/graperank">GrapeRank</a> to come up with a 
-            verification score between 0 and 100. When one profile (whose score is above 0) follows another, that profile's score gets a bump up, 
-            leveling out at the max score of 100. Mutes and reports push a score down. But have no fear: if an 
-            unverified account follows, mutes, or reports someone, that follow, mute, or report is <i>completely ignored</i>{' '}
-            by virtue of having a verification score of 0.
-          </p>
-
-          <p>  
-            So it doesn't matter how many spambots are spun up. A thousand, a million. Without social proof, they will all be ignored.
-          </p>
-
           <h2 style={{ fontSize: '1.1rem', marginTop: '1.5rem' }}>Two Points of View</h2>
           <p>
             Every search is filtered through a <strong>point of view</strong>. By default, every profile's verification score
@@ -102,12 +75,14 @@ export default function BrainstormPersonalization() {
             Personalization is entirely optional. The house point of view works well for most searches.
             Your personalized perspective simply lets you see the nostr world through your own trust network.
           </p>
+
+          <p style={{ marginTop: '1rem', opacity: 0.7, fontSize: '0.9rem' }}>
+            Curious how the underlying mechanics work?
+            See <a href="/how-search-works" style={{ color: '#a5b4fc' }}>How Search Works</a>.
+          </p>
         </div>
       </div>
 
-      <div className="bs-footer">
-        <a href="https://brainstorm.nosfabrica.com/" target="_blank" rel="noopener noreferrer" className="bs-footer-link">Personalize my Search</a>
-      </div>
     </div>
   );
 }

--- a/ui/src/pages/BrainstormPersonalization.jsx
+++ b/ui/src/pages/BrainstormPersonalization.jsx
@@ -23,20 +23,45 @@ export default function BrainstormPersonalization() {
       </div>
 
       <div className="bsp-content" style={{ maxWidth: 680, margin: '0 auto', padding: '2rem 1.5rem' }}>
-        <h1 style={{ fontSize: '1.5rem', marginBottom: '1.5rem' }}>How Personalization Works</h1>
+        <h1 style={{ fontSize: '1.5rem', marginBottom: '1.5rem' }}>How Personalized Search Works</h1>
 
-        <div style={{ lineHeight: 1.7, fontSize: '0.95rem', opacity: 0.85 }}>
+        <div style={{ lineHeight: 1.7, fontSize: '0.95rem', opacity: 0.85, display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <h2 style={{ fontSize: '1.1rem', marginTop: '1.5rem' }}>Search</h2>
           <p>
             Brainstorm indexes millions of nostr profiles (and growing) and lets you search them by name,
-            bio, NIP-05, or website. Legitimate nostr profiles are <a href="https://primal.net/straycat/graperank">distinguished</a>{' '}
-            from spam, impersonators and other bad actors using a combination of factors including follows, mutes, and reports.
-            But what makes this process unique is <strong>personalization</strong>: 
-            search results are ranked and filtered from <em>your</em> perspective, using input from <em>your</em> extended community.
+            bio, NIP-05, or website. Under the hood we are using <a href="https://meilisearch.com" target="_blank" >Meilisearch</a>,
+            a lightning-fast, open-source, and developer-friendly search engine designed to provide instant, 
+            typo-tolerant full-text and hybrid (semantic) search.
+          </p>
+
+          <h2 style={{ fontSize: '1.1rem', marginTop: '1.5rem' }}>Verification</h2>
+          <p>
+            Brainstorm harnesses organic signals from your community to distinguish "legitimate" nostr accounts from spam, 
+            impersonators, bots, and other bad actors seeking to weasel their way onto the screen in front of your eyes.
+          </p>
+
+          <p>  
+            Currently we rely upon follows, mutes, and reports, processed
+            using a method called <a href="https://primal.net/straycat/graperank">GrapeRank</a> to come up with a 
+            verification score between 0 and 100. When one profile (whose score is above 0) follows another, that profile's score gets a bump up, 
+            leveling out at the max score of 100. Mutes and reports push a score down. But have no fear: if an 
+            unverified account follows, mutes, or reports someone, that follow, mute, or report is <i>completely ignored</i>{' '}
+            by virtue of having a verification score of 0.
+          </p>
+
+          <p>  
+            So it doesn't matter how many spambots are spun up. A thousand, a million. Without social proof, they will all be ignored.
           </p>
 
           <h2 style={{ fontSize: '1.1rem', marginTop: '1.5rem' }}>Two Points of View</h2>
           <p>
-            Every search is filtered through a <strong>point of view</strong>. There are two options:
+            Every search is filtered through a <strong>point of view</strong>. By default, every profile's verification score
+            starts out at 0, meaning "unverified", with the exception of the profile designated as the reference (the point of view) profile, 
+            whose score is fixed at 100. Think of this as meaning that <i>you</i> are, by default, 100 percent certain that{' '}
+            <i>you</i> are not an impersonator or some other bad actor!
+          </p>
+          <p>
+            There are two options:
           </p>
           <ul style={{ paddingLeft: '1.2rem', marginTop: '0.5rem' }}>
             <li style={{ marginBottom: '0.5rem' }}>
@@ -44,8 +69,12 @@ export default function BrainstormPersonalization() {
               operator of this instance. Available to everyone, no sign-in required.
             </li>
             <li>
-              <strong>My Point of View</strong> — Your personalized perspective. Uses trust scores
-              derived from <em>your</em> extended community. Requires sign-in and calculated Trust Scores.
+              <strong>My Point of View</strong> — Your personalized perspective. Uses trust scores{' '}
+              derived from <em>your</em> extended community, calculated and made available to platforms
+              like <a href="https://brainstorm.world" >brainstorm.world</a> by a
+              service such as <a href="https://brainstorm.nosfabrica.com" target="_blank">My Brainstorm</a>.
+              Or if you prefer, you can be your own trust scores service provider by running the{' '}
+              <a href="https://github.com/nosfabrica" target="_blank">open source code</a>.
             </li>
           </ul>
 
@@ -77,7 +106,7 @@ export default function BrainstormPersonalization() {
       </div>
 
       <div className="bs-footer">
-        <a href="https://brainstorm.nosfabrica.com/" target="_blank" rel="noopener noreferrer" className="bs-footer-link">My Brainstorm</a>
+        <a href="https://brainstorm.nosfabrica.com/" target="_blank" rel="noopener noreferrer" className="bs-footer-link">Personalize my Search</a>
       </div>
     </div>
   );

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { nip19 } from 'nostr-tools';
 import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu from '../components/BrainstormUserMenu';
@@ -67,7 +67,6 @@ function CopyButton({ value }) {
 export default function BrainstormProfile() {
   const { pubkey } = useParams();
   const [searchParams] = useSearchParams();
-  const navigate = useNavigate();
   const { user, login, logout } = useAuth();
 
   // POV suffix can be passed as ?pov=<8char> from the search page
@@ -186,15 +185,8 @@ export default function BrainstormProfile() {
     <div className="bsp-page">
       {/* Top bar */}
       <div className="bsp-top-bar">
-        <button
-          className="bsp-back-btn"
-          onClick={() => navigate(-1)}
-        >
-          ← Back to search
-        </button>
         <a href="/" className="bsp-logo">
           <img src="/brainstorm.svg" alt="" className="bsp-logo-img" />
-          Brainstorm
         </a>
         <div className="bsp-auth">
           <BrainstormUserMenu user={user} login={login} logout={logout} />

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -29,7 +29,7 @@ function shortPubkey(pk) {
 /* ── Trust Score Tags ────────────────────────────────── */
 
 const TRUST_METRICS = [
-  { tag: 'rank',                         label: 'Verification Score',          icon: '🏅', description: 'Composite trust rank (0–100)' },
+  { tag: 'rank',                         label: 'Verification Score',          icon: '🏅', description: 'Community-mediated Verification Score (a.k.a. rank) (0–100 percent).' },
   { tag: 'followers',                    label: 'Verified Followers',          icon: '👥', description: 'Verified Follower count, based on the Verification Score being above a threshold (2 by default).' },
   { tag: 'hops',                         label: 'Hops',              icon: '🔗', description: 'Degrees of separation' },
   { tag: 'personalizedGrapeRank_influence', label: 'Influence',      icon: '📊', description: 'GrapeRank influence score' },

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -29,8 +29,8 @@ function shortPubkey(pk) {
 /* ── Trust Score Tags ────────────────────────────────── */
 
 const TRUST_METRICS = [
-  { tag: 'rank',                         label: 'WoT Rank',          icon: '🏅', description: 'Composite trust rank (0–100)' },
-  { tag: 'followers',                    label: 'Followers',          icon: '👥', description: 'Verified follower count' },
+  { tag: 'rank',                         label: 'Verification Score',          icon: '🏅', description: 'Composite trust rank (0–100)' },
+  { tag: 'followers',                    label: 'Verified Followers',          icon: '👥', description: 'Verified Follower count, based on the Verification Score being above a threshold (2 by default).' },
   { tag: 'hops',                         label: 'Hops',              icon: '🔗', description: 'Degrees of separation' },
   { tag: 'personalizedGrapeRank_influence', label: 'Influence',      icon: '📊', description: 'GrapeRank influence score' },
   { tag: 'personalizedGrapeRank_average',   label: 'Average',        icon: '📈', description: 'GrapeRank average rating' },

--- a/ui/src/pages/BrainstormSearch.jsx
+++ b/ui/src/pages/BrainstormSearch.jsx
@@ -876,6 +876,8 @@ export default function BrainstormSearch() {
   if (!hasResults && !loading && !error) {
     return (
       <div className="bs-page">
+        {/* Top-left: About */}
+        <a href="/about" className="bs-top-link">About</a>
         {/* Top-right auth area */}
         <div className="bs-top-bar">
           <UserMenu user={user} login={login} logout={logout} pov={pov} setPov={setPov} filters={filters} setFilters={setFilters} sortConfig={sortConfig} setSortConfig={setSortConfig} onWotReady={setMyWotReady} />
@@ -1020,12 +1022,8 @@ export default function BrainstormSearch() {
         </div>
 
         <div className="bs-footer">
-          <a href="/about" className="bs-footer-link">About</a>
-          <span className="bs-footer-sep">&middot;</span>
           <a href="/developers" className="bs-footer-link">Developers</a>
-          <span className="bs-footer-sep">&middot;</span>
           <a href="/how-search-works" className="bs-footer-link">How search works</a>
-          <span className="bs-footer-sep">&middot;</span>
           <a href="/settings" className="bs-footer-link">Settings</a>
         </div>
       </div>

--- a/ui/src/pages/BrainstormSearch.jsx
+++ b/ui/src/pages/BrainstormSearch.jsx
@@ -61,6 +61,22 @@ function HousePovLabel() {
   );
 }
 
+/* ── My POV Label (the logged-in user's own profile, mirrors HousePovLabel) ─ */
+
+function MyPovLabel({ user }) {
+  if (!user) return <strong>My WoT</strong>;
+  const name = user.profile?.display_name || user.profile?.name || user.pubkey.slice(0, 8) + '…';
+  const picture = user.profile?.picture;
+  return (
+    <a href={`/user/${user.pubkey}`} className="bs-usermenu-pov-link">
+      {picture && (
+        <img src={picture} alt="" className="bs-usermenu-pov-avatar" onError={e => { e.target.style.display = 'none'; }} />
+      )}
+      <strong>{name}</strong>
+    </a>
+  );
+}
+
 /* ── User Menu (avatar + dropdown panel) ─────────────── */
 
 const EXTERNAL_RELAYS = ['wss://relay.primal.net', 'wss://relay.damus.io', 'wss://nos.lol'];
@@ -521,7 +537,7 @@ function UserMenu({ user, login, logout, pov, setPov, filters, setFilters, sortC
             <div className="bs-usermenu-pov-indicator">
               Searching as:{' '}
               {pov === 'user' && myWotReady ? (
-                <strong>My WoT</strong>
+                <MyPovLabel user={user} />
               ) : (
                 <HousePovLabel />
               )}
@@ -959,7 +975,7 @@ export default function BrainstormSearch() {
             </span>
             <span className="bs-personalization-sep">·</span>
             <a href="/personalization" className="bs-personalization-link">
-              Tell me more!
+              What is this?
             </a>
 
             {showPovPicker && (
@@ -1004,9 +1020,9 @@ export default function BrainstormSearch() {
         </div>
 
         <div className="bs-footer">
-          <a href="https://brainstorm.nosfabrica.com/" target="_blank" rel="noopener noreferrer" className="bs-footer-link">My Brainstorm</a>
-          <span className="bs-footer-sep">&middot;</span>
           <a href="/developers" className="bs-footer-link">Developers</a>
+          <span className="bs-footer-sep">&middot;</span>
+          <a href="/settings" className="bs-footer-link">Settings</a>
         </div>
       </div>
     );

--- a/ui/src/pages/BrainstormSearch.jsx
+++ b/ui/src/pages/BrainstormSearch.jsx
@@ -663,10 +663,10 @@ function ResultCard({ hit, povSuffix }) {
             {(getWotScore(hit, 'rank', povSuffix) != null || getWotScore(hit, 'followers', povSuffix) != null) && (
               <div className="bs-result-wot">
                 {getWotScore(hit, 'rank', povSuffix) != null && (
-                  <span className="bs-wot-badge bs-wot-rank">🏅 rank: {getWotScore(hit, 'rank', povSuffix)}</span>
+                  <span className="bs-wot-badge bs-wot-rank">🏅 Verification Score: {getWotScore(hit, 'rank', povSuffix)}</span>
                 )}
                 {getWotScore(hit, 'followers', povSuffix) != null && (
-                  <span className="bs-wot-badge bs-wot-followers">👥 followers: {getWotScore(hit, 'followers', povSuffix)}</span>
+                  <span className="bs-wot-badge bs-wot-followers">👥 Verified Followers: {getWotScore(hit, 'followers', povSuffix)}</span>
                 )}
               </div>
             )}

--- a/ui/src/pages/BrainstormSearch.jsx
+++ b/ui/src/pages/BrainstormSearch.jsx
@@ -1022,6 +1022,8 @@ export default function BrainstormSearch() {
         <div className="bs-footer">
           <a href="/developers" className="bs-footer-link">Developers</a>
           <span className="bs-footer-sep">&middot;</span>
+          <a href="/how-search-works" className="bs-footer-link">How search works</a>
+          <span className="bs-footer-sep">&middot;</span>
           <a href="/settings" className="bs-footer-link">Settings</a>
         </div>
       </div>

--- a/ui/src/pages/BrainstormSearch.jsx
+++ b/ui/src/pages/BrainstormSearch.jsx
@@ -1020,6 +1020,8 @@ export default function BrainstormSearch() {
         </div>
 
         <div className="bs-footer">
+          <a href="/about" className="bs-footer-link">About</a>
+          <span className="bs-footer-sep">&middot;</span>
           <a href="/developers" className="bs-footer-link">Developers</a>
           <span className="bs-footer-sep">&middot;</span>
           <a href="/how-search-works" className="bs-footer-link">How search works</a>

--- a/ui/src/pages/BrainstormSettings.jsx
+++ b/ui/src/pages/BrainstormSettings.jsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu, { useHouseProfile } from '../components/BrainstormUserMenu';
 
@@ -24,7 +23,6 @@ function timeAgoShort(unixSeconds) {
 
 export default function BrainstormSettings() {
   const { user, login, logout } = useAuth();
-  const navigate = useNavigate();
 
   // WoT pipeline state
   const [wotStatus, setWotStatus] = useState({
@@ -377,10 +375,8 @@ export default function BrainstormSettings() {
     return (
       <div className="bss-page">
         <div className="bss-top-bar">
-          <a href="/" className="bss-back">← Back to Search</a>
           <a href="/" className="bsp-logo">
             <img src="/brainstorm.svg" alt="" className="bsp-logo-img" />
-            Brainstorm
           </a>
           <BrainstormUserMenu user={user} login={login} logout={logout} />
         </div>
@@ -397,10 +393,8 @@ export default function BrainstormSettings() {
     <div className="bss-page">
       {/* Top bar */}
       <div className="bss-top-bar">
-        <a href="/" className="bss-back">← Back to Search</a>
         <a href="/" className="bsp-logo">
           <img src="/brainstorm.svg" alt="" className="bsp-logo-img" />
-          Brainstorm
         </a>
         <div className="bss-auth">
           <BrainstormUserMenu user={user} login={login} logout={logout} />

--- a/ui/src/pages/users/Search.jsx
+++ b/ui/src/pages/users/Search.jsx
@@ -165,7 +165,7 @@ function UserPreviewCard({ pubkey, searchHit }) {
                     padding: '0.1rem 0.5rem', borderRadius: '4px',
                     backgroundColor: 'rgba(88, 166, 255, 0.12)', color: '#58a6ff',
                   }}>
-                    🏅 rank: {searchHit.wot_rank}
+                    🏅 Verification Score: {searchHit.wot_rank}
                   </span>
                 )}
                 {searchHit.wot_followers != null && (
@@ -173,7 +173,7 @@ function UserPreviewCard({ pubkey, searchHit }) {
                     padding: '0.1rem 0.5rem', borderRadius: '4px',
                     backgroundColor: 'rgba(63, 185, 80, 0.12)', color: '#3fb950',
                   }}>
-                    👥 followers: {searchHit.wot_followers}
+                    👥 Verified Followers: {searchHit.wot_followers}
                   </span>
                 )}
               </div>

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -2234,6 +2234,21 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   padding: 1rem 1.5rem;
   z-index: 10;
 }
+.bs-top-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 1rem 1.5rem;
+  z-index: 10;
+  color: #a5b4fc;
+  text-decoration: none;
+  font-size: 0.85rem;
+  opacity: 0.6;
+}
+.bs-top-link:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
 .bs-link-btn {
   background: none;
   border: 1px solid rgba(255,255,255,0.15);
@@ -2883,8 +2898,10 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
 
 /* ── Footer ── */
 .bs-footer {
-  text-align: center;
-  padding: 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 3rem;
   font-size: 0.75rem;
   opacity: 0.35;
 }


### PR DESCRIPTION
## Summary

Promotes #54 from staging to main. Six-stage cosmetic refresh covering Verification rename, page split (\`/personalization\` ↔ \`/how-search-works\`), new \`/about\`, unified header across all non-landing pages, extended rename to result badges + admin search, and experimental corner-anchored landing layout.

See #54 for the per-stage breakdown and full test plan.

## Verified on staging

David verified on staging.brainstorm.world; changes look as expected.

## On merge

CI redeploys brainstorm.world. No functional impact — pure UI/copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)