### PR TITLE
Catch-all routes: friendly NotFound + settings redirect

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -70,6 +70,7 @@ import BrainstormPersonalization from './pages/BrainstormPersonalization';
 import BrainstormHowSearchWorks from './pages/BrainstormHowSearchWorks';
 import BrainstormAbout from './pages/BrainstormAbout';
 import BrainstormDevelopers from './pages/BrainstormDevelopers';
+import NotFound from './pages/NotFound';
 const router = createBrowserRouter([
   {
     path: '/',
@@ -265,10 +266,13 @@ const router = createBrowserRouter([
           { path: 'uuids', handle: { crumb: 'Concept UUIDs' } },
           { path: 'firmware', handle: { crumb: 'Firmware' } },
           { path: 'auditing', handle: { crumb: 'Auditing Tools' } },
+          { path: '*', element: <Navigate to="/tapestry/settings/relays" replace /> },
         ],
       },
+      { path: '*', element: <NotFound />, handle: { crumb: 'Not Found' } },
     ],
   },
+  { path: '*', element: <NotFound /> },
 ]);
 
 export default function App() {

--- a/ui/src/pages/NotFound.jsx
+++ b/ui/src/pages/NotFound.jsx
@@ -1,0 +1,31 @@
+import { Link, useLocation } from 'react-router-dom';
+
+/**
+ * Catch-all "page not found" rendered for any URL that doesn't match a defined
+ * route. Used at the top level (`/foo`) and under `/tapestry/*` to give visitors
+ * a clear message and a way home, instead of React Router's default error UI.
+ */
+export default function NotFound() {
+  const location = useLocation();
+  const inTapestry = location.pathname.startsWith('/tapestry');
+  const homeHref = inTapestry ? '/tapestry' : '/';
+  const homeLabel = inTapestry ? 'Dashboard' : 'Brainstorm Search';
+
+  return (
+    <div style={{
+      maxWidth: 560,
+      margin: '6rem auto',
+      padding: '2rem 1.5rem',
+      textAlign: 'center',
+      lineHeight: 1.6,
+    }}>
+      <h1 style={{ fontSize: '2rem', marginBottom: '0.5rem' }}>Page not found</h1>
+      <p style={{ opacity: 0.6, marginBottom: '1.5rem' }}>
+        No route matched <code style={{ background: 'rgba(255,255,255,0.06)', padding: '0.1rem 0.35rem', borderRadius: 4 }}>{location.pathname}</code>.
+      </p>
+      <p>
+        <Link to={homeHref} style={{ color: '#a5b4fc' }}>← Return to {homeLabel}</Link>
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes the React Router default error UI (\"Unexpected Application Error! 404 Not Found — Hey developer 👋\") that appeared on direct navigation to any unmatched URL: `/foo`, `/tapestry/foo`, `/tapestry/settings/system`, etc.

Caught while verifying [#81](https://github.com/nous-clawds4/tapestry/pull/81)'s System-tab removal in Chrome on staging — the deleted `/tapestry/settings/system` URL hit the error page. Investigation showed the issue is broader than that one URL: it's the route tree's default behaviour for any unmatched path. The user confirmed the same error on `/tapestry/foo`, so the fix lands at multiple levels.

## Changes

- **New `ui/src/pages/NotFound.jsx`** — small \"Page not found\" message with the offending pathname and a link home (Dashboard if inside `/tapestry`, Brainstorm Search otherwise).
- **`ui/src/App.jsx`** — three catch-all entries:
  - top-level `*` → `<NotFound />` (catches `/foo`)
  - `/tapestry/*` → `<NotFound />` (catches `/tapestry/foo`)
  - `/tapestry/settings/*` → `<Navigate to=\"/tapestry/settings/relays\" replace />` (settings sub-paths default to the first tab — common case is \"user wants settings, just pick a tab\")

## Bug caught locally before push

Initial draft used `<Navigate to=\"relays\" replace />` (relative) for the settings catch-all. That created an infinite redirect loop because `/tapestry/settings/system` → `/tapestry/settings/system/relays` (the appended segment is also unmatched). Switched to absolute path. Smoke-tested all three catch-alls in Chrome on `:8080` after the fix; no console errors, redirects land correctly.

## Test plan

- [ ] Direct nav to `https://staging.brainstorm.world/tapestry/settings/system` lands on `/tapestry/settings/relays`, no error.
- [ ] Direct nav to `https://staging.brainstorm.world/tapestry/foo` shows \"Page not found\" with link to Dashboard.
- [ ] Direct nav to `https://staging.brainstorm.world/foo` shows \"Page not found\" with link to Brainstorm Search.
- [ ] Existing legit routes (`/`, `/user/:pk`, `/tapestry`, `/tapestry/concepts`, `/tapestry/settings/relays`) still render normally.
- [ ] Console clean on all of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)