### PR TITLE
Drop Verified Followers from /user/:pubkey count row

### DIFF
--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -91,7 +91,6 @@ export default function BrainstormProfile() {
 
   const { data: userData, loading: userDataLoading } = useUserData(pubkey);
   const followingCount = userData?.followingCount ?? null;
-  const verifiedFollowerCount = userData?.verifiedFollowerCount ?? null;
   const fmtCount = (n) => (n == null ? '—' : new Intl.NumberFormat().format(n));
 
   const npub = useMemo(() => {
@@ -231,19 +230,11 @@ export default function BrainstormProfile() {
               </div>
             </div>
 
-            {/* Counts: Following / Verified Followers (Owner POV) */}
-            <div
-              className={`bsp-counts ${userDataLoading ? 'bsp-counts-loading' : ''}`}
-              title="Counts shown from the perspective of this instance's owner."
-            >
+            {/* Following count */}
+            <div className={`bsp-counts ${userDataLoading ? 'bsp-counts-loading' : ''}`}>
               <span className="bsp-count">
                 <span className="bsp-count-value">{fmtCount(followingCount)}</span>
                 <span className="bsp-count-label">Following</span>
-              </span>
-              <span className="bsp-count-sep" aria-hidden="true">·</span>
-              <span className="bsp-count">
-                <span className="bsp-count-value">{fmtCount(verifiedFollowerCount)}</span>
-                <span className="bsp-count-label">Verified Followers</span>
               </span>
             </div>
 

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3402,9 +3402,6 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
 .bsp-count-label {
   opacity: 0.6;
 }
-.bsp-count-sep {
-  opacity: 0.3;
-}
 .bsp-counts-loading .bsp-count-value {
   opacity: 0.4;
 }


### PR DESCRIPTION
## Summary

Follow-up to #70. Removes the Verified Followers span from the new count row on the public profile page, leaving just `X Following`.

The Reputation section's trust-metric grid already shows a Verified Followers card (sourced from Meilisearch's `wot_followers_<suffix>`). Displaying it in two places risked showing two different numbers on the same page — the Reputation card uses POV-suffixed Meilisearch scores, while the new row used the precomputed Owner-POV `verifiedFollowerCount` property on the `NostrUser` node. Single source of truth wins.

## Files changed

- **`ui/src/pages/BrainstormProfile.jsx`** — drops the `verifiedFollowerCount` derivation, the separator span, and the second `<span class="bsp-count">`. Also drops the (now-misleading) `title` on the row, since `followingCount` is the user's own kind-3 list (POV-independent).
- **`ui/src/styles.css`** — removes the now-unused `.bsp-count-sep` rule.

`useUserData.js` is untouched — it still fetches the full payload, ready for future fields.

## Test plan

- [ ] Verify on `staging.brainstorm.world/user/<pubkey>` — only `X Following` appears in the new row, no `·`, no second number.
- [ ] Verify the Reputation section still shows the Verified Followers card (no regression in that area).
- [ ] Verify zero / unknown pubkey paths still render `—` placeholder cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)