### PR TITLE
Add deploy-tags.yml: CI/CD for tags.brainstorm.world

### DIFF
--- a/.github/workflows/deploy-tags.yml
+++ b/.github/workflows/deploy-tags.yml
@@ -1,0 +1,28 @@
+name: Deploy to Tags
+
+on:
+  push:
+    branches: [feat/pubkey-tagging-target]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        timeout-minutes: 60
+        with:
+          host: ${{ secrets.DEPLOY_HOST_TAGS }}
+          username: ${{ secrets.DEPLOY_USER_TAGS }}
+          key: ${{ secrets.DEPLOY_SSH_KEY_TAGS }}
+          command_timeout: 25m
+          script: |
+            cd /opt/tapestry
+            git checkout -- docker-compose.yml 2>/dev/null
+            git checkout feat/pubkey-tagging-target 2>/dev/null || git checkout -b feat/pubkey-tagging-target origin/feat/pubkey-tagging-target
+            git pull origin feat/pubkey-tagging-target
+            # Tags droplet uses host nginx on port 80, so Docker must bind to 8080 on localhost only
+            sed -i 's/"80:80"/"127.0.0.1:8080:80"/' docker-compose.yml
+            docker compose up -d --build
+            docker image prune -f


### PR DESCRIPTION
## Summary

Adds a CI/CD workflow for `tags.brainstorm.world` (the droplet hosting the `feat/pubkey-tagging-target` branch). Mirrors `deploy-magic-carpet.yml` exactly — same SSH-action pattern, same `docker compose up -d --build` script, same `127.0.0.1:8080:80` port remap for the host-nginx setup.

Differences from `deploy-magic-carpet.yml`:
- triggers on `push` to `feat/pubkey-tagging-target`
- reads `DEPLOY_HOST_TAGS` / `DEPLOY_USER_TAGS` / `DEPLOY_SSH_KEY_TAGS`
- branch references in the script point at `feat/pubkey-tagging-target`
- comment identifies the tags droplet

## ⚠️ Before merging — add the 3 secrets

Merging this PR is itself a push to `feat/pubkey-tagging-target`, which triggers the new workflow. If the secrets aren't set yet, the first run fails noisily on the SSH step.

Required repo secrets (Settings → Secrets and variables → Actions):

- `DEPLOY_HOST_TAGS` — droplet IP or hostname
- `DEPLOY_USER_TAGS` — SSH user (typically `root` based on the manual setup)
- `DEPLOY_SSH_KEY_TAGS` — private SSH key (PEM, full file content including `-----BEGIN/END-----`)

## Test plan

- [ ] Confirm the 3 secrets are set in repo settings before merging.
- [ ] Merge — the merge commit's push to `feat/pubkey-tagging-target` triggers the first deploy.
- [ ] Watch `deploy-tags.yml` run completes successfully.
- [ ] `https://tags.brainstorm.world/` reaches 3 consecutive 200s after deploy (per [OPERATIONS.md §8.5](../OPERATIONS.md#8-operational-gotchas-weve-hit)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)