### PR TITLE
Promote staging → main: Following count on /user/:pubkey

### DIFF
--- a/ui/src/hooks/useUserData.js
+++ b/ui/src/hooks/useUserData.js
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook: fetch a NostrUser's aggregate counts from `/api/get-user-data`.
+ * Defaults to Owner POV (API default when observerPubkey is omitted).
+ * Returns { data, loading, error }.
+ */
+export default function useUserData(pubkey) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!pubkey) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    fetch(`/api/get-user-data?pubkey=${pubkey}`, { signal: controller.signal })
+      .then(r => r.json())
+      .then(json => {
+        if (json?.success && json.data) {
+          setData(json.data);
+        } else {
+          setData(null);
+          setError(json?.error || 'No data');
+        }
+      })
+      .catch(err => {
+        if (err.name === 'AbortError') return;
+        setError(err.message || 'Fetch failed');
+        setData(null);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [pubkey]);
+
+  return { data, loading, error };
+}

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -91,7 +91,6 @@ export default function BrainstormProfile() {
 
   const { data: userData, loading: userDataLoading } = useUserData(pubkey);
   const followingCount = userData?.followingCount ?? null;
-  const verifiedFollowerCount = userData?.verifiedFollowerCount ?? null;
   const fmtCount = (n) => (n == null ? '—' : new Intl.NumberFormat().format(n));
 
   const npub = useMemo(() => {
@@ -231,19 +230,11 @@ export default function BrainstormProfile() {
               </div>
             </div>
 
-            {/* Counts: Following / Verified Followers (Owner POV) */}
-            <div
-              className={`bsp-counts ${userDataLoading ? 'bsp-counts-loading' : ''}`}
-              title="Counts shown from the perspective of this instance's owner."
-            >
+            {/* Following count */}
+            <div className={`bsp-counts ${userDataLoading ? 'bsp-counts-loading' : ''}`}>
               <span className="bsp-count">
                 <span className="bsp-count-value">{fmtCount(followingCount)}</span>
                 <span className="bsp-count-label">Following</span>
-              </span>
-              <span className="bsp-count-sep" aria-hidden="true">·</span>
-              <span className="bsp-count">
-                <span className="bsp-count-value">{fmtCount(verifiedFollowerCount)}</span>
-                <span className="bsp-count-label">Verified Followers</span>
               </span>
             </div>
 

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -4,6 +4,7 @@ import { nip19 } from 'nostr-tools';
 import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu from '../components/BrainstormUserMenu';
 import { useProfileActions } from '../hooks/useProfileActions';
+import useUserData from '../hooks/useUserData';
 import ConfirmDialog from '../components/ConfirmDialog';
 import ReportModal from '../components/ReportModal';
 
@@ -87,6 +88,11 @@ export default function BrainstormProfile() {
   } = useProfileActions(pubkey, user?.pubkey);
 
   const showActions = user && user.pubkey !== pubkey;
+
+  const { data: userData, loading: userDataLoading } = useUserData(pubkey);
+  const followingCount = userData?.followingCount ?? null;
+  const verifiedFollowerCount = userData?.verifiedFollowerCount ?? null;
+  const fmtCount = (n) => (n == null ? '—' : new Intl.NumberFormat().format(n));
 
   const npub = useMemo(() => {
     try { return nip19.npubEncode(pubkey); } catch { return null; }
@@ -223,6 +229,22 @@ export default function BrainstormProfile() {
                 {profile?.nip05 && <div className="bsp-nip05">✅ {profile.nip05}</div>}
                 {profileAge && <span className="bsp-age">Updated {profileAge}</span>}
               </div>
+            </div>
+
+            {/* Counts: Following / Verified Followers (Owner POV) */}
+            <div
+              className={`bsp-counts ${userDataLoading ? 'bsp-counts-loading' : ''}`}
+              title="Counts shown from the perspective of this instance's owner."
+            >
+              <span className="bsp-count">
+                <span className="bsp-count-value">{fmtCount(followingCount)}</span>
+                <span className="bsp-count-label">Following</span>
+              </span>
+              <span className="bsp-count-sep" aria-hidden="true">·</span>
+              <span className="bsp-count">
+                <span className="bsp-count-value">{fmtCount(verifiedFollowerCount)}</span>
+                <span className="bsp-count-label">Verified Followers</span>
+              </span>
             </div>
 
             {/* Action buttons */}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3402,9 +3402,6 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
 .bsp-count-label {
   opacity: 0.6;
 }
-.bsp-count-sep {
-  opacity: 0.3;
-}
 .bsp-counts-loading .bsp-count-value {
   opacity: 0.4;
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3381,6 +3381,34 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   opacity: 0.4;
 }
 
+/* Following / Verified Followers row (under header, above actions) */
+.bsp-counts {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 0.5rem 0 0.25rem;
+  font-size: 0.9rem;
+}
+.bsp-count {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+.bsp-count-value {
+  font-weight: 600;
+  color: var(--text-primary, #e2e8f0);
+}
+.bsp-count-label {
+  opacity: 0.6;
+}
+.bsp-count-sep {
+  opacity: 0.3;
+}
+.bsp-counts-loading .bsp-count-value {
+  opacity: 0.4;
+}
+
 /* Sections */
 .bsp-section {
   margin-bottom: 1.5rem;


### PR DESCRIPTION
## Summary

Promotes the staging branch to main after verification on `staging.brainstorm.world`. Net user-facing change for production: a `X Following` count now appears on the public profile page at `/user/:pubkey`, sitting between the header and the Follow/Mute/Report buttons (Twitter/Damus-style).

## What's bundled

Two PRs that merged to staging since main last took:

- **#70** — Add Following / Verified Followers counts to `/user/:pubkey`. Wired the new row to the existing `GET /api/get-user-data` endpoint (Owner POV, default).
- **#72** — Drop Verified Followers from the new row. The Reputation section's trust-metric grid already shows a Verified Followers card from Meilisearch; keeping that as the single source of truth avoids displaying two potentially-different numbers (Owner-POV Neo4j count vs. POV-suffixed Meilisearch score) on the same page.

Net result: only `X Following` is in the new row.

## Deferred follow-ups (not in this promotion)

- All / verified / highly-reported / highly-muted toggle.
- Click-through to listings (React analog of `/legacy/grapevine-analysis.html`).
- POV switcher (always Owner POV).
- Threshold consolidation: the codebase has three values for "verification" (`0.01`, `0.05`, `0.1`); aligning them is the front edge of a bigger PoV/parameter-management refactor and stays its own future PR.

## Test plan

- [ ] After merge: confirm `deploy-brainstorm.yml` ran, `brainstorm.world` is back up.
- [ ] Visual: `https://brainstorm.world/user/<pubkey>` shows `X Following` row with a real number.
- [ ] No regression in the Reputation section's Verified Followers card.
- [ ] Spot-check on mobile width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)