### PR TITLE
Add WoT + trustedAssertions router presets; cap userProfiles

### DIFF
--- a/setup/router-presets.json
+++ b/setup/router-presets.json
@@ -28,7 +28,7 @@
     "name": "userProfiles",
     "description": "Continuous kind 0 profile sync — keeps local user profiles up to date from profile-aggregating relays",
     "dir": "down",
-    "filter": { "kinds": [0] },
+    "filter": { "kinds": [0], "limit": 5 },
     "urls": [
       "wss://wot.grapevine.network",
       "wss://profiles.nostr1.com",
@@ -47,6 +47,30 @@
       "wss://nip85.brainstorm.world",
       "wss://nip85.nostr1.com",
       "wss://nip85.grapevine.network"
+    ],
+    "pluginDown": "",
+    "pluginUp": "",
+    "defaultEnabled": false
+  },
+  {
+    "name": "WoT",
+    "description": "Relays that maintain Web of Trust (WoT) data (follows, reports, mutes)",
+    "dir": "both",
+    "filter": { "kinds": [3, 1984, 10000], "limit": 5 },
+    "urls": [
+      "wss://wot.grapevine.network"
+    ],
+    "pluginDown": "",
+    "pluginUp": "",
+    "defaultEnabled": false
+  },
+  {
+    "name": "trustedAssertions",
+    "description": "Relays that maintain Trusted Assertions (NIP-85 custom NIP)",
+    "dir": "up",
+    "filter": { "kinds": [30382], "limit": 5 },
+    "urls": [
+      "wss://nip85.brainstorm.world"
     ],
     "pluginDown": "",
     "pluginUp": "",


### PR DESCRIPTION
## Summary

Adds two new strfry-router presets (`WoT`, `trustedAssertions`) and tightens the existing `userProfiles` filter with a `limit: 5` cap, matching the convention used by every other kind-bearing preset.

## Changes

`setup/router-presets.json`:

- **userProfiles** filter: `{kinds:[0]}` → `{kinds:[0], limit:5}`. Brings it in line with `dcosl`, `dcosl2`, `trustedLists` which already have `limit:5`.
- **WoT (new):** `dir=both`, kinds 3 (follows), 1984 (reports), 10000 (mutes), urls=[`wss://wot.grapevine.network`].
- **trustedAssertions (new):** `dir=up`, kind 30382, urls=[`wss://nip85.brainstorm.world`].

All new entries are `defaultEnabled: false`, so deployments with an existing `/var/lib/brainstorm/router-state.json` are unaffected at runtime — the new presets only surface in the active state if an operator hits `POST /api/strfry/router-restore-defaults`. Verified locally: `GET /api/strfry/router-presets` returns the new shapes; brainstorm restarts clean.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs to completion.
- [ ] Smoke test on `staging.brainstorm.world` — Tier 1 stability, Tier 2 sanity, Tier 3 `GET /api/strfry/router-presets` returns 6 presets including `WoT` and `trustedAssertions` with correct shapes, Tier 5 neighboring strfry endpoints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)