### PR TITLE
Promote staging → main: CLAUDE.md root pointer + verified-cutoffs consolidation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# Tapestry / Brainstorm Search
+
+Decentralized knowledge-graph protocol and search engine on nostr. Reference deployment runs at brainstorm.world.
+
+Before starting work, read both:
+
+- [BIBLE.md](./BIBLE.md) — architecture, protocol, data model, API, design decisions (universal, fork-agnostic)
+- [OPERATIONS.md](./OPERATIONS.md) — brainstorm.world deployment: branches, CI/CD, droplets, gotchas

--- a/config/graperank.conf.template
+++ b/config/graperank.conf.template
@@ -65,6 +65,18 @@ export REPORT_RATING=-0.1
 export REPORT_CONFIDENCE=0.5
 export FOLLOW_CONFIDENCE_OF_OBSERVER=0.5
 
+# Cutoff for "is this rater influential enough to count toward the verified*Count
+# property on a NostrUser node?" Used by:
+#   src/algos/follows-mutes-reports/calculateVerified{Follower,Muter,Reporter}Counts.sh
+#   src/api/grapevineInteractions/queries/cypherQueries.js (legacy verified* listings)
+# Customer-side equivalents read VERIFIED_*_INFLUENCE_CUTOFF from the customer's own
+# graperank.conf (defaulting to 0.01 — more permissive). PREFERENCES_AUDIT.md §6.2
+# unified the previously-fragmented owner-side values (0.1) and listing values (0.05)
+# at 0.05.
+export VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF=0.05
+export VERIFIED_MUTERS_INFLUENCE_CUTOFF=0.05
+export VERIFIED_REPORTERS_INFLUENCE_CUTOFF=0.05
+
 # WHEN LAST CALCULATED: unix timestamp; 0 indicates not yet calculated
 export WHEN_LAST_CALCULATED=0
 

--- a/docs/PREFERENCES_AUDIT.md
+++ b/docs/PREFERENCES_AUDIT.md
@@ -290,9 +290,22 @@ Each of #1–#6 is small, isolated, reversible. Could ship as a single `chore/` 
 
 ### 6.2 Consolidate the verification threshold
 
-Pick **one** settings key — e.g., `settings.wot.influenceCutoffs.{verified}` or `settings.grapevine.verificationThreshold` (naming TBD) — and migrate every site listed in [§4 Pattern A](#4-fragmentation-patterns) to read from it. Decide whether the chosen value is `0.01` or `0.05` or `0.1` or a new compromise (the current values were not chosen together; pick deliberately).
+**Status: partially closed.** When digging into the specifics we found the 17 affected sites split into three semantic buckets, not one:
 
-This is a **single-number consolidation** but touches both the owner and customer pipelines, so it's also when the team has to choose between Pattern E remediation strategies (do owner and customer use the same cutoff, or different-but-explicit ones?). It's worth doing this *before* the bigger Pattern B work because it forces the conversation about owner-customer relationships in a small, well-bounded context.
+- **Bucket A — verified counts** (6 sites): owner-side `calculate{Follower,Muter,Reporter}Counts.sh` at `0.1`, customer-side at `0.01` (configurable). Writes the `verified*Count` properties on `NostrUser` / `NostrUserWotMetricsCard`.
+- **Bucket B — legacy verified-* listings** (4 sites): `src/api/grapevineInteractions/queries/cypherQueries.js` at `0.05`. The verifiedFollowers/etc. lists that the legacy `/legacy/grapevine-analysis.html` page uses.
+- **Bucket C — general "include this user" filters** (7 sites): search keyword endpoint, whitelist export, NIP-85 publish. All at `0.01`. Conceptually distinct from the verified-count idea — these answer "is this user real enough to surface" rather than "is this user verified".
+
+Buckets A and B share semantics: a listing OF a count should match the count's threshold. The `0.1`/`0.05` mismatch was the original fragmentation we noticed (a count of 100 verified followers click-through to a list showing 150). **PR (this work) consolidates A + B at `0.05`** by:
+- Adding `VERIFIED_{FOLLOWERS,MUTERS,REPORTERS}_INFLUENCE_CUTOFF` to the owner-side `config/graperank.conf.template` (defaulting to `0.05`).
+- Making owner-side `calculateVerified*Counts.sh` read these from `/etc/graperank.conf` (with `0.05` fallback if unset).
+- Making `cypherQueries.js` read the same params via `getConfigFromFile` (also defaulting to `0.05`).
+
+Bucket C is **deferred** — distinct purpose, may legitimately want different values.
+
+Owner-side and customer-side still maintain their own conf files (`/etc/graperank.conf` vs. `customers/<n>/preferences/graperank.conf`); the §6.3 question of unifying those planes is separate.
+
+Existing `verifiedFollowerCount` properties on Neo4j nodes carry the OLD `0.1`-based values until the next batch run. Operators wanting the new values immediately can manually trigger the relevant scripts.
 
 ### 6.3 Decide on owner ↔ customer parallel planes (the big one)
 

--- a/src/algos/follows-mutes-reports/calculateVerifiedFollowerCounts.sh
+++ b/src/algos/follows-mutes-reports/calculateVerifiedFollowerCounts.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 
 source /etc/brainstorm.conf # BRAINSTORM_LOG_DIR
+# Owner-side verified-follower cutoff. Read from /etc/graperank.conf if defined;
+# fall back to 0.05 (the unified value from PREFERENCES_AUDIT §6.2 consolidation).
+[ -f /etc/graperank.conf ] && source /etc/graperank.conf
+CUTOFF=${VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF:-0.05}
 
 touch ${BRAINSTORM_LOG_DIR}/calculateVerifiedFollowerCounts.log
 chown brainstorm:brainstorm ${BRAINSTORM_LOG_DIR}/calculateVerifiedFollowerCounts.log
 
-echo "$(date): Starting calculateVerifiedFollowerCounts"
-echo "$(date): Starting calculateVerifiedFollowerCounts" >> ${BRAINSTORM_LOG_DIR}/calculateVerifiedFollowerCounts.log
+echo "$(date): Starting calculateVerifiedFollowerCounts (cutoff=${CUTOFF})"
+echo "$(date): Starting calculateVerifiedFollowerCounts (cutoff=${CUTOFF})" >> ${BRAINSTORM_LOG_DIR}/calculateVerifiedFollowerCounts.log
 
 CYPHER1="
 MATCH (n:NostrUser)<-[f:FOLLOWS]-(m:NostrUser)
-WHERE m.influence > 0.1
+WHERE m.influence > ${CUTOFF}
 WITH n, count(f) AS verifiedFollowerCount
 SET n.verifiedFollowerCount = verifiedFollowerCount
 RETURN COUNT(n) AS numUsersUpdated"
@@ -19,7 +23,7 @@ RETURN COUNT(n) AS numUsersUpdated"
 CYPHER2="
 MATCH (n:NostrUser)
 OPTIONAL MATCH (n)<-[f:FOLLOWS]-(m:NostrUser)
-WHERE m.influence > 0.1
+WHERE m.influence > ${CUTOFF}
 WITH n, count(f) as verifiedFollowerCount
 WHERE verifiedFollowerCount = 0
 SET n.verifiedFollowerCount = 0

--- a/src/algos/follows-mutes-reports/calculateVerifiedMuterCounts.sh
+++ b/src/algos/follows-mutes-reports/calculateVerifiedMuterCounts.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 
 source /etc/brainstorm.conf # BRAINSTORM_LOG_DIR
+[ -f /etc/graperank.conf ] && source /etc/graperank.conf
+CUTOFF=${VERIFIED_MUTERS_INFLUENCE_CUTOFF:-0.05}
 
 touch ${BRAINSTORM_LOG_DIR}/calculateVerifiedMuterCounts.log
 chown brainstorm:brainstorm ${BRAINSTORM_LOG_DIR}/calculateVerifiedMuterCounts.log
 
-echo "$(date): Starting calculateVerifiedMuterCounts"
-echo "$(date): Starting calculateVerifiedMuterCounts" >> ${BRAINSTORM_LOG_DIR}/calculateVerifiedMuterCounts.log
+echo "$(date): Starting calculateVerifiedMuterCounts (cutoff=${CUTOFF})"
+echo "$(date): Starting calculateVerifiedMuterCounts (cutoff=${CUTOFF})" >> ${BRAINSTORM_LOG_DIR}/calculateVerifiedMuterCounts.log
 
 CYPHER1="
 MATCH (n:NostrUser)<-[f:MUTES]-(m:NostrUser)
-WHERE m.influence > 0.1
+WHERE m.influence > ${CUTOFF}
 WITH n, count(f) AS verifiedMuterCount
 SET n.verifiedMuterCount = verifiedMuterCount
 RETURN COUNT(n) AS numUsersUpdated"
@@ -19,7 +21,7 @@ RETURN COUNT(n) AS numUsersUpdated"
 CYPHER2="
 MATCH (n:NostrUser)
 OPTIONAL MATCH (n)<-[f:MUTES]-(m:NostrUser)
-WHERE m.influence > 0.1
+WHERE m.influence > ${CUTOFF}
 WITH n, count(f) as verifiedMuterCount
 WHERE verifiedMuterCount = 0
 SET n.verifiedMuterCount = 0

--- a/src/algos/follows-mutes-reports/calculateVerifiedReporterCounts.sh
+++ b/src/algos/follows-mutes-reports/calculateVerifiedReporterCounts.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 
 source /etc/brainstorm.conf # BRAINSTORM_LOG_DIR
+[ -f /etc/graperank.conf ] && source /etc/graperank.conf
+CUTOFF=${VERIFIED_REPORTERS_INFLUENCE_CUTOFF:-0.05}
 
 touch ${BRAINSTORM_LOG_DIR}/calculateVerifiedReporterCounts.log
 chown brainstorm:brainstorm ${BRAINSTORM_LOG_DIR}/calculateVerifiedReporterCounts.log
 
-echo "$(date): Starting calculateVerifiedReporterCounts"
-echo "$(date): Starting calculateVerifiedReporterCounts" >> ${BRAINSTORM_LOG_DIR}/calculateVerifiedReporterCounts.log
+echo "$(date): Starting calculateVerifiedReporterCounts (cutoff=${CUTOFF})"
+echo "$(date): Starting calculateVerifiedReporterCounts (cutoff=${CUTOFF})" >> ${BRAINSTORM_LOG_DIR}/calculateVerifiedReporterCounts.log
 
 CYPHER1="
 MATCH (n:NostrUser)<-[f:REPORTS]-(m:NostrUser)
-WHERE m.influence > 0.1
+WHERE m.influence > ${CUTOFF}
 WITH n, count(f) AS verifiedReporterCount
 SET n.verifiedReporterCount = verifiedReporterCount
 RETURN COUNT(n) AS numUsersUpdated"
@@ -19,7 +21,7 @@ RETURN COUNT(n) AS numUsersUpdated"
 CYPHER2="
 MATCH (n:NostrUser)
 OPTIONAL MATCH (n)<-[f:REPORTS]-(m:NostrUser)
-WHERE m.influence > 0.1
+WHERE m.influence > ${CUTOFF}
 WITH n, count(f) as verifiedReporterCount
 WHERE verifiedReporterCount = 0
 SET n.verifiedReporterCount = 0

--- a/src/api/grapevineInteractions/queries/cypherQueries.js
+++ b/src/api/grapevineInteractions/queries/cypherQueries.js
@@ -1,4 +1,15 @@
 // This file contains the cypher queries for the Grapevine Interactions API
+//
+// Verified-* listings filter by an influence threshold sourced from
+// /etc/graperank.conf (VERIFIED_{FOLLOWERS,MUTERS,REPORTERS}_INFLUENCE_CUTOFF).
+// Default 0.05, matching the cutoff the owner-side count algos write into the
+// `verified*Count` properties on NostrUser. Read at module load — restart the
+// brainstorm process to pick up changes to /etc/graperank.conf.
+
+const { getConfigFromFile } = require('../../../utils/config');
+const VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF = getConfigFromFile('VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF', '0.05');
+const VERIFIED_MUTERS_INFLUENCE_CUTOFF = getConfigFromFile('VERIFIED_MUTERS_INFLUENCE_CUTOFF', '0.05');
+const VERIFIED_REPORTERS_INFLUENCE_CUTOFF = getConfigFromFile('VERIFIED_REPORTERS_INFLUENCE_CUTOFF', '0.05');
 
 module.exports = {
     cypherQueries: [
@@ -15,11 +26,11 @@ RETURN followee.pubkey AS pubkey, followee.hops AS hops, followee.influence AS i
         {
             interactionType: 'verifiedFollows',
             title: 'Verified Follows',
-            description: `All verified (🍇-Rank > 0.05) profiles followed by {{observee}}.`,
+            description: `All verified (🍇-Rank > ${VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF}) profiles followed by {{observee}}.`,
             cypherQuery: `
 MATCH (observee:NostrUser {pubkey: $observee})
 OPTIONAL MATCH (observee)-[f:FOLLOWS]->(followee:NostrUser)
-WHERE followee.influence > 0.05
+WHERE followee.influence > ${VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF}
 RETURN followee.pubkey AS pubkey, followee.hops AS hops, followee.influence AS influence
             `
         },
@@ -36,11 +47,11 @@ RETURN follower.pubkey AS pubkey, follower.hops AS hops, follower.influence AS i
         {
             interactionType: 'verifiedFollowers',
             title: 'Verified Followers',
-            description: `All verified (🍇-Rank > 0.05) profiles following {{observee}}.`,
+            description: `All verified (🍇-Rank > ${VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF}) profiles following {{observee}}.`,
             cypherQuery: `
 MATCH (observee:NostrUser {pubkey: $observee})
 OPTIONAL MATCH (follower:NostrUser)-[f:FOLLOWS]->(observee)
-WHERE follower.influence > 0.05
+WHERE follower.influence > ${VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF}
 RETURN follower.pubkey AS pubkey, follower.hops AS hops, follower.influence AS influence
             `
         },
@@ -67,11 +78,11 @@ RETURN muter.pubkey AS pubkey, muter.hops AS hops, muter.influence AS influence
         {
             interactionType: 'verifiedMuters',
             title: 'Verified Muters',
-            description: `All verified (🍇-Rank > 0.05) profiles muting {{observee}}.`,
+            description: `All verified (🍇-Rank > ${VERIFIED_MUTERS_INFLUENCE_CUTOFF}) profiles muting {{observee}}.`,
             cypherQuery: `
 MATCH (observee:NostrUser {pubkey: $observee})
 OPTIONAL MATCH (muter:NostrUser)-[m:MUTES]->(observee)
-WHERE muter.influence > 0.05
+WHERE muter.influence > ${VERIFIED_MUTERS_INFLUENCE_CUTOFF}
 RETURN muter.pubkey AS pubkey, muter.hops AS hops, muter.influence AS influence
             `
         },
@@ -98,11 +109,11 @@ RETURN reporter.pubkey AS pubkey, reporter.hops AS hops, reporter.influence AS i
         {
             interactionType: 'verifiedReporters',
             title: 'Verified Reporters',
-            description: `All verified (🍇-Rank > 0.05) profiles reporting {{observee}}.`,
+            description: `All verified (🍇-Rank > ${VERIFIED_REPORTERS_INFLUENCE_CUTOFF}) profiles reporting {{observee}}.`,
             cypherQuery: `
 MATCH (observee:NostrUser {pubkey: $observee})
 OPTIONAL MATCH (reporter:NostrUser)-[r:REPORTS]->(observee)
-WHERE reporter.influence > 0.05
+WHERE reporter.influence > ${VERIFIED_REPORTERS_INFLUENCE_CUTOFF}
 RETURN reporter.pubkey AS pubkey, reporter.hops AS hops, reporter.influence AS influence
             `
         },


### PR DESCRIPTION
## Summary
Promotes two changes verified on staging:
- [#95](https://github.com/nous-clawds4/tapestry/pull/95) — Add `CLAUDE.md` root pointer at repo root, directing Claude Code sessions to read BIBLE.md and OPERATIONS.md before starting work. Docs only.
- [#96](https://github.com/nous-clawds4/tapestry/pull/96) — Consolidate verified-* cutoffs (PREFERENCES_AUDIT §6.2, buckets A+B).

## Test plan
- [ ] Merge triggers `deploy-brainstorm.yml` → `brainstorm.world` (production).
- [ ] Confirm `CLAUDE.md` appears at the repo root post-deploy.
- [ ] Verify the settings UI reflects the consolidated verified-* cutoffs (per #96).
- [ ] Spot-check no regressions in Meilisearch profile search, profile pages, or NIP-50 relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)