### PR TITLE
Promote staging → main: fix meili sort 'None' option

### DIFF
--- a/src/api/search/profiles/meili/index.js
+++ b/src/api/search/profiles/meili/index.js
@@ -174,10 +174,18 @@ async function handleMeiliSearchProfiles(req, res) {
     }
 
     // Namespace sort: { metric: "followers", direction: "desc" } → wot_followers_<suffix>:desc
+    //
+    // Three-layer cascade (already resolved into the local `sort` variable above):
+    //   1. User's saved sortConfig (per-user, /var/lib/brainstorm/user-prefs/<pubkey>.json)
+    //   2. House's grapevine.searchPreferences.sort (settings.json, owner-controlled)
+    //   3. None — fall through to Meilisearch's text-relevance ranking
+    //
+    // "None" is represented as { metric: null } in user prefs. The `sort?.metric`
+    // check correctly treats both that case AND a fully-null `sort` as
+    // "do not impose a sort" — we send no `sort` param downstream and let
+    // Meilisearch rank by text relevance.
     if (sort?.metric && povSuffix) {
       url.searchParams.set('sort', `wot_${sort.metric}_${povSuffix}:${sort.direction || 'desc'}`);
-    } else if (povSuffix) {
-      url.searchParams.set('sort', `wot_followers_${povSuffix}:desc`);
     }
 
     // ── Step 4: Forward to nostr-search-api (parallel with NIP-05 if active) ──


### PR DESCRIPTION
## Summary

Promotes #56 from staging to main. Fixes the Meilisearch proxy bug where picking "None (text relevance only)" in Search Preferences silently fell back to followers-desc sorting. Restores the intended three-layer cascade (user → house → text relevance).

See #56 for full diagnosis and behavioral notes.

## Verified on staging

David verified — "None" now produces text-relevance ordering as expected; explicit metric sorts (followers/rank, asc/desc) still work.

## On merge

CI redeploys brainstorm.world. Behavioral change for visitors who never opened Search Preferences: results now ordered by text relevance instead of followers-desc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)