### PR TITLE
Promote staging → main: BIBLE updates + Meilisearch panic workaround

### DIFF
--- a/BIBLE.md
+++ b/BIBLE.md
@@ -3,7 +3,7 @@
 > **Audience:** AI agents and developers joining the Tapestry project.
 > Read this file to fully onboard — it covers what Tapestry is, how it works, what's been built, what's in progress, and how to contribute.
 
-**Last updated:** 2026-04-25 (NIP-05 server endpoint)
+**Last updated:** 2026-04-25 (search-prefs cascade fix + auth gate, cosmetic refresh)
 
 ---
 
@@ -662,8 +662,8 @@ External nostr clients can search via the relay WebSocket at `wss://<host>/relay
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/api/grapevine/preferences` | Get search preferences (POV pubkey, metrics, filters, sort) |
-| PUT | `/api/grapevine/preferences` | Save search preferences |
+| GET | `/api/grapevine/preferences` | Get house-wide search preferences (POV pubkey, metrics, filters, sort). Public read — the inline picker and anonymous visitors need to be able to read the resolved house default. |
+| PUT | `/api/grapevine/preferences` | Update house-wide search preferences. **Owner/admin only.** These are site-wide defaults that cascade to all users without per-user overrides (see §14 "Search-preferences cascade"). |
 
 ### User Preferences
 
@@ -764,7 +764,9 @@ Legacy Brainstorm HTML pages are served at `/legacy/` (not part of the React SPA
 /                                 Brainstorm Search (landing + results)
 ├── user/:pubkey                  Profile detail (follow, mute, report)
 ├── settings                      Search settings (WoT pipeline, metrics, filters)
-├── personalization               WoT personalization guide
+├── about                         Brainstorm + NosFabrica overview, links to nostr
+├── how-search-works              Mechanics: Meilisearch + Verification (GrapeRank)
+├── personalization               POV explainer (House vs My Point of View)
 └── developers                    NIP-50 developer integration docs
 
 /tapestry/                        Dashboard (Getting Started + stats)
@@ -1023,6 +1025,26 @@ The `nip05` key (added 2026-04-25) backs the `/.well-known/nostr.json` endpoint:
 ```
 
 `names` maps the local-part of the NIP-05 identifier (e.g., `"brainstorm"` for `brainstorm@brainstorm.world`) to a hex pubkey. `relays` advertises where the holder of that pubkey can be reached. Editing happens via the owner-gated `PUT /api/settings` (see §11) or — for first-time prod registration — directly in the volume's `settings.json` (see §15 "Editing settings.json on a deployed droplet").
+
+### Search-preferences cascade
+
+The Meilisearch proxy (`src/api/search/profiles/meili/index.js` lines 137–181) resolves `sort` and `filter` for each search request through three layers:
+
+1. **User's per-user prefs** — `/var/lib/brainstorm/user-prefs/<pubkey>.json`, written via `PUT /api/user-prefs` by signed-in users. *(Underlying API works; no UI exposes sort/filter writes here today — see §17 "What's In Progress".)*
+2. **House-wide prefs** — `settings.grapevine.searchPreferences.{filters,sort}`, written via `PUT /api/grapevine/preferences` (owner/admin only since 2026-04-25). The `/tapestry/grapevine/search-preferences` page is the UI.
+3. **Text relevance** — Meilisearch's default ranking when no `sort` param is sent.
+
+Three distinct sort intents on the user side:
+
+| Intent | `userPrefs.sortConfig` value | Cascade behavior |
+|--------|------------------------------|------------------|
+| Use house default | `null` or absent | falls through to house prefs → if house has nothing, text relevance |
+| Force text relevance | `{ metric: null, direction: 'desc' }` | overrides house, no sort param sent |
+| Specific metric | `{ metric: 'rank', direction: 'desc' }` | overrides house, that metric used |
+
+Same shape for filters: `null`/absent = use house, `{}` = explicit no filters, `{key: value}` = specific filters.
+
+**Historical note:** prior to 2026-04-25, the proxy unconditionally forced `wot_followers:desc` whenever a POV suffix existed and no explicit metric was selected — so the user-side "None" option was unreachable, and the default for unconfigured installs was followers-desc rather than text relevance. Fix removed the forced fallback; default behavior now matches the cascade above.
 
 ### brainstorm.conf
 
@@ -1388,6 +1410,9 @@ docker compose exec tapestry strfry sync wss://dcosl.brainstorm.world \
 - ✅ Owner-seeded warm start for first-time customers — if the owner is within 3 directed FOLLOWS hops downstream of the customer, seed from the owner's `NostrUser` scorecards; otherwise cold start
 - ✅ GrapeRank observability — per-phase timing in structured events, `iteration_complete` event with convergence metrics (iterations, max_diff, warm_start_source), persistent per-customer `graperank_history.jsonl`
 - ✅ NIP-05 server endpoint at `/.well-known/nostr.json` — settings-backed registry under `nip05.names` and `nip05.relays`. Public read with CORS open + 5-minute soft cache. Owner-only writes via `PUT /api/settings` validated for name regex (`/^[a-z0-9._-]+$/`), 64-char hex pubkeys, and `wss://`/`ws://` relay URLs. First identifier in production: `brainstorm@brainstorm.world` (2026-04-25).
+- ✅ Cosmetic refresh (2026-04-25) — Verification rename ("WoT Rank" → "Verification Score", "Followers" → "Verified Followers"); `/personalization` split into `/personalization` (POV philosophy) + new `/how-search-works` (Meilisearch + GrapeRank mechanics); new `/about` page; unified header (no back button, no wordmark) on all non-landing pages; experimental corner-anchored landing layout (About top-left, Developers / How search works / Settings spread across the footer corners + middle); MyPovLabel — the user's profile pic + name show in "Searching as:" when "My WoT" is the active POV.
+- ✅ Meilisearch sort cascade fix (2026-04-25) — removed the forced `wot_followers:desc` fallback that was preventing the user-side "None (text relevance only)" option from taking effect. Three-layer cascade now resolves cleanly: user prefs → house prefs → text relevance. Default behavior for unconfigured installs becomes text relevance instead of followers-desc; owner can still establish a house-wide default via Search Preferences. See §14 "Search-preferences cascade".
+- ✅ Owner/admin auth gate on `PUT /api/grapevine/preferences` (2026-04-25) — the dashboard's House Search Defaults page (`/tapestry/grapevine/search-preferences`) now requires owner/admin role for saves. Previously the endpoint was publicly writable; anyone could rewrite site-wide defaults. Page heading updated to "House Search Defaults"; non-owners see a view-only banner and disabled save button. GET stays public so anonymous visitors and the inline picker can read the resolved house defaults.
 
 ### CLI (tapestry-cli repo)
 

--- a/BIBLE.md
+++ b/BIBLE.md
@@ -142,7 +142,7 @@ Standard contribution flow: branch off `staging` → PR into `staging` → verif
 | **supervisord** | — | Process manager inside the container. Controls all services (neo4j, strfry, strfry-router, nip50-proxy, stream-consumer, brainstorm). |
 | **redis** | 6379 (Docker network only) | Separate Docker container. Message queue for streaming ETL — buffers events between strfry and the Neo4j consumer. ~50MB RAM. |
 | **nostr-search-api** | 3069 | Search API server. Connects to strfry via WebSocket for live kind 0 ingestion, proxies search queries to Meilisearch, handles WoT score loading. |
-| **nostr-search-meili** | 7700 | Meilisearch instance. Full-text search index for nostr profiles. Searchable by name, NIP-05, bio, website, Lightning address. |
+| **nostr-search-meili** | 7700 | Meilisearch instance (pinned at `v1.12.8`). Full-text search index for nostr profiles. Searchable by name, NIP-05, bio, website, Lightning address. **Known issue:** v1.12 panics on certain queries (e.g. `q=primal`) due to a milli interner u16 overflow — `nostr-search/src/search.js` catches the panic and returns a friendly notice in place of a 500. See issue #63 for upgrade plan. |
 
 ### Docker Volumes
 
@@ -1410,6 +1410,7 @@ docker compose exec tapestry strfry sync wss://dcosl.brainstorm.world \
 - **GrapeRank performance optimization** — first wave (warm start) shipped; the ~55% of remaining runtime spent in the ratings-interpretation phase is the next optimization target
 - **Relay Discovery** — Vinney's feature for trust-weighted relay endorsement and tagging. Lives on `feature-relay-discovery`. Was briefly on main via PR #35 (2026-04-19) and pulled back via PR #46/#47 (2026-04-24) for further development. Awaiting rework.
 - **Magic Carpet bounty system** — Matthias's sandbox feature on `feature-magic-carpet`, deployed to `magic-carpet.brainstorm.world`. SQLite-backed bounties + NIP-57 zap flow. Per Matthias's roadmap; not for production.
+- **Meilisearch upgrade (#63)** — currently pinned at v1.12.8, which panics on certain queries (e.g. `q=primal`) due to an internal interner u16 overflow in milli. Workaround in place: `nostr-search/src/search.js` catches the panic and returns a friendly notice in place of a 500. Real fix is to upgrade Meilisearch to a version that resolves this; verify index compatibility + reindex if needed; remove the workaround. Tracked in issue #63 with full upgrade plan and risk notes.
 
 ---
 

--- a/nostr-search/src/search.js
+++ b/nostr-search/src/search.js
@@ -141,6 +141,33 @@ app.get('/api/search', async (req, res) => {
 
     res.json(result);
   } catch (err) {
+    // Workaround for a known Meilisearch internal panic on certain queries:
+    //   panicked at crates/milli/src/search/new/interner.rs:60:
+    //   assertion failed: self.stable_store.len() < u16::MAX as usize
+    //
+    // Some query strings (e.g. "primal" — popular substring of primal.net,
+    // which appears in tons of profile fields) cause Meilisearch's term
+    // interner to overflow its u16 capacity (65535 entries) due to typo +
+    // prefix expansion across multiple fields. The bug is in milli, not
+    // here. Until Meilisearch is upgraded to a version that fixes this
+    // (currently pinned to v1.12.8 in docker-compose.yml), we catch the
+    // 500 here and return an empty result with a friendly notice the UI
+    // can render in place of "Search service unavailable".
+    //
+    // Tracking issue: see tapestry repo for "Upgrade Meilisearch to fix
+    // interner u16 overflow panic on certain queries".
+    const isMeiliPanic = err.message && err.message.includes('panicked');
+    if (isMeiliPanic) {
+      console.warn(`[search] Meilisearch panic for q="${(q || '').slice(0, 40)}", returning friendly notice. Error: ${err.message}`);
+      return res.json({
+        hits: [],
+        query: (q || '').trim(),
+        processingTimeMs: 0,
+        estimatedTotalHits: 0,
+        _searchTooBroad: true,
+        _notice: 'This query matches too many results — try adding more characters or modifying the search in some other way.',
+      });
+    }
     res.status(500).json({ error: err.message });
   }
 });

--- a/ui/src/pages/BrainstormSearch.jsx
+++ b/ui/src/pages/BrainstormSearch.jsx
@@ -694,6 +694,7 @@ export default function BrainstormSearch() {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState(null);
   const [meta, setMeta] = useState(null);
+  const [searchNotice, setSearchNotice] = useState(null); // friendly message in place of "No results found" (e.g. when Meilisearch panics on too-broad queries — see nostr-search/src/search.js)
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(null);
@@ -756,6 +757,7 @@ export default function BrainstormSearch() {
       setResults(null);
       setMeta(null);
       setError(null);
+      setSearchNotice(null);
     } else {
       setLoadingMore(true);
     }
@@ -778,6 +780,10 @@ export default function BrainstormSearch() {
 
       // Store NIP-05 verified result (if any)
       setNip05Result(data.nip05Result || null);
+
+      // Friendly notice in place of "No results found" — surfaced when the
+      // server side gracefully degrades (e.g. Meilisearch interner panic).
+      setSearchNotice(data._searchTooBroad ? data._notice : null);
 
       if (offset === 0) {
         setResults(data.hits || []);
@@ -1140,7 +1146,7 @@ export default function BrainstormSearch() {
             <div className="bs-results-meta">
               <span>
                 {results.length === 0
-                  ? 'No results found'
+                  ? (searchNotice || 'No results found')
                   : `About ${meta?.estimatedTotalHits?.toLocaleString() || '?'} results`}
               </span>
               {meta?.processingTimeMs != null && (


### PR DESCRIPTION
## Summary

Promotes two PRs from staging to main in one shot, since both already landed on staging:

- **#62** — BIBLE updates documenting the search-prefs three-layer cascade, the owner/admin auth gate on \`PUT /api/grapevine/preferences\`, and the cosmetic-refresh routes (\`/about\`, \`/how-search-works\`).
- **#64** — Workaround for the Meilisearch v1.12 interner u16 overflow panic on certain queries (\`primal\`, \`prima\`). Returns a friendly notice instead of a 502. Tracking issue **#63** has the full upgrade plan.

## Verified on staging

David verified both — BIBLE renders correctly; \`curl q=primal\` against staging returns the friendly notice instead of 502.

## On merge

CI redeploys brainstorm.world. Production behavior:

- BIBLE on the deployed instance reflects current state (docs only — no runtime effect)
- \`q=primal\`/\`q=prima\` searches stop showing "Search service unavailable" — they get the actionable tip instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)