### PR TITLE
Persist SESSION_SECRET across container rebuilds

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,7 +10,20 @@ RELAY_URL="${RELAY_URL:-ws://localhost:7777}"
 
 BRAINSTORM_MODULE_BASE_DIR="/usr/local/lib/node_modules/brainstorm/"
 BRAINSTORM_NODE_BIN="$(which node)"
-SESSION_SECRET="$(openssl rand -hex 32)"
+
+# Persist SESSION_SECRET across container rebuilds. Stored on the tapestry-data
+# volume so that user session cookies remain valid through deploys. To force-rotate
+# (e.g., after a security incident), delete the file: every active session ends
+# the next time the container starts.
+SESSION_SECRET_FILE="/var/lib/brainstorm/session.secret"
+if [ -s "$SESSION_SECRET_FILE" ]; then
+  SESSION_SECRET="$(cat "$SESSION_SECRET_FILE")"
+else
+  SESSION_SECRET="$(openssl rand -hex 32)"
+  mkdir -p "$(dirname "$SESSION_SECRET_FILE")"
+  printf '%s' "$SESSION_SECRET" > "$SESSION_SECRET_FILE"
+  chmod 600 "$SESSION_SECRET_FILE"
+fi
 
 # Calculate owner npub (best effort, fallback to unassigned)
 OWNER_NPUB="unassigned"


### PR DESCRIPTION
## Summary

Companion to #90. Fixes the actual root cause of the "logged out on every deploy" UX, which #90's Redis-backed session store **alone** couldn't fix.

## The bug

`docker/entrypoint.sh:13` (before this PR):

\`\`\`bash
SESSION_SECRET="\$(openssl rand -hex 32)"
\`\`\`

That ran unconditionally on every container start. \`docker compose up -d --build\` recreates the brainstorm container on every deploy, so SESSION_SECRET rotated to a fresh random value every time. Every existing user cookie (signed with the OLD secret) became invalid the moment the container restarted — express-session treats unsigned-validatable cookies as if absent → user is logged out.

Discovered the hard way: signed in to staging via NIP-07 after #90 deployed, triggered a second deploy (#91), session was lost. Curl-level testing on staging confirmed Redis was correctly persisting session DATA across the deploy — proof that the new session middleware was working. Reading entrypoint.sh revealed the secret rotation as the actual culprit.

## The fix

Persist \`SESSION_SECRET\` to \`/var/lib/brainstorm/session.secret\` (on the \`tapestry-data\` Docker volume, which survives rebuilds). On first startup, generate-and-write. On subsequent startups, read the existing value.

To force-rotate after a security incident: delete the file. Every active session ends on the next container start.

## Verification

- Logic verified with a local temp-file script: iter 1 generated and persisted a 64-char hex value; iter 2 read back the same value; deletion + iter 3 regenerated to a new value. Persistence and rotation both work.
- Real verification path: sign in to staging once → trigger any other staging deploy → confirm still signed in. Test plan below.

## Test plan

- [ ] After merge: \`deploy-staging.yml\` runs.
- [ ] Sign in to staging via NIP-07.
- [ ] Trigger another small staging deploy (any commit will do).
- [ ] After that second deploy, confirm still signed in. **This is the actual proof that the auth-gate-after-deploy hassle is fixed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)