### PR TITLE
Fix Meilisearch sort: respect 'None' option, restore three-layer cascade

### DIFF
--- a/src/api/search/profiles/meili/index.js
+++ b/src/api/search/profiles/meili/index.js
@@ -174,10 +174,18 @@ async function handleMeiliSearchProfiles(req, res) {
     }
 
     // Namespace sort: { metric: "followers", direction: "desc" } → wot_followers_<suffix>:desc
+    //
+    // Three-layer cascade (already resolved into the local `sort` variable above):
+    //   1. User's saved sortConfig (per-user, /var/lib/brainstorm/user-prefs/<pubkey>.json)
+    //   2. House's grapevine.searchPreferences.sort (settings.json, owner-controlled)
+    //   3. None — fall through to Meilisearch's text-relevance ranking
+    //
+    // "None" is represented as { metric: null } in user prefs. The `sort?.metric`
+    // check correctly treats both that case AND a fully-null `sort` as
+    // "do not impose a sort" — we send no `sort` param downstream and let
+    // Meilisearch rank by text relevance.
     if (sort?.metric && povSuffix) {
       url.searchParams.set('sort', `wot_${sort.metric}_${povSuffix}:${sort.direction || 'desc'}`);
-    } else if (povSuffix) {
-      url.searchParams.set('sort', `wot_followers_${povSuffix}:desc`);
     }
 
     // ── Step 4: Forward to nostr-search-api (parallel with NIP-05 if active) ──


### PR DESCRIPTION
## Summary

When a user picks **"None (text relevance only)"** in Search Preferences, search results were still being sorted by followers descending. The bug was an else-if fallback in the Meilisearch proxy that forced \`wot_followers:desc\` whenever a POV suffix existed and no explicit sort metric was selected.

## What was happening

\`\`\`js
// Before:
if (sort?.metric && povSuffix) { /* use the user's metric */ }
else if (povSuffix) {
  // forces wot_followers:desc whenever a POV exists, regardless of intent
  url.searchParams.set('sort', \`wot_followers_\${povSuffix}:desc\`);
}
\`\`\`

The condition \`sort?.metric\` evaluates falsy for **two distinct states** that the code couldn't tell apart:

| State | \`sort\` value | What user expected |
|-------|----------------|--------------------|
| Picked "None" explicitly | \`{ metric: null, direction: 'desc' }\` | no sort, text relevance |
| Never set a preference | \`null\` | (debatable — see below) |

Both fell through to the followers-desc fallback. So "None" was effectively unreachable.

## What this PR does

Removes the else-if entirely. The single conditional now reads:

\`\`\`js
if (sort?.metric && povSuffix) {
  url.searchParams.set('sort', \`wot_\${sort.metric}_\${povSuffix}:\${sort.direction || 'desc'}\`);
}
// otherwise: no sort param — Meilisearch ranks by text relevance
\`\`\`

This restores the intended three-layer cascade documented inline (the comment was rewritten to be explicit):

1. **User's saved \`sortConfig\`** — per-user, \`/var/lib/brainstorm/user-prefs/<pubkey>.json\`
2. **House's \`grapevine.searchPreferences.sort\`** — settings.json, owner-controlled
3. **None** — Meilisearch text-relevance ranking

The owner-controlled second layer is structurally supported via the existing \`PUT /api/settings\` endpoint. There's no UI for owners to edit it yet — that's a separate follow-up.

## Behavioral change for users who never opened Search Preferences

Before: forced \`wot_followers:desc\` for everyone with a POV suffix configured.
After: text relevance for those users, unless the house default is set.

This is a UX shift, but it matches David's stated preference: text relevance should be the default, WoT sort should be an opt-in for users (or owner-set as a house default).

## Test plan

- [ ] In Search Preferences: pick "None (text relevance only)" → save → run a search → results no longer ordered by followers desc; ordering reflects Meilisearch relevance for the query
- [ ] Pick "Followers · Descending" → save → run a search → results sorted by followers desc as before
- [ ] Pick "Followers · Ascending" → results sorted asc as before
- [ ] Pick "Rank · Descending" → results sorted by rank desc
- [ ] Sign out / use as anonymous visitor: confirm baseline is now text relevance (assuming no \`grapevine.searchPreferences.sort\` is set in settings.json)
- [ ] If you set a house default via \`PUT /api/settings\` with \`grapevine.searchPreferences.sort = { metric: 'followers', direction: 'desc' }\`: anonymous visitors get followers-desc; signed-in users still override it via their own sortConfig

## Stats

1 file changed, 10 insertions / 2 deletions (most of the +10 is the rewritten comment documenting the cascade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)