### PR TITLE
Promote staging → main: owner panel in user dropdown

### DIFF
--- a/ui/src/components/BrainstormUserMenu.jsx
+++ b/ui/src/components/BrainstormUserMenu.jsx
@@ -83,22 +83,6 @@ export default function BrainstormUserMenu({ user, login, logout }) {
 
   return (
     <div className="bs-usermenu" ref={menuRef}>
-      {/* Dashboard grid icon for owner/admin */}
-      {isOwnerOrAdmin && (
-        <a href="/tapestry/" className="bs-usermenu-grid-btn" title="Dashboard">
-          <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-            <rect x="1" y="1" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="7" y="1" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="13" y="1" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="1" y="7" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="7" y="7" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="13" y="7" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="1" y="13" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="7" y="13" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="13" y="13" width="4" height="4" rx="1" fill="currentColor"/>
-          </svg>
-        </a>
-      )}
       <button
         className="bs-usermenu-avatar-btn"
         onClick={() => setOpen(!open)}
@@ -150,6 +134,29 @@ export default function BrainstormUserMenu({ user, login, logout }) {
               Sign out
             </button>
           </div>
+
+          {isOwnerOrAdmin && (
+            <div className="bs-usermenu-admin-panel">
+              <div className="bs-usermenu-admin-label">
+                <span className="bs-usermenu-admin-dot" />
+                {user.classification === 'owner' ? 'Owner' : 'Admin'}
+              </div>
+              <a
+                href="/tapestry/"
+                className="bs-usermenu-admin-btn"
+                onClick={() => setOpen(false)}
+              >
+                Tapestry Dashboard
+              </a>
+              <a
+                href="/legacy/"
+                className="bs-usermenu-admin-btn"
+                onClick={() => setOpen(false)}
+              >
+                Legacy Dashboard
+              </a>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/ui/src/pages/BrainstormSearch.jsx
+++ b/ui/src/pages/BrainstormSearch.jsx
@@ -492,22 +492,6 @@ function UserMenu({ user, login, logout, pov, setPov, filters, setFilters, sortC
 
   return (
     <div className="bs-usermenu" ref={menuRef}>
-      {/* Dashboard grid icon for owner/admin */}
-      {isOwnerOrAdmin && (
-        <a href="/tapestry/" className="bs-usermenu-grid-btn" title="Dashboard">
-          <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-            <rect x="1" y="1" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="7" y="1" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="13" y="1" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="1" y="7" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="7" y="7" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="13" y="7" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="1" y="13" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="7" y="13" width="4" height="4" rx="1" fill="currentColor"/>
-            <rect x="13" y="13" width="4" height="4" rx="1" fill="currentColor"/>
-          </svg>
-        </a>
-      )}
       <button
         className="bs-usermenu-avatar-btn"
         onClick={() => setOpen(!open)}
@@ -557,6 +541,29 @@ function UserMenu({ user, login, logout, pov, setPov, filters, setFilters, sortC
               Sign out
             </button>
           </div>
+
+          {isOwnerOrAdmin && (
+            <div className="bs-usermenu-admin-panel">
+              <div className="bs-usermenu-admin-label">
+                <span className="bs-usermenu-admin-dot" />
+                {user.classification === 'owner' ? 'Owner' : 'Admin'}
+              </div>
+              <a
+                href="/tapestry/"
+                className="bs-usermenu-admin-btn"
+                onClick={() => setOpen(false)}
+              >
+                Tapestry Dashboard
+              </a>
+              <a
+                href="/legacy/"
+                className="bs-usermenu-admin-btn"
+                onClick={() => setOpen(false)}
+              >
+                Legacy Dashboard
+              </a>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -2416,21 +2416,6 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   align-items: center;
   gap: 0.4rem;
 }
-.bs-usermenu-grid-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  color: rgba(255,255,255,0.75);
-  text-decoration: none;
-  transition: background 0.15s, color 0.15s;
-}
-.bs-usermenu-grid-btn:hover {
-  background: rgba(255,255,255,0.12);
-  color: #fff;
-}
 .bs-usermenu-avatar-btn {
   background: none;
   border: none;
@@ -2619,6 +2604,51 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
 }
 .bs-usermenu-signout:hover {
   background: rgba(255,255,255,0.06);
+}
+.bs-usermenu-admin-panel {
+  padding: 0.75rem 1rem 0.9rem;
+  border-top: 1px solid rgba(255,255,255,0.06);
+  background: rgba(251, 191, 36, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.bs-usermenu-admin-label {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #fbbf24;
+  margin-bottom: 0.15rem;
+}
+.bs-usermenu-admin-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #fbbf24;
+  box-shadow: 0 0 6px rgba(251, 191, 36, 0.7);
+  flex-shrink: 0;
+}
+.bs-usermenu-admin-btn {
+  display: block;
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid rgba(251, 191, 36, 0.25);
+  border-radius: 8px;
+  background: rgba(251, 191, 36, 0.06);
+  color: #fcd34d;
+  font-size: 0.8rem;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.bs-usermenu-admin-btn:hover {
+  background: rgba(251, 191, 36, 0.12);
+  border-color: rgba(251, 191, 36, 0.45);
 }
 .bs-usermenu-action-btn {
   background: none;


### PR DESCRIPTION
## Summary
Promote [#58](https://github.com/nous-clawds4/tapestry/pull/58) (verified on `staging.brainstorm.world`) to production.

- Removes the standalone `/tapestry` grid icon from the search page user menu.
- Adds an owner/admin-gated panel below Sign Out in the avatar dropdown with **Tapestry Dashboard** (`/tapestry/`) and **Legacy Dashboard** (`/legacy/`) buttons.

## Test plan
- [ ] After merge + CI deploy, smoke check `brainstorm.world` signed in as owner — confirm the panel renders correctly and both buttons work.
- [ ] Confirm signed-out and non-owner views are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)