### PR TITLE
Add /api/get-user-counts (strfry-backed); speed up Following count

### DIFF
--- a/src/api/export/users/index.js
+++ b/src/api/export/users/index.js
@@ -6,7 +6,7 @@
 const { handleGetProfiles } = require('./queries/profiles');
 const { handleGetProfileScores } = require('./queries/get-profile-scores');
 const { handleGetNip56Profiles } = require('./queries/nip56-profiles');
-const { handleGetUserData } = require('./queries/userdata');
+const { handleGetUserData, handleGetUserCounts } = require('./queries/userdata');
 const { handleGetNetworkProximity } = require('./queries/proximity');
 const { handleGetNpubFromPubkey } = require('./queries/get-npub-from-pubkey');
 const { handleGetPubkeyFromNpub } = require('./queries/get-pubkey-from-npub');
@@ -19,6 +19,7 @@ module.exports = {
     handleGetProfileScores,
     handleGetNip56Profiles,
     handleGetUserData,
+    handleGetUserCounts,
     handleGetNetworkProximity,
     handleGetNpubFromPubkey,
     handleGetPubkeyFromNpub

--- a/src/api/export/users/queries/userdata.js
+++ b/src/api/export/users/queries/userdata.js
@@ -5,6 +5,7 @@
  */
 
 const neo4j = require('neo4j-driver');
+const { exec } = require('child_process');
 const { getConfigFromFile } = require('../../../../utils/config');
 const fs = require('fs');
 const path = require('path');
@@ -285,80 +286,56 @@ function handleGetUserData(req, res) {
 }
 
 /**
- * Get the precomputed count properties on a NostrUser node.
- * Lightweight alternative to handleGetUserData when the caller only needs
- * counts (followingCount, followerCount, verifiedFollowerCount, etc.) and
- * doesn't need the expensive observer-relative graph metrics
- * (frenCount, mutualFollowerCount, recommendations, etc.).
+ * Get count metrics for a user that can be derived directly from strfry.
  *
- * Returns Owner POV (NostrUser node properties). No graph traversals.
+ * Currently returns just `followingCount`, computed as the number of `p` tags
+ * on the user's most recent kind 3 event. Reads from strfry rather than from
+ * the precomputed `NostrUser.followingCount` property because the property is
+ * batch-recomputed by calculateFollowingCounts.sh and can lag the kind 3 event
+ * by hours/days. The kind 3 event is the source of truth.
+ *
+ * Other counts (followerCount, verifiedFollowerCount, etc.) require either
+ * inverse strfry scans (slow) or Neo4j (stale + dependent on graph crawl), so
+ * they're not included here. If we need them later, this endpoint can grow
+ * a hybrid implementation: strfry for follow*, Neo4j for the WoT-derived counts.
  */
 function handleGetUserCounts(req, res) {
-  try {
-    const pubkey = req.query.pubkey;
-    if (!pubkey) {
-      return res.status(400).json({ success: false, error: 'Missing pubkey parameter' });
-    }
-    if (!nip19.npubEncode(pubkey).startsWith('npub')) {
-      return res.status(400).json({ success: false, error: 'Invalid pubkey parameter' });
-    }
-
-    const neo4jUri = getConfigFromFile('NEO4J_URI', 'bolt://localhost:7687');
-    const neo4jUser = getConfigFromFile('NEO4J_USER', 'neo4j');
-    const neo4jPassword = getConfigFromFile('NEO4J_PASSWORD', 'neo4j');
-
-    const driver = neo4j.driver(neo4jUri, neo4j.auth.basic(neo4jUser, neo4jPassword));
-    const session = driver.session();
-
-    const cypherQuery = `
-      MATCH (u:NostrUser {pubkey: $pubkey})
-      RETURN u.followingCount         AS followingCount,
-             u.followerCount          AS followerCount,
-             u.verifiedFollowerCount  AS verifiedFollowerCount,
-             u.mutingCount            AS mutingCount,
-             u.muterCount             AS muterCount,
-             u.verifiedMuterCount     AS verifiedMuterCount,
-             u.reportingCount         AS reportingCount,
-             u.reporterCount          AS reporterCount,
-             u.verifiedReporterCount  AS verifiedReporterCount
-    `;
-
-    const toInt = (v) => (v == null ? null : parseInt(v.toString(), 10));
-
-    session.run(cypherQuery, { pubkey })
-      .then(result => {
-        if (result.records.length === 0) {
-          return res.json({ success: false, message: 'No data found for this user' });
-        }
-        const r = result.records[0];
-        res.status(200).json({
-          success: true,
-          data: {
-            pubkey,
-            followingCount: toInt(r.get('followingCount')),
-            followerCount: toInt(r.get('followerCount')),
-            verifiedFollowerCount: toInt(r.get('verifiedFollowerCount')),
-            mutingCount: toInt(r.get('mutingCount')),
-            muterCount: toInt(r.get('muterCount')),
-            verifiedMuterCount: toInt(r.get('verifiedMuterCount')),
-            reportingCount: toInt(r.get('reportingCount')),
-            reporterCount: toInt(r.get('reporterCount')),
-            verifiedReporterCount: toInt(r.get('verifiedReporterCount')),
-          }
-        });
-      })
-      .catch(error => {
-        console.error('Error in handleGetUserCounts:', error);
-        res.status(500).json({ success: false, message: error.message });
-      })
-      .finally(() => {
-        session.close();
-        driver.close();
-      });
-  } catch (error) {
-    console.error('Error in handleGetUserCounts:', error);
-    res.status(500).json({ success: false, message: error.message });
+  const pubkey = req.query.pubkey;
+  if (!pubkey) {
+    return res.status(400).json({ success: false, error: 'Missing pubkey parameter' });
   }
+  if (!/^[0-9a-f]{64}$/i.test(pubkey)) {
+    return res.status(400).json({ success: false, error: 'Invalid pubkey parameter' });
+  }
+
+  const filter = JSON.stringify({ kinds: [3], authors: [pubkey], limit: 1 });
+  const cmd = `strfry scan '${filter}'`;
+
+  exec(cmd, { maxBuffer: 16 * 1024 * 1024 }, (error, stdout) => {
+    if (error) {
+      console.error('handleGetUserCounts strfry scan error:', error.message);
+      return res.status(500).json({ success: false, message: error.message });
+    }
+
+    let followingCount = null;
+    for (const line of stdout.trim().split('\n')) {
+      if (!line) continue;
+      try {
+        const event = JSON.parse(line);
+        if (Array.isArray(event.tags)) {
+          followingCount = event.tags.filter(t => Array.isArray(t) && t[0] === 'p').length;
+        }
+        break;
+      } catch {
+        // skip strfry log lines
+      }
+    }
+
+    res.status(200).json({
+      success: true,
+      data: { pubkey, followingCount }
+    });
+  });
 }
 
 module.exports = {

--- a/src/api/export/users/queries/userdata.js
+++ b/src/api/export/users/queries/userdata.js
@@ -284,6 +284,84 @@ function handleGetUserData(req, res) {
   }
 }
 
+/**
+ * Get the precomputed count properties on a NostrUser node.
+ * Lightweight alternative to handleGetUserData when the caller only needs
+ * counts (followingCount, followerCount, verifiedFollowerCount, etc.) and
+ * doesn't need the expensive observer-relative graph metrics
+ * (frenCount, mutualFollowerCount, recommendations, etc.).
+ *
+ * Returns Owner POV (NostrUser node properties). No graph traversals.
+ */
+function handleGetUserCounts(req, res) {
+  try {
+    const pubkey = req.query.pubkey;
+    if (!pubkey) {
+      return res.status(400).json({ success: false, error: 'Missing pubkey parameter' });
+    }
+    if (!nip19.npubEncode(pubkey).startsWith('npub')) {
+      return res.status(400).json({ success: false, error: 'Invalid pubkey parameter' });
+    }
+
+    const neo4jUri = getConfigFromFile('NEO4J_URI', 'bolt://localhost:7687');
+    const neo4jUser = getConfigFromFile('NEO4J_USER', 'neo4j');
+    const neo4jPassword = getConfigFromFile('NEO4J_PASSWORD', 'neo4j');
+
+    const driver = neo4j.driver(neo4jUri, neo4j.auth.basic(neo4jUser, neo4jPassword));
+    const session = driver.session();
+
+    const cypherQuery = `
+      MATCH (u:NostrUser {pubkey: $pubkey})
+      RETURN u.followingCount         AS followingCount,
+             u.followerCount          AS followerCount,
+             u.verifiedFollowerCount  AS verifiedFollowerCount,
+             u.mutingCount            AS mutingCount,
+             u.muterCount             AS muterCount,
+             u.verifiedMuterCount     AS verifiedMuterCount,
+             u.reportingCount         AS reportingCount,
+             u.reporterCount          AS reporterCount,
+             u.verifiedReporterCount  AS verifiedReporterCount
+    `;
+
+    const toInt = (v) => (v == null ? null : parseInt(v.toString(), 10));
+
+    session.run(cypherQuery, { pubkey })
+      .then(result => {
+        if (result.records.length === 0) {
+          return res.json({ success: false, message: 'No data found for this user' });
+        }
+        const r = result.records[0];
+        res.status(200).json({
+          success: true,
+          data: {
+            pubkey,
+            followingCount: toInt(r.get('followingCount')),
+            followerCount: toInt(r.get('followerCount')),
+            verifiedFollowerCount: toInt(r.get('verifiedFollowerCount')),
+            mutingCount: toInt(r.get('mutingCount')),
+            muterCount: toInt(r.get('muterCount')),
+            verifiedMuterCount: toInt(r.get('verifiedMuterCount')),
+            reportingCount: toInt(r.get('reportingCount')),
+            reporterCount: toInt(r.get('reporterCount')),
+            verifiedReporterCount: toInt(r.get('verifiedReporterCount')),
+          }
+        });
+      })
+      .catch(error => {
+        console.error('Error in handleGetUserCounts:', error);
+        res.status(500).json({ success: false, message: error.message });
+      })
+      .finally(() => {
+        session.close();
+        driver.close();
+      });
+  } catch (error) {
+    console.error('Error in handleGetUserCounts:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+}
+
 module.exports = {
-  handleGetUserData
+  handleGetUserData,
+  handleGetUserCounts
 };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -209,6 +209,7 @@ async function register(app) {
     app.get('/api/get-profile-scores', users.handleGetProfileScores);
     app.get('/api/get-nip56-profiles', users.handleGetNip56Profiles);
     app.get('/api/get-user-data', users.handleGetUserData);
+    app.get('/api/get-user-counts', users.handleGetUserCounts);
     app.get('/api/get-network-proximity', users.handleGetNetworkProximity);
     app.get('/api/get-npub-from-pubkey', users.handleGetNpubFromPubkey);
     app.get('/api/get-pubkey-from-npub', users.handleGetPubkeyFromNpub);

--- a/ui/src/hooks/useUserCounts.js
+++ b/ui/src/hooks/useUserCounts.js
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react';
 
 /**
- * Hook: fetch a NostrUser's aggregate counts from `/api/get-user-data`.
- * Defaults to Owner POV (API default when observerPubkey is omitted).
+ * Hook: fetch a NostrUser's precomputed counts from `/api/get-user-counts`.
+ * Owner POV (NostrUser node properties). Lightweight — no graph traversals.
  * Returns { data, loading, error }.
  */
-export default function useUserData(pubkey) {
+export default function useUserCounts(pubkey) {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -22,7 +22,7 @@ export default function useUserData(pubkey) {
     setLoading(true);
     setError(null);
 
-    fetch(`/api/get-user-data?pubkey=${pubkey}`, { signal: controller.signal })
+    fetch(`/api/get-user-counts?pubkey=${pubkey}`, { signal: controller.signal })
       .then(r => r.json())
       .then(json => {
         if (json?.success && json.data) {

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -4,7 +4,7 @@ import { nip19 } from 'nostr-tools';
 import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu from '../components/BrainstormUserMenu';
 import { useProfileActions } from '../hooks/useProfileActions';
-import useUserData from '../hooks/useUserData';
+import useUserCounts from '../hooks/useUserCounts';
 import ConfirmDialog from '../components/ConfirmDialog';
 import ReportModal from '../components/ReportModal';
 
@@ -89,8 +89,8 @@ export default function BrainstormProfile() {
 
   const showActions = user && user.pubkey !== pubkey;
 
-  const { data: userData, loading: userDataLoading } = useUserData(pubkey);
-  const followingCount = userData?.followingCount ?? null;
+  const { data: userCounts, loading: userCountsLoading } = useUserCounts(pubkey);
+  const followingCount = userCounts?.followingCount ?? null;
   const fmtCount = (n) => (n == null ? '—' : new Intl.NumberFormat().format(n));
 
   const npub = useMemo(() => {
@@ -231,7 +231,7 @@ export default function BrainstormProfile() {
             </div>
 
             {/* Following count */}
-            <div className={`bsp-counts ${userDataLoading ? 'bsp-counts-loading' : ''}`}>
+            <div className={`bsp-counts ${userCountsLoading ? 'bsp-counts-loading' : ''}`}>
               <span className="bsp-count">
                 <span className="bsp-count-value">{fmtCount(followingCount)}</span>
                 <span className="bsp-count-label">Following</span>


### PR DESCRIPTION
## Summary

The Following count on `/user/:pubkey` is currently sourced from `/api/get-user-data`, which runs ~9 `OPTIONAL MATCH` graph traversals against the 30M-edge FOLLOWS graph before returning. **Measured on production: ~16 seconds per request, even though the page only consumes one field (`followingCount`).**

This PR adds a dedicated lightweight endpoint and switches the profile page to use it.

## Implementation

- **New endpoint `GET /api/get-user-counts?pubkey=<x>`** ([src/api/export/users/queries/userdata.js](src/api/export/users/queries/userdata.js)): reads the user's most recent kind 3 event from strfry and counts `p` tags. No Neo4j involvement.
- **Hook rename:** `ui/src/hooks/useUserData.js` → `useUserCounts.js`. Same shape, just calls the new URL. `BrainstormProfile.jsx` updated accordingly.
- **`/api/get-user-data` stays as-is.** `/legacy/profile.html` still depends on the full payload.

### Why strfry instead of `NostrUser.followingCount`?

Two reasons:

1. **Freshness.** The Neo4j `followingCount` property is recomputed by [calculateFollowingCounts.sh](src/algos/follows-mutes-reports/calculateFollowingCounts.sh) on a batch schedule, **not** by streaming ETL. The streaming ETL maintains the FOLLOWS *edges*; the count property is a periodic snapshot. Between batch runs, the count lags the actual kind 3 event by hours/days. The kind 3 event is the source of truth.
2. **Coverage.** Works for any user whose kind 3 we have in strfry, even if the graph crawl hasn't crawled their FOLLOWS edges yet.

The earlier draft of this PR read from `NostrUser.followingCount` directly. Switched after timing confirmed strfry is fast enough on its own and avoids the staleness problem.

## Measured timings

For pubkey `04c915da…` (1,800 follows) on production:

| Endpoint | 3-run average |
|---|---|
| `/api/get-user-data` (current) | **~16.6 s** |
| `/api/strfry/scan` (raw, returns full kind 3) | ~0.30 s |
| `/api/get-user-counts` (new — uses strfry under the hood, returns just the count) | not yet measured on prod; ~40 ms locally for the same kind 3 |

Expected production latency for the new endpoint: comparable to `/api/strfry/scan` since the heavy lifting is the LMDB lookup. Probably ~200–400 ms — orders of magnitude better than ~16 s.

## Trade-offs

- **Drops other counts.** This endpoint now returns only `{ pubkey, followingCount }`. Earlier draft also returned `followerCount`, `verifiedFollowerCount`, etc. — those need Neo4j (or an inverse strfry scan, which is slow), so they're not included. If we re-add Verified Followers or other counts later, this endpoint can grow into a hybrid: strfry for follow* counts, Neo4j for the WoT-derived ones.
- **Wire payload.** The endpoint internally fetches the full kind 3 event (~130 KB for jack-tier users) but returns only ~80 bytes to the client.

## Known follow-up

Swagger docs at `/docs` aren't updated for the new endpoint. Audit pending; tracked separately.

## Test plan

- [ ] On `staging.brainstorm.world`, time `curl /api/get-user-counts?pubkey=<pk>` vs `curl /api/get-user-data?pubkey=<pk>` — expect orders-of-magnitude difference.
- [ ] Visual: profile page Following count appears nearly instantly.
- [ ] Sanity: number matches the p-tag count on the user's most recent kind 3 (and matches what nostr clients like Damus show).
- [ ] Regression check: `/legacy/profile.html?pubkey=<pk>` still works (it still uses `/api/get-user-data`).
- [ ] Edge case: pubkey with no kind 3 in strfry → returns `followingCount: null`, page shows `—`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)