### PR TITLE
Fix Firmware Install gate: query Neo4j instead of stale config flag

### DIFF
--- a/src/api/status/queries/expectedNeo4jSchema.js
+++ b/src/api/status/queries/expectedNeo4jSchema.js
@@ -1,0 +1,44 @@
+/**
+ * Canonical list of Neo4j constraints and indexes that the Brainstorm schema
+ * requires. Mirrors what setup/neo4jConstraintsAndIndexes.sh creates. Used by
+ * the constraints-status handler to verify the database is ready before the UI
+ * lets the user install firmware.
+ *
+ * If the setup script is updated, update this list too.
+ */
+
+const EXPECTED_CONSTRAINTS = [
+    'nostrEvent_id',
+    'nostrEvent_uuid',
+    'nostrEventTag_uuid',
+    'nostrUser_pubkey',
+    'SetOfNostrUserWotMetricsCards_observee_pubkey',
+    'nostrUserWotMetricsCard_unique_combination_1',
+    'nostrUserWotMetricsCard_unique_combination_2',
+];
+
+const EXPECTED_INDEXES = [
+    'nostrEvent_kind',
+    'nostrUser_hops',
+    'nostrUser_personalizedPageRank',
+    'nostrUser_influence',
+    'nostrUser_verifiedFollowerCount',
+    'nostrUser_verifiedMuterCount',
+    'nostrUser_verifiedReporterCount',
+    'nostrUser_followerInput',
+    'nostrUserWotMetricsCard_customer_id',
+    'nostrUserWotMetricsCard_observer_pubkey',
+    'nostrUserWotMetricsCard_observee_pubkey',
+    'nostrUserWotMetricsCard_hops',
+    'nostrUserWotMetricsCard_personalizedPageRank',
+    'nostrUserWotMetricsCard_influence',
+    'nostrUserWotMetricsCard_verifiedFollowerCount',
+    'nostrUserWotMetricsCard_verifiedMuterCount',
+    'nostrUserWotMetricsCard_verifiedReporterCount',
+    'nostrUserWotMetricsCard_followerInput',
+];
+
+module.exports = {
+    EXPECTED_CONSTRAINTS,
+    EXPECTED_INDEXES,
+};

--- a/src/api/status/queries/neo4j-constraints.js
+++ b/src/api/status/queries/neo4j-constraints.js
@@ -1,41 +1,77 @@
 /**
  * Neo4j Constraints Status Query Handler
- * 
- * This module provides a query handler to check the status of Neo4j constraints
+ *
+ * Reports whether all Brainstorm-required constraints and (online) indexes
+ * exist in the running Neo4j instance. The Firmware settings page uses this
+ * to gate the Install Firmware button — see ui/src/pages/settings/FirmwareExplorer.jsx.
  */
 
-const { getConfigFromFile } = require('../../../utils/config');
+const { exec } = require('child_process');
+const { promisify } = require('util');
+const { getNeo4jConnection } = require('../../../utils/config');
+const { EXPECTED_CONSTRAINTS, EXPECTED_INDEXES } = require('./expectedNeo4jSchema');
 
-/**
- * Handles returning the Neo4j constraints setup timestamp
- * 
- * @param {object} req - Express request object
- * @param {object} res - Express response object
- */
-function handleGetNeo4jConstraintsStatus(req, res) {
+const execAsync = promisify(exec);
+
+async function runCypher(query) {
+    const { user, password } = getNeo4jConnection();
+    if (!password) {
+        throw new Error('Neo4j password not configured (NEO4J_PASSWORD)');
+    }
+    const command = `cypher-shell -u ${user} -p ${password} "${query}"`;
+    const { stdout } = await execAsync(command);
+    return stdout;
+}
+
+// cypher-shell prints YIELD'd string columns as quoted tokens (e.g. `"nostrEvent_id"`).
+// Pull every quoted token out of the output and put it in a Set.
+function parseQuotedNames(output) {
+    const names = new Set();
+    const re = /"([^"]+)"/g;
+    let m;
+    while ((m = re.exec(output)) !== null) {
+        names.add(m[1]);
+    }
+    return names;
+}
+
+async function handleGetNeo4jConstraintsStatus(req, res) {
     console.log('Getting Neo4j constraints setup status...');
-    
+
     try {
-        // Get the BRAINSTORM_CREATED_CONSTRAINTS_AND_INDEXES from configuration
-        const constraintsTimestamp = parseInt(getConfigFromFile('BRAINSTORM_CREATED_CONSTRAINTS_AND_INDEXES', '0'), 10);
-        
-        // Return the status
+        const [constraintsOut, indexesOut] = await Promise.all([
+            runCypher('SHOW CONSTRAINTS YIELD name;'),
+            runCypher("SHOW INDEXES YIELD name, state WHERE state = 'ONLINE' RETURN name;"),
+        ]);
+
+        const constraintNames = parseQuotedNames(constraintsOut);
+        const indexNames = parseQuotedNames(indexesOut);
+
+        const missingConstraints = EXPECTED_CONSTRAINTS.filter(n => !constraintNames.has(n));
+        const missingIndexes = EXPECTED_INDEXES.filter(n => !indexNames.has(n));
+        const ready = missingConstraints.length === 0 && missingIndexes.length === 0;
+        const timestamp = ready ? Math.floor(Date.now() / 1000) : 0;
+
         return res.json({
             success: true,
-            constraintsTimestamp: constraintsTimestamp,
-            status: constraintsTimestamp > 0 ? 'set up' : 'not set up',
-            setupTime: constraintsTimestamp > 0 ? new Date(constraintsTimestamp * 1000).toISOString() : null
+            constraintsTimestamp: timestamp,
+            status: ready ? 'set up' : 'not set up',
+            setupTime: ready ? new Date(timestamp * 1000).toISOString() : null,
+            missingConstraints,
+            missingIndexes,
         });
     } catch (error) {
         console.error('Error getting Neo4j constraints status:', error);
         return res.json({
             success: false,
             error: error.message,
-            constraintsTimestamp: 0
+            constraintsTimestamp: 0,
+            status: 'not set up',
+            setupTime: null,
         });
     }
 }
 
 module.exports = {
-    handleGetNeo4jConstraintsStatus
+    handleGetNeo4jConstraintsStatus,
 };


### PR DESCRIPTION
## Summary

The `/api/status/neo4j-constraints` endpoint was reading the `BRAINSTORM_CREATED_CONSTRAINTS_AND_INDEXES` flag from `/etc/brainstorm.conf` instead of querying Neo4j. That flag is only ever set by [setup/neo4jConstraintsAndIndexes.sh](setup/neo4jConstraintsAndIndexes.sh) — a bare-metal install script never invoked from the Docker entrypoint — so it stayed at `0` locally even when constraints/indexes were present, disabling the **Install Firmware** button on `/tapestry/settings/firmware` with a misleading **"⚠️ Neo4j constraints & indexes must be set up first"** warning.

The same bug exists on staging and production (both return `constraintsTimestamp: 0`), but it was hidden:
- **Staging**: firmware fully installed → install button section suppressed by `!isInstalled`.
- **Production**: `partial: true (28/34)` → anyone clicking "Complete Install" today would also hit the disabled button.

## Changes

- **`src/api/status/queries/neo4j-constraints.js`** — replaces the `getConfigFromFile` lookup with `SHOW CONSTRAINTS YIELD name` and `SHOW INDEXES YIELD name, state WHERE state = 'ONLINE' RETURN name` against Neo4j via `cypher-shell` (matches the pattern in `src/api/status/queries/neo4j.js`). Compares results against an expected name list. Returns `success`/`constraintsTimestamp`/`status`/`setupTime` (backward-compatible) plus new `missingConstraints`/`missingIndexes` arrays.
- **`src/api/status/queries/expectedNeo4jSchema.js`** (new) — canonical lists of 7 expected constraints + 18 expected indexes, extracted from `setup/neo4jConstraintsAndIndexes.sh`. Single source of truth for future schema changes.

## Test plan

- [x] Local: `curl /api/status/neo4j-constraints` returns `status: "set up"`, empty `missingConstraints` / `missingIndexes`.
- [x] Local: Firmware page renders enabled Install button, no warning.
- [x] Negative test: dropping `nostrEvent_id` in Neo4j makes endpoint report `missingConstraints: ["nostrEvent_id"]`; recreating it clears the missing list.
- [ ] Staging: confirm the Firmware page still renders correctly (firmware fully installed there, so install section should remain hidden).
- [ ] Staging API: `curl https://staging.brainstorm.world/api/status/neo4j-constraints` should return `status: "set up"` once the deploy completes.

## Follow-ups (out of scope)

- Once we're confident no other consumer reads `BRAINSTORM_CREATED_CONSTRAINTS_AND_INDEXES`, delete the dead `sed` block in `setup/neo4jConstraintsAndIndexes.sh:204-220` and the variable initialization in `bin/install.js`/`docker/entrypoint.sh`. Quick grep confirmed only the status endpoint read it.
- Surface `missingConstraints`/`missingIndexes` in the UI warning so the user knows exactly what's missing.
- Consider auto-creating the constraints/indexes on first Docker-stack startup so a fresh container works out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)