### PR TITLE
Promote staging → main: dynamic OWNER_PUBKEY + relay lists

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -480,6 +480,14 @@ async function register(app) {
     app.get('/api/assistant/status', assistantApi.handleAssistantStatus);
     app.get('/api/assistant/pubkey', assistantApi.handleGetTAPubkey);
 
+    // ── Owner pubkey (public) ──
+    const ownerApi = require('./owner');
+    app.get('/api/owner/pubkey', ownerApi.handleGetOwnerPubkey);
+
+    // ── Public aRelays list ──
+    const relaysApi = require('./relays');
+    app.get('/api/relays', relaysApi.handleGetRelays);
+
     // ── Tapestry Property API ──
     const { registerPropertyRoutes } = require('./property');
     registerPropertyRoutes(app);

--- a/src/api/owner/index.js
+++ b/src/api/owner/index.js
@@ -1,0 +1,20 @@
+/**
+ * Owner endpoints — public, no auth.
+ */
+
+const { getConfigFromFile } = require('../../utils/config');
+
+/**
+ * GET /api/owner/pubkey
+ * Returns the instance owner's nostr pubkey. Public — pubkeys are not secret.
+ * Mirrors the shape of /api/assistant/pubkey for the Tapestry Assistant.
+ */
+function handleGetOwnerPubkey(req, res) {
+  const pubkey = getConfigFromFile('BRAINSTORM_OWNER_PUBKEY', '');
+  if (!pubkey) {
+    return res.status(404).json({ success: false, error: 'Owner pubkey not configured' });
+  }
+  return res.json({ success: true, pubkey });
+}
+
+module.exports = { handleGetOwnerPubkey };

--- a/src/api/relays/index.js
+++ b/src/api/relays/index.js
@@ -1,0 +1,23 @@
+/**
+ * Public relay-list endpoint — no auth.
+ * Surfaces settings.aRelays so UI components don't have to hardcode relay arrays.
+ */
+
+const { getSettings } = require('../../config/settings');
+
+/**
+ * GET /api/relays
+ * Returns the configured aRelays object from settings. Public — relay URLs
+ * are not sensitive.
+ */
+function handleGetRelays(req, res) {
+  try {
+    const settings = getSettings();
+    const aRelays = settings?.aRelays || {};
+    return res.json({ success: true, aRelays });
+  } catch (err) {
+    return res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+module.exports = { handleGetRelays };

--- a/ui/src/config/pubkeys.js
+++ b/ui/src/config/pubkeys.js
@@ -1,5 +1,6 @@
-// Well-known pubkeys for the Tapestry instance
-// TA_PUBKEY is now fetched dynamically — use useConfig().taPubkey instead
+// Well-known pubkeys.
+// OWNER_PUBKEY and TA_PUBKEY are now fetched dynamically — use useConfig().ownerPubkey / .taPubkey.
+// DAVE_PUBKEY remains as a NosFabrica-specific cosmetic constant (pins David's pubkey with a 🧑‍💻 emoji
+// in author lists). Out of scope for this cleanup; flagged in docs/PREFERENCES_AUDIT.md.
 
-export const OWNER_PUBKEY = '15f7dafc4624b1e6b00ab7f863de1a53b71967528070ec7d1837c7a40c1c7270';
 export const DAVE_PUBKEY = 'e5272de914bd301755c439b88e6959a43c9d2664831f093c51e9c799a16a102f';

--- a/ui/src/context/ConfigContext.jsx
+++ b/ui/src/context/ConfigContext.jsx
@@ -8,16 +8,28 @@ export function useConfig() {
 
 export function ConfigProvider({ children }) {
   const [taPubkey, setTaPubkey] = useState(null);
+  const [ownerPubkey, setOwnerPubkey] = useState(null);
+  const [aRelays, setARelays] = useState(null);
 
   useEffect(() => {
     fetch('/api/assistant/pubkey')
       .then(r => r.json())
       .then(d => { if (d.success) setTaPubkey(d.pubkey); })
       .catch(() => {});
+
+    fetch('/api/owner/pubkey')
+      .then(r => r.json())
+      .then(d => { if (d.success) setOwnerPubkey(d.pubkey); })
+      .catch(() => {});
+
+    fetch('/api/relays')
+      .then(r => r.json())
+      .then(d => { if (d.success) setARelays(d.aRelays); })
+      .catch(() => {});
   }, []);
 
   return (
-    <ConfigContext.Provider value={{ taPubkey }}>
+    <ConfigContext.Provider value={{ taPubkey, ownerPubkey, aRelays }}>
       {children}
     </ConfigContext.Provider>
   );

--- a/ui/src/context/TrustContext.jsx
+++ b/ui/src/context/TrustContext.jsx
@@ -1,5 +1,5 @@
-import { createContext, useContext, useState, useCallback } from 'react';
-import { OWNER_PUBKEY } from '../config/pubkeys';
+import { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import { useConfig } from './ConfigContext';
 
 const STORAGE_KEY = 'tapestry_trust_method';
 
@@ -10,11 +10,8 @@ const SCORING_METHODS = [
   { id: 'trust-everyone', label: 'Trust Everyone' },
 ];
 
-const DEFAULT_STATE = {
-  povPubkey: OWNER_PUBKEY,
-  scoringMethod: 'trusted-assertions-rank',
-  trustedListId: '',  // d-tag identifier for selected kind 30392 Trusted List
-};
+const DEFAULT_SCORING_METHOD = 'trusted-assertions-rank';
+const DEFAULT_TRUSTED_LIST_ID = '';
 
 function loadState() {
   try {
@@ -22,15 +19,15 @@ function loadState() {
     if (stored) {
       const parsed = JSON.parse(stored);
       return {
-        povPubkey: parsed.povPubkey || DEFAULT_STATE.povPubkey,
+        povPubkey: parsed.povPubkey || null,
         scoringMethod: SCORING_METHODS.some(m => m.id === parsed.scoringMethod)
           ? parsed.scoringMethod
-          : DEFAULT_STATE.scoringMethod,
-        trustedListId: parsed.trustedListId || DEFAULT_STATE.trustedListId,
+          : DEFAULT_SCORING_METHOD,
+        trustedListId: parsed.trustedListId || DEFAULT_TRUSTED_LIST_ID,
       };
     }
   } catch {}
-  return { ...DEFAULT_STATE };
+  return { povPubkey: null, scoringMethod: DEFAULT_SCORING_METHOD, trustedListId: DEFAULT_TRUSTED_LIST_ID };
 }
 
 function saveState(state) {
@@ -50,7 +47,15 @@ export function useTrust() {
 export { SCORING_METHODS };
 
 export function TrustProvider({ children }) {
+  const { ownerPubkey } = useConfig();
   const [state, setState] = useState(loadState);
+
+  // Once the owner pubkey arrives from the server, default povPubkey to it
+  // (only if the user hasn't set their own — i.e. we restored null from storage).
+  useEffect(() => {
+    if (!ownerPubkey) return;
+    setState(prev => (prev.povPubkey ? prev : { ...prev, povPubkey: ownerPubkey }));
+  }, [ownerPubkey]);
 
   const setPovPubkey = useCallback((pubkey) => {
     setState(prev => {
@@ -77,14 +82,15 @@ export function TrustProvider({ children }) {
   }, []);
 
   const resetToOwner = useCallback(() => {
+    if (!ownerPubkey) return;
     setState(prev => {
-      const next = { ...prev, povPubkey: OWNER_PUBKEY };
+      const next = { ...prev, povPubkey: ownerPubkey };
       saveState(next);
       return next;
     });
-  }, []);
+  }, [ownerPubkey]);
 
-  const isOwnerPov = state.povPubkey === OWNER_PUBKEY;
+  const isOwnerPov = ownerPubkey != null && state.povPubkey === ownerPubkey;
 
   const value = {
     povPubkey: state.povPubkey,

--- a/ui/src/pages/BrainstormSearch.jsx
+++ b/ui/src/pages/BrainstormSearch.jsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useAuth } from '../context/AuthContext';
+import { useConfig } from '../context/ConfigContext';
 import { useHouseProfile } from '../components/BrainstormUserMenu';
 import { nip19 } from 'nostr-tools';
 
@@ -79,10 +80,10 @@ function MyPovLabel({ user }) {
 
 /* ── User Menu (avatar + dropdown panel) ─────────────── */
 
-const EXTERNAL_RELAYS = ['wss://relay.primal.net', 'wss://relay.damus.io', 'wss://nos.lol'];
 const POV_STORAGE_PREFIX = 'bs_pov_';
 
 function UserMenu({ user, login, logout, pov, setPov, filters, setFilters, sortConfig, setSortConfig, onWotReady }) {
+  const { aRelays } = useConfig();
   const [open, setOpen] = useState(false);
   const menuRef = useRef(null);
 
@@ -301,7 +302,7 @@ function UserMenu({ user, login, logout, pov, setPov, filters, setFilters, sortC
         } catch {}
 
         if (!event10040) {
-          const relays = EXTERNAL_RELAYS.join(',');
+          const relays = (aRelays?.aPopularGeneralPurposeRelays || []).join(',');
           try {
             const extResp = await fetch(`/api/relay/external?filter=${encodeURIComponent(localFilter)}&relays=${encodeURIComponent(relays)}`);
             const extData = await extResp.json();

--- a/ui/src/pages/BrainstormSettings.jsx
+++ b/ui/src/pages/BrainstormSettings.jsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useAuth } from '../context/AuthContext';
+import { useConfig } from '../context/ConfigContext';
 import BrainstormUserMenu, { useHouseProfile } from '../components/BrainstormUserMenu';
 
 /* ── Helpers ──────────────────────────────────────────── */
 
-const EXTERNAL_RELAYS = ['wss://relay.primal.net', 'wss://relay.damus.io', 'wss://nos.lol'];
 const POV_STORAGE_PREFIX = 'bs_pov_';
 
 function timeAgoShort(unixSeconds) {
@@ -23,6 +23,7 @@ function timeAgoShort(unixSeconds) {
 
 export default function BrainstormSettings() {
   const { user, login, logout } = useAuth();
+  const { aRelays } = useConfig();
 
   // WoT pipeline state
   const [wotStatus, setWotStatus] = useState({
@@ -227,7 +228,7 @@ export default function BrainstormSettings() {
         } catch {}
 
         if (!event10040) {
-          const relays = EXTERNAL_RELAYS.join(',');
+          const relays = (aRelays?.aPopularGeneralPurposeRelays || []).join(',');
           try {
             const extResp = await fetch(`/api/relay/external?filter=${encodeURIComponent(localFilter)}&relays=${encodeURIComponent(relays)}`);
             const extData = await extResp.json();

--- a/ui/src/pages/concepts/AddNodeAsElement.jsx
+++ b/ui/src/pages/concepts/AddNodeAsElement.jsx
@@ -7,11 +7,11 @@ import useNeo4jLabels from '../../hooks/useNeo4jLabels';
 import AuthorCell from '../../components/AuthorCell';
 
 // Known authors pinned at top of Author selector
-import { OWNER_PUBKEY, DAVE_PUBKEY } from '../../config/pubkeys';
+import { DAVE_PUBKEY } from '../../config/pubkeys';
 import { useConfig } from '../../context/ConfigContext';
 
 export default function AddNodeAsElement() {
-  const { taPubkey: TA_PUBKEY } = useConfig();
+  const { taPubkey: TA_PUBKEY, ownerPubkey } = useConfig();
   const { concept, uuid } = useOutletContext();
   const navigate = useNavigate();
   const { user } = useAuth();
@@ -39,11 +39,11 @@ export default function AddNodeAsElement() {
     if (!authorRows) return [];
     const others = authorRows
       .map(r => r.pk)
-      .filter(pk => pk !== OWNER_PUBKEY && pk !== TA_PUBKEY && pk !== DAVE_PUBKEY);
+      .filter(pk => pk !== ownerPubkey && pk !== TA_PUBKEY && pk !== DAVE_PUBKEY);
     const pinned = [];
     // Only include pinned entries if they exist in the data
     const allPks = new Set(authorRows.map(r => r.pk));
-    if (allPks.has(OWNER_PUBKEY)) pinned.push(OWNER_PUBKEY);
+    if (allPks.has(ownerPubkey)) pinned.push(ownerPubkey);
     if (allPks.has(DAVE_PUBKEY)) pinned.push(DAVE_PUBKEY);
     if (allPks.has(TA_PUBKEY)) pinned.push(TA_PUBKEY);
     return [...pinned, ...others];
@@ -56,7 +56,7 @@ export default function AddNodeAsElement() {
     const p = authorDropdownProfiles?.get(pk);
     const name = p?.name || p?.display_name;
     const short = pk.slice(0, 8) + '…';
-    if (pk === OWNER_PUBKEY) return name ? `👑 ${name}` : `👑 Owner (${short})`;
+    if (pk === ownerPubkey) return name ? `👑 ${name}` : `👑 Owner (${short})`;
     if (pk === DAVE_PUBKEY) return name ? `🧑‍💻 ${name}` : `🧑‍💻 Dave (${short})`;
     if (pk === TA_PUBKEY) return name ? `🤖 ${name}` : `🤖 Assistant (${short})`;
     return name ? `${name} (${short})` : short;

--- a/ui/src/pages/concepts/ConceptElements.jsx
+++ b/ui/src/pages/concepts/ConceptElements.jsx
@@ -4,7 +4,7 @@ import { useCypher } from '../../hooks/useCypher';
 import DataTable from '../../components/DataTable';
 import useProfiles from '../../hooks/useProfiles';
 import AuthorCell from '../../components/AuthorCell';
-import { OWNER_PUBKEY, DAVE_PUBKEY } from '../../config/pubkeys';
+import { DAVE_PUBKEY } from '../../config/pubkeys';
 import { useConfig } from '../../context/ConfigContext';
 
 function ValidationCell({ status, errors }) {
@@ -20,7 +20,7 @@ function ValidationCell({ status, errors }) {
 }
 
 export default function ConceptElements() {
-  const { taPubkey: TA_PUBKEY } = useConfig();
+  const { taPubkey: TA_PUBKEY, ownerPubkey } = useConfig();
   const { uuid } = useOutletContext();
   const navigate = useNavigate();
 
@@ -220,10 +220,10 @@ export default function ConceptElements() {
   const authorOptions = useMemo(() => {
     const pksSet = new Set(authorPubkeys);
     const pinned = [];
-    if (pksSet.has(OWNER_PUBKEY)) pinned.push(OWNER_PUBKEY);
+    if (pksSet.has(ownerPubkey)) pinned.push(ownerPubkey);
     if (pksSet.has(DAVE_PUBKEY)) pinned.push(DAVE_PUBKEY);
     if (pksSet.has(TA_PUBKEY)) pinned.push(TA_PUBKEY);
-    const others = authorPubkeys.filter(pk => pk !== OWNER_PUBKEY && pk !== TA_PUBKEY && pk !== DAVE_PUBKEY);
+    const others = authorPubkeys.filter(pk => pk !== ownerPubkey && pk !== TA_PUBKEY && pk !== DAVE_PUBKEY);
     return [...pinned, ...others];
   }, [authorPubkeys]);
 
@@ -231,7 +231,7 @@ export default function ConceptElements() {
     const p = profiles?.[pk];
     const name = p?.name || p?.display_name;
     const short = pk.slice(0, 8) + '…';
-    if (pk === OWNER_PUBKEY) return name ? `👑 ${name}` : `👑 Owner (${short})`;
+    if (pk === ownerPubkey) return name ? `👑 ${name}` : `👑 Owner (${short})`;
     if (pk === DAVE_PUBKEY) return name ? `🧑‍💻 ${name}` : `🧑‍💻 Dave (${short})`;
     if (pk === TA_PUBKEY) return name ? `🤖 ${name}` : `🤖 Assistant (${short})`;
     return name ? `${name} (${short})` : short;

--- a/ui/src/pages/concepts/ConceptList.jsx
+++ b/ui/src/pages/concepts/ConceptList.jsx
@@ -5,7 +5,7 @@ import DataTable from '../../components/DataTable';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import useProfiles from '../../hooks/useProfiles';
 import AuthorCell from '../../components/AuthorCell';
-import { OWNER_PUBKEY, DAVE_PUBKEY } from '../../config/pubkeys';
+import { DAVE_PUBKEY } from '../../config/pubkeys';
 import { useConfig } from '../../context/ConfigContext';
 
 const QUERY = `
@@ -56,7 +56,7 @@ const QUERY = `
 `;
 
 export default function ConceptList() {
-  const { taPubkey: TA_PUBKEY } = useConfig();
+  const { taPubkey: TA_PUBKEY, ownerPubkey } = useConfig();
   const { data, loading, error } = useCypher(QUERY);
   const navigate = useNavigate();
   const [healthMap, setHealthMap] = useState({});
@@ -103,10 +103,10 @@ export default function ConceptList() {
     const allPks = [...new Set(enrichedData.map(r => r.author).filter(Boolean))];
     const pinned = [];
     const pksSet = new Set(allPks);
-    if (pksSet.has(OWNER_PUBKEY)) pinned.push(OWNER_PUBKEY);
+    if (pksSet.has(ownerPubkey)) pinned.push(ownerPubkey);
     if (pksSet.has(DAVE_PUBKEY)) pinned.push(DAVE_PUBKEY);
     if (pksSet.has(TA_PUBKEY)) pinned.push(TA_PUBKEY);
-    const others = allPks.filter(pk => pk !== OWNER_PUBKEY && pk !== TA_PUBKEY && pk !== DAVE_PUBKEY);
+    const others = allPks.filter(pk => pk !== ownerPubkey && pk !== TA_PUBKEY && pk !== DAVE_PUBKEY);
     return [...pinned, ...others];
   }, [enrichedData]);
 
@@ -114,7 +114,7 @@ export default function ConceptList() {
     const p = profiles?.[pk];
     const name = p?.name || p?.display_name;
     const short = pk.slice(0, 8) + '…';
-    if (pk === OWNER_PUBKEY) return name ? `👑 ${name}` : `👑 Owner (${short})`;
+    if (pk === ownerPubkey) return name ? `👑 ${name}` : `👑 Owner (${short})`;
     if (pk === DAVE_PUBKEY) return name ? `🧑‍💻 ${name}` : `🧑‍💻 Dave (${short})`;
     if (pk === TA_PUBKEY) return name ? `🤖 ${name}` : `🤖 Assistant (${short})`;
     return name ? `${name} (${short})` : short;

--- a/ui/src/pages/databases/Neo4jOverview.jsx
+++ b/ui/src/pages/databases/Neo4jOverview.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import useProfiles from '../../hooks/useProfiles';
-import { OWNER_PUBKEY, DAVE_PUBKEY } from '../../config/pubkeys';
+import { DAVE_PUBKEY } from '../../config/pubkeys';
 import { useConfig } from '../../context/ConfigContext';
 
 function shortPubkey(pk) {
@@ -10,7 +10,7 @@ function shortPubkey(pk) {
 }
 
 export default function Neo4jOverview() {
-  const { taPubkey: TA_PUBKEY } = useConfig();
+  const { taPubkey: TA_PUBKEY, ownerPubkey } = useConfig();
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -45,7 +45,7 @@ export default function Neo4jOverview() {
     const p = profiles?.[pk];
     const name = p?.name || p?.display_name;
     const short = shortPubkey(pk);
-    if (pk === OWNER_PUBKEY) return name ? `👑 ${name}` : `👑 Owner (${short})`;
+    if (pk === ownerPubkey) return name ? `👑 ${name}` : `👑 Owner (${short})`;
     if (pk === DAVE_PUBKEY) return name ? `🧑‍💻 ${name}` : `🧑‍💻 Dave (${short})`;
     if (pk === TA_PUBKEY) return name ? `🤖 ${name}` : `🤖 Assistant (${short})`;
     return name ? `${name} (${short})` : short;

--- a/ui/src/pages/events/DListItemsList.jsx
+++ b/ui/src/pages/events/DListItemsList.jsx
@@ -5,7 +5,7 @@ import Breadcrumbs from '../../components/Breadcrumbs';
 import { queryRelay } from '../../api/relay';
 import useProfiles from '../../hooks/useProfiles';
 import AuthorCell from '../../components/AuthorCell';
-import { OWNER_PUBKEY, DAVE_PUBKEY } from '../../config/pubkeys';
+import { DAVE_PUBKEY } from '../../config/pubkeys';
 import { useConfig } from '../../context/ConfigContext';
 
 function getTag(event, name, index = 1) {
@@ -29,7 +29,7 @@ function shortPubkey(pk) {
 }
 
 export default function DListItemsList() {
-  const { taPubkey: TA_PUBKEY } = useConfig();
+  const { taPubkey: TA_PUBKEY, ownerPubkey } = useConfig();
   const navigate = useNavigate();
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -94,10 +94,10 @@ export default function DListItemsList() {
     const allPks = [...new Set(rows.map(r => r.author))];
     const pinned = [];
     const pksSet = new Set(allPks);
-    if (pksSet.has(OWNER_PUBKEY)) pinned.push(OWNER_PUBKEY);
+    if (pksSet.has(ownerPubkey)) pinned.push(ownerPubkey);
     if (pksSet.has(DAVE_PUBKEY)) pinned.push(DAVE_PUBKEY);
     if (pksSet.has(TA_PUBKEY)) pinned.push(TA_PUBKEY);
-    const others = allPks.filter(pk => pk !== OWNER_PUBKEY && pk !== TA_PUBKEY && pk !== DAVE_PUBKEY);
+    const others = allPks.filter(pk => pk !== ownerPubkey && pk !== TA_PUBKEY && pk !== DAVE_PUBKEY);
     return [...pinned, ...others];
   }, [rows]);
 
@@ -111,7 +111,7 @@ export default function DListItemsList() {
     const p = profiles?.[pk];
     const name = p?.name || p?.display_name;
     const short = pk.slice(0, 8) + '…';
-    if (pk === OWNER_PUBKEY) return name ? `👑 ${name}` : `👑 Owner (${short})`;
+    if (pk === ownerPubkey) return name ? `👑 ${name}` : `👑 Owner (${short})`;
     if (pk === DAVE_PUBKEY) return name ? `🧑‍💻 ${name}` : `🧑‍💻 Dave (${short})`;
     if (pk === TA_PUBKEY) return name ? `🤖 ${name}` : `🤖 Assistant (${short})`;
     return name ? `${name} (${short})` : short;

--- a/ui/src/pages/grapevine/SearchPreferences.jsx
+++ b/ui/src/pages/grapevine/SearchPreferences.jsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import { useAuth } from '../../context/AuthContext';
+import { useConfig } from '../../context/ConfigContext';
 
 /**
  * Search Preferences — configure WoT scoring for profile search.
@@ -11,13 +12,6 @@ import { useAuth } from '../../context/AuthContext';
  * 3. Sync Trusted Assertions (kind 30382) from the NIP-85 relay into local strfry via negentropy
  * 4. Load scores from local strfry into Meilisearch
  */
-
-const RELAY_SEARCH_LIST = [
-  'wss://relay.damus.io',
-  'wss://relay.primal.net',
-  'wss://nos.lol',
-  'wss://purplepag.es',
-];
 
 function npubToHex(npub) {
   try {
@@ -46,8 +40,8 @@ function isValidPubkey(str) {
   return /^[0-9a-f]{64}$/.test(str);
 }
 
-async function fetchKind10040(pubkey) {
-  for (const relayUrl of RELAY_SEARCH_LIST) {
+async function fetchKind10040(pubkey, relays) {
+  for (const relayUrl of relays) {
     try {
       const event = await new Promise((resolve, reject) => {
         const ws = new WebSocket(relayUrl);
@@ -116,6 +110,8 @@ export default function SearchPreferences() {
 
   // Owner/admin detection — only owners can save these site-wide defaults.
   const { user } = useAuth();
+  const { aRelays } = useConfig();
+  const popularRelays = aRelays?.aPopularGeneralPurposeRelays || [];
   const isOwnerOrAdmin = user?.classification === 'owner' || user?.classification === 'admin';
 
   // Filter & Sort settings
@@ -177,7 +173,7 @@ export default function SearchPreferences() {
           if (prefs.sort) setSortConfig(prefs.sort);
 
           // Auto-lookup the 10040 to restore full state
-          const event = await fetchKind10040(prefs.povPubkey);
+          const event = await fetchKind10040(prefs.povPubkey, popularRelays);
           if (event) {
             setEvent10040(event);
             const metrics = parseMetrics(event);
@@ -237,9 +233,9 @@ export default function SearchPreferences() {
     setLoading(true);
 
     try {
-      const event = await fetchKind10040(hex);
+      const event = await fetchKind10040(hex, popularRelays);
       if (!event) {
-        setError(`No kind 10040 event found for this pubkey on ${RELAY_SEARCH_LIST.length} relays.`);
+        setError(`No kind 10040 event found for this pubkey on ${popularRelays.length} relays.`);
         return;
       }
 

--- a/ui/src/pages/grapevine/TrustDetermination.jsx
+++ b/ui/src/pages/grapevine/TrustDetermination.jsx
@@ -2,7 +2,6 @@ import { useMemo, useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import { useTrust, SCORING_METHODS } from '../../context/TrustContext';
-import { OWNER_PUBKEY } from '../../config/pubkeys';
 import useProfiles from '../../hooks/useProfiles';
 import { queryRelay } from '../../api/relay';
 

--- a/ui/src/pages/lists/Index.jsx
+++ b/ui/src/pages/lists/Index.jsx
@@ -5,7 +5,7 @@ import Breadcrumbs from '../../components/Breadcrumbs';
 import { queryRelay } from '../../api/relay';
 import useProfiles from '../../hooks/useProfiles';
 import AuthorCell from '../../components/AuthorCell';
-import { OWNER_PUBKEY, DAVE_PUBKEY } from '../../config/pubkeys';
+import { DAVE_PUBKEY } from '../../config/pubkeys';
 import { useConfig } from '../../context/ConfigContext';
 
 /**
@@ -39,7 +39,7 @@ function shortPubkey(pk) {
 }
 
 export default function DListsIndex() {
-  const { taPubkey: TA_PUBKEY } = useConfig();
+  const { taPubkey: TA_PUBKEY, ownerPubkey } = useConfig();
   const navigate = useNavigate();
   const [headers, setHeaders] = useState([]);
   const [items, setItems] = useState([]);
@@ -148,10 +148,10 @@ export default function DListsIndex() {
     const allPks = [...new Set(rows.map(r => r.author))];
     const pinned = [];
     const pksSet = new Set(allPks);
-    if (pksSet.has(OWNER_PUBKEY)) pinned.push(OWNER_PUBKEY);
+    if (pksSet.has(ownerPubkey)) pinned.push(ownerPubkey);
     if (pksSet.has(DAVE_PUBKEY)) pinned.push(DAVE_PUBKEY);
     if (pksSet.has(TA_PUBKEY)) pinned.push(TA_PUBKEY);
-    const others = allPks.filter(pk => pk !== OWNER_PUBKEY && pk !== TA_PUBKEY && pk !== DAVE_PUBKEY);
+    const others = allPks.filter(pk => pk !== ownerPubkey && pk !== TA_PUBKEY && pk !== DAVE_PUBKEY);
     return [...pinned, ...others];
   }, [rows]);
 
@@ -163,7 +163,7 @@ export default function DListsIndex() {
     const p = profiles?.[pk];
     const name = p?.name || p?.display_name;
     const short = pk.slice(0, 8) + '…';
-    if (pk === OWNER_PUBKEY) return name ? `👑 ${name}` : `👑 Owner (${short})`;
+    if (pk === ownerPubkey) return name ? `👑 ${name}` : `👑 Owner (${short})`;
     if (pk === DAVE_PUBKEY) return name ? `🧑‍💻 ${name}` : `🧑‍💻 Dave (${short})`;
     if (pk === TA_PUBKEY) return name ? `🤖 ${name}` : `🤖 Assistant (${short})`;
     return name ? `${name} (${short})` : short;

--- a/ui/src/pages/nodes/Index.jsx
+++ b/ui/src/pages/nodes/Index.jsx
@@ -6,7 +6,7 @@ import useNeo4jLabels from '../../hooks/useNeo4jLabels';
 import AuthorCell from '../../components/AuthorCell';
 import Breadcrumbs from '../../components/Breadcrumbs';
 
-import { OWNER_PUBKEY, DAVE_PUBKEY } from '../../config/pubkeys';
+import { DAVE_PUBKEY } from '../../config/pubkeys';
 import { useConfig } from '../../context/ConfigContext';
 
 const PAGE_SIZE = 50;
@@ -24,7 +24,7 @@ function formatAge(createdAt) {
 }
 
 export default function NodesIndex() {
-  const { taPubkey: TA_PUBKEY } = useConfig();
+  const { taPubkey: TA_PUBKEY, ownerPubkey } = useConfig();
   const navigate = useNavigate();
 
   // Filters
@@ -46,10 +46,10 @@ export default function NodesIndex() {
     if (!authorRows) return [];
     const allPks = new Set(authorRows.map(r => r.pk));
     const pinned = [];
-    if (allPks.has(OWNER_PUBKEY)) pinned.push(OWNER_PUBKEY);
+    if (allPks.has(ownerPubkey)) pinned.push(ownerPubkey);
     if (allPks.has(DAVE_PUBKEY)) pinned.push(DAVE_PUBKEY);
     if (allPks.has(TA_PUBKEY)) pinned.push(TA_PUBKEY);
-    const others = authorRows.map(r => r.pk).filter(pk => pk !== OWNER_PUBKEY && pk !== TA_PUBKEY && pk !== DAVE_PUBKEY);
+    const others = authorRows.map(r => r.pk).filter(pk => pk !== ownerPubkey && pk !== TA_PUBKEY && pk !== DAVE_PUBKEY);
     return [...pinned, ...others];
   }, [authorRows]);
   const authorDropdownProfiles = useProfiles(authorOptions);
@@ -58,7 +58,7 @@ export default function NodesIndex() {
     const p = authorDropdownProfiles?.[pk];
     const name = p?.name || p?.display_name;
     const short = pk.slice(0, 8) + '…';
-    if (pk === OWNER_PUBKEY) return name ? `👑 ${name}` : `👑 Owner (${short})`;
+    if (pk === ownerPubkey) return name ? `👑 ${name}` : `👑 Owner (${short})`;
     if (pk === DAVE_PUBKEY) return name ? `🧑‍💻 ${name}` : `🧑‍💻 Dave (${short})`;
     if (pk === TA_PUBKEY) return name ? `🤖 ${name}` : `🤖 Assistant (${short})`;
     return name ? `${name} (${short})` : short;

--- a/ui/src/pages/users/UserDetail.jsx
+++ b/ui/src/pages/users/UserDetail.jsx
@@ -4,6 +4,7 @@ import { nip19 } from 'nostr-tools';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import useProfiles from '../../hooks/useProfiles';
 import { useTrust } from '../../context/TrustContext';
+import { useConfig } from '../../context/ConfigContext';
 import { useCypher } from '../../hooks/useCypher';
 import { queryRelay } from '../../api/relay';
 import AuthorCell from '../../components/AuthorCell';
@@ -46,6 +47,7 @@ export default function UserDetail() {
   const { pubkey } = useParams();
   const navigate = useNavigate();
   const { povPubkey, setPovPubkey } = useTrust();
+  const { aRelays } = useConfig();
   const isCurrentPov = povPubkey === pubkey;
   const pubkeys = useMemo(() => [pubkey], [pubkey]);
   const profiles = useProfiles(pubkeys);
@@ -61,10 +63,10 @@ export default function UserDetail() {
     try {
       return nip19.nprofileEncode({
         pubkey,
-        relays: ['wss://relay.damus.io', 'wss://nos.lol', 'wss://relay.primal.net'],
+        relays: aRelays?.aPopularGeneralPurposeRelays || [],
       });
     } catch { return null; }
-  }, [pubkey]);
+  }, [pubkey, aRelays]);
 
   return (
     <div className="page">


### PR DESCRIPTION
## Summary

Promotes staging to main. Single PR bundled — the most substantive of the §6.1 quick-wins.

- **#80** — Make `OWNER_PUBKEY` and relay lists dynamic in the UI. Adds `GET /api/owner/pubkey` and `GET /api/relays` (mirrors the existing `/api/assistant/pubkey` shape), extends `ConfigContext` with `ownerPubkey` and `aRelays`, migrates 9 `OWNER_PUBKEY` consumers and 4 hardcoded-relay consumers to use the dynamic values, removes the literal owner-pubkey string from `ui/src/config/pubkeys.js`. 18 files changed, 139 ins / 70 del.

## Net production impact

- **No user-visible change for brainstorm.world.** The owner pubkey is the same (`15f7dafc...`) — just sourced from `/api/owner/pubkey` at runtime instead of a JS literal. The 👑 emoji, TrustContext OWNER badge, owner-pinning behaviour all keep working.
- **Real fix for non-NosFabrica deployments.** Confirmed observably on staging: TrustDetermination correctly identifies `e5272de9...` (Dave / staging-owner) as the OWNER. Before this PR, every fork would have shown `15f7dafc...` regardless of who actually owned the instance.
- New endpoint surface: `/api/owner/pubkey`, `/api/relays`. Both public, no auth. The pre-existing `/api/owner-info` is untouched.

## Verification trail

- #80 staging deploy [#25293120317](https://github.com/nous-clawds4/tapestry/actions/runs/25293120317), 1m13s ✓
- Stability poll caught 3 consecutive 200s + 5s settle (per `OPERATIONS §8.5`)
- API smoke tests all 200 (new endpoints, regression endpoints)
- Bundle inspection: hardcoded `15f7dafc...` literal absent (0 occurrences); `/api/owner/pubkey` and `/api/relays` URLs present
- Chrome visual on staging: TrustDetermination shows `straycat OWNER e5272de9...6a102f`. Console clean.

## Test plan

- [ ] After merge: `deploy-brainstorm.yml` runs to completion.
- [ ] `https://brainstorm.world/api/owner/pubkey` returns `15f7dafc...`.
- [ ] `https://brainstorm.world/api/relays` returns the configured `aRelays` object.
- [ ] `https://brainstorm.world/tapestry/grapevine/trust-determination` (signed in) still shows OWNER badge correctly.
- [ ] No regression on existing routes / pages / `/api/owner-info`.

## Out of scope (intentional follow-ups)

- `ui/src/utils/nostrPublish.js` still has a module-level `PUBLISH_RELAYS` constant. Non-component utility; migrating requires more refactor than this PR's scope.
- `DAVE_PUBKEY` remains in `ui/src/config/pubkeys.js`. Cosmetic NosFabrica-ism (pins David with 🧑‍💻), not a functional bug.
- Redis session-store migration — separate small PR planned next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)