### PR TITLE
Promote staging → main: WoT + trustedAssertions router presets

### DIFF
--- a/setup/router-presets.json
+++ b/setup/router-presets.json
@@ -28,7 +28,7 @@
     "name": "userProfiles",
     "description": "Continuous kind 0 profile sync — keeps local user profiles up to date from profile-aggregating relays",
     "dir": "down",
-    "filter": { "kinds": [0] },
+    "filter": { "kinds": [0], "limit": 5 },
     "urls": [
       "wss://wot.grapevine.network",
       "wss://profiles.nostr1.com",
@@ -47,6 +47,30 @@
       "wss://nip85.brainstorm.world",
       "wss://nip85.nostr1.com",
       "wss://nip85.grapevine.network"
+    ],
+    "pluginDown": "",
+    "pluginUp": "",
+    "defaultEnabled": false
+  },
+  {
+    "name": "WoT",
+    "description": "Relays that maintain Web of Trust (WoT) data (follows, reports, mutes)",
+    "dir": "both",
+    "filter": { "kinds": [3, 1984, 10000], "limit": 5 },
+    "urls": [
+      "wss://wot.grapevine.network"
+    ],
+    "pluginDown": "",
+    "pluginUp": "",
+    "defaultEnabled": false
+  },
+  {
+    "name": "trustedAssertions",
+    "description": "Relays that maintain Trusted Assertions (NIP-85 custom NIP)",
+    "dir": "up",
+    "filter": { "kinds": [30382], "limit": 5 },
+    "urls": [
+      "wss://nip85.brainstorm.world"
     ],
     "pluginDown": "",
     "pluginUp": "",


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`. Single bundled change: two new strfry-router presets and a tightened filter on the existing `userProfiles` preset.

## Bundled

- **#105** — Add WoT and trustedAssertions router presets; cap userProfiles filter

## Net production impact

Operators visiting the router-config UI will see two new opt-in preset entries (`WoT`, `trustedAssertions`) and a `limit: 5` cap on the `userProfiles` preset. **Zero runtime change** for existing deployments — `defaultEnabled: false` on both new entries, and the persisted `/var/lib/brainstorm/router-state.json` is unchanged by the file edit. New presets only enter active state when an operator explicitly hits `POST /api/strfry/router-restore-defaults`. No forced sign-out, no schema migration, no downstream impact on data already in Neo4j.

## Verification trail

- **Staging deploy:** [run 25301944504](https://github.com/nous-clawds4/tapestry/actions/runs/25301944504) ✓ 1m10s
- **Staging smoke (2026-05-04 05:02 UTC):** Tier 1 stable in 3 polls; Tier 2 6/6 pages + 5/5 APIs + meili search clean; Tier 3 `GET /api/strfry/router-presets` returned 6 presets with all expected shapes (WoT/trustedAssertions/userProfiles); Tier 5 router-plugins + router-presets 200.
- **Local pre-flight:** docker cp + supervisorctl restart brainstorm clean; same Tier 3 verification passed.

## Test plan

- [ ] After merge: `deploy-brainstorm.yml` runs to completion.
- [ ] Smoke test on `brainstorm.world` — Tier 1 stability, Tier 2 sanity, Tier 3 `GET /api/strfry/router-presets` returns 6 presets including `WoT`/`trustedAssertions`, Tier 5 neighboring strfry endpoints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)