### PR TITLE
OPERATIONS §8.5: note post-stability flicker

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -196,4 +196,6 @@ done
 
 For human users hitting the site immediately after a deploy: refresh once or twice. The flicker resolves on its own.
 
+**Post-stability flicker:** observed once on the #88 production deploy — the 3-consecutive-200s threshold was reached, but the next request burst a few seconds later still got 502s before settling for good. The brainstorm process can briefly cycle once more after first appearing stable. If a smoke test fails right after a streak-based stability check, retry once before treating it as a real failure.
+
 **Long-term fix candidate:** the deploy script could `curl --retry` an API endpoint as a final step before exiting, so CI doesn't report success until brainstorm is actually serving. Not yet done — left as a separate operational improvement.


### PR DESCRIPTION
## Summary

One-paragraph addendum to `OPERATIONS.md §8.5` documenting an observation from the #88 prod deploy: the 3-consecutive-200s stability check can be satisfied, then the next request burst can still 502 before settling for good. Recommend retrying once before treating a post-stability 502 as a real failure.

Pure docs. No code change.

## Why this PR exists

This PR also serves as the second-deploy in the staging session-persistence verification for #90 (Redis session store): user signs in to staging, this small deploy goes through, user should remain signed in afterward. If they do, that's empirical proof on staging that sessions survive deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)