### PR TITLE
Redis-backed session store

### DIFF
--- a/bin/control-panel.js
+++ b/bin/control-panel.js
@@ -152,12 +152,22 @@ app.use('/legacy', express.static(path.join(__dirname, '../public')));
 app.use('/libs/chart.js', express.static(path.join(__dirname, '../node_modules/chart.js/dist')));
 app.use('/libs/chartjs-adapter-date-fns', express.static(path.join(__dirname, '../node_modules/chartjs-adapter-date-fns/dist')));
 
-// Session middleware
+// Session middleware — Redis-backed so sessions survive Docker rebuilds.
+const RedisStore = require('connect-redis').default;
+const Redis = require('ioredis');
+const sessionRedisHost = getConfigFromFile('REDIS_HOST', 'redis');
+const sessionRedisPort = parseInt(getConfigFromFile('REDIS_PORT', '6379'), 10);
+const sessionRedisClient = new Redis({ host: sessionRedisHost, port: sessionRedisPort });
+sessionRedisClient.on('error', (err) => console.error('Session-store Redis error:', err.message));
 app.use(session({
+    store: new RedisStore({ client: sessionRedisClient, prefix: 'brainstorm:sess:' }),
     secret: getConfigFromFile('SESSION_SECRET', 'brainstorm-default-session-secret-please-change-in-production'),
     resave: false,
-    saveUninitialized: true,
-    cookie: { secure: useHTTPS } // Set to true if using HTTPS
+    saveUninitialized: false,
+    cookie: {
+        secure: useHTTPS,
+        maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
+    },
 }));
 
 // Helper function to serve HTML files

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "archiver": "^7.0.1",
         "chart.js": "^4.4.1",
         "chartjs-adapter-date-fns": "^3.0.0",
+        "connect-redis": "^7.1.1",
         "cors": "^2.8.5",
         "d3": "^7.9.0",
         "dotenv": "^16.4.7",
@@ -956,6 +957,18 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/connect-redis": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-7.1.1.tgz",
+      "integrity": "sha512-M+z7alnCJiuzKa8/1qAYdGUXHYfDnLolOGAUjOioB07pP39qxjG+X9ibsud7qUBc4jMV5Mcy3ugGv8eFcgamJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "express-session": ">=1"
       }
     },
     "node_modules/content-disposition": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "archiver": "^7.0.1",
     "chart.js": "^4.4.1",
     "chartjs-adapter-date-fns": "^3.0.0",
+    "connect-redis": "^7.1.1",
     "cors": "^2.8.5",
     "d3": "^7.9.0",
     "dotenv": "^16.4.7",

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -90,25 +90,7 @@ const { registerNip05Routes } = require('./nip05');
  * @param {Object} app - Express app instance
  */
 async function register(app) {
-    // We need to make sure session middleware is applied to the app
-    // Check if it's already been applied
-    if (!app._brainstormSessionConfigured) {
-        console.log('Configuring session middleware for Brainstorm API...');
-        
-        // Load express-session only if needed
-        const session = require('express-session');
-        
-        // Configure session middleware - this must match the main app's configuration
-        app.use(session({
-            secret: getConfigFromFile('SESSION_SECRET', 'brainstorm-default-session-secret-please-change-in-production'),
-            resave: false,
-            saveUninitialized: true,
-            cookie: { secure: false } // Set secure:true if using HTTPS
-        }));
-        
-        // Mark session as configured
-        app._brainstormSessionConfigured = true;
-    }
+    // Session middleware is configured in the entrypoint (bin/control-panel.js).
 
     // ── NIP-05 server endpoint (.well-known/nostr.json, public, CORS open) ──
     registerNip05Routes(app);


### PR DESCRIPTION
## Summary

Switches the session middleware from express-session's default `MemoryStore` to `connect-redis` backed by the existing `ioredis` client and the `redis` Docker container that the streaming ETL already uses. Sessions now persist for 30 days across brainstorm process restarts and full Docker rebuilds — fixing the "have to sign in again after every deploy" UX flagged in `OPERATIONS.md §8.5` companion notes.

## Changes

- **`bin/control-panel.js`** — the actual entrypoint where the original session middleware lived. Replaces the MemoryStore-default `session({...})` config with a Redis-backed one (`store: new RedisStore(...)`, `saveUninitialized: false`, `cookie.maxAge: 30 days`).
- **`src/api/index.js`** — drops a redundant duplicate session-middleware setup that was inside `register()` behind an `_brainstormSessionConfigured` flag. Caused by two `app.use(session(...))` calls being layered on the same Express app — the entrypoint's MemoryStore one always won the save semantics, so any Redis-backed config inside `register()` was dead code.
- **`package.json` / `package-lock.json`** — adds `connect-redis@^7.1.1` (compatible with both `express-session@^1.18` and the existing `ioredis@^5.10.1`).

## Local verification

- New brainstorm log shows the Redis-backed session middleware initializing cleanly. The `connect.session() MemoryStore is not designed for a production environment` deprecation warning is gone from stderr.
- End-to-end persistence test:
  1. `redis-cli FLUSHDB` to start clean.
  2. POST `/api/auth/verify` with the owner pubkey → server writes `req.session.challenge` and `req.session.pubkey`.
  3. Redis: `brainstorm:sess:<id>` key present with TTL 2,592,000s (30 days). Value contains the challenge, pubkey, and cookie metadata.
  4. `docker exec tapestry supervisorctl restart brainstorm` → process restarts.
  5. Same Redis key still present with same data. Sign-in flow can resume from where it left off.

## Impact on this deploy specifically

This deploy itself will log everyone out once (cookies on disk reference old MemoryStore session IDs that don't exist in Redis). After signing in again, sessions persist through all subsequent deploys.

## Out of scope (intentional follow-ups)

- HTTPS-aware secure cookie flag (`cookie.secure` based on `trust proxy` + `X-Forwarded-Proto`). Currently uses local `useHTTPS` bool — production runs behind nginx terminating SSL, so cookies are technically marked non-secure in production. Working as-was, separate hardening PR.
- Default `SESSION_SECRET` in source still falls through to a literal default string if `brainstorm.conf` doesn't set it. Security smell, separate PR.
- Deploy script `curl --retry` to wait for brainstorm Express to bind before CI exits (the post-deploy 502 flicker from `OPERATIONS.md §8.5`).

## Test plan

- [ ] After merge: `deploy-staging.yml` runs.
- [ ] Stability poll on staging.brainstorm.world.
- [ ] Sign in via NIP-07 once on staging.
- [ ] Trigger a second deploy (or `supervisorctl restart` if accessible) — confirm session survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)