### PR TITLE
Add CLAUDE.md root pointer to BIBLE.md and OPERATIONS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# Tapestry / Brainstorm Search
+
+Decentralized knowledge-graph protocol and search engine on nostr. Reference deployment runs at brainstorm.world.
+
+Before starting work, read both:
+
+- [BIBLE.md](./BIBLE.md) — architecture, protocol, data model, API, design decisions (universal, fork-agnostic)
+- [OPERATIONS.md](./OPERATIONS.md) — brainstorm.world deployment: branches, CI/CD, droplets, gotchas


### PR DESCRIPTION
## Summary
- Add a 5-line `CLAUDE.md` at repo root that instructs Claude Code sessions to read [BIBLE.md](./BIBLE.md) and [OPERATIONS.md](./OPERATIONS.md) before starting work.
- Loaded automatically by Claude Code when a session starts inside this repo — applies to David, Vinney, Matthias, and any future contributor without per-user setup.
- Does not duplicate content from BIBLE/OPERATIONS; just points at them with a one-line orientation.

## Test plan
- [ ] After merge, confirm `CLAUDE.md` appears at the repo root on `staging`.
- [ ] Start a fresh Claude Code session in a checkout of `staging` and verify it reads `BIBLE.md` and `OPERATIONS.md` early in the session.
- [ ] No code or config changes; `deploy-staging.yml` will run but is a no-op for site behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)