### PR TITLE
Gracefully degrade on Meilisearch interner panic (workaround for #63)

### DIFF
--- a/BIBLE.md
+++ b/BIBLE.md
@@ -142,7 +142,7 @@ Standard contribution flow: branch off `staging` → PR into `staging` → verif
 | **supervisord** | — | Process manager inside the container. Controls all services (neo4j, strfry, strfry-router, nip50-proxy, stream-consumer, brainstorm). |
 | **redis** | 6379 (Docker network only) | Separate Docker container. Message queue for streaming ETL — buffers events between strfry and the Neo4j consumer. ~50MB RAM. |
 | **nostr-search-api** | 3069 | Search API server. Connects to strfry via WebSocket for live kind 0 ingestion, proxies search queries to Meilisearch, handles WoT score loading. |
-| **nostr-search-meili** | 7700 | Meilisearch instance. Full-text search index for nostr profiles. Searchable by name, NIP-05, bio, website, Lightning address. |
+| **nostr-search-meili** | 7700 | Meilisearch instance (pinned at `v1.12.8`). Full-text search index for nostr profiles. Searchable by name, NIP-05, bio, website, Lightning address. **Known issue:** v1.12 panics on certain queries (e.g. `q=primal`) due to a milli interner u16 overflow — `nostr-search/src/search.js` catches the panic and returns a friendly notice in place of a 500. See issue #63 for upgrade plan. |
 
 ### Docker Volumes
 
@@ -1410,6 +1410,7 @@ docker compose exec tapestry strfry sync wss://dcosl.brainstorm.world \
 - **GrapeRank performance optimization** — first wave (warm start) shipped; the ~55% of remaining runtime spent in the ratings-interpretation phase is the next optimization target
 - **Relay Discovery** — Vinney's feature for trust-weighted relay endorsement and tagging. Lives on `feature-relay-discovery`. Was briefly on main via PR #35 (2026-04-19) and pulled back via PR #46/#47 (2026-04-24) for further development. Awaiting rework.
 - **Magic Carpet bounty system** — Matthias's sandbox feature on `feature-magic-carpet`, deployed to `magic-carpet.brainstorm.world`. SQLite-backed bounties + NIP-57 zap flow. Per Matthias's roadmap; not for production.
+- **Meilisearch upgrade (#63)** — currently pinned at v1.12.8, which panics on certain queries (e.g. `q=primal`) due to an internal interner u16 overflow in milli. Workaround in place: `nostr-search/src/search.js` catches the panic and returns a friendly notice in place of a 500. Real fix is to upgrade Meilisearch to a version that resolves this; verify index compatibility + reindex if needed; remove the workaround. Tracked in issue #63 with full upgrade plan and risk notes.
 
 ---
 

--- a/nostr-search/src/search.js
+++ b/nostr-search/src/search.js
@@ -141,6 +141,33 @@ app.get('/api/search', async (req, res) => {
 
     res.json(result);
   } catch (err) {
+    // Workaround for a known Meilisearch internal panic on certain queries:
+    //   panicked at crates/milli/src/search/new/interner.rs:60:
+    //   assertion failed: self.stable_store.len() < u16::MAX as usize
+    //
+    // Some query strings (e.g. "primal" — popular substring of primal.net,
+    // which appears in tons of profile fields) cause Meilisearch's term
+    // interner to overflow its u16 capacity (65535 entries) due to typo +
+    // prefix expansion across multiple fields. The bug is in milli, not
+    // here. Until Meilisearch is upgraded to a version that fixes this
+    // (currently pinned to v1.12.8 in docker-compose.yml), we catch the
+    // 500 here and return an empty result with a friendly notice the UI
+    // can render in place of "Search service unavailable".
+    //
+    // Tracking issue: see tapestry repo for "Upgrade Meilisearch to fix
+    // interner u16 overflow panic on certain queries".
+    const isMeiliPanic = err.message && err.message.includes('panicked');
+    if (isMeiliPanic) {
+      console.warn(`[search] Meilisearch panic for q="${(q || '').slice(0, 40)}", returning friendly notice. Error: ${err.message}`);
+      return res.json({
+        hits: [],
+        query: (q || '').trim(),
+        processingTimeMs: 0,
+        estimatedTotalHits: 0,
+        _searchTooBroad: true,
+        _notice: 'This query matches too many results — try adding more characters or modifying the search in some other way.',
+      });
+    }
     res.status(500).json({ error: err.message });
   }
 });

--- a/ui/src/pages/BrainstormSearch.jsx
+++ b/ui/src/pages/BrainstormSearch.jsx
@@ -694,6 +694,7 @@ export default function BrainstormSearch() {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState(null);
   const [meta, setMeta] = useState(null);
+  const [searchNotice, setSearchNotice] = useState(null); // friendly message in place of "No results found" (e.g. when Meilisearch panics on too-broad queries — see nostr-search/src/search.js)
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(null);
@@ -756,6 +757,7 @@ export default function BrainstormSearch() {
       setResults(null);
       setMeta(null);
       setError(null);
+      setSearchNotice(null);
     } else {
       setLoadingMore(true);
     }
@@ -778,6 +780,10 @@ export default function BrainstormSearch() {
 
       // Store NIP-05 verified result (if any)
       setNip05Result(data.nip05Result || null);
+
+      // Friendly notice in place of "No results found" — surfaced when the
+      // server side gracefully degrades (e.g. Meilisearch interner panic).
+      setSearchNotice(data._searchTooBroad ? data._notice : null);
 
       if (offset === 0) {
         setResults(data.hits || []);
@@ -1140,7 +1146,7 @@ export default function BrainstormSearch() {
             <div className="bs-results-meta">
               <span>
                 {results.length === 0
-                  ? 'No results found'
+                  ? (searchNotice || 'No results found')
                   : `About ${meta?.estimatedTotalHits?.toLocaleString() || '?'} results`}
               </span>
               {meta?.processingTimeMs != null && (


### PR DESCRIPTION
## Summary

Workaround for a known Meilisearch v1.12 panic on certain queries (e.g. \`q=primal\`). Real fix is the Meilisearch upgrade tracked in **#63**; this PR ships the user-facing degradation so the symptom stops being a scary "Search service unavailable" error and becomes actionable guidance.

## What was broken

Searching for \`prima\`, \`primal\`, or any query that overflows Meilisearch's milli interner returns a 500 from the search service:

\`\`\`
panicked at crates/milli/src/search/new/interner.rs:60:13:
assertion failed: self.stable_store.len() < u16::MAX as usize
\`\`\`

Reproducible on prod, staging, and locally:

\`\`\`bash
curl 'https://brainstorm.world/api/search/profiles/meili?q=primal&wotPov=house'
# {"success":false,"error":"Search service unavailable","detail":"nostr-search-api returned 500"}
\`\`\`

Root cause is Meilisearch's u16-indexed interner overflowing when typo + prefix expansion across multiple full-text fields produces too many candidates. \`primal\` triggers it because the substring is in millions of profile fields (primal.net references). Same panic, different threshold for other terms.

## What this PR does

| File | Change |
|------|--------|
| \`nostr-search/src/search.js\` | Catch block detects \`'panicked'\` in \`err.message\`, returns HTTP 200 with \`hits: []\`, \`_searchTooBroad: true\`, and a friendly \`_notice\` ("This query matches too many results — try adding more characters or modifying the search in some other way."). Other errors still propagate as 500. |
| \`ui/src/pages/BrainstormSearch.jsx\` | New \`searchNotice\` state, cleared per search, populated from \`data._notice\` when the server signals \`_searchTooBroad\`. The "No results found" line is replaced with the notice when present. |
| \`BIBLE.md\` | §4 nostr-search-meili row gets a "Known issue" callout pointing at #63. §17 "What's In Progress" gets a Meilisearch upgrade entry. |

The tapestry-side proxy (\`src/api/search/profiles/meili/index.js\`) needed no change — it passes 200 responses through unmodified.

## What this PR does NOT do

- Doesn't fix the Meilisearch panic (that's #63 — requires upgrade + reindex verification)
- Doesn't make affected searches actually return results — they still return empty, just with a friendly tip
- Doesn't change behavior for queries that don't trigger the panic

## Test plan (verify on staging.brainstorm.world)

- [ ] \`curl 'https://staging.brainstorm.world/api/search/profiles/meili?q=primal&wotPov=house'\` → returns HTTP 200 with \`hits: []\`, \`_searchTooBroad: true\`, and the notice (was previously HTTP 502)
- [ ] Same for \`q=prima\`
- [ ] Other queries still return real results (\`q=purple\`, \`q=damus\`, etc.)
- [ ] In the UI: open staging.brainstorm.world, do an initial search (e.g. "purple"), then in the top results bar type \`primal\` letter by letter — should show "This query matches too many results..." in the meta row instead of a red "Search service unavailable" banner
- [ ] Top bar typing \`Primall\` (which doesn't trigger the panic) still returns normal results
- [ ] Real errors (e.g. shut down the meili container, then search) still surface as actual error states, not the friendly notice

## Stats

3 files changed, 36 insertions / 2 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)