### PR TITLE
Promote staging → main: session persistence + ops docs

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -199,3 +199,11 @@ For human users hitting the site immediately after a deploy: refresh once or twi
 **Post-stability flicker:** observed once on the #88 production deploy — the 3-consecutive-200s threshold was reached, but the next request burst a few seconds later still got 502s before settling for good. The brainstorm process can briefly cycle once more after first appearing stable. If a smoke test fails right after a streak-based stability check, retry once before treating it as a real failure.
 
 **Long-term fix candidate:** the deploy script could `curl --retry` an API endpoint as a final step before exiting, so CI doesn't report success until brainstorm is actually serving. Not yet done — left as a separate operational improvement.
+
+### 8.6. 2026-05-03: SESSION_SECRET rotated on every container start, invalidating all cookies
+
+While verifying the Redis-backed session store landed in #90, we noticed users were still being logged out on every deploy — even though Redis correctly persisted session data across container rebuilds. The actual root cause: `docker/entrypoint.sh` regenerated `SESSION_SECRET="$(openssl rand -hex 32)"` unconditionally on every container start. Each `docker compose up -d --build` recreates the brainstorm container; `entrypoint.sh` re-ran; secret rotated; every existing user cookie failed signed-validation; express-session treated cookies as absent → users logged out, despite Redis still holding the session data.
+
+**Fix (PR #92):** persist `SESSION_SECRET` to `/var/lib/brainstorm/session.secret` on the `tapestry-data` volume. Generate-once-and-store, read on subsequent starts. To force-rotate after a security incident: delete the file; every active session ends on the next container start.
+
+**Lesson:** when fixing a "session persistence" UX, both the *store* (where data lives) and the *secret* (which validates cookies referencing that data) need to survive container rebuilds. Either alone is insufficient.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -196,4 +196,6 @@ done
 
 For human users hitting the site immediately after a deploy: refresh once or twice. The flicker resolves on its own.
 
+**Post-stability flicker:** observed once on the #88 production deploy — the 3-consecutive-200s threshold was reached, but the next request burst a few seconds later still got 502s before settling for good. The brainstorm process can briefly cycle once more after first appearing stable. If a smoke test fails right after a streak-based stability check, retry once before treating it as a real failure.
+
 **Long-term fix candidate:** the deploy script could `curl --retry` an API endpoint as a final step before exiting, so CI doesn't report success until brainstorm is actually serving. Not yet done — left as a separate operational improvement.

--- a/bin/control-panel.js
+++ b/bin/control-panel.js
@@ -152,12 +152,22 @@ app.use('/legacy', express.static(path.join(__dirname, '../public')));
 app.use('/libs/chart.js', express.static(path.join(__dirname, '../node_modules/chart.js/dist')));
 app.use('/libs/chartjs-adapter-date-fns', express.static(path.join(__dirname, '../node_modules/chartjs-adapter-date-fns/dist')));
 
-// Session middleware
+// Session middleware — Redis-backed so sessions survive Docker rebuilds.
+const RedisStore = require('connect-redis').default;
+const Redis = require('ioredis');
+const sessionRedisHost = getConfigFromFile('REDIS_HOST', 'redis');
+const sessionRedisPort = parseInt(getConfigFromFile('REDIS_PORT', '6379'), 10);
+const sessionRedisClient = new Redis({ host: sessionRedisHost, port: sessionRedisPort });
+sessionRedisClient.on('error', (err) => console.error('Session-store Redis error:', err.message));
 app.use(session({
+    store: new RedisStore({ client: sessionRedisClient, prefix: 'brainstorm:sess:' }),
     secret: getConfigFromFile('SESSION_SECRET', 'brainstorm-default-session-secret-please-change-in-production'),
     resave: false,
-    saveUninitialized: true,
-    cookie: { secure: useHTTPS } // Set to true if using HTTPS
+    saveUninitialized: false,
+    cookie: {
+        secure: useHTTPS,
+        maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
+    },
 }));
 
 // Helper function to serve HTML files

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,7 +10,20 @@ RELAY_URL="${RELAY_URL:-ws://localhost:7777}"
 
 BRAINSTORM_MODULE_BASE_DIR="/usr/local/lib/node_modules/brainstorm/"
 BRAINSTORM_NODE_BIN="$(which node)"
-SESSION_SECRET="$(openssl rand -hex 32)"
+
+# Persist SESSION_SECRET across container rebuilds. Stored on the tapestry-data
+# volume so that user session cookies remain valid through deploys. To force-rotate
+# (e.g., after a security incident), delete the file: every active session ends
+# the next time the container starts.
+SESSION_SECRET_FILE="/var/lib/brainstorm/session.secret"
+if [ -s "$SESSION_SECRET_FILE" ]; then
+  SESSION_SECRET="$(cat "$SESSION_SECRET_FILE")"
+else
+  SESSION_SECRET="$(openssl rand -hex 32)"
+  mkdir -p "$(dirname "$SESSION_SECRET_FILE")"
+  printf '%s' "$SESSION_SECRET" > "$SESSION_SECRET_FILE"
+  chmod 600 "$SESSION_SECRET_FILE"
+fi
 
 # Calculate owner npub (best effort, fallback to unassigned)
 OWNER_NPUB="unassigned"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "archiver": "^7.0.1",
         "chart.js": "^4.4.1",
         "chartjs-adapter-date-fns": "^3.0.0",
+        "connect-redis": "^7.1.1",
         "cors": "^2.8.5",
         "d3": "^7.9.0",
         "dotenv": "^16.4.7",
@@ -956,6 +957,18 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/connect-redis": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-7.1.1.tgz",
+      "integrity": "sha512-M+z7alnCJiuzKa8/1qAYdGUXHYfDnLolOGAUjOioB07pP39qxjG+X9ibsud7qUBc4jMV5Mcy3ugGv8eFcgamJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "express-session": ">=1"
       }
     },
     "node_modules/content-disposition": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "archiver": "^7.0.1",
     "chart.js": "^4.4.1",
     "chartjs-adapter-date-fns": "^3.0.0",
+    "connect-redis": "^7.1.1",
     "cors": "^2.8.5",
     "d3": "^7.9.0",
     "dotenv": "^16.4.7",

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -90,25 +90,7 @@ const { registerNip05Routes } = require('./nip05');
  * @param {Object} app - Express app instance
  */
 async function register(app) {
-    // We need to make sure session middleware is applied to the app
-    // Check if it's already been applied
-    if (!app._brainstormSessionConfigured) {
-        console.log('Configuring session middleware for Brainstorm API...');
-        
-        // Load express-session only if needed
-        const session = require('express-session');
-        
-        // Configure session middleware - this must match the main app's configuration
-        app.use(session({
-            secret: getConfigFromFile('SESSION_SECRET', 'brainstorm-default-session-secret-please-change-in-production'),
-            resave: false,
-            saveUninitialized: true,
-            cookie: { secure: false } // Set secure:true if using HTTPS
-        }));
-        
-        // Mark session as configured
-        app._brainstormSessionConfigured = true;
-    }
+    // Session middleware is configured in the entrypoint (bin/control-panel.js).
 
     // ── NIP-05 server endpoint (.well-known/nostr.json, public, CORS open) ──
     registerNip05Routes(app);


### PR DESCRIPTION
## Summary

Promotes staging to main. Four PRs bundled — the session-persistence fix and its surrounding documentation.

## Bundled

- **#90** — Redis-backed session store. Switches `express-session` from default `MemoryStore` to `connect-redis` backed by the existing `ioredis` client. Session DATA now lives in Redis (which survives container rebuilds), not in the brainstorm process's memory.
- **#92** — Persistent `SESSION_SECRET`. Fixes the actual root cause of "logged out on every deploy" — `entrypoint.sh` was regenerating `SESSION_SECRET` to a fresh random value on every container start, invalidating all signed cookies. Now stored at `/var/lib/brainstorm/session.secret` on the `tapestry-data` volume; generated once, reused on subsequent starts.
- **#91** — `OPERATIONS.md §8.5` addendum noting the post-stability 502 flicker observed during the #88 prod deploy.
- **#93** — `OPERATIONS.md §8.6` documenting the SESSION_SECRET rotation gotcha that #92 fixed, and the "both store and secret must survive rebuilds" lesson.

#90 alone wouldn't have fixed the UX (cookies still invalidated by SESSION_SECRET rotation). #92 alone wouldn't have fixed the UX (sessions still in MemoryStore, wiped by container rebuild). The two together fix it. Documentation in #91/#93.

## Verification on staging

End-to-end persistence proven:
1. Signed in to `staging.brainstorm.world` via NIP-07 after #90+#91+#92 landed.
2. Triggered another staging deploy (#93).
3. Post-deploy: `/api/auth/status` returns `{authenticated:true, pubkey:"15f7dafc..."}` from the same Chrome session. Settings page renders fully (5 tabs, Router Management UI, all streams). Router uptime confirms brainstorm process restarted; user session survived.

## Net production impact

- **One last forced sign-out for current users.** When the prod brainstorm container is recreated by this deploy, `/var/lib/brainstorm/session.secret` doesn't exist yet on the prod volume, so `entrypoint.sh` will generate a fresh secret and write it. Every existing prod cookie (signed against the prior random per-deploy secret) becomes invalid one last time.
- **After that, sign-ins persist across all subsequent deploys.** Both for human users and the autonomous Chrome verification cycle.

## Test plan

- [ ] After merge: `deploy-brainstorm.yml` runs.
- [ ] Stability poll on `brainstorm.world`.
- [ ] Sign in once via NIP-07. From this point forward, sign-in survives deploys.
- [ ] Sanity: existing endpoints (`/api/get-user-data`, `/api/get-user-counts`, search, etc.) continue to function.

## Out of scope (intentional follow-ups)

- HTTPS-aware secure cookie flag (`cookie.secure` based on `trust proxy` + `X-Forwarded-Proto`).
- Adding a named volume for the redis container in docker-compose.yml (belt-and-suspenders — currently relies on the redis container surviving normal `up -d --build` operations, which it empirically does).
- The deploy-script `curl --retry` from `OPERATIONS §8.5` to wait for brainstorm Express to bind before CI exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)