### PR TITLE
Add Following / Verified Followers counts to /user/:pubkey

### DIFF
--- a/ui/src/hooks/useUserData.js
+++ b/ui/src/hooks/useUserData.js
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook: fetch a NostrUser's aggregate counts from `/api/get-user-data`.
+ * Defaults to Owner POV (API default when observerPubkey is omitted).
+ * Returns { data, loading, error }.
+ */
+export default function useUserData(pubkey) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!pubkey) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    fetch(`/api/get-user-data?pubkey=${pubkey}`, { signal: controller.signal })
+      .then(r => r.json())
+      .then(json => {
+        if (json?.success && json.data) {
+          setData(json.data);
+        } else {
+          setData(null);
+          setError(json?.error || 'No data');
+        }
+      })
+      .catch(err => {
+        if (err.name === 'AbortError') return;
+        setError(err.message || 'Fetch failed');
+        setData(null);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [pubkey]);
+
+  return { data, loading, error };
+}

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -4,6 +4,7 @@ import { nip19 } from 'nostr-tools';
 import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu from '../components/BrainstormUserMenu';
 import { useProfileActions } from '../hooks/useProfileActions';
+import useUserData from '../hooks/useUserData';
 import ConfirmDialog from '../components/ConfirmDialog';
 import ReportModal from '../components/ReportModal';
 
@@ -87,6 +88,11 @@ export default function BrainstormProfile() {
   } = useProfileActions(pubkey, user?.pubkey);
 
   const showActions = user && user.pubkey !== pubkey;
+
+  const { data: userData, loading: userDataLoading } = useUserData(pubkey);
+  const followingCount = userData?.followingCount ?? null;
+  const verifiedFollowerCount = userData?.verifiedFollowerCount ?? null;
+  const fmtCount = (n) => (n == null ? '—' : new Intl.NumberFormat().format(n));
 
   const npub = useMemo(() => {
     try { return nip19.npubEncode(pubkey); } catch { return null; }
@@ -223,6 +229,22 @@ export default function BrainstormProfile() {
                 {profile?.nip05 && <div className="bsp-nip05">✅ {profile.nip05}</div>}
                 {profileAge && <span className="bsp-age">Updated {profileAge}</span>}
               </div>
+            </div>
+
+            {/* Counts: Following / Verified Followers (Owner POV) */}
+            <div
+              className={`bsp-counts ${userDataLoading ? 'bsp-counts-loading' : ''}`}
+              title="Counts shown from the perspective of this instance's owner."
+            >
+              <span className="bsp-count">
+                <span className="bsp-count-value">{fmtCount(followingCount)}</span>
+                <span className="bsp-count-label">Following</span>
+              </span>
+              <span className="bsp-count-sep" aria-hidden="true">·</span>
+              <span className="bsp-count">
+                <span className="bsp-count-value">{fmtCount(verifiedFollowerCount)}</span>
+                <span className="bsp-count-label">Verified Followers</span>
+              </span>
             </div>
 
             {/* Action buttons */}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3381,6 +3381,34 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   opacity: 0.4;
 }
 
+/* Following / Verified Followers row (under header, above actions) */
+.bsp-counts {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 0.5rem 0 0.25rem;
+  font-size: 0.9rem;
+}
+.bsp-count {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+.bsp-count-value {
+  font-weight: 600;
+  color: var(--text-primary, #e2e8f0);
+}
+.bsp-count-label {
+  opacity: 0.6;
+}
+.bsp-count-sep {
+  opacity: 0.3;
+}
+.bsp-counts-loading .bsp-count-value {
+  opacity: 0.4;
+}
+
 /* Sections */
 .bsp-section {
   margin-bottom: 1.5rem;


### PR DESCRIPTION
## Summary

Adds two counts to the public profile page at `/user/:pubkey`, Twitter/Damus-style, beneath the header and above the Follow/Mute/Report actions:

- `X Following`
- `Y Verified Followers`

Numbers pull from the existing `GET /api/get-user-data?pubkey=<x>` endpoint using the **Owner POV** (the API's default when `observerPubkey` is omitted). `verifiedFollowerCount` is the precomputed property on the `NostrUser` node (`influence > 0.1`, set by `src/algos/follows-mutes-reports/calculateVerifiedFollowerCounts.sh`).

While loading or on error, the row renders dim `—` placeholders so the layout doesn't jump.

## Files changed

- **`ui/src/hooks/useUserData.js`** (new) — fetches `/api/get-user-data`, returns `{ data, loading, error }`, AbortController cancellation.
- **`ui/src/pages/BrainstormProfile.jsx`** — imports the hook, renders the count row.
- **`ui/src/styles.css`** — adds `.bsp-counts` row styles (matches existing `.bsp-*` convention; baseline-aligned, dim labels, `·` separator).

## Out of scope (deferred)

- All / verified / highly-reported / highly-muted toggle.
- Click-through to listings (the React analog of `/legacy/grapevine-analysis.html`).
- POV switcher (always Owner POV in v1).
- Dashboard `/tapestry/users/:pubkey`.
- Threshold consolidation: the codebase has three values for "verification" (`0.01`, `0.05`, `0.1`); aligning them is the front edge of a bigger PoV/parameter-management refactor and is its own PR.

## Known cosmetic overlap

The "Reputation" section further down the page already shows a "Verified Followers" card from Meilisearch. The number there can differ from the one in this new row — that section uses `wot_followers_<suffix>` for whichever POV the page is viewing, while the new row uses Neo4j's precomputed Owner-POV count. Pre-existing inconsistency, not introduced by this PR; will be addressed when we tackle threshold/PoV management.

## Test plan

- [ ] Verify counts render on `staging.brainstorm.world/user/<pubkey>` (Neo4j here is populated; my local dev Neo4j is empty so I could only verify the placeholder path locally).
- [ ] Verify zero-followers case (a pubkey with `verifiedFollowerCount = 0`) shows `0 Verified Followers`, not `—`.
- [ ] Verify unknown / not-in-graph pubkey shows `—` placeholders, no crash, no console errors.
- [ ] Verify on mobile width — row wraps cleanly, no horizontal overflow.
- [ ] Sanity-check that the number matches what `/legacy/profile.html?pubkey=<same>` shows for the same pubkey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)