### PR TITLE
Promote staging → main: copy refinements on /developers and /personalization

### DIFF
--- a/ui/src/pages/BrainstormDevelopers.jsx
+++ b/ui/src/pages/BrainstormDevelopers.jsx
@@ -135,16 +135,12 @@ export default function BrainstormDevelopers() {
         {/* Open source */}
         <h2 style={{ fontSize: '1.1rem', marginTop: '2rem' }}>Open-source</h2>
         <ul>
-          <a href="https://github.com/nous-clawds4/tapestry" target="_blank">Brainstorm Search</a> (this website)
+          <a href="https://github.com/nous-clawds4/tapestry" target="_blank">Brainstorm Search repo</a> (this website)
         </ul>
         <ul>
-          <a href="https://github.com/nosfabrica" target="_blank">My Brainstorm</a> (personalization service)
+          <a href="https://github.com/nosfabrica" target="_blank">NosFabrica repos</a> (personalization service)
         </ul>
 
-        {/* Footer */}
-        <div style={{ marginTop: '3rem', paddingTop: '1.5rem', borderTop: '1px solid rgba(255,255,255,0.1)', opacity: 0.5, fontSize: '0.85rem', textAlign: 'center' }}>
-          <a href="https://brainstorm.nosfabrica.com/" target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'underline' }}>Personalize my Search</a>
-        </div>
       </div>
     </div>
   );

--- a/ui/src/pages/BrainstormPersonalization.jsx
+++ b/ui/src/pages/BrainstormPersonalization.jsx
@@ -25,21 +25,22 @@ export default function BrainstormPersonalization() {
             Every search is filtered through a <strong>point of view</strong>. By default, every profile's verification score
             starts out at 0, meaning "unverified", with the exception of the profile designated as the reference (the point of view) profile, 
             whose score is fixed at 100. Think of this as meaning that <i>you</i> are, by default, 100 percent certain that{' '}
-            <i>you</i> are not an impersonator or some other bad actor!
+            <i>you</i> are not an impersonator or some other bad actor! As for the rest of the nostr profiles out there, they are presumed
+            "unverified" until your trusted community says otherwise.
           </p>
           <p>
-            There are two options:
+            We provide you with two options:
           </p>
           <ul style={{ paddingLeft: '1.2rem', marginTop: '0.5rem' }}>
             <li style={{ marginBottom: '0.5rem' }}>
-              <strong>House Point of View</strong> — The default. Uses trust scores calculated by the
-              operator of this instance. Available to everyone, no sign-in required.
+              <strong>House Point of View</strong> — The default. Uses trust scores selected by the
+              operator of this instance, the "house". Available to everyone, no need for a nostr account, no sign-in required.
             </li>
             <li>
               <strong>My Point of View</strong> — Your personalized perspective. Uses trust scores{' '}
               derived from <em>your</em> extended community, calculated and made available to platforms
               like <a href="https://brainstorm.world" >brainstorm.world</a> by a
-              service such as <a href="https://brainstorm.nosfabrica.com" target="_blank">My Brainstorm</a>.
+              service such as the one at <a href="https://brainstorm.nosfabrica.com" target="_blank">brainstorm.nosfabrica.com</a>.
               Or if you prefer, you can be your own trust scores service provider by running the{' '}
               <a href="https://github.com/nosfabrica" target="_blank">open source code</a>.
             </li>


### PR DESCRIPTION
## Summary

Promotes #66 from staging to main. Two files of cosmetic copy refinements (Open-source link labels on /developers, expanded POV explanation on /personalization, removal of the external "Personalize my Search" link from the /developers footer).

See #66 for the full per-line breakdown.

## Verified on staging

David verified the copy changes render as expected.

## On merge

CI redeploys brainstorm.world. No behavior or layout changes — pure copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)