### PR TITLE
Promote staging → main: strfry-backed Following count

### DIFF
--- a/src/api/export/users/index.js
+++ b/src/api/export/users/index.js
@@ -6,7 +6,7 @@
 const { handleGetProfiles } = require('./queries/profiles');
 const { handleGetProfileScores } = require('./queries/get-profile-scores');
 const { handleGetNip56Profiles } = require('./queries/nip56-profiles');
-const { handleGetUserData } = require('./queries/userdata');
+const { handleGetUserData, handleGetUserCounts } = require('./queries/userdata');
 const { handleGetNetworkProximity } = require('./queries/proximity');
 const { handleGetNpubFromPubkey } = require('./queries/get-npub-from-pubkey');
 const { handleGetPubkeyFromNpub } = require('./queries/get-pubkey-from-npub');
@@ -19,6 +19,7 @@ module.exports = {
     handleGetProfileScores,
     handleGetNip56Profiles,
     handleGetUserData,
+    handleGetUserCounts,
     handleGetNetworkProximity,
     handleGetNpubFromPubkey,
     handleGetPubkeyFromNpub

--- a/src/api/export/users/queries/userdata.js
+++ b/src/api/export/users/queries/userdata.js
@@ -5,6 +5,7 @@
  */
 
 const neo4j = require('neo4j-driver');
+const { exec } = require('child_process');
 const { getConfigFromFile } = require('../../../../utils/config');
 const fs = require('fs');
 const path = require('path');
@@ -285,80 +286,56 @@ function handleGetUserData(req, res) {
 }
 
 /**
- * Get the precomputed count properties on a NostrUser node.
- * Lightweight alternative to handleGetUserData when the caller only needs
- * counts (followingCount, followerCount, verifiedFollowerCount, etc.) and
- * doesn't need the expensive observer-relative graph metrics
- * (frenCount, mutualFollowerCount, recommendations, etc.).
+ * Get count metrics for a user that can be derived directly from strfry.
  *
- * Returns Owner POV (NostrUser node properties). No graph traversals.
+ * Currently returns just `followingCount`, computed as the number of `p` tags
+ * on the user's most recent kind 3 event. Reads from strfry rather than from
+ * the precomputed `NostrUser.followingCount` property because the property is
+ * batch-recomputed by calculateFollowingCounts.sh and can lag the kind 3 event
+ * by hours/days. The kind 3 event is the source of truth.
+ *
+ * Other counts (followerCount, verifiedFollowerCount, etc.) require either
+ * inverse strfry scans (slow) or Neo4j (stale + dependent on graph crawl), so
+ * they're not included here. If we need them later, this endpoint can grow
+ * a hybrid implementation: strfry for follow*, Neo4j for the WoT-derived counts.
  */
 function handleGetUserCounts(req, res) {
-  try {
-    const pubkey = req.query.pubkey;
-    if (!pubkey) {
-      return res.status(400).json({ success: false, error: 'Missing pubkey parameter' });
-    }
-    if (!nip19.npubEncode(pubkey).startsWith('npub')) {
-      return res.status(400).json({ success: false, error: 'Invalid pubkey parameter' });
-    }
-
-    const neo4jUri = getConfigFromFile('NEO4J_URI', 'bolt://localhost:7687');
-    const neo4jUser = getConfigFromFile('NEO4J_USER', 'neo4j');
-    const neo4jPassword = getConfigFromFile('NEO4J_PASSWORD', 'neo4j');
-
-    const driver = neo4j.driver(neo4jUri, neo4j.auth.basic(neo4jUser, neo4jPassword));
-    const session = driver.session();
-
-    const cypherQuery = `
-      MATCH (u:NostrUser {pubkey: $pubkey})
-      RETURN u.followingCount         AS followingCount,
-             u.followerCount          AS followerCount,
-             u.verifiedFollowerCount  AS verifiedFollowerCount,
-             u.mutingCount            AS mutingCount,
-             u.muterCount             AS muterCount,
-             u.verifiedMuterCount     AS verifiedMuterCount,
-             u.reportingCount         AS reportingCount,
-             u.reporterCount          AS reporterCount,
-             u.verifiedReporterCount  AS verifiedReporterCount
-    `;
-
-    const toInt = (v) => (v == null ? null : parseInt(v.toString(), 10));
-
-    session.run(cypherQuery, { pubkey })
-      .then(result => {
-        if (result.records.length === 0) {
-          return res.json({ success: false, message: 'No data found for this user' });
-        }
-        const r = result.records[0];
-        res.status(200).json({
-          success: true,
-          data: {
-            pubkey,
-            followingCount: toInt(r.get('followingCount')),
-            followerCount: toInt(r.get('followerCount')),
-            verifiedFollowerCount: toInt(r.get('verifiedFollowerCount')),
-            mutingCount: toInt(r.get('mutingCount')),
-            muterCount: toInt(r.get('muterCount')),
-            verifiedMuterCount: toInt(r.get('verifiedMuterCount')),
-            reportingCount: toInt(r.get('reportingCount')),
-            reporterCount: toInt(r.get('reporterCount')),
-            verifiedReporterCount: toInt(r.get('verifiedReporterCount')),
-          }
-        });
-      })
-      .catch(error => {
-        console.error('Error in handleGetUserCounts:', error);
-        res.status(500).json({ success: false, message: error.message });
-      })
-      .finally(() => {
-        session.close();
-        driver.close();
-      });
-  } catch (error) {
-    console.error('Error in handleGetUserCounts:', error);
-    res.status(500).json({ success: false, message: error.message });
+  const pubkey = req.query.pubkey;
+  if (!pubkey) {
+    return res.status(400).json({ success: false, error: 'Missing pubkey parameter' });
   }
+  if (!/^[0-9a-f]{64}$/i.test(pubkey)) {
+    return res.status(400).json({ success: false, error: 'Invalid pubkey parameter' });
+  }
+
+  const filter = JSON.stringify({ kinds: [3], authors: [pubkey], limit: 1 });
+  const cmd = `strfry scan '${filter}'`;
+
+  exec(cmd, { maxBuffer: 16 * 1024 * 1024 }, (error, stdout) => {
+    if (error) {
+      console.error('handleGetUserCounts strfry scan error:', error.message);
+      return res.status(500).json({ success: false, message: error.message });
+    }
+
+    let followingCount = null;
+    for (const line of stdout.trim().split('\n')) {
+      if (!line) continue;
+      try {
+        const event = JSON.parse(line);
+        if (Array.isArray(event.tags)) {
+          followingCount = event.tags.filter(t => Array.isArray(t) && t[0] === 'p').length;
+        }
+        break;
+      } catch {
+        // skip strfry log lines
+      }
+    }
+
+    res.status(200).json({
+      success: true,
+      data: { pubkey, followingCount }
+    });
+  });
 }
 
 module.exports = {

--- a/src/api/export/users/queries/userdata.js
+++ b/src/api/export/users/queries/userdata.js
@@ -284,6 +284,84 @@ function handleGetUserData(req, res) {
   }
 }
 
+/**
+ * Get the precomputed count properties on a NostrUser node.
+ * Lightweight alternative to handleGetUserData when the caller only needs
+ * counts (followingCount, followerCount, verifiedFollowerCount, etc.) and
+ * doesn't need the expensive observer-relative graph metrics
+ * (frenCount, mutualFollowerCount, recommendations, etc.).
+ *
+ * Returns Owner POV (NostrUser node properties). No graph traversals.
+ */
+function handleGetUserCounts(req, res) {
+  try {
+    const pubkey = req.query.pubkey;
+    if (!pubkey) {
+      return res.status(400).json({ success: false, error: 'Missing pubkey parameter' });
+    }
+    if (!nip19.npubEncode(pubkey).startsWith('npub')) {
+      return res.status(400).json({ success: false, error: 'Invalid pubkey parameter' });
+    }
+
+    const neo4jUri = getConfigFromFile('NEO4J_URI', 'bolt://localhost:7687');
+    const neo4jUser = getConfigFromFile('NEO4J_USER', 'neo4j');
+    const neo4jPassword = getConfigFromFile('NEO4J_PASSWORD', 'neo4j');
+
+    const driver = neo4j.driver(neo4jUri, neo4j.auth.basic(neo4jUser, neo4jPassword));
+    const session = driver.session();
+
+    const cypherQuery = `
+      MATCH (u:NostrUser {pubkey: $pubkey})
+      RETURN u.followingCount         AS followingCount,
+             u.followerCount          AS followerCount,
+             u.verifiedFollowerCount  AS verifiedFollowerCount,
+             u.mutingCount            AS mutingCount,
+             u.muterCount             AS muterCount,
+             u.verifiedMuterCount     AS verifiedMuterCount,
+             u.reportingCount         AS reportingCount,
+             u.reporterCount          AS reporterCount,
+             u.verifiedReporterCount  AS verifiedReporterCount
+    `;
+
+    const toInt = (v) => (v == null ? null : parseInt(v.toString(), 10));
+
+    session.run(cypherQuery, { pubkey })
+      .then(result => {
+        if (result.records.length === 0) {
+          return res.json({ success: false, message: 'No data found for this user' });
+        }
+        const r = result.records[0];
+        res.status(200).json({
+          success: true,
+          data: {
+            pubkey,
+            followingCount: toInt(r.get('followingCount')),
+            followerCount: toInt(r.get('followerCount')),
+            verifiedFollowerCount: toInt(r.get('verifiedFollowerCount')),
+            mutingCount: toInt(r.get('mutingCount')),
+            muterCount: toInt(r.get('muterCount')),
+            verifiedMuterCount: toInt(r.get('verifiedMuterCount')),
+            reportingCount: toInt(r.get('reportingCount')),
+            reporterCount: toInt(r.get('reporterCount')),
+            verifiedReporterCount: toInt(r.get('verifiedReporterCount')),
+          }
+        });
+      })
+      .catch(error => {
+        console.error('Error in handleGetUserCounts:', error);
+        res.status(500).json({ success: false, message: error.message });
+      })
+      .finally(() => {
+        session.close();
+        driver.close();
+      });
+  } catch (error) {
+    console.error('Error in handleGetUserCounts:', error);
+    res.status(500).json({ success: false, message: error.message });
+  }
+}
+
 module.exports = {
-  handleGetUserData
+  handleGetUserData,
+  handleGetUserCounts
 };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -209,6 +209,7 @@ async function register(app) {
     app.get('/api/get-profile-scores', users.handleGetProfileScores);
     app.get('/api/get-nip56-profiles', users.handleGetNip56Profiles);
     app.get('/api/get-user-data', users.handleGetUserData);
+    app.get('/api/get-user-counts', users.handleGetUserCounts);
     app.get('/api/get-network-proximity', users.handleGetNetworkProximity);
     app.get('/api/get-npub-from-pubkey', users.handleGetNpubFromPubkey);
     app.get('/api/get-pubkey-from-npub', users.handleGetPubkeyFromNpub);

--- a/ui/src/hooks/useUserCounts.js
+++ b/ui/src/hooks/useUserCounts.js
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react';
 
 /**
- * Hook: fetch a NostrUser's aggregate counts from `/api/get-user-data`.
- * Defaults to Owner POV (API default when observerPubkey is omitted).
+ * Hook: fetch a NostrUser's precomputed counts from `/api/get-user-counts`.
+ * Owner POV (NostrUser node properties). Lightweight — no graph traversals.
  * Returns { data, loading, error }.
  */
-export default function useUserData(pubkey) {
+export default function useUserCounts(pubkey) {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -22,7 +22,7 @@ export default function useUserData(pubkey) {
     setLoading(true);
     setError(null);
 
-    fetch(`/api/get-user-data?pubkey=${pubkey}`, { signal: controller.signal })
+    fetch(`/api/get-user-counts?pubkey=${pubkey}`, { signal: controller.signal })
       .then(r => r.json())
       .then(json => {
         if (json?.success && json.data) {

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -4,7 +4,7 @@ import { nip19 } from 'nostr-tools';
 import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu from '../components/BrainstormUserMenu';
 import { useProfileActions } from '../hooks/useProfileActions';
-import useUserData from '../hooks/useUserData';
+import useUserCounts from '../hooks/useUserCounts';
 import ConfirmDialog from '../components/ConfirmDialog';
 import ReportModal from '../components/ReportModal';
 
@@ -89,8 +89,8 @@ export default function BrainstormProfile() {
 
   const showActions = user && user.pubkey !== pubkey;
 
-  const { data: userData, loading: userDataLoading } = useUserData(pubkey);
-  const followingCount = userData?.followingCount ?? null;
+  const { data: userCounts, loading: userCountsLoading } = useUserCounts(pubkey);
+  const followingCount = userCounts?.followingCount ?? null;
   const fmtCount = (n) => (n == null ? '—' : new Intl.NumberFormat().format(n));
 
   const npub = useMemo(() => {
@@ -231,7 +231,7 @@ export default function BrainstormProfile() {
             </div>
 
             {/* Following count */}
-            <div className={`bsp-counts ${userDataLoading ? 'bsp-counts-loading' : ''}`}>
+            <div className={`bsp-counts ${userCountsLoading ? 'bsp-counts-loading' : ''}`}>
               <span className="bsp-count">
                 <span className="bsp-count-value">{fmtCount(followingCount)}</span>
                 <span className="bsp-count-label">Following</span>


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`. Net production-facing change: the Following count on `/user/:pubkey` should now appear nearly instantly (down from ~16 s) and reflect the user's actual most-recent kind 3 event (no longer a stale batch snapshot).

## What's bundled

Single PR landed on staging since main last took:

- **#74** — Add `/api/get-user-counts` endpoint that reads the user's most recent kind 3 event from strfry and counts `p` tags. Profile page hook (`useUserCounts.js`) and component (`BrainstormProfile.jsx`) updated to use it. `/api/get-user-data` is untouched — `/legacy/profile.html` still depends on it.

Two commits on the branch: an initial Neo4j-based implementation, then a switch to strfry once timing/freshness analysis showed strfry was the better data source. Full rationale in the PR body of #74.

## Expected impact on production

- Following count latency drops from ~16 s to a few hundred ms.
- Number reflects the live kind 3 event, not the batch-recomputed `NostrUser.followingCount` property.
- Reduces Neo4j load — every profile page view skips the ~9 graph traversals previously triggered by `/api/get-user-data`.

## Deferred

- Swagger docs for the new endpoint — chip already spawned for a broader Swagger coverage audit.
- Re-adding Verified Followers or other counts to the new row — when we want them, the endpoint can grow into a hybrid (strfry for follow*, Neo4j for WoT-derived counts).

## Test plan

- [ ] After merge: confirm `deploy-brainstorm.yml` ran and `brainstorm.world` is back up.
- [ ] Visual on `https://brainstorm.world/user/<pubkey>`: Following count appears within a second.
- [ ] Time `curl https://brainstorm.world/api/get-user-counts?pubkey=<pk>` — expect a few hundred ms.
- [ ] Sanity: number matches the p-tag count on the user's latest kind 3 (and what other nostr clients show).
- [ ] Regression: `/legacy/profile.html?pubkey=<pk>` still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)