### PR TITLE
Add treasureMaps router preset + kind 10040 to Negentropy Sync

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -131,6 +131,28 @@ These were unified at `0.05` during the [PREFERENCES_AUDIT §6.2 consolidation](
 
 Existing `verifiedFollowerCount` properties in Neo4j carry the value computed at the last batch run. Changing the cutoff in `/etc/graperank.conf` doesn't update the stored values until the next time the script runs.
 
+## Router Presets
+
+The strfry-router daemon syncs configurable streams of nostr events between this instance's local strfry and other relays. Streams are managed via two files plus a UI tab:
+
+| File | Role |
+|------|------|
+| `setup/router-presets.json` | Shipped preset definitions (in-repo, read-only). Each entry has `name`, `description`, `dir` (`down` \| `up` \| `both`), `filter`, `urls`, optional plugin paths, and `defaultEnabled`. |
+| `/var/lib/brainstorm/router-state.json` | Per-instance enabled/disabled state for each stream (on the `tapestry-data` Docker volume — persists across container rebuilds). |
+| `/etc/strfry-router-tapestry.config` | Generated config consumed by the strfry-router daemon. Rewritten on every toggle/restart. |
+
+The Router Management tab at `/tapestry/settings/relays` is the UI: it shows configured streams from `router-state.json`, and a **📋 Presets** button reveals additional presets from `router-presets.json` that haven't been added yet. Clicking "+ Add" on a preset inserts it into the operator's state with `enabled` matching its `defaultEnabled`; toggling enabled/disabled rewrites the daemon config and restarts `strfry-router` via `supervisorctl`.
+
+### Adding a new preset
+
+1. Append an entry to `setup/router-presets.json` following the existing shape. Use `defaultEnabled: false` unless there's a clear reason an arriving operator should start syncing immediately.
+2. Deploy. Operators discover the new preset via the **📋 Presets** button → "+ Add". This is the established pattern — see commit `bb4c83e7` for an example of two presets added this way.
+3. If documenting customer-facing impact, note that the preset is opt-in: existing instances won't start syncing the new kind(s) until an operator clicks Add and enables it.
+
+### Negentropy preset system (future work)
+
+The Negentropy Sync tab on the same page uses a hardcoded `KIND_PRESETS` array in `ui/src/pages/settings/RelaySettings.jsx`. Adding a kind is currently a code change (append one row). A future story ([engineering-team/stories/3-router-presets-auto-appear-in-streams.md](../engineering-team/stories/3-router-presets-auto-appear-in-streams.md) tracks a related router-preset UX improvement; a separate story will define a parallel **Negentropy preset system** mirroring how router presets work today — JSON-defined, opt-in, with the same Presets popup pattern). Until then, treat each Negentropy kind addition as a small one-line UI change.
+
 ## Settings API
 
 All endpoints require **Owner** authentication (NIP-07 login).

--- a/engineering-team/decisions/0002-treasure-maps-router-preset.md
+++ b/engineering-team/decisions/0002-treasure-maps-router-preset.md
@@ -1,6 +1,6 @@
 # ADR 0002: Add `treasureMaps` router preset + 10040 to Negentropy Sync
 
-**Status:** Accepted
+**Status:** Accepted (revised during Phase 3 — see "Revision history" at end)
 **Date:** 2026-05-13
 **Story:** `engineering-team/stories/2-treasure-maps-router-preset.md`
 
@@ -15,60 +15,65 @@ The Router Management system is implemented in `src/api/strfry/routerConfig.js`.
 
 The Negentropy Sync UI's Event Kinds picker is a hardcoded `KIND_PRESETS` array in `ui/src/pages/settings/RelaySettings.jsx` (lines 769–774). The sync backend passes the kinds array transparently to `strfry sync`, so adding a kind is purely a UI config change.
 
-**The hidden architectural complexity is in upgrade behavior.** `ensureState()` in `routerConfig.js` (lines 56–77) is one-shot: it initializes `router-state.json` from `router-presets.json` only if no state file exists. After first boot, the state file is the source of truth and is never re-synced with presets. So *adding a new preset to `router-presets.json` does not automatically surface it on existing instances* — `router-state.json` already exists and doesn't know about the new preset. An operator would have to either click "Restore Defaults" (resets *all* preset states, destroying operator-set toggles) or manually delete the state file (loses non-preset custom streams). Neither is an acceptable upgrade path.
+**Preset discovery on existing instances follows an established UI pattern.** New presets added to `router-presets.json` appear in the **"📋 Presets" popup** in the Router Management tab as soon as they deploy (the popup is sourced from `GET /api/strfry/router-presets`, which reads the JSON file directly via `loadPresets()`, no state mutation involved). The popup's "+ Add" button (`handleImportPreset` in `RelaySettings.jsx:341`) builds a new stream entry with `enabled: !!preset.defaultEnabled`, so opt-in semantics are respected automatically. This is the documented and established discovery path: precedent commit `bb4c83e7` ("Add WoT and trustedAssertions router presets") explicitly notes *"operators opt in via the router-config UI or POST /api/strfry/router-restore-defaults"*.
 
-The Concept Graph at `/api/concept-graph/summaries` was consulted (36 foundational concepts: `nostr-event`, `nostr-kind`, `web-of-trust`, `graperank`, etc.). Router presets, treasure maps, and negentropy are not yet modeled in the graph. No firmware reinstall is required for this change — no concept schemas are modified.
+The Concept Graph at `/api/concept-graph/summaries` was consulted (36 foundational concepts). Router presets, treasure maps, and negentropy are not yet modeled in the graph. No firmware reinstall is required — no concept schemas are modified.
 
 ## Options considered
 
-### Option A — Additive merge in `ensureState()` (chosen)
+### Option A — Additive merge in `ensureState()` (rejected during Phase 3)
 
-Modify `ensureState()` so that on every call, it additively merges presets from `router-presets.json` into the loaded state. For each preset whose `name` is *not* already in `state.streams`, append a new stream entry using the preset's `defaultEnabled`. Presets already in state are left untouched — operator-set toggles are preserved.
+Modify `ensureState()` to additively merge presets from `router-presets.json` into the loaded state, so new presets auto-appear in the operator's main "Streams" list without requiring the Presets popup click.
 
-**Pros:**
-- New presets appear on existing instances on the next deploy with their `defaultEnabled` setting respected (off for `treasureMaps`, satisfying the opt-in AC).
-- Operator-set state for existing presets is never overwritten.
-- Small change — ~10 lines of new logic in one function. No schema migration.
-- Symmetrical with the existing `handleRestoreDefaults` shape, just narrower.
+**Why rejected:** The Tester phase caught two problems:
+- The story's acceptance criteria don't require auto-appear behavior. AC-1 says the preset is "visible in the list of available presets" — which is the Presets popup, already satisfied by the existing pattern.
+- Worse, the merge as scoped wouldn't actually deliver the auto-appear UX it claimed. `ensureState` is called from POST handlers only (`handleToggleStream`, `handleUpdateRouterConfig`). The Router tab's initial render calls `GET /api/strfry/router-status` (in `routerStatus.js`), which has its own `loadState()` and never calls `ensureState`. So the merge wouldn't fire until the operator performed some interaction — defeating the "auto" part.
 
-**Cons:**
-- Subtlety: a preset *removed* from `router-presets.json` would linger as an orphan in state. Acceptable — no removals planned, can be added later if needed.
-- Runs on every `ensureState()` call (per-request via the toggle handler). Negligible cost — a JSON parse and a list comparison over ~10 items.
+To genuinely deliver auto-appear, both `routerConfig.js#ensureState` and `routerStatus.js#loadState` would need the merge (or a refactor to share one path). That expanded scope wasn't in the story, contradicts the `bb4c83e7` precedent, and is better tracked as its own focused effort.
 
 ### Option B — Document "click Restore Defaults to pick up new presets"
 
-Don't modify `ensureState()`. Document in BIBLE.md / OPERATIONS.md that whenever new presets land, operators must click "Restore Defaults" to pick them up.
+Don't modify any state logic. Document that operators must click "Restore Defaults" to pick up new presets.
+
+**Why rejected:** "Restore Defaults" is destructive (overwrites all preset enable states), so this is bad guidance even though it would work. Also unnecessary — the Presets popup already gives a non-destructive path.
+
+### Option C — Refactor: presets as source of truth, state file as sparse overlay
+
+Larger refactor; cleaner conceptual model.
+
+**Why rejected:** Out of proportion to story scope. Risk of regression in non-preset (custom) stream handling. Best as its own cleanup story if preset churn justifies it.
+
+### Option D — Match existing precedent: ship the JSON + JSX + docs only (chosen)
+
+Three minimal additions:
+
+1. Append the `treasureMaps` entry to `setup/router-presets.json`.
+2. Append a `Treasure Maps (10040)` entry to the `KIND_PRESETS` array in `RelaySettings.jsx`.
+3. Document the router preset system in BIBLE.md / docs/CONFIGURATION.md and note the planned Negentropy preset system as future work.
+
+Operators discover the new preset via the existing 📋 Presets popup ("+ Add" → preset appears in their Streams list disabled → operator toggles to enable).
 
 **Pros:**
-- Zero code change.
+- Matches the precedent set by `bb4c83e7` exactly. Operators with prior preset experience need no retraining.
+- Smallest possible change. Two short config-style additions and a docs paragraph.
+- Zero risk to existing state-management code.
+- Opt-in semantics fall out of the existing `handleImportPreset` logic (`enabled: !!preset.defaultEnabled`).
 
 **Cons:**
-- Invisible behavior change. Operators wouldn't know the new preset exists unless they read the changelog.
-- "Restore Defaults" is destructive — it overwrites all preset enable states. An operator who's carefully toggled some on / others off would lose those choices.
-- The problem recurs for every future preset addition.
-
-### Option C — Refactor: presets are the source of truth, state file is a sparse overlay
-
-State file stores only `{name: enabled}` overrides. At config-generation time, merge presets (definitions) with state (overrides).
-
-**Pros:**
-- Cleaner conceptual model. Solves preset removal cleanly. Preset definition updates (URL changes, filter changes) would also propagate automatically.
-
-**Cons:**
-- Larger refactor touching `loadState`, `saveState`, `generateConfig`, `handleToggleStream`, `handleUpdateRouterConfig`, `handleRestoreDefaults`. Out of proportion to this story's scope.
-- Risk of regressions in handling of non-preset custom streams (operator-added URLs/filters).
-- Better as its own cleanup story when preset churn justifies it.
+- Operators won't see the new preset in their main Streams list until they explicitly click "📋 Presets" → "+ Add". The "auto-appear in Streams list" UX is a separate, deferred improvement.
 
 ## Decision
 
-We chose **Option A** — additive merge in `ensureState()`. Solves the upgrade-path problem with the minimum change footprint, preserves operator-set toggle state, and the orphaned-preset cost is acceptable given no removals are planned. Option C is the right long-term shape but is out of scope for this story.
+We chose **Option D** — match existing precedent.
+
+We considered improving the discovery UX as part of this story (Option A), but rejected it during Phase 3 once the Tester noticed it (a) wasn't required by any AC, (b) wasn't fully delivered by the proposed code change without expanded scope, and (c) contradicted the established precedent for adding presets. The discovery UX improvement is filed as story #3 (`engineering-team/stories/3-router-presets-auto-appear-in-streams.md`) for a future cycle.
 
 ## Consequences
 
-- **Enables:** Future preset additions become deploy-and-done — operators see new presets in the UI on the next deploy with the documented `defaultEnabled` state.
-- **Constrains:** A removed preset persists in state until manually cleared. Acceptable; follow-up cleanup possible.
-- **Edge case for future:** If a future preset is added with `defaultEnabled: true`, the merge surfaces it as enabled in state but won't push the config (no `applyConfig` call inside `ensureState`). The new stream wouldn't run until the operator triggers any action that calls `applyConfig`. Not an issue for `treasureMaps` (defaultEnabled: false) but worth noting in code comments. Trivially fixable later by calling `applyConfig(state)` from `ensureState()` after `appended === true`, but deferred until we actually add a `defaultEnabled: true` preset — needless restart on every cold boot otherwise.
-- **Firmware reinstall required?** No — no concept schemas changed.
+- **Enables:** Continuous bidirectional sync of kind 10040 events (once enabled by operator). Negentropy Sync can target kind 10040.
+- **Constrains:** Operators must click "📋 Presets" → "+ Add" → toggle to use the new preset. Consistent with how `WoT` and `trustedAssertions` presets are activated today.
+- **New debt:** Story #3 captures the "auto-appear in main Streams list" UX improvement.
+- **Firmware reinstall required?** No.
 
 ## Implementation notes
 
@@ -88,25 +93,21 @@ Concrete file-level guidance:
   }
   ```
 
-- **File: `src/api/strfry/routerConfig.js`** — Modify `ensureState()` (currently lines 56–77). After the existing early-init path, add an additive merge pass:
-  1. Load presets.
-  2. Build a Set of existing stream names from `state.streams`.
-  3. For each preset whose `name` is not in that set, push a new stream entry with the preset's fields and `enabled: !!p.defaultEnabled, preset: true`.
-  4. If any entries were appended, call `saveState(state)` once before returning.
-  
-  **Critical constraint:** do not touch existing entries. Operator-set toggles must be preserved.
-
 - **File: `ui/src/pages/settings/RelaySettings.jsx`** — Insert into `KIND_PRESETS` (currently lines 769–774):
   ```javascript
   { label: 'Treasure Maps (10040)', kinds: [10040] },
   ```
-  Place it after the Profiles entry — Profiles and Treasure Maps are both per-user signal events, so they belong adjacent.
+  Place after the Profiles entry — Profiles and Treasure Maps are both per-user signal events.
 
-- **File: `BIBLE.md` and/or `docs/CONFIGURATION.md`** — Add a short section describing the router preset system: presets in `setup/router-presets.json`, per-instance enable state at `/var/lib/brainstorm/router-state.json`, `defaultEnabled` semantics, and the additive-merge upgrade behavior introduced by this ADR. Append a forward-looking note that a Negentropy preset system mirroring this design is planned future work, pointing at the current `KIND_PRESETS` hardcoded array as the spot a future implementer should refactor.
+- **File: `BIBLE.md` and/or `docs/CONFIGURATION.md`** — Add a short section describing the router preset system: presets in `setup/router-presets.json`; per-instance enable state at `/var/lib/brainstorm/router-state.json`; `defaultEnabled` semantics; the established discovery flow (operator clicks "📋 Presets" in the Router tab UI → "+ Add" → toggle). Append a forward-looking note that a Negentropy preset system mirroring the router preset system is planned future work, pointing at the current `KIND_PRESETS` hardcoded array as the spot a future implementer should refactor.
 
 ## Out of scope
 
-- Preset *removal* handling in `ensureState()`.
-- Option C-style refactor.
+- Auto-appear of new presets in the main Streams list (story #3).
+- Preset *removal* handling.
 - Auto-enabling on fresh instances (`defaultEnabled: false` is explicit).
 - Author allowlisting for 10040 sync.
+
+## Revision history
+
+**2026-05-13** — Initial draft chose Option A (additive merge in `ensureState`). During Phase 3 (Test Design), the Tester noticed that (a) no AC required the merge, (b) the merge as scoped wouldn't actually deliver the auto-appear UX without expanding into `routerStatus.js`, and (c) the precedent (`bb4c83e7`) explicitly relies on the existing Presets-popup discovery flow without state-merge logic. The ADR was revised to Option D and the auto-appear UX was filed as story #3 for a future cycle. This is exactly the kind of mid-flow correction the engineering-team gates are designed to surface — recorded here so the pattern is visible in the project's decision history.

--- a/engineering-team/decisions/0002-treasure-maps-router-preset.md
+++ b/engineering-team/decisions/0002-treasure-maps-router-preset.md
@@ -1,0 +1,112 @@
+# ADR 0002: Add `treasureMaps` router preset + 10040 to Negentropy Sync
+
+**Status:** Accepted
+**Date:** 2026-05-13
+**Story:** `engineering-team/stories/2-treasure-maps-router-preset.md`
+
+## Context
+
+Story #2 asks for two parallel changes on `/tapestry/settings/relays`:
+
+1. **Router Management tab:** add an opt-in preset `treasureMaps` that streams kind 10040 (Treasure Maps) bidirectionally with three popular general-purpose relays.
+2. **Negentropy Sync tab:** add kind 10040 as a selectable Event Kinds option.
+
+The Router Management system is implemented in `src/api/strfry/routerConfig.js`. Presets live in `setup/router-presets.json`; per-instance enabled/disabled state lives at `/var/lib/brainstorm/router-state.json`. The activation flow is: UI POSTs `/api/strfry/router-toggle` → updates `router-state.json` → `generateConfig(state.streams)` → writes `/etc/strfry-router-tapestry.config` → `supervisorctl restart strfry-router`. An existing preset `dcosl` uses `dir: "both"` and is the natural template.
+
+The Negentropy Sync UI's Event Kinds picker is a hardcoded `KIND_PRESETS` array in `ui/src/pages/settings/RelaySettings.jsx` (lines 769–774). The sync backend passes the kinds array transparently to `strfry sync`, so adding a kind is purely a UI config change.
+
+**The hidden architectural complexity is in upgrade behavior.** `ensureState()` in `routerConfig.js` (lines 56–77) is one-shot: it initializes `router-state.json` from `router-presets.json` only if no state file exists. After first boot, the state file is the source of truth and is never re-synced with presets. So *adding a new preset to `router-presets.json` does not automatically surface it on existing instances* — `router-state.json` already exists and doesn't know about the new preset. An operator would have to either click "Restore Defaults" (resets *all* preset states, destroying operator-set toggles) or manually delete the state file (loses non-preset custom streams). Neither is an acceptable upgrade path.
+
+The Concept Graph at `/api/concept-graph/summaries` was consulted (36 foundational concepts: `nostr-event`, `nostr-kind`, `web-of-trust`, `graperank`, etc.). Router presets, treasure maps, and negentropy are not yet modeled in the graph. No firmware reinstall is required for this change — no concept schemas are modified.
+
+## Options considered
+
+### Option A — Additive merge in `ensureState()` (chosen)
+
+Modify `ensureState()` so that on every call, it additively merges presets from `router-presets.json` into the loaded state. For each preset whose `name` is *not* already in `state.streams`, append a new stream entry using the preset's `defaultEnabled`. Presets already in state are left untouched — operator-set toggles are preserved.
+
+**Pros:**
+- New presets appear on existing instances on the next deploy with their `defaultEnabled` setting respected (off for `treasureMaps`, satisfying the opt-in AC).
+- Operator-set state for existing presets is never overwritten.
+- Small change — ~10 lines of new logic in one function. No schema migration.
+- Symmetrical with the existing `handleRestoreDefaults` shape, just narrower.
+
+**Cons:**
+- Subtlety: a preset *removed* from `router-presets.json` would linger as an orphan in state. Acceptable — no removals planned, can be added later if needed.
+- Runs on every `ensureState()` call (per-request via the toggle handler). Negligible cost — a JSON parse and a list comparison over ~10 items.
+
+### Option B — Document "click Restore Defaults to pick up new presets"
+
+Don't modify `ensureState()`. Document in BIBLE.md / OPERATIONS.md that whenever new presets land, operators must click "Restore Defaults" to pick them up.
+
+**Pros:**
+- Zero code change.
+
+**Cons:**
+- Invisible behavior change. Operators wouldn't know the new preset exists unless they read the changelog.
+- "Restore Defaults" is destructive — it overwrites all preset enable states. An operator who's carefully toggled some on / others off would lose those choices.
+- The problem recurs for every future preset addition.
+
+### Option C — Refactor: presets are the source of truth, state file is a sparse overlay
+
+State file stores only `{name: enabled}` overrides. At config-generation time, merge presets (definitions) with state (overrides).
+
+**Pros:**
+- Cleaner conceptual model. Solves preset removal cleanly. Preset definition updates (URL changes, filter changes) would also propagate automatically.
+
+**Cons:**
+- Larger refactor touching `loadState`, `saveState`, `generateConfig`, `handleToggleStream`, `handleUpdateRouterConfig`, `handleRestoreDefaults`. Out of proportion to this story's scope.
+- Risk of regressions in handling of non-preset custom streams (operator-added URLs/filters).
+- Better as its own cleanup story when preset churn justifies it.
+
+## Decision
+
+We chose **Option A** — additive merge in `ensureState()`. Solves the upgrade-path problem with the minimum change footprint, preserves operator-set toggle state, and the orphaned-preset cost is acceptable given no removals are planned. Option C is the right long-term shape but is out of scope for this story.
+
+## Consequences
+
+- **Enables:** Future preset additions become deploy-and-done — operators see new presets in the UI on the next deploy with the documented `defaultEnabled` state.
+- **Constrains:** A removed preset persists in state until manually cleared. Acceptable; follow-up cleanup possible.
+- **Edge case for future:** If a future preset is added with `defaultEnabled: true`, the merge surfaces it as enabled in state but won't push the config (no `applyConfig` call inside `ensureState`). The new stream wouldn't run until the operator triggers any action that calls `applyConfig`. Not an issue for `treasureMaps` (defaultEnabled: false) but worth noting in code comments. Trivially fixable later by calling `applyConfig(state)` from `ensureState()` after `appended === true`, but deferred until we actually add a `defaultEnabled: true` preset — needless restart on every cold boot otherwise.
+- **Firmware reinstall required?** No — no concept schemas changed.
+
+## Implementation notes
+
+Concrete file-level guidance:
+
+- **File: `setup/router-presets.json`** — Append a new preset object:
+  ```json
+  {
+    "name": "treasureMaps",
+    "description": "Bidirectional sync of kind 10040 (TA Treasure Maps) with popular general-purpose relays",
+    "dir": "both",
+    "filter": { "kinds": [10040] },
+    "urls": ["wss://relay.damus.io", "wss://nos.lol", "wss://relay.primal.net"],
+    "pluginDown": "",
+    "pluginUp": "",
+    "defaultEnabled": false
+  }
+  ```
+
+- **File: `src/api/strfry/routerConfig.js`** — Modify `ensureState()` (currently lines 56–77). After the existing early-init path, add an additive merge pass:
+  1. Load presets.
+  2. Build a Set of existing stream names from `state.streams`.
+  3. For each preset whose `name` is not in that set, push a new stream entry with the preset's fields and `enabled: !!p.defaultEnabled, preset: true`.
+  4. If any entries were appended, call `saveState(state)` once before returning.
+  
+  **Critical constraint:** do not touch existing entries. Operator-set toggles must be preserved.
+
+- **File: `ui/src/pages/settings/RelaySettings.jsx`** — Insert into `KIND_PRESETS` (currently lines 769–774):
+  ```javascript
+  { label: 'Treasure Maps (10040)', kinds: [10040] },
+  ```
+  Place it after the Profiles entry — Profiles and Treasure Maps are both per-user signal events, so they belong adjacent.
+
+- **File: `BIBLE.md` and/or `docs/CONFIGURATION.md`** — Add a short section describing the router preset system: presets in `setup/router-presets.json`, per-instance enable state at `/var/lib/brainstorm/router-state.json`, `defaultEnabled` semantics, and the additive-merge upgrade behavior introduced by this ADR. Append a forward-looking note that a Negentropy preset system mirroring this design is planned future work, pointing at the current `KIND_PRESETS` hardcoded array as the spot a future implementer should refactor.
+
+## Out of scope
+
+- Preset *removal* handling in `ensureState()`.
+- Option C-style refactor.
+- Auto-enabling on fresh instances (`defaultEnabled: false` is explicit).
+- Author allowlisting for 10040 sync.

--- a/engineering-team/reviews/2-treasure-maps-router-preset.md
+++ b/engineering-team/reviews/2-treasure-maps-router-preset.md
@@ -1,0 +1,82 @@
+# Review: Story 2 — `treasureMaps` router preset + 10040 to Negentropy Sync
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-13
+**Diff:** `git diff origin/staging..HEAD` — 5 commits (`80df36d9`, `c3e347b4`, `1e108e6b`, `9df34029`, `eb243bbd`)
+**Story:** `engineering-team/stories/2-treasure-maps-router-preset.md`
+**ADR:** `engineering-team/decisions/0002-treasure-maps-router-preset.md` (Option D after Phase 3 revision)
+**Test plan:** `engineering-team/stories/2-treasure-maps-router-preset.test-plan.md`
+
+## Quality gates (run by reviewer, not trusted)
+
+- **`npm test`** — **PASS** (6 tests: 1 config-loading + 5 story-#2). Output:
+  ```
+  treasure-maps-router-preset suite:
+    ✓ treasureMaps preset exists in setup/router-presets.json with correct shape
+    ✓ generateConfig with treasureMaps enabled emits a bidirectional kind-10040 stream block
+    ✓ generateConfig with treasureMaps disabled omits its stream block
+    ✓ RelaySettings.jsx KIND_PRESETS contains the Treasure Maps (10040) option
+    ✓ BIBLE.md or docs/CONFIGURATION.md documents the router preset system and the planned Negentropy preset system
+  Overall: PASS
+  ```
+- **`npm run test:playwright`** — *Not run*. The Playwright spec at `tests/brainstorm/treasure-maps-router-preset.spec.js` requires a deployed instance; per the test plan it's exercised against staging after the implementation lands. Will be run during the staging smoke-test phase.
+- _Lint not configured — skipped._
+- _Typecheck not configured — skipped._
+- _Build not configured — skipped._
+
+## Spec adherence
+
+| AC | Coverage | Status |
+|---|---|---|
+| AC-1 — preset visible in Presets popup | `treasureMaps preset exists in router-presets.json with correct shape` + Playwright `Router tab Presets popup lists treasureMaps` | ✓ |
+| AC-2 — defaultEnabled: false | covered by AC-1 file-parse assertion | ✓ |
+| AC-3 — enable → daemon streams 10040 bidirectionally | `generateConfig with treasureMaps enabled emits a bidirectional kind-10040 stream block` | ✓ |
+| AC-4 — relays are damus / nos.lol / primal | covered by AC-1 url-array assertion | ✓ |
+| AC-5 — disable → stream block absent | `generateConfig with treasureMaps disabled omits its stream block` | ✓ |
+| AC-6 — state persists across container restart | Not covered by a new test (documented in test plan §"Not covered"); relies on the preexisting `/var/lib/brainstorm/` Docker volume mechanism that every other preset already uses in production | ✓ (acceptable per test plan) |
+| AC-7 — Negentropy Event Kinds includes 10040 | `RelaySettings.jsx KIND_PRESETS contains the Treasure Maps (10040) option` + Playwright | ✓ |
+| AC-8 — docs updated | `BIBLE.md or docs/CONFIGURATION.md documents the router preset system and the planned Negentropy preset system` | ✓ |
+
+No criterion silently dropped; no behavior added that isn't in the story.
+
+## ADR adherence
+
+- Files changed match ADR Implementation notes exactly: `setup/router-presets.json`, `src/api/strfry/routerConfig.js` (the `generateConfig` export was a Tester-driven addition documented in the test plan; it's a one-line module-exports change with no behavior impact), `ui/src/pages/settings/RelaySettings.jsx`, `docs/CONFIGURATION.md`.
+- No `ensureState()` change — correctly absent per the Option D revision recorded in the ADR's Revision history section.
+- No new dependencies. No neighboring refactor.
+- KIND_PRESETS entry placed after Profiles per ADR ("Profiles and Treasure Maps are both per-user signal events, so they belong adjacent").
+
+## Concept-graph integrity
+
+Not applicable — no concept definitions touched, no firmware files modified, no graph schemas changed. ADR explicitly stated "No firmware reinstall required."
+
+## Things tests can't catch
+
+- **Secrets / credentials:** None added. ✓
+- **Debug logging:** None introduced. ✓
+- **Commented-out code:** None. ✓
+- **Leftover TODOs:** None. ✓
+- **Relay URLs sanity-checked:** `wss://relay.damus.io`, `wss://nos.lol`, `wss://relay.primal.net` — all three are well-known public relays referenced elsewhere in the codebase (e.g. `docs/CONFIGURATION.md:77`, `setup/router-presets.json:21`); no typos. ✓
+- **`generateConfig` export:** the new export is a 1-line addition to `module.exports`. Function is a pure transformation of an input array to a string; exposing it doesn't widen the API surface in any concerning way. ✓
+- **JSON validity:** trailing-comma / structure clean; verified by `JSON.parse` in the test, which would have failed otherwise. ✓
+- **Forward link in CONFIGURATION.md → engineering-team/stories/3-...:** relative path is correct (`../engineering-team/stories/3-router-presets-auto-appear-in-streams.md` from `docs/`); target file exists. ✓
+
+## House rules check
+
+- No new lint / typecheck / build tooling added. ✓
+- Concept Graph API authority — not applicable to this change.
+- Firmware reinstall — not applicable.
+
+## Findings
+
+### Blocking
+None.
+
+### Non-blocking
+1. **`docs/CONFIGURATION.md:152`** — The "Negentropy preset system (future work)" paragraph has slightly awkward sentence structure. The inline link to story #3 sits inside a parenthetical alongside the mention of *a separate (yet-to-be-filed) story* for the Negentropy preset system itself — which can read as if story #3 is about the Negentropy work when it actually tracks a different (router-preset auto-appear) UX improvement. The content is technically accurate and the test gate doesn't fail on it; flagged here purely as a wording polish opportunity for a future doc pass. Suggested phrasing: pull the story-#3 reference out of the Negentropy paragraph entirely (it belongs near the "Adding a new preset" section as a related improvement note), and let the Negentropy paragraph stand on its own as a clean forward-looking statement. Not blocking — the test plan's spec for AC-8 is met as-is.
+
+## Verdict
+
+**PASS**
+
+Five-phase flow executed cleanly: PO story → ADR (with mid-flow descope to Option D when the Tester noticed a spec/scope mismatch — exactly the value the gates are designed to surface) → failing tests proven correct → minimal implementation (38 LOC across 4 files) → test gate green. Diff is mergeable as-is. Recommended next step: open a PR from `feat/treasureMaps-router-preset` → `staging`, follow the standard `cycle-staging` → `cycle-prod` promotion path documented in [OPERATIONS.md §1](../../OPERATIONS.md).

--- a/engineering-team/stories/2-treasure-maps-router-preset.md
+++ b/engineering-team/stories/2-treasure-maps-router-preset.md
@@ -1,0 +1,54 @@
+# Story 2: Add `treasureMaps` router preset and kind 10040 to Negentropy Sync
+
+**Status:** Approved
+**Created:** 2026-05-13
+**Type:** Feature
+
+## Background
+
+Kind 10040 events (NIP-85 "TA Treasure Maps") are how a customer advertises which delegated signers publish their Trusted Assertions and at which relay. The Brainstorm Web of Trust pipeline depends on having each relevant customer's 10040 in local strfry — backend pipelines like `/api/get-all-10040-authors-locally` enumerate POVs from local strfry and skip anyone whose 10040 isn't there.
+
+Today, operators have to import each 10040 manually (via the `/settings` Import button shipped in [#117](https://github.com/nous-clawds4/tapestry/pull/117), or via the user-detail page's Update button). That works for one-off bring-up but doesn't catch *changes* — when a customer publishes an updated Treasure Map, this instance won't see it until someone manually re-imports. For an instance serving multiple customers, manual import doesn't scale.
+
+The fix is to treat 10040 like other event kinds the router already maintains (kind 0 profiles, kind 9998/9999 DCoSL events, etc.): add it as a router preset operators can toggle on. Volume is fine — across the nostr ecosystem there are at most low-thousands of kind 10040 publishers, trivial for strfry.
+
+## User-facing description
+
+**As an operator of a Brainstorm instance**, I want to enable continuous bidirectional sync of kind 10040 events with popular general-purpose relays, **so that** new and updated customer Treasure Maps land in my local strfry automatically — without me having to import them by hand — and my own customers' Treasure Maps propagate outward to other Brainstorm instances.
+
+## Acceptance criteria
+
+- [ ] On `/tapestry/settings/relays` Router Management tab, a new preset named `treasureMaps` is visible in the list of available presets.
+- [ ] The `treasureMaps` preset defaults to OFF — operators deploying a fresh instance do not start syncing 10040s until they explicitly enable it on the Router Management tab.
+- [ ] When an operator enables the preset, the strfry-router daemon reloads and begins exchanging kind 10040 events with the configured relays in *both* directions (inbound from upstream, outbound from this instance's own published 10040s).
+- [ ] The configured relays for this preset are: `wss://relay.damus.io`, `wss://nos.lol`, `wss://relay.primal.net`.
+- [ ] When an operator disables the preset, the bidirectional stream stops on the next router reload.
+- [ ] The preset's enabled/disabled state persists across container restarts — toggling it on, then running a deploy that rebuilds the container, results in the preset still being on.
+- [ ] On `/tapestry/settings/relays` Negentropy Sync tab, the Event Kinds picker offers a new option for kind 10040 (Treasure Maps). Selecting it and running a sync produces a strfry sync command filtered to `kinds: [10040]`.
+- [ ] Documentation: `BIBLE.md` and/or `docs/CONFIGURATION.md` is updated to describe the router presets system (which doesn't currently appear in detail in either doc). The docs also state that a Negentropy preset system analogous to the router preset system is planned future work.
+
+## Concepts touched
+
+Concept-graph handles to be resolved by Architect via `/api/concept-graph/summaries`:
+
+- Kind 10040 (TA Treasure Map / NIP-85)
+- Kind 30382 (Trusted Assertion) — the events 10040 *references*; not directly touched but the reason 10040 matters
+- strfry-router preset system
+- Negentropy Sync UI
+
+## Out of scope
+
+- **Building a Negentropy preset system.** A future story can add a preset/profile system for the Negentropy Sync tab mirroring how router presets work. The Negentropy Sync change in *this* story is purely a one-item addition to the existing hardcoded Event Kinds picker.
+- **Whitelisting which 10040 authors to sync.** This story syncs *all* 10040 events from the configured popular relays. A future story can add author allowlists.
+- **Auto-enabling the preset on existing instances.** The preset is opt-in, so existing operators are unaffected until they choose to turn it on.
+- **Changes to the per-user Import button on `/settings`.** That stays in place as a fast per-user fallback for fresh-droplet bring-up.
+
+## Open questions
+
+None at draft time. Design choices (preset name `treasureMaps`, the three relay URLs, doc updates, test scope) were resolved with the user before this story was drafted.
+
+## Linked artifacts
+
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/2-treasure-maps-router-preset.md
+++ b/engineering-team/stories/2-treasure-maps-router-preset.md
@@ -49,6 +49,6 @@ None at draft time. Design choices (preset name `treasureMaps`, the three relay 
 
 ## Linked artifacts
 
-- ADR: (filled in after Architecture phase)
+- ADR: `engineering-team/decisions/0002-treasure-maps-router-preset.md`
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/2-treasure-maps-router-preset.md
+++ b/engineering-team/stories/2-treasure-maps-router-preset.md
@@ -51,4 +51,4 @@ None at draft time. Design choices (preset name `treasureMaps`, the three relay 
 
 - ADR: `engineering-team/decisions/0002-treasure-maps-router-preset.md`
 - Test plan: `engineering-team/stories/2-treasure-maps-router-preset.test-plan.md`
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/2-treasure-maps-router-preset.md` (PASS)

--- a/engineering-team/stories/2-treasure-maps-router-preset.md
+++ b/engineering-team/stories/2-treasure-maps-router-preset.md
@@ -50,5 +50,5 @@ None at draft time. Design choices (preset name `treasureMaps`, the three relay 
 ## Linked artifacts
 
 - ADR: `engineering-team/decisions/0002-treasure-maps-router-preset.md`
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/2-treasure-maps-router-preset.test-plan.md`
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/2-treasure-maps-router-preset.test-plan.md
+++ b/engineering-team/stories/2-treasure-maps-router-preset.test-plan.md
@@ -1,0 +1,86 @@
+# Test Plan: Story 2 — `treasureMaps` router preset + 10040 to Negentropy Sync
+
+**Story:** `engineering-team/stories/2-treasure-maps-router-preset.md`
+**ADR:** `engineering-team/decisions/0002-treasure-maps-router-preset.md` (revised — Option D chosen)
+**Date:** 2026-05-13
+
+## Coverage map
+
+Every acceptance criterion maps to at least one automated test. The Option D scope means there's no `ensureState` behavioral change to test — the surface area is preset shape, generated-config output, UI radio option, and docs presence.
+
+| Criterion | Test name | File | Level |
+|---|---|---|---|
+| AC-1 (preset visible in Presets popup) | `treasureMaps preset exists in router-presets.json with correct shape` | `test/treasure-maps-router-preset.test.js` | unit (file parse) |
+| AC-1 (Playwright UI confirmation) | `Router tab Presets popup lists treasureMaps` | `tests/brainstorm/treasure-maps-router-preset.spec.js` | Playwright |
+| AC-2 (defaultEnabled: false) | covered by AC-1 file-parse assertion (`defaultEnabled === false`) | same | unit |
+| AC-3 (enable → daemon streams 10040 bidirectionally) | `generateConfig with treasureMaps enabled emits a bidirectional kind-10040 stream block` | `test/treasure-maps-router-preset.test.js` | unit (pure function) |
+| AC-4 (relays = damus, nos.lol, primal) | covered by AC-1 file-parse assertion (urls array) | same | unit |
+| AC-5 (disable → stream block absent) | `generateConfig with treasureMaps disabled omits its stream block` | `test/treasure-maps-router-preset.test.js` | unit (pure function) |
+| AC-6 (state persists across container restart) | NOT covered by a new test — relies on existing `/var/lib/brainstorm/router-state.json` persistence on the `tapestry-data` Docker volume, which is exercised by every other preset already in production. Test plan documents this rather than adding a synthetic test that mocks the volume. | (n/a) | (existing infrastructure) |
+| AC-7 (Negentropy Event Kinds picker has 10040) | `RelaySettings.jsx KIND_PRESETS contains the Treasure Maps (10040) option` | `test/treasure-maps-router-preset.test.js` | unit (source regex) |
+| AC-7 (Playwright UI confirmation) | `Negentropy Sync tab Event Kinds picker offers Treasure Maps (10040)` | `tests/brainstorm/treasure-maps-router-preset.spec.js` | Playwright |
+| AC-8 (docs updated) | `BIBLE.md or docs/CONFIGURATION.md documents the router preset system and notes the planned Negentropy preset system` | `test/treasure-maps-router-preset.test.js` | unit (file grep) |
+
+## Edge cases
+
+- [x] **Direction is exactly `"both"`** — AC-3 test asserts the string `dir = "both"`, not just that some `dir` key is present.
+- [x] **All three URLs present** — AC-1 test iterates the expected list and asserts each is in `urls`.
+- [x] **Disabled state respected at config-gen time** — separate AC-5 test confirms the same data with `enabled: false` does NOT appear in the generated config.
+- [x] **`generateConfig` is reachable for unit testing** — the AC-3 test asserts `typeof generateConfig === 'function'` first, so the failure mode is a clear "must be exported from routerConfig" rather than a TypeError on an undefined function. The Implementer will need to add the export as part of satisfying these tests; that change is in-scope per ADR Option D's "smallest possible code change" goal (one-line export tweak).
+
+## Not covered
+
+- **AC-6 cross-container-restart persistence.** Out of scope for an automated test — would require spinning up two container generations and comparing state file. The mechanism is preexisting; relies on the `tapestry-data` Docker named volume mounting `/var/lib/brainstorm/`. Verified by manual smoke-test step after deploy: enable the preset on staging, redeploy, confirm it's still enabled.
+- **Live bidirectional streaming with real relays.** Out of scope for unit tests — requires real WebSocket connections to the three relays plus a published 10040 event to observe. Verified manually post-deploy by enabling the preset and checking that local strfry receives kind 10040 events: `docker compose exec tapestry strfry scan --count '{"kinds":[10040]}'` before and after a short wait.
+
+## Test infrastructure
+
+- **Test framework:** project's existing hand-rolled Node runner (`node test/test.js`). Playwright for browser flows.
+- **No new dependencies.** The unit tests use only `fs`, `path`, and `require()`.
+- **Playwright preconditions:** A reachable Brainstorm instance. Defaults to local docker stack at `http://localhost:8080`; override via `BRAINSTORM_BASE_URL` to target staging. Auth on `/tapestry/settings/relays` may be required — Playwright tests check for the *presence* of the preset row and the Event Kinds radio option, which should be visible even if interactions require sign-in.
+- **`generateConfig` export:** The unit test for AC-3/AC-5 requires `generateConfig` to be exported from `src/api/strfry/routerConfig.js`. Currently it's a module-private helper. The Implementer adds the export to satisfy the test.
+
+## How to run
+
+Unit tests via the existing entry:
+```
+npm test
+```
+
+Playwright tests against local stack on `:8080`:
+```
+npm run test:playwright
+```
+
+Playwright tests against staging:
+```
+BRAINSTORM_BASE_URL=https://staging.brainstorm.world npm run test:playwright
+```
+
+## Verification
+
+Confirmed failing on the pre-implementation tree at commit `1e108e6b` (`adr: revise 0002 …`).
+
+```
+treasure-maps-router-preset suite:
+  ✗ treasureMaps preset exists in setup/router-presets.json with correct shape
+      treasureMaps preset not found in setup/router-presets.json
+  ✗ generateConfig with treasureMaps enabled emits a bidirectional kind-10040 stream block
+      generateConfig must be exported from src/api/strfry/routerConfig.js so this behavior is unit-testable
+  ✗ generateConfig with treasureMaps disabled omits its stream block
+      generateConfig must be exported
+  ✗ RelaySettings.jsx KIND_PRESETS contains the Treasure Maps (10040) option
+      RelaySettings.jsx KIND_PRESETS must include { label: "Treasure Maps (10040)", kinds: [10040] }
+  ✗ BIBLE.md or docs/CONFIGURATION.md documents the router preset system and the planned Negentropy preset system
+      docs must contain a forward-looking note about the planned Negentropy preset system
+
+Test Results
+-------------
+Configuration Loading:                PASS
+treasure-maps-router-preset suite:    FAIL (0 passed, 5 failed)
+Overall:                              FAIL
+```
+
+Each failure message directly identifies what the Implementer needs to add. No typo / import-error failures — all 5 are spec-driven.
+
+Playwright spec at `tests/brainstorm/treasure-maps-router-preset.spec.js` is not run pre-implementation since it requires a deployed instance; it will be exercised against staging after the implementation lands.

--- a/engineering-team/stories/3-router-presets-auto-appear-in-streams.md
+++ b/engineering-team/stories/3-router-presets-auto-appear-in-streams.md
@@ -1,0 +1,52 @@
+# Story 3: Router presets auto-appear in the main Streams list
+
+**Status:** Draft (deferred — see "Origin" below)
+**Created:** 2026-05-13
+**Type:** Feature (UX improvement)
+
+## Background
+
+In the Router Management tab (`/tapestry/settings/relays`), the "main Streams list" displays whatever is in `/var/lib/brainstorm/router-state.json`. New presets added to `setup/router-presets.json` are only discoverable by clicking the **"📋 Presets"** button, which surfaces a separate "Available Presets" popup. From there, an operator clicks "+ Add" to insert the preset into their state, and then toggles it to enable.
+
+The existing discovery flow works, but it has a visibility gap: operators who don't notice the "📋 Presets" button (or who skim the page expecting the new preset to appear inline) won't realize a new preset is available after a deploy that ships one. As we accumulate more presets over time, the discoverability cost grows.
+
+A potential improvement: when the deploy ships a new preset, the operator's main Streams list automatically shows the new entry (in its `defaultEnabled` state), so it's visible *without* requiring a Presets-popup click. The operator can still ignore, enable, or remove it.
+
+## User-facing description
+
+**As an operator of a Brainstorm instance**, I want new presets that ship with a deploy to appear in my main Streams list automatically (in their `defaultEnabled` state), **so that** I don't have to remember to check the "📋 Presets" popup after each deploy to see if something new is available.
+
+## Acceptance criteria
+
+- [ ] After a deploy that adds a new preset to `setup/router-presets.json`, the operator's main Streams list on the Router Management tab shows the new preset entry on the *first* page load — without requiring a click into the "📋 Presets" popup or any other operator action.
+- [ ] The new preset appears with `enabled` matching its `defaultEnabled` value. (For `treasureMaps` shipped via [story #2](2-treasure-maps-router-preset.md), this is `false` — visible but off.)
+- [ ] Existing operator-set toggle state on *other* presets is preserved across this change. An operator who has enabled `userProfiles` and disabled `dcosl` continues to have those toggles after the new preset auto-appears.
+- [ ] If the operator removes the auto-appeared preset via the existing delete UI, it does *not* re-appear on subsequent page loads. (Removed entries stay removed.)
+- [ ] Behavior is consistent regardless of whether the operator hits the Router tab via a GET (`/api/strfry/router-status`) or via a POST endpoint (`/api/strfry/router-toggle`, `/api/strfry/router-config`). Both paths see the auto-appeared preset.
+
+## Concepts touched
+
+- strfry-router preset system
+- Router state persistence (`router-state.json`)
+
+## Out of scope
+
+- Auto-applying enabled presets to the active strfry-router config without an explicit operator toggle. (If the auto-appeared preset has `defaultEnabled: true`, this story does not run `applyConfig` for it; the operator's first toggle action does.)
+- Preset *removal* handling at the JSON level (i.e. a preset removed from `router-presets.json` lingering as an orphan in state). Tracked separately if it becomes a real problem.
+- Refactoring the state-as-overlay model (was Option C in ADR 0002 — large refactor, deferred).
+
+## Open questions
+
+- **Where the merge logic should live.** Two natural candidates: a shared utility called by both `routerConfig.js#ensureState` and `routerStatus.js#loadState`, or a centralized re-architecture. Architect's call when this story is picked up.
+- **Whether to add a UI affordance for "this preset was auto-added"** — e.g. a small badge so the operator knows it wasn't from their explicit "+ Add" click. Probably YAGNI but worth considering.
+- **What to do if the JSON has the same preset name as an existing custom (non-preset) stream.** Edge case; resolve in Architecture.
+
+## Origin
+
+Filed during the Tester phase of [story #2](2-treasure-maps-router-preset.md) (see [ADR 0002 — Revision history](../decisions/0002-treasure-maps-router-preset.md#revision-history)). The first draft of ADR 0002 proposed an additive merge in `ensureState()` as part of story #2's scope; on closer look it (a) wasn't required by any of story #2's ACs, (b) wouldn't actually deliver the auto-appear UX without expanded scope into `routerStatus.js`, and (c) contradicted the established precedent for shipping new presets (commit `bb4c83e7`). The UX idea was descoped from story #2 and captured here for future consideration.
+
+## Linked artifacts
+
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/setup/router-presets.json
+++ b/setup/router-presets.json
@@ -75,5 +75,19 @@
     "pluginDown": "",
     "pluginUp": "",
     "defaultEnabled": false
+  },
+  {
+    "name": "treasureMaps",
+    "description": "Bidirectional sync of kind 10040 (TA Treasure Maps) with popular general-purpose relays",
+    "dir": "both",
+    "filter": { "kinds": [10040] },
+    "urls": [
+      "wss://relay.damus.io",
+      "wss://nos.lol",
+      "wss://relay.primal.net"
+    ],
+    "pluginDown": "",
+    "pluginUp": "",
+    "defaultEnabled": false
   }
 ]

--- a/src/api/strfry/routerConfig.js
+++ b/src/api/strfry/routerConfig.js
@@ -324,6 +324,7 @@ async function initRouter() {
 }
 
 module.exports = {
+  generateConfig,
   handleUpdateRouterConfig,
   handleToggleStream,
   handleGetPresets,

--- a/test/test.js
+++ b/test/test.js
@@ -1,17 +1,17 @@
 /**
- * Basic test for Brainstorm
- * 
- * This is a simple test to verify that the package is working correctly.
- * In a real-world scenario, you would use a testing framework like Jest or Mocha.
+ * Brainstorm test entry point. Runs in two phases:
+ *   1. Hand-rolled smoke tests (config loading).
+ *   2. Story-scoped test suites under test/*.test.js.
+ *
+ * Exit code is 0 only if every phase passes.
  */
 
 const { loadConfig } = require('../lib/config');
 
-// Mock environment variables for testing
+// Mock environment variables for the config smoke check
 process.env.BRAINSTORM_RELAY_URL = 'wss://test-relay.com';
 process.env.BRAINSTORM_RELAY_PUBKEY = 'test-pubkey';
 
-// Test configuration loading
 function testConfigLoading() {
   try {
     const config = loadConfig();
@@ -23,14 +23,30 @@ function testConfigLoading() {
   }
 }
 
-// Run tests
-console.log('Running Brainstorm tests...');
-const configTest = testConfigLoading();
+const treasureMaps = require('./treasure-maps-router-preset.test.js');
 
-console.log('\nTest Results:');
-console.log('-------------');
-console.log(`Configuration Loading: ${configTest ? 'PASS' : 'FAIL'}`);
-console.log(`Overall: ${configTest ? 'PASS' : 'FAIL'}`);
+async function main() {
+  console.log('Running Brainstorm tests...\n');
 
-// Exit with appropriate code
-process.exit(configTest ? 0 : 1);
+  const configOk = testConfigLoading();
+  console.log(`\nConfiguration Loading: ${configOk ? 'PASS' : 'FAIL'}\n`);
+
+  console.log('treasure-maps-router-preset suite:');
+  const treasureMapsResult = await treasureMaps.run();
+
+  console.log('\nTest Results');
+  console.log('-------------');
+  console.log(`Configuration Loading:                ${configOk ? 'PASS' : 'FAIL'}`);
+  console.log(
+    `treasure-maps-router-preset suite:    ${treasureMapsResult.fail === 0 ? 'PASS' : 'FAIL'} (${treasureMapsResult.pass} passed, ${treasureMapsResult.fail} failed)`
+  );
+
+  const overallOk = configOk && treasureMapsResult.fail === 0;
+  console.log(`Overall:                              ${overallOk ? 'PASS' : 'FAIL'}`);
+  process.exit(overallOk ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('Test runner crashed:', err);
+  process.exit(1);
+});

--- a/test/treasure-maps-router-preset.test.js
+++ b/test/treasure-maps-router-preset.test.js
@@ -1,0 +1,131 @@
+/**
+ * Failing tests for story #2: treasureMaps router preset + 10040 to Negentropy Sync.
+ * See engineering-team/stories/2-treasure-maps-router-preset.test-plan.md
+ *
+ * Each test maps to one or more acceptance criteria. Tests are designed to fail
+ * on the pre-implementation tree and pass once the Implementer lands the changes
+ * described in ADR 0002 (Option D).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PRESETS_PATH = path.resolve(__dirname, '../setup/router-presets.json');
+const RELAY_SETTINGS_PATH = path.resolve(__dirname, '../ui/src/pages/settings/RelaySettings.jsx');
+const BIBLE_PATH = path.resolve(__dirname, '../BIBLE.md');
+const CONFIG_DOC_PATH = path.resolve(__dirname, '../docs/CONFIGURATION.md');
+
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'Assertion failed');
+}
+
+// ── AC-1, AC-2, AC-4 ─────────────────────────────────────────
+test('treasureMaps preset exists in setup/router-presets.json with correct shape', () => {
+  const presets = JSON.parse(fs.readFileSync(PRESETS_PATH, 'utf8'));
+  const tm = presets.find(p => p.name === 'treasureMaps');
+  assert(tm, 'treasureMaps preset not found in setup/router-presets.json');
+
+  assert(tm.dir === 'both', `expected dir="both", got "${tm.dir}"`);
+  assert(tm.filter && Array.isArray(tm.filter.kinds), 'filter.kinds must be an array');
+  assert(
+    tm.filter.kinds.length === 1 && tm.filter.kinds[0] === 10040,
+    `expected filter.kinds=[10040], got ${JSON.stringify(tm.filter.kinds)}`
+  );
+  assert(tm.defaultEnabled === false, `expected defaultEnabled=false, got ${tm.defaultEnabled}`);
+
+  const expectedUrls = ['wss://relay.damus.io', 'wss://nos.lol', 'wss://relay.primal.net'];
+  assert(Array.isArray(tm.urls), 'urls must be an array');
+  assert(tm.urls.length === expectedUrls.length, `expected ${expectedUrls.length} urls, got ${tm.urls.length}`);
+  for (const url of expectedUrls) {
+    assert(tm.urls.includes(url), `expected urls to include ${url}; got ${JSON.stringify(tm.urls)}`);
+  }
+});
+
+// ── AC-3 ─────────────────────────────────────────────────────
+test('generateConfig with treasureMaps enabled emits a bidirectional kind-10040 stream block', () => {
+  const routerConfig = require('../src/api/strfry/routerConfig');
+  assert(
+    typeof routerConfig.generateConfig === 'function',
+    'generateConfig must be exported from src/api/strfry/routerConfig.js so this behavior is unit-testable'
+  );
+
+  const streams = [{
+    name: 'treasureMaps',
+    dir: 'both',
+    filter: { kinds: [10040] },
+    urls: ['wss://relay.damus.io', 'wss://nos.lol', 'wss://relay.primal.net'],
+    enabled: true,
+  }];
+  const config = routerConfig.generateConfig(streams);
+
+  assert(config.includes('treasureMaps {'), 'config must contain a treasureMaps stream block');
+  assert(config.includes('dir = "both"'), 'config must specify dir = "both"');
+  assert(config.includes('"kinds":[10040]'), 'config must include filter with kinds:[10040]');
+  for (const url of streams[0].urls) {
+    assert(config.includes(url), `config must include url ${url}`);
+  }
+});
+
+// ── AC-5 ─────────────────────────────────────────────────────
+test('generateConfig with treasureMaps disabled omits its stream block', () => {
+  const { generateConfig } = require('../src/api/strfry/routerConfig');
+  assert(typeof generateConfig === 'function', 'generateConfig must be exported');
+
+  const streams = [{
+    name: 'treasureMaps',
+    dir: 'both',
+    filter: { kinds: [10040] },
+    urls: ['wss://relay.damus.io'],
+    enabled: false,
+  }];
+  const config = generateConfig(streams);
+  assert(!config.includes('treasureMaps {'), 'disabled preset must not appear in generated config');
+});
+
+// ── AC-7 ─────────────────────────────────────────────────────
+test('RelaySettings.jsx KIND_PRESETS contains the Treasure Maps (10040) option', () => {
+  const src = fs.readFileSync(RELAY_SETTINGS_PATH, 'utf8');
+  const re = /label:\s*['"`]Treasure Maps \(10040\)['"`]\s*,\s*kinds:\s*\[\s*10040\s*\]/;
+  assert(
+    re.test(src),
+    'RelaySettings.jsx KIND_PRESETS must include { label: "Treasure Maps (10040)", kinds: [10040] }'
+  );
+});
+
+// ── AC-8 ─────────────────────────────────────────────────────
+test('BIBLE.md or docs/CONFIGURATION.md documents the router preset system and the planned Negentropy preset system', () => {
+  const bible = fs.existsSync(BIBLE_PATH) ? fs.readFileSync(BIBLE_PATH, 'utf8') : '';
+  const config = fs.existsSync(CONFIG_DOC_PATH) ? fs.readFileSync(CONFIG_DOC_PATH, 'utf8') : '';
+  const combined = bible + '\n' + config;
+
+  assert(/router preset/i.test(combined), 'docs must contain a router preset section');
+  assert(
+    /negentropy preset/i.test(combined),
+    'docs must contain a forward-looking note about the planned Negentropy preset system'
+  );
+});
+
+// ── Runner ───────────────────────────────────────────────────
+async function run() {
+  let pass = 0;
+  let fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/tests/brainstorm/treasure-maps-router-preset.spec.js
+++ b/tests/brainstorm/treasure-maps-router-preset.spec.js
@@ -1,0 +1,46 @@
+/**
+ * Playwright UI checks for story #2: treasureMaps router preset + 10040 Negentropy Sync.
+ * See engineering-team/stories/2-treasure-maps-router-preset.test-plan.md
+ *
+ * Preconditions:
+ *   - A reachable Brainstorm instance. Defaults to BRAINSTORM_BASE_URL or http://localhost:8080.
+ *   - The Implementer's changes deployed to that instance.
+ *
+ * These checks verify the *presence* of the new preset row and the new Event Kinds
+ * radio option. Interaction-level tests (toggle on, refresh, observe daemon config)
+ * are out of scope for this Playwright spec — they require auth and side-effect
+ * verification on the droplet. Smoke-tested manually post-deploy.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = process.env.BRAINSTORM_BASE_URL || 'http://localhost:8080';
+const RELAYS_URL = `${BASE_URL}/tapestry/settings/relays`;
+
+test.describe('Story 2 — treasureMaps router preset + 10040 Negentropy Sync', () => {
+  test('Router tab Presets popup lists treasureMaps', async ({ page }) => {
+    await page.goto(RELAYS_URL);
+
+    // The Router Management tab should be selected by default (or click into it).
+    // Click the "📋 Presets" button to open the Available Presets popup.
+    const presetsButton = page.getByRole('button', { name: /Presets/i });
+    await presetsButton.click();
+
+    // Expect to see a row mentioning treasureMaps (the preset name) and kind 10040.
+    await expect(page.getByText(/treasureMaps/i)).toBeVisible();
+    await expect(page.getByText(/Treasure Maps/i)).toBeVisible();
+  });
+
+  test('Negentropy Sync tab Event Kinds picker offers Treasure Maps (10040)', async ({ page }) => {
+    await page.goto(RELAYS_URL);
+
+    // Switch to the Negentropy Sync tab.
+    const syncTab = page.getByRole('button', { name: /Negentropy Sync/i }).or(
+      page.getByRole('tab', { name: /Negentropy Sync/i })
+    );
+    await syncTab.first().click();
+
+    // The Event Kinds picker should now include a "Treasure Maps (10040)" radio option.
+    await expect(page.getByText(/Treasure Maps \(10040\)/)).toBeVisible();
+  });
+});

--- a/ui/src/pages/settings/RelaySettings.jsx
+++ b/ui/src/pages/settings/RelaySettings.jsx
@@ -769,6 +769,7 @@ function TimestampPicker({ label, value, onChange, disabled }) {
 const KIND_PRESETS = [
   { label: 'DCoSL (9998, 9999, 39998, 39999)', kinds: [9998, 9999, 39998, 39999] },
   { label: 'Profiles (0)', kinds: [0] },
+  { label: 'Treasure Maps (10040)', kinds: [10040] },
   { label: 'WoT (3, 1984, 10000)', kinds: [3, 1984, 10000] },
   { label: 'All (no filter)', kinds: [] },
 ];


### PR DESCRIPTION
## Summary

Adds an opt-in `treasureMaps` router preset for bidirectional sync of kind 10040 (NIP-85 TA Treasure Maps) with popular general-purpose relays, plus a "Treasure Maps (10040)" option in the Negentropy Sync tab's Event Kinds picker. Lets operators keep customer Treasure Maps fresh continuously instead of importing them by hand (per-user fallback button on `/settings` stays in place).

Shipped via the full five-phase engineering-team flow (story → ADR → tests → impl → review). ADR was mid-flow descoped from a load-bearing `ensureState()` merge to a minimal "match existing preset precedent" approach after the Tester noticed it didn't actually map to any AC. Deferred UX improvement filed as story #3.

## Changes

Production code (4 files, +38 LOC):
- `setup/router-presets.json` — append `treasureMaps` entry (`dir: "both"`, `kinds: [10040]`, three relays, `defaultEnabled: false`)
- `src/api/strfry/routerConfig.js` — export `generateConfig` for unit testability
- `ui/src/pages/settings/RelaySettings.jsx` — add `Treasure Maps (10040)` row to Negentropy Sync `KIND_PRESETS`
- `docs/CONFIGURATION.md` — new "Router Presets" section + forward-looking note on the planned Negentropy preset system

Engineering-team artifacts:
- `engineering-team/stories/2-treasure-maps-router-preset.md`
- `engineering-team/stories/2-treasure-maps-router-preset.test-plan.md`
- `engineering-team/stories/3-router-presets-auto-appear-in-streams.md` (deferred follow-up)
- `engineering-team/decisions/0002-treasure-maps-router-preset.md`
- `engineering-team/reviews/2-treasure-maps-router-preset.md` (PASS)
- `test/treasure-maps-router-preset.test.js` + wiring in `test/test.js`
- `tests/brainstorm/treasure-maps-router-preset.spec.js`

## Test plan

- [ ] After merge: `deploy-staging.yml` runs to completion.
- [ ] Tier 1 stability poll on `staging.brainstorm.world` reaches 3 consecutive 200s.
- [ ] Tier 2 sanity reachability: standard endpoints return 200.
- [ ] Tier 3 PR-specific:
  - [ ] `GET /api/strfry/router-presets` returns a preset entry with `name: "treasureMaps"`, `dir: "both"`, `filter.kinds: [10040]`, three expected URLs, and `defaultEnabled: false`.
  - [ ] Deployed JS bundle contains the string `Treasure Maps (10040)` (proves the Negentropy KIND_PRESETS entry shipped).
- [ ] Tier 5 regression: `/api/search/profiles/meili?q=jack&limit=2` still returns hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)