### PR TITLE
Gate house search-preferences PUT to owner/admin; relabel page

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -309,8 +309,12 @@ async function register(app) {
     app.get('/api/relay/external', handleFetchExternalEvents);
 
     // Settings endpoints (owner-only except GET merged)
+    // /api/grapevine/preferences writes to the HOUSE config (settings.grapevine.searchPreferences)
+    // which cascades to all users who haven't set their own override. GET stays public so
+    // unauthenticated visitors and the inline picker can read the resolved house defaults.
+    // PUT is owner/admin only — these are site-wide defaults.
     app.get('/api/grapevine/preferences', handleGetGrapevinePreferences);
-    app.put('/api/grapevine/preferences', handleUpdateGrapevinePreferences);
+    app.put('/api/grapevine/preferences', requireOwner, handleUpdateGrapevinePreferences);
     app.get('/api/user-prefs', handleGetUserPrefs);
     app.put('/api/user-prefs', handleUpdateUserPrefs);
     app.get('/api/settings', requireOwner, handleGetSettings);

--- a/src/api/settings/grapevinePrefApi.js
+++ b/src/api/settings/grapevinePrefApi.js
@@ -1,11 +1,19 @@
 /**
- * Public Grapevine preferences endpoints.
+ * Grapevine preferences endpoints — house-wide search defaults.
  *
- * GET  /api/grapevine/preferences  — read current search preferences
- * PUT  /api/grapevine/preferences  — save search preferences
+ * GET  /api/grapevine/preferences  — read current house search preferences (public)
+ * PUT  /api/grapevine/preferences  — update house search preferences (owner/admin only,
+ *                                    gated by requireOwner middleware in src/api/index.js)
  *
- * These are public (no auth required) since they're part of the
- * search UI flow. Stored under settings.grapevine.searchPreferences.
+ * Stored under settings.grapevine.searchPreferences. These are SITE-WIDE defaults that
+ * cascade to all users who haven't set their own per-user override (per-user overrides
+ * live in /var/lib/brainstorm/user-prefs/<pubkey>.json via /api/user-prefs).
+ *
+ * The Meilisearch proxy resolves: user prefs → house prefs (these) → text-relevance.
+ *
+ * GET stays public because unauthenticated visitors (and the inline picker) need to
+ * be able to read the resolved house defaults to render hints / display the active
+ * sort. Only the write path is gated.
  */
 
 const { getSettings, updateOverrides } = require('../../config/settings');

--- a/ui/src/pages/grapevine/SearchPreferences.jsx
+++ b/ui/src/pages/grapevine/SearchPreferences.jsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import Breadcrumbs from '../../components/Breadcrumbs';
+import { useAuth } from '../../context/AuthContext';
 
 /**
  * Search Preferences — configure WoT scoring for profile search.
@@ -113,6 +114,10 @@ export default function SearchPreferences() {
   // Meilisearch score status
   const [meiliScoreStatus, setMeiliScoreStatus] = useState(null);
 
+  // Owner/admin detection — only owners can save these site-wide defaults.
+  const { user } = useAuth();
+  const isOwnerOrAdmin = user?.classification === 'owner' || user?.classification === 'admin';
+
   // Filter & Sort settings
   // filters: { rank: { enabled: true, cutoff: 2 }, followers: { enabled: false, cutoff: 0 } }
   // sort: { metric: 'followers', direction: 'desc' }
@@ -143,8 +148,10 @@ export default function SearchPreferences() {
   // Check on mount and after score loads
   useEffect(() => { checkMeiliScores(); }, [checkMeiliScores]);
 
-  // Save preferences to server
+  // Save preferences to server (owner/admin only — silently no-op for everyone else
+  // to avoid spurious 403s from the auto-save calls that fire during POV lookup, sync, etc.)
   const savePreferences = useCallback(async (prefs) => {
+    if (!isOwnerOrAdmin) return;
     try {
       await fetch('/api/grapevine/preferences', {
         method: 'PUT',
@@ -152,7 +159,7 @@ export default function SearchPreferences() {
         body: JSON.stringify(prefs),
       });
     } catch { /* best effort */ }
-  }, []);
+  }, [isOwnerOrAdmin]);
 
   // Load saved preferences on mount
   useEffect(() => {
@@ -449,13 +456,24 @@ export default function SearchPreferences() {
   return (
     <div className="page">
       <Breadcrumbs />
-      <h1>⚙️ Search Preferences</h1>
+      <h1>⚙️ House Search Defaults</h1>
       {initialLoading && <p style={{ opacity: 0.5 }}>Loading saved preferences...</p>}
       <p className="subtitle">
-        Configure Web of Trust scoring for profile search. Select a Point of View
-        (observer) and choose which trust metrics to use for filtering and ranking
-        search results.
+        Configure the Web-of-Trust defaults for profile search across this instance.
+        Select a Point of View (observer) and choose which trust metrics to use for
+        filtering and ranking. <strong>These are site-wide defaults</strong> that
+        affect every visitor who hasn't set their own personal preferences.
       </p>
+      {!isOwnerOrAdmin && (
+        <div style={{
+          padding: '0.75rem 1rem', border: '1px solid #d29922', borderRadius: '8px',
+          backgroundColor: 'rgba(210, 153, 34, 0.08)', color: '#d29922',
+          fontSize: '0.85rem', marginBottom: '1rem',
+        }}>
+          🔒 <strong>View only.</strong> These are owner/admin-only settings.
+          You can browse the current house defaults, but saving requires the owner or admin role.
+        </div>
+      )}
 
       {/* Step 1: POV Selection */}
       <div style={sectionStyle}>
@@ -646,7 +664,8 @@ export default function SearchPreferences() {
           {/* Save button */}
           <button
             className="btn btn-primary"
-            disabled={!filterSortDirty}
+            disabled={!filterSortDirty || !isOwnerOrAdmin}
+            title={!isOwnerOrAdmin ? 'Saving site-wide defaults requires the owner or admin role' : undefined}
             onClick={async () => {
               await savePreferences({
                 povPubkey, metrics: availableMetrics.map(m => m.metric),


### PR DESCRIPTION
## Summary

Closes a security gap and a UX confusion in one focused change. \`PUT /api/grapevine/preferences\` writes site-wide search defaults but had no auth gate — anyone could rewrite the house-wide sort/filter/POV configuration. The dashboard page (\`/tapestry/grapevine/search-preferences\`) presented the controls as personal preferences while writing globally.

This is **path X.1** from the design discussion. Path X.2 (build the missing per-user preference UI) is deferred to its own work.

## Changes

### Server

| File | Change |
|------|--------|
| \`src/api/index.js\` | PUT \`/api/grapevine/preferences\` now uses the existing \`requireOwner\` middleware (same one used by \`/api/settings\`). GET stays public. |
| \`src/api/settings/grapevinePrefApi.js\` | Header comment rewritten to document the auth model and the user → house → text-relevance cascade. |

### Client

| File | Change |
|------|--------|
| \`ui/src/pages/grapevine/SearchPreferences.jsx\` | Page heading: "Search Preferences" → "**House Search Defaults**". Subtitle says explicitly "These are site-wide defaults." Non-owners see a yellow banner: "View only. These are owner/admin-only settings." Save button disabled for non-owners with explanatory tooltip. \`savePreferences\` helper silently no-ops for non-owners so auto-save calls (during POV lookup / sync / score-load flows) don't generate 403 noise. |

## Out of scope (deferred follow-ups)

- **Per-user preference UI** (path X.2). Today no UI lets a regular user set their own sort/filter override — they're stuck with the house defaults. \`/api/user-prefs\` PUT exists but no client code writes to it for sort/filter. Building this UI is its own design discussion.
- **Unit tests for the meili-proxy three-layer cascade.** The cascade is inline in the route handler; testing it cleanly needs either a small refactor to extract a helper or supertest setup. Worth its own focused PR.

## Test plan (verify on staging.brainstorm.world)

- [ ] As anonymous visitor: hit \`/tapestry/grapevine/search-preferences\` → page loads, view-only banner shows, save button is disabled with tooltip
- [ ] As anonymous visitor: \`curl -XPUT https://staging.brainstorm.world/api/grapevine/preferences -H 'Content-Type: application/json' -d '{"sort":{"metric":"rank","direction":"desc"}}'\` → returns **401 Not authenticated** (was previously a silent 200 that rewrote the house defaults)
- [ ] Sign in as a non-owner regular user: same UI behavior as anonymous (view-only, disabled save). Auto-saves during interactions don't generate visible errors.
- [ ] Sign in as the owner: full edit access. Save button enables when changes pending. Save succeeds (200). Other users' searches reflect the new defaults.
- [ ] GET \`/api/grapevine/preferences\` is still publicly readable (used by inline picker on the search page).
- [ ] Existing house-defaults sort/filter still cascade correctly into searches.

## Stats

3 files changed, 44 insertions / 13 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)