### PR TITLE
OPERATIONS §8.6: document SESSION_SECRET rotation gotcha

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -199,3 +199,11 @@ For human users hitting the site immediately after a deploy: refresh once or twi
 **Post-stability flicker:** observed once on the #88 production deploy — the 3-consecutive-200s threshold was reached, but the next request burst a few seconds later still got 502s before settling for good. The brainstorm process can briefly cycle once more after first appearing stable. If a smoke test fails right after a streak-based stability check, retry once before treating it as a real failure.
 
 **Long-term fix candidate:** the deploy script could `curl --retry` an API endpoint as a final step before exiting, so CI doesn't report success until brainstorm is actually serving. Not yet done — left as a separate operational improvement.
+
+### 8.6. 2026-05-03: SESSION_SECRET rotated on every container start, invalidating all cookies
+
+While verifying the Redis-backed session store landed in #90, we noticed users were still being logged out on every deploy — even though Redis correctly persisted session data across container rebuilds. The actual root cause: `docker/entrypoint.sh` regenerated `SESSION_SECRET="$(openssl rand -hex 32)"` unconditionally on every container start. Each `docker compose up -d --build` recreates the brainstorm container; `entrypoint.sh` re-ran; secret rotated; every existing user cookie failed signed-validation; express-session treated cookies as absent → users logged out, despite Redis still holding the session data.
+
+**Fix (PR #92):** persist `SESSION_SECRET` to `/var/lib/brainstorm/session.secret` on the `tapestry-data` volume. Generate-once-and-store, read on subsequent starts. To force-rotate after a security incident: delete the file; every active session ends on the next container start.
+
+**Lesson:** when fixing a "session persistence" UX, both the *store* (where data lives) and the *secret* (which validates cookies referencing that data) need to survive container rebuilds. Either alone is insufficient.


### PR DESCRIPTION
## Summary

Adds a new entry to `OPERATIONS.md §8` documenting the gotcha that was fixed in #92: `entrypoint.sh` was regenerating `SESSION_SECRET` on every container start, invalidating all signed cookies even though Redis (post-#90) correctly persisted session data.

Pure docs. Captures the lesson "both store and secret must survive rebuilds" so future maintainers reading the persistence logic understand why it's there.

## Why this PR exists

Doubles as the second-deploy in the staging session-persistence verification cycle for #92. User has signed in to staging via NIP-07 since #92 deployed; this small deploy goes through; if user remains signed in afterward, that's empirical proof on staging that the auth-gate-after-deploy hassle is genuinely fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)