### PR TITLE
Cosmetic copy refinements on /developers and /personalization

### DIFF
--- a/ui/src/pages/BrainstormDevelopers.jsx
+++ b/ui/src/pages/BrainstormDevelopers.jsx
@@ -135,16 +135,12 @@ export default function BrainstormDevelopers() {
         {/* Open source */}
         <h2 style={{ fontSize: '1.1rem', marginTop: '2rem' }}>Open-source</h2>
         <ul>
-          <a href="https://github.com/nous-clawds4/tapestry" target="_blank">Brainstorm Search</a> (this website)
+          <a href="https://github.com/nous-clawds4/tapestry" target="_blank">Brainstorm Search repo</a> (this website)
         </ul>
         <ul>
-          <a href="https://github.com/nosfabrica" target="_blank">My Brainstorm</a> (personalization service)
+          <a href="https://github.com/nosfabrica" target="_blank">NosFabrica repos</a> (personalization service)
         </ul>
 
-        {/* Footer */}
-        <div style={{ marginTop: '3rem', paddingTop: '1.5rem', borderTop: '1px solid rgba(255,255,255,0.1)', opacity: 0.5, fontSize: '0.85rem', textAlign: 'center' }}>
-          <a href="https://brainstorm.nosfabrica.com/" target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'underline' }}>Personalize my Search</a>
-        </div>
       </div>
     </div>
   );

--- a/ui/src/pages/BrainstormPersonalization.jsx
+++ b/ui/src/pages/BrainstormPersonalization.jsx
@@ -25,21 +25,22 @@ export default function BrainstormPersonalization() {
             Every search is filtered through a <strong>point of view</strong>. By default, every profile's verification score
             starts out at 0, meaning "unverified", with the exception of the profile designated as the reference (the point of view) profile, 
             whose score is fixed at 100. Think of this as meaning that <i>you</i> are, by default, 100 percent certain that{' '}
-            <i>you</i> are not an impersonator or some other bad actor!
+            <i>you</i> are not an impersonator or some other bad actor! As for the rest of the nostr profiles out there, they are presumed
+            "unverified" until your trusted community says otherwise.
           </p>
           <p>
-            There are two options:
+            We provide you with two options:
           </p>
           <ul style={{ paddingLeft: '1.2rem', marginTop: '0.5rem' }}>
             <li style={{ marginBottom: '0.5rem' }}>
-              <strong>House Point of View</strong> — The default. Uses trust scores calculated by the
-              operator of this instance. Available to everyone, no sign-in required.
+              <strong>House Point of View</strong> — The default. Uses trust scores selected by the
+              operator of this instance, the "house". Available to everyone, no need for a nostr account, no sign-in required.
             </li>
             <li>
               <strong>My Point of View</strong> — Your personalized perspective. Uses trust scores{' '}
               derived from <em>your</em> extended community, calculated and made available to platforms
               like <a href="https://brainstorm.world" >brainstorm.world</a> by a
-              service such as <a href="https://brainstorm.nosfabrica.com" target="_blank">My Brainstorm</a>.
+              service such as the one at <a href="https://brainstorm.nosfabrica.com" target="_blank">brainstorm.nosfabrica.com</a>.
               Or if you prefer, you can be your own trust scores service provider by running the{' '}
               <a href="https://github.com/nosfabrica" target="_blank">open source code</a>.
             </li>


### PR DESCRIPTION
## Summary

Continuation of the earlier cosmetic narrative pass. Two files, copy only — no behavior or layout changes. 2 files changed, +8 / -11.

## Changes

### \`ui/src/pages/BrainstormDevelopers.jsx\`
- Open-source link labels clarified: "Brainstorm Search" → "Brainstorm Search repo"; "My Brainstorm" → "NosFabrica repos" (matches the link target, an org page with multiple repos).
- Page footer with external "Personalize my Search" link **removed** — consistent with the earlier cleanup that moved this external link out of \`/personalization\` and \`/how-search-works\` footers. External link now lives only in the body of \`/personalization\` where it has the most semantic context.

### \`ui/src/pages/BrainstormPersonalization.jsx\` — Two POVs section
- Adds a clarifying sentence: "As for the rest of the nostr profiles out there, they are presumed 'unverified' until your trusted community says otherwise."
- Softer transition: "There are two options:" → "We provide you with two options:"
- House POV bullet: "calculated by the operator" → "selected by the operator of this instance, the 'house'" (introduces the "house" term inline)
- House POV bullet: "no sign-in required" → "no need for a nostr account, no sign-in required" (accessible for non-nostr users)
- My POV bullet: "service such as My Brainstorm" → "service such as the one at brainstorm.nosfabrica.com" (matches Developers page; drops the "My Brainstorm" product-name framing)

## Test plan

Docs/copy only — visual verification on staging:

- [ ] \`/developers\` page: Open-source section reads "Brainstorm Search repo" and "NosFabrica repos"; no footer link to brainstorm.nosfabrica.com at the bottom of the page
- [ ] \`/personalization\` page: Two POVs section reads naturally with the new copy; "house" term is introduced inline; My POV bullet links to "the one at brainstorm.nosfabrica.com" (not "My Brainstorm")

🤖 Generated with [Claude Code](https://claude.com/claude-code)