### PR TITLE
Promote staging → main: fix silent strfry-redis patch failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,13 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 # Copy Redis patches first (before strfry clone, for Docker layer caching)
 COPY patches/strfry-redis/ /tmp/strfry-redis-patches/
 
-# Compile strfry from source with Redis integration
-RUN git clone https://github.com/hoytech/strfry.git /usr/local/src/strfry \
+# Compile strfry from source with Redis integration.
+# Pinned to a specific tag so the Redis patch is applied against a known
+# upstream signature. Bumping this requires verifying patches/strfry-redis/
+# still applies cleanly (the apply-patches.sh validation will fail loudly
+# at build time if a sed pattern stops matching).
+ARG STRFRY_REF=1.1.0
+RUN git clone --branch "$STRFRY_REF" --depth 1 https://github.com/hoytech/strfry.git /usr/local/src/strfry \
     && cd /usr/local/src/strfry \
     && git submodule update --init \
     && bash /tmp/strfry-redis-patches/apply-patches.sh /usr/local/src/strfry \

--- a/patches/strfry-redis/apply-patches.sh
+++ b/patches/strfry-redis/apply-patches.sh
@@ -45,13 +45,21 @@ if ! grep -q "redis_init" "$STRFRY_DIR/golpe/main.cpp.tt"; then
     # Add #include at the top of the file (after the first #include)
     sed -i '0,/#include/{s/#include/#include "redis.h"\n#include/}' "$STRFRY_DIR/golpe/main.cpp.tt"
 
-    # Insert redis_init AFTER loadConfig (inside run(), where cfg() is available)
-    sed -i '/loadConfig(configFile);/a\
+    # Insert redis_init AFTER loadConfig (inside run(), where cfg() is available).
+    # Match prefix "loadConfig(configFile" so this works against both upstream's
+    # historical 1-arg signature and current 2-arg signature.
+    sed -i '/loadConfig(configFile/a\
 \
     // Initialize Redis connection for streaming ETL\
     if (redis_init(cfg().redis__host.c_str(), cfg().redis__port) != 0) {\
         LW << "Failed to connect to Redis — streaming ETL disabled";\
     }' "$STRFRY_DIR/golpe/main.cpp.tt"
+
+    # Verify the insertion actually landed — sed silently no-ops on no-match.
+    if ! grep -q "redis_init" "$STRFRY_DIR/golpe/main.cpp.tt"; then
+        echo "ERROR: redis_init insertion in golpe/main.cpp.tt failed — sed pattern did not match. Upstream signature may have changed again." >&2
+        exit 1
+    fi
     echo "  Added redis.h include and redis_init() to golpe/main.cpp.tt"
 else
     echo "  redis_init already in golpe/main.cpp.tt (skipping)"
@@ -79,6 +87,13 @@ static const std::unordered_set<uint64_t> REDIS_ALLOW_KINDS = {\
                                     redis_rpush("strfry:events", ev.jsonStr.c_str());\
                                 }\
                             }' "$STRFRY_DIR/src/WriterPipeline.h"
+
+    # Verify both insertions actually landed.
+    if ! grep -q "REDIS_ALLOW_KINDS" "$STRFRY_DIR/src/WriterPipeline.h" \
+       || ! grep -q "redis_rpush" "$STRFRY_DIR/src/WriterPipeline.h"; then
+        echo "ERROR: WriterPipeline.h patch failed — sed pattern did not match. Upstream may have changed." >&2
+        exit 1
+    fi
     echo "  Added Redis integration to WriterPipeline.h"
 else
     echo "  Redis already in WriterPipeline.h (skipping)"


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`. Single bundled change: the strfry-redis patch fix that resurrects the streaming ETL on freshly-built images.

## Bundled

- **[#109](https://github.com/nous-clawds4/tapestry/pull/109)** — Fix silent strfry-redis patch failure; pin strfry to 1.1.0. Broadens the apply-patches.sh sed match for golpe's `loadConfig(...)` (works for both 1-arg and 2-arg signatures), adds `grep -q ... || exit 1` validation gates so any future upstream drift fails the build loudly, and pins strfry to tag 1.1.0 so builds are reproducible. Closes [#108](https://github.com/nous-clawds4/tapestry/issues/108).

## Net production impact

Production's currently-running strfry binary is working — it was built from a Docker layer cache that predates the upstream `loadConfig` signature change, so the original sed pattern matched at the time. This deploy invalidates that cache (both `Dockerfile` and `patches/strfry-redis/apply-patches.sh` changed), so the strfry layer rebuilds against the pinned 1.1.0 tag with the new validation. Functionally equivalent ETL hook in the new binary; structurally more robust against future drift. No data loss; sessions persist (SESSION_SECRET is volume-backed). Brief streaming-ETL pause during container restart, then resumes — same behavior we observed on staging.

## Verification trail

- [#109](https://github.com/nous-clawds4/tapestry/pull/109) deployed to staging. User verified data is flowing into Neo4j on `staging.brainstorm.world` as expected (NostrUser and FOLLOWS counts growing under live nostr traffic).
- Local end-to-end verification before staging: rebuilt image had `"Failed to connect to Redis"` string in `strfry`, `LLEN strfry:events` grew under load, consumer drained it, NostrUser +797 / FOLLOWS +3034 within minutes of restart.

## Test plan

- [ ] After merge: `deploy-brainstorm.yml` runs to completion.
- [ ] Stability poll on `https://brainstorm.world` (3 consecutive 200s).
- [ ] Tier 2 sanity reachability passes.
- [ ] Tier 3 PR-specific: confirm the new strfry binary on prod contains the patch (`docker exec tapestry strings /usr/local/bin/strfry | grep "Failed to connect to Redis"` should return non-empty — same check that distinguished prod-working from staging-broken before this fix).
- [ ] Tier 3 PR-specific: confirm `LLEN strfry:events` is non-zero or transient under live traffic, NostrUser/FOLLOWS counts continue to grow on prod.
- [ ] Tier 5 regression sweep — no unrelated breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)