### PR TITLE
Add Magic Carpet bounty cap fields

### DIFF
--- a/BIBLE.md
+++ b/BIBLE.md
@@ -1434,7 +1434,7 @@ The bounties subsystem lets a list curator (Alice) offer Lightning sats to any t
 
 ### Model
 
-- **Bounty = a row in SQLite**, not a nostr event. Bounties are app-level metadata (no cross-client coordination needed for a PoC). Schema lives in `src/db/bounties.js`; table is `bounties(id, issuer_pubkey, list_coordinate, amount_sats, criteria, expiration, created_at, status)`. DB file is `/var/lib/brainstorm/bounties.db` in prod (tapestry-data volume) or `./data/bounties.db` in dev.
+- **Bounty = a row in SQLite**, not a nostr event. Bounties are app-level metadata (no cross-client coordination needed for a PoC). Schema lives in `src/db/bounties.js`; table is `bounties(id, issuer_pubkey, list_coordinate, amount_sats, bounty_cap_sats, reward_per_item, max_rewards_per_npub, criteria, expiration, created_at, status)`. DB file is `/var/lib/brainstorm/bounties.db` in prod (tapestry-data volume) or `./data/bounties.db` in dev.
 - **Claim = an ordinary kind-39999 ListItem** on the bountied list, published through tapestry's existing `/tapestry/lists/:id/items/new` flow. No new event kind, no new submission endpoint. Correlation is implicit: claims are items on `bounty.list_coordinate` by pubkeys trusted by the issuer (rank ≥ 2), created after `bounty.created_at`.
 - **Payment = NIP-57 zap** tagging the claim's event id. Client signs kind-9734, posts to the recipient's LNURL callback, gets back an invoice. Kind-9735 receipt (published by the LNURL provider) is the proof of payment.
 - **Fulfilled status = derived**: the bounty is considered `fulfilled` when any kind-9735 receipt exists whose embedded zap request pubkey (parsed from the receipt's `description` tag per NIP-57) equals `bounty.issuer_pubkey`, targeting the bounty's list coordinate.
@@ -1449,7 +1449,7 @@ Set `DEV_SKIP_TRUST_CHECK=true` in `.env` to bypass the rank gate for local deve
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/api/bounties` | Create a bounty (session required). Body: `{ listCoordinate, amountSats, criteria, expiration? }`. |
+| POST | `/api/bounties` | Create a bounty (session required). Body: `{ listCoordinate, amountSats, bountyCapSats, rewardPerItem?, maxRewardsPerNpub?, criteria, expiration? }`. |
 | GET | `/api/bounties` | List bounties (`?status=open\|all`). Each includes a derived status. |
 | GET | `/api/bounties/eligible?viewer=<hex>` | Bounties whose issuer trusts the viewer at rank ≥ 2. |
 | GET | `/api/bounties/:id` | Single bounty + derived claims + zap receipts. |

--- a/src/api/bounties.js
+++ b/src/api/bounties.js
@@ -12,8 +12,7 @@ const {
   markFulfilled,
 } = require('../db/bounties');
 const { rank } = require('../lib/trust-rank');
-
-const COORDINATE_RE = /^(\d+):([0-9a-f]{64}):(.+)$/;
+const { normalizeBountyCreatePayload } = require('../lib/bounty-fields');
 
 function requireAuthed(req, res, next) {
   if (!req.session?.authenticated || !req.session?.pubkey) {
@@ -81,32 +80,16 @@ async function listClaimsFor(bounty, { trustFilter = true } = {}) {
 }
 
 async function handleCreateBounty(req, res) {
-  const { listCoordinate, amountSats, criteria, expiration } = req.body || {};
-
-  if (!listCoordinate || !COORDINATE_RE.test(listCoordinate)) {
-    return res.status(400).json({ success: false, error: 'listCoordinate must be <kind>:<pubkey>:<dtag>' });
-  }
-  const amt = Number(amountSats);
-  if (!Number.isInteger(amt) || amt <= 0) {
-    return res.status(400).json({ success: false, error: 'amountSats must be a positive integer' });
-  }
-  if (typeof criteria !== 'string' || !criteria.trim()) {
-    return res.status(400).json({ success: false, error: 'criteria is required' });
-  }
-  let exp = null;
-  if (expiration !== undefined && expiration !== null && expiration !== '') {
-    exp = Number(expiration);
-    if (!Number.isInteger(exp) || exp <= 0) {
-      return res.status(400).json({ success: false, error: 'expiration must be a unix timestamp' });
-    }
+  let payload;
+  try {
+    payload = normalizeBountyCreatePayload(req.body || {});
+  } catch (err) {
+    return res.status(err.statusCode || 400).json({ success: false, error: err.message });
   }
 
   const row = createBounty({
     issuerPubkey: req.session.pubkey,
-    listCoordinate,
-    amountSats: amt,
-    criteria: criteria.trim(),
-    expiration: exp,
+    ...payload,
   });
   res.json({ success: true, bounty: row });
 }

--- a/src/db/bounties.js
+++ b/src/db/bounties.js
@@ -28,6 +28,9 @@ db.exec(`
     issuer_pubkey   TEXT NOT NULL,
     list_coordinate TEXT NOT NULL,
     amount_sats     INTEGER NOT NULL CHECK (amount_sats > 0),
+    bounty_cap_sats INTEGER NOT NULL CHECK (bounty_cap_sats > 0),
+    reward_per_item INTEGER NOT NULL DEFAULT 0 CHECK (reward_per_item IN (0,1)),
+    max_rewards_per_npub INTEGER CHECK (max_rewards_per_npub IS NULL OR max_rewards_per_npub > 0),
     criteria        TEXT NOT NULL,
     expiration      INTEGER,
     created_at      INTEGER NOT NULL,
@@ -38,9 +41,25 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_bounties_status ON bounties(status);
 `);
 
+function ensureBountyColumn(name, alterSql) {
+  const columns = db.prepare('PRAGMA table_info(bounties)').all();
+  if (!columns.some(c => c.name === name)) db.exec(alterSql);
+}
+
+ensureBountyColumn('bounty_cap_sats', 'ALTER TABLE bounties ADD COLUMN bounty_cap_sats INTEGER');
+ensureBountyColumn('reward_per_item', 'ALTER TABLE bounties ADD COLUMN reward_per_item INTEGER NOT NULL DEFAULT 0');
+ensureBountyColumn('max_rewards_per_npub', 'ALTER TABLE bounties ADD COLUMN max_rewards_per_npub INTEGER');
+db.exec(`UPDATE bounties SET bounty_cap_sats = amount_sats WHERE bounty_cap_sats IS NULL`);
+
 const insertStmt = db.prepare(`
-  INSERT INTO bounties (id, issuer_pubkey, list_coordinate, amount_sats, criteria, expiration, created_at, status)
-  VALUES (@id, @issuer_pubkey, @list_coordinate, @amount_sats, @criteria, @expiration, @created_at, 'open')
+  INSERT INTO bounties (
+    id, issuer_pubkey, list_coordinate, amount_sats, bounty_cap_sats,
+    reward_per_item, max_rewards_per_npub, criteria, expiration, created_at, status
+  )
+  VALUES (
+    @id, @issuer_pubkey, @list_coordinate, @amount_sats, @bounty_cap_sats,
+    @reward_per_item, @max_rewards_per_npub, @criteria, @expiration, @created_at, 'open'
+  )
 `);
 const selectOpenStmt = db.prepare(`
   SELECT * FROM bounties
@@ -53,13 +72,25 @@ const selectByIdStmt = db.prepare(`SELECT * FROM bounties WHERE id = ?`);
 const selectByIssuerStmt = db.prepare(`SELECT * FROM bounties WHERE issuer_pubkey = ? ORDER BY created_at DESC`);
 const markFulfilledStmt = db.prepare(`UPDATE bounties SET status = 'fulfilled' WHERE id = ?`);
 
-function createBounty({ issuerPubkey, listCoordinate, amountSats, criteria, expiration }) {
+function createBounty({
+  issuerPubkey,
+  listCoordinate,
+  amountSats,
+  bountyCapSats,
+  rewardPerItem = false,
+  maxRewardsPerNpub = null,
+  criteria,
+  expiration,
+}) {
   const id = uuidv4();
   const row = {
     id,
     issuer_pubkey: issuerPubkey,
     list_coordinate: listCoordinate,
     amount_sats: amountSats,
+    bounty_cap_sats: bountyCapSats,
+    reward_per_item: rewardPerItem ? 1 : 0,
+    max_rewards_per_npub: rewardPerItem ? maxRewardsPerNpub : null,
     criteria,
     expiration: expiration ?? null,
     created_at: Math.floor(Date.now() / 1000),

--- a/src/lib/bounty-fields.js
+++ b/src/lib/bounty-fields.js
@@ -1,0 +1,93 @@
+const COORDINATE_RE = /^(\d+):([0-9a-f]{64}):(.+)$/;
+
+class BountyValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'BountyValidationError';
+    this.statusCode = 400;
+  }
+}
+
+function readField(body, camelName, snakeName = camelName) {
+  return body[camelName] ?? body[snakeName];
+}
+
+function requiredPositiveInteger(value, fieldName) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new BountyValidationError(`${fieldName} must be a positive integer`);
+  }
+  return n;
+}
+
+function optionalPositiveInteger(value, fieldName) {
+  if (value === undefined || value === null || value === '') return null;
+  return requiredPositiveInteger(value, fieldName);
+}
+
+function optionalUnixTimestamp(value) {
+  if (value === undefined || value === null || value === '') return null;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new BountyValidationError('expiration must be a unix timestamp');
+  }
+  return n;
+}
+
+function optionalBoolean(value, fieldName, defaultValue = false) {
+  if (value === undefined || value === null || value === '') return defaultValue;
+  if (value === true || value === false) return value;
+  if (value === 1 || value === '1' || value === 'true') return true;
+  if (value === 0 || value === '0' || value === 'false') return false;
+  throw new BountyValidationError(`${fieldName} must be a boolean`);
+}
+
+function normalizeBountyCreatePayload(body = {}) {
+  const listCoordinate = readField(body, 'listCoordinate', 'list_coordinate');
+  if (!listCoordinate || !COORDINATE_RE.test(listCoordinate)) {
+    throw new BountyValidationError('listCoordinate must be <kind>:<pubkey>:<dtag>');
+  }
+
+  const amountSats = requiredPositiveInteger(
+    readField(body, 'amountSats', 'amount_sats'),
+    'amountSats'
+  );
+  const bountyCapSats = requiredPositiveInteger(
+    readField(body, 'bountyCapSats', 'bounty_cap_sats'),
+    'bountyCapSats'
+  );
+  if (bountyCapSats < amountSats) {
+    throw new BountyValidationError('bountyCapSats must be greater than or equal to amountSats');
+  }
+
+  const rewardPerItem = optionalBoolean(
+    readField(body, 'rewardPerItem', 'reward_per_item'),
+    'rewardPerItem',
+    false
+  );
+  const rawMaxRewards = readField(body, 'maxRewardsPerNpub', 'max_rewards_per_npub');
+  const maxRewardsPerNpub = optionalPositiveInteger(rawMaxRewards, 'maxRewardsPerNpub');
+  if (!rewardPerItem && maxRewardsPerNpub !== null) {
+    throw new BountyValidationError('maxRewardsPerNpub only applies when rewardPerItem is true');
+  }
+
+  const criteria = body.criteria;
+  if (typeof criteria !== 'string' || !criteria.trim()) {
+    throw new BountyValidationError('criteria is required');
+  }
+
+  return {
+    listCoordinate,
+    amountSats,
+    bountyCapSats,
+    rewardPerItem,
+    maxRewardsPerNpub,
+    criteria: criteria.trim(),
+    expiration: optionalUnixTimestamp(body.expiration),
+  };
+}
+
+module.exports = {
+  BountyValidationError,
+  normalizeBountyCreatePayload,
+};

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,9 @@
  * In a real-world scenario, you would use a testing framework like Jest or Mocha.
  */
 
+const assert = require('assert');
 const { loadConfig } = require('../lib/config');
+const { normalizeBountyCreatePayload } = require('../src/lib/bounty-fields');
 
 // Mock environment variables for testing
 process.env.BRAINSTORM_RELAY_URL = 'wss://test-relay.com';
@@ -23,14 +25,66 @@ function testConfigLoading() {
   }
 }
 
+function testBountyFieldValidation() {
+  const listCoordinate = `39998:${'a'.repeat(64)}:sleepy-dwarfs`;
+  try {
+    const base = normalizeBountyCreatePayload({
+      listCoordinate,
+      amountSats: 1000,
+      bountyCapSats: 5000,
+      criteria: 'Useful list items',
+    });
+    assert.strictEqual(base.rewardPerItem, false);
+    assert.strictEqual(base.maxRewardsPerNpub, null);
+    assert.strictEqual(base.bountyCapSats, 5000);
+
+    const perItem = normalizeBountyCreatePayload({
+      listCoordinate,
+      amountSats: 1000,
+      bountyCapSats: 5000,
+      rewardPerItem: true,
+      maxRewardsPerNpub: 3,
+      criteria: 'Useful list items',
+    });
+    assert.strictEqual(perItem.rewardPerItem, true);
+    assert.strictEqual(perItem.maxRewardsPerNpub, 3);
+
+    assert.throws(() => normalizeBountyCreatePayload({
+      listCoordinate,
+      amountSats: 1000,
+      criteria: 'Missing cap',
+    }), /bountyCapSats/);
+    assert.throws(() => normalizeBountyCreatePayload({
+      listCoordinate,
+      amountSats: 1000,
+      bountyCapSats: 999,
+      criteria: 'Cap below base reward',
+    }), /greater than or equal/);
+    assert.throws(() => normalizeBountyCreatePayload({
+      listCoordinate,
+      amountSats: 1000,
+      bountyCapSats: 5000,
+      rewardPerItem: false,
+      maxRewardsPerNpub: 3,
+      criteria: 'Misplaced per-item cap',
+    }), /only applies/);
+    return true;
+  } catch (error) {
+    console.error('Bounty field validation failed:', error.message);
+    return false;
+  }
+}
+
 // Run tests
 console.log('Running Brainstorm tests...');
 const configTest = testConfigLoading();
+const bountyFieldsTest = testBountyFieldValidation();
 
 console.log('\nTest Results:');
 console.log('-------------');
 console.log(`Configuration Loading: ${configTest ? 'PASS' : 'FAIL'}`);
-console.log(`Overall: ${configTest ? 'PASS' : 'FAIL'}`);
+console.log(`Bounty Field Validation: ${bountyFieldsTest ? 'PASS' : 'FAIL'}`);
+console.log(`Overall: ${configTest && bountyFieldsTest ? 'PASS' : 'FAIL'}`);
 
 // Exit with appropriate code
-process.exit(configTest ? 0 : 1);
+process.exit(configTest && bountyFieldsTest ? 0 : 1);

--- a/ui/src/api/bounties.js
+++ b/ui/src/api/bounties.js
@@ -16,12 +16,28 @@ export async function getBounty(id) {
   return parseJsonOrThrow(resp);
 }
 
-export async function createBounty({ listCoordinate, amountSats, criteria, expiration }) {
+export async function createBounty({
+  listCoordinate,
+  amountSats,
+  bountyCapSats,
+  rewardPerItem,
+  maxRewardsPerNpub,
+  criteria,
+  expiration,
+}) {
   const resp = await fetch('/api/bounties', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
-    body: JSON.stringify({ listCoordinate, amountSats, criteria, expiration }),
+    body: JSON.stringify({
+      listCoordinate,
+      amountSats,
+      bountyCapSats,
+      rewardPerItem,
+      maxRewardsPerNpub,
+      criteria,
+      expiration,
+    }),
   });
   return (await parseJsonOrThrow(resp)).bounty;
 }

--- a/ui/src/pages/bounties/BountyDetail.jsx
+++ b/ui/src/pages/bounties/BountyDetail.jsx
@@ -4,6 +4,7 @@ import Breadcrumbs from '../../components/Breadcrumbs';
 import PaymentCode from '../../components/PaymentCode';
 import { getBounty } from '../../api/bounties';
 import { zapContributor } from '../../utils/zap';
+import { capText, formatSats, maxRewardsText, rewardScopeLabel } from '../../utils/bountyTerms';
 
 function short(pk) { return pk ? pk.slice(0, 8) + '…' : '—'; }
 function age(ts) {
@@ -121,11 +122,15 @@ export default function BountyDetail() {
       <div style={{ marginBottom: '1.5rem' }}>
         <div style={{ fontSize: '0.8rem', opacity: 0.55, letterSpacing: '0.08em', textTransform: 'uppercase' }}>Bounty</div>
         <h1 style={{ margin: '0.2rem 0 0.4rem', color: '#f2a134' }}>
-          {bounty.amount_sats.toLocaleString()} sats
+          {formatSats(bounty.amount_sats)} sats
           <span style={{ fontSize: '0.8rem', marginLeft: '0.8rem', padding: '0.2rem 0.5rem', background: derived === 'open' ? '#2ea043' : '#8b949e', color: '#fff', borderRadius: 3, verticalAlign: 'middle' }}>
             {derived}
           </span>
         </h1>
+        <div style={{ fontSize: '0.85rem', opacity: 0.75, marginBottom: '0.35rem' }}>
+          {rewardScopeLabel(bounty)} / {capText(bounty)}
+          {maxRewardsText(bounty) && <span> / {maxRewardsText(bounty)}</span>}
+        </div>
         <div style={{ fontSize: '0.9rem', opacity: 0.85 }}>{bounty.criteria}</div>
         <div style={{ fontSize: '0.8rem', opacity: 0.6, marginTop: '0.4rem' }}>
           issued by <code>{short(bounty.issuer_pubkey)}</code> · {age(bounty.created_at)}

--- a/ui/src/pages/bounties/BountyList.jsx
+++ b/ui/src/pages/bounties/BountyList.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import { listBounties } from '../../api/bounties';
+import { capText, formatSats, maxRewardsText, rewardScopeLabel } from '../../utils/bountyTerms';
 
 function short(pk) { return pk ? pk.slice(0, 8) + '…' : '—'; }
 function age(ts) {
@@ -69,8 +70,10 @@ export default function BountyList() {
                 </div>
               </div>
               <div style={{ textAlign: 'right' }}>
-                <div style={{ color: '#f2a134', fontSize: '1.4rem', fontWeight: 700 }}>{b.amount_sats.toLocaleString()}</div>
-                <div style={{ fontSize: '0.7rem', opacity: 0.6, letterSpacing: '0.05em' }}>SATS</div>
+                <div style={{ color: '#f2a134', fontSize: '1.4rem', fontWeight: 700 }}>{formatSats(b.amount_sats)}</div>
+                <div style={{ fontSize: '0.7rem', opacity: 0.6, letterSpacing: '0.05em' }}>{rewardScopeLabel(b).toUpperCase()}</div>
+                <div style={{ fontSize: '0.75rem', opacity: 0.65, marginTop: '0.25rem' }}>{capText(b)}</div>
+                {maxRewardsText(b) && <div style={{ fontSize: '0.75rem', opacity: 0.65 }}>{maxRewardsText(b)}</div>}
                 <div style={{ marginTop: '0.4rem' }}>
                   <StatusBadge status={b.derivedStatus || b.status} />
                 </div>

--- a/ui/src/pages/bounties/BountyNew.jsx
+++ b/ui/src/pages/bounties/BountyNew.jsx
@@ -13,6 +13,9 @@ export default function BountyNew() {
 
   const [listCoordinate, setListCoordinate] = useState(params.get('concept') || '');
   const [amountSats, setAmountSats] = useState(1000);
+  const [bountyCapSats, setBountyCapSats] = useState(1000);
+  const [rewardPerItem, setRewardPerItem] = useState(false);
+  const [maxRewardsPerNpub, setMaxRewardsPerNpub] = useState('');
   const [criteria, setCriteria] = useState('');
   const [expiration, setExpiration] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -24,8 +27,13 @@ export default function BountyNew() {
     }
   }, [authLoading, user, navigate]);
 
+  const amount = Number(amountSats);
+  const cap = Number(bountyCapSats);
+  const maxRewards = Number(maxRewardsPerNpub);
   const valid = COORDINATE_RE.test(listCoordinate)
-    && Number.isInteger(Number(amountSats)) && Number(amountSats) > 0
+    && Number.isInteger(amount) && amount > 0
+    && Number.isInteger(cap) && cap >= amount
+    && (!rewardPerItem || maxRewardsPerNpub === '' || (Number.isInteger(maxRewards) && maxRewards > 0))
     && criteria.trim().length > 0;
 
   async function handleSubmit(e) {
@@ -36,7 +44,10 @@ export default function BountyNew() {
     try {
       const row = await createBounty({
         listCoordinate,
-        amountSats: Number(amountSats),
+        amountSats: amount,
+        bountyCapSats: cap,
+        rewardPerItem,
+        maxRewardsPerNpub: rewardPerItem && maxRewardsPerNpub !== '' ? maxRewards : undefined,
         criteria: criteria.trim(),
         expiration: expiration ? Math.floor(new Date(expiration).getTime() / 1000) : undefined,
       });
@@ -71,7 +82,7 @@ export default function BountyNew() {
         </label>
 
         <label>
-          <div style={{ marginBottom: 4, fontWeight: 600 }}>Reward (sats)</div>
+          <div style={{ marginBottom: 4, fontWeight: 600 }}>Base reward (sats)</div>
           <input
             type="number"
             min={1}
@@ -82,6 +93,47 @@ export default function BountyNew() {
             style={{ width: '100%', padding: '0.5rem', background: '#0d1117', border: '1px solid #30363d', borderRadius: 4, color: '#c9d1d9' }}
           />
         </label>
+
+        <label>
+          <div style={{ marginBottom: 4, fontWeight: 600 }}>Bounty cap (sats)</div>
+          <input
+            type="number"
+            min={amount || 1}
+            step={1}
+            value={bountyCapSats}
+            onChange={e => setBountyCapSats(e.target.value)}
+            required
+            style={{ width: '100%', padding: '0.5rem', background: '#0d1117', border: '1px solid #30363d', borderRadius: 4, color: '#c9d1d9' }}
+          />
+          <small style={{ opacity: 0.6 }}>Total sats reserved for this bounty.</small>
+        </label>
+
+        <label style={{ display: 'flex', gap: '0.6rem', alignItems: 'flex-start' }}>
+          <input
+            type="checkbox"
+            checked={rewardPerItem}
+            onChange={e => setRewardPerItem(e.target.checked)}
+            style={{ marginTop: '0.2rem' }}
+          />
+          <span>
+            <span style={{ display: 'block', fontWeight: 600 }}>Reward each item</span>
+            <small style={{ opacity: 0.6 }}>Off means one base reward per contributor.</small>
+          </span>
+        </label>
+
+        {rewardPerItem && (
+          <label>
+            <div style={{ marginBottom: 4, fontWeight: 600 }}>Max rewards per contributor (optional)</div>
+            <input
+              type="number"
+              min={1}
+              step={1}
+              value={maxRewardsPerNpub}
+              onChange={e => setMaxRewardsPerNpub(e.target.value)}
+              style={{ width: '100%', padding: '0.5rem', background: '#0d1117', border: '1px solid #30363d', borderRadius: 4, color: '#c9d1d9' }}
+            />
+          </label>
+        )}
 
         <label>
           <div style={{ marginBottom: 4, fontWeight: 600 }}>Criteria</div>

--- a/ui/src/pages/bounties/Eligibility.jsx
+++ b/ui/src/pages/bounties/Eligibility.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import { useAuth } from '../../context/AuthContext';
 import { getEligible } from '../../api/bounties';
+import { capText, formatSats, maxRewardsText, rewardScopeLabel } from '../../utils/bountyTerms';
 
 function short(pk) { return pk ? pk.slice(0, 8) + '…' : '—'; }
 function age(ts) {
@@ -84,8 +85,10 @@ export default function Eligibility() {
                   </div>
                 </div>
                 <div style={{ textAlign: 'right', minWidth: 140 }}>
-                  <div style={{ color: '#f2a134', fontSize: '1.4rem', fontWeight: 700 }}>{b.amount_sats.toLocaleString()}</div>
-                  <div style={{ fontSize: '0.7rem', opacity: 0.6, letterSpacing: '0.05em', marginBottom: '0.5rem' }}>SATS</div>
+                  <div style={{ color: '#f2a134', fontSize: '1.4rem', fontWeight: 700 }}>{formatSats(b.amount_sats)}</div>
+                  <div style={{ fontSize: '0.7rem', opacity: 0.6, letterSpacing: '0.05em' }}>{rewardScopeLabel(b).toUpperCase()}</div>
+                  <div style={{ fontSize: '0.75rem', opacity: 0.65, marginTop: '0.25rem' }}>{capText(b)}</div>
+                  {maxRewardsText(b) && <div style={{ fontSize: '0.75rem', opacity: 0.65, marginBottom: '0.5rem' }}>{maxRewardsText(b)}</div>}
                   <Link
                     to={claimHref}
                     style={{ display: 'inline-block', padding: '0.4rem 0.9rem', background: '#2ea043', color: '#fff', borderRadius: 4, textDecoration: 'none', fontWeight: 600 }}

--- a/ui/src/pages/bounties/PaymentsDue.jsx
+++ b/ui/src/pages/bounties/PaymentsDue.jsx
@@ -5,6 +5,7 @@ import PaymentCode from '../../components/PaymentCode';
 import { useAuth } from '../../context/AuthContext';
 import { getPaymentsDue } from '../../api/bounties';
 import { zapContributor } from '../../utils/zap';
+import { capText, formatSats, maxRewardsText, rewardScopeLabel } from '../../utils/bountyTerms';
 
 function short(pk) { return pk ? pk.slice(0, 8) + '…' : '—'; }
 
@@ -42,7 +43,7 @@ function PendingClaimRow({ claim, bountyAmount }) {
           disabled={busy}
           style={{ padding: '0.35rem 0.8rem', background: '#f2a134', color: '#0d1117', border: 'none', borderRadius: 4, fontWeight: 700, cursor: busy ? 'wait' : 'pointer' }}
         >
-          {busy ? 'Loading…' : `Zap ${bountyAmount}`}
+          {busy ? 'Loading…' : `Zap ${formatSats(bountyAmount)} sats`}
         </button>
       </div>
       {payment && <PaymentCode payment={payment} />}
@@ -96,7 +97,14 @@ export default function PaymentsDue() {
               </Link>
               <div style={{ fontSize: '0.8rem', opacity: 0.6, fontFamily: 'monospace' }}>{bounty.list_coordinate}</div>
             </div>
-            <div style={{ color: '#f2a134', fontWeight: 700 }}>{bounty.amount_sats.toLocaleString()} sats</div>
+            <div style={{ color: '#f2a134', fontWeight: 700, textAlign: 'right' }}>
+              <div>{formatSats(bounty.amount_sats)} sats</div>
+              <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>{rewardScopeLabel(bounty)}</div>
+            </div>
+          </div>
+          <div style={{ fontSize: '0.8rem', opacity: 0.7, marginBottom: '0.5rem' }}>
+            {capText(bounty)}
+            {maxRewardsText(bounty) && <span> / {maxRewardsText(bounty)}</span>}
           </div>
           {pendingClaims.map(c => (
             <PendingClaimRow key={c.event.id} claim={c} bountyAmount={bounty.amount_sats} />

--- a/ui/src/pages/bounties/PaymentsToMe.jsx
+++ b/ui/src/pages/bounties/PaymentsToMe.jsx
@@ -4,6 +4,7 @@ import Breadcrumbs from '../../components/Breadcrumbs';
 import Bolt12Setup from '../../components/Bolt12Setup';
 import { useAuth } from '../../context/AuthContext';
 import { getPaymentsToMe } from '../../api/bounties';
+import { capText, formatSats, maxRewardsText, rewardScopeLabel } from '../../utils/bountyTerms';
 
 function short(pk) { return pk ? pk.slice(0, 8) + '…' : '—'; }
 function age(ts) {
@@ -97,8 +98,11 @@ function Row({ entry, kind }) {
             )}
           </div>
         </div>
-        <div style={{ color: '#f2a134', fontWeight: 700, whiteSpace: 'nowrap' }}>
-          {bounty.amount_sats.toLocaleString()} sats
+        <div style={{ color: '#f2a134', fontWeight: 700, whiteSpace: 'nowrap', textAlign: 'right' }}>
+          <div>{formatSats(bounty.amount_sats)} sats</div>
+          <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>{rewardScopeLabel(bounty)}</div>
+          <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>{capText(bounty)}</div>
+          {maxRewardsText(bounty) && <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>{maxRewardsText(bounty)}</div>}
         </div>
       </div>
     </div>

--- a/ui/src/pages/lists/NewDListItem.jsx
+++ b/ui/src/pages/lists/NewDListItem.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../../context/AuthContext';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import { childDTag, randomDTag } from '../../utils/dtag';
 import { getBounty } from '../../api/bounties';
+import { capText, maxRewardsText, rewardText } from '../../utils/bountyTerms';
 
 function getTag(event, name, index = 1) {
   const tag = event.tags?.find(t => t[0] === name);
@@ -218,7 +219,10 @@ export default function NewDListItem() {
           <div style={{ fontSize: '0.85rem', opacity: 0.8 }}>
             Issuer: <code>{bountyInfo.bounty.issuer_pubkey.slice(0, 8)}…</code>
             {' · '}
-            Reward: <strong style={{ color: '#f2a134' }}>{bountyInfo.bounty.amount_sats.toLocaleString()} sats</strong>
+            Reward: <strong style={{ color: '#f2a134' }}>{rewardText(bountyInfo.bounty)}</strong>
+            {' · '}
+            {capText(bountyInfo.bounty)}
+            {maxRewardsText(bountyInfo.bounty) && ` / ${maxRewardsText(bountyInfo.bounty)}`}
             {' · '}
             The issuer (or anyone) may zap you if they approve your submission.
           </div>

--- a/ui/src/utils/bountyTerms.js
+++ b/ui/src/utils/bountyTerms.js
@@ -1,0 +1,25 @@
+export function formatSats(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n.toLocaleString() : '0';
+}
+
+export function bountyCapSats(bounty) {
+  return bounty?.bounty_cap_sats ?? bounty?.amount_sats ?? 0;
+}
+
+export function rewardScopeLabel(bounty) {
+  return bounty?.reward_per_item ? 'per item' : 'per contributor';
+}
+
+export function rewardText(bounty) {
+  return `${formatSats(bounty?.amount_sats)} sats ${rewardScopeLabel(bounty)}`;
+}
+
+export function capText(bounty) {
+  return `${formatSats(bountyCapSats(bounty))} sats cap`;
+}
+
+export function maxRewardsText(bounty) {
+  if (!bounty?.reward_per_item || !bounty?.max_rewards_per_npub) return null;
+  return `max ${bounty.max_rewards_per_npub} rewards per contributor`;
+}


### PR DESCRIPTION
## Summary
- add Magic Carpet bounty total fields for cap, reward scope, and per-contributor max rewards
- validate create payloads so bountyCapSats is required, cap is not below the base reward, and maxRewardsPerNpub only applies to per-item bounties
- surface the cap/scope terms across bounty creation, lists, details, eligibility, payments, and claim banners

Fixes #39

## Tests
- npm test
- node --check src/lib/bounty-fields.js
- node --check src/api/bounties.js
- node --check src/db/bounties.js
- node --check test/test.js