### PR TITLE
docs(OPERATIONS): record tags.brainstorm.world target + engineering-team divergence gotcha

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -22,15 +22,16 @@
 
 ## 1. Deploy targets
 
-Three long-lived branches, three Digital Ocean droplets, three CI/CD workflows:
+Four long-lived branches, four Digital Ocean droplets, four CI/CD workflows:
 
 | Branch | Workflow | Target | Purpose |
 |--------|----------|--------|---------|
 | `main` | `deploy-brainstorm.yml` | `brainstorm.world` | Production. PRs merge here only after staging verification. |
 | `staging` | `deploy-staging.yml` | `staging.brainstorm.world` | Pre-production verification. PRs from feature branches land here first. |
 | `feature-magic-carpet` | `deploy-magic-carpet.yml` | `magic-carpet.brainstorm.world` | Long-lived sandbox for Matthias's bounty-system work. |
+| `feat/pubkey-tagging-target` | `deploy-tags.yml` | `tags.brainstorm.world` | Long-lived sandbox for the pubkey-tagging feature work (NIP-85 profile-tagging UX). |
 
-Each workflow uses repo secrets named `DEPLOY_HOST_<NAME>`, `DEPLOY_USER_<NAME>`, `DEPLOY_SSH_KEY_<NAME>` where `<NAME>` is `BRAINSTORM`, `STAGING`, or `MAGIC_CARPET`.
+Each workflow uses repo secrets named `DEPLOY_HOST_<NAME>`, `DEPLOY_USER_<NAME>`, `DEPLOY_SSH_KEY_<NAME>` where `<NAME>` is `BRAINSTORM`, `STAGING`, `MAGIC_CARPET`, or `TAGS`.
 
 ### Standard branch promotion flow
 
@@ -48,7 +49,7 @@ For Matthias's sandbox: he PRs from his fork's `magic-carpet` branch into our `f
 
 ## 2. Branches
 
-In addition to the three deploy-target branches:
+In addition to the four deploy-target branches:
 
 | Branch | Status | Owner | Purpose |
 |--------|--------|-------|---------|
@@ -65,7 +66,7 @@ In addition to the three deploy-target branches:
 
 ## 3. CI/CD workflows
 
-GitHub Actions workflows in `.github/workflows/`. All three follow the same SSH-action pattern:
+GitHub Actions workflows in `.github/workflows/`. All four follow the same SSH-action pattern:
 
 1. Restore `docker-compose.yml` to repo version (`git checkout --`)
 2. Pull latest code from the corresponding branch
@@ -102,6 +103,12 @@ Short-lived feature branches (`feat/*`, `fix/*`, `chore/*`) are NOT protected; t
 ### Sandbox: `magic-carpet.brainstorm.world`
 
 - (specs to be filled in — sized for a small WoT-user count)
+
+### Sandbox: `tags.brainstorm.world`
+
+- (specs to be filled in)
+- Behind host nginx + Certbot SSL; Docker stack binds to `127.0.0.1:8080`
+- Stood up 2026-05-12; first CI/CD deploy via `deploy-tags.yml` ran successfully against PR #119.
 
 ### Empirical RAM/disk on production (April 2026)
 
@@ -207,3 +214,11 @@ While verifying the Redis-backed session store landed in #90, we noticed users w
 **Fix (PR #92):** persist `SESSION_SECRET` to `/var/lib/brainstorm/session.secret` on the `tapestry-data` volume. Generate-once-and-store, read on subsequent starts. To force-rotate after a security incident: delete the file; every active session ends on the next container start.
 
 **Lesson:** when fixing a "session persistence" UX, both the *store* (where data lives) and the *secret* (which validates cookies referencing that data) need to survive container rebuilds. Either alone is insufficient.
+
+### 8.7. 2026-05-13: engineering-team scaffolding on main but not on staging
+
+While preparing a new 5-phase engineering-team flow off `staging`, we discovered `engineering-team/` (templates, roles, workflows, README), `AGENTS.md`, and the engineering-team section of `CLAUDE.md` existed on `main` but not on `staging` — about 850 lines of agent-workflow scaffolding silently absent from the pre-production branch. Tracing it back: [PR #111](https://github.com/nous-clawds4/tapestry/pull/111) (commit `4acbe321` — "Add claude 'engineering team' concept") was merged directly to `main`, bypassing staging. All subsequent `staging → main` promotions carried staging's diff *into* main but never the reverse direction — git merges are one-way — so the two branches drifted by exactly that scaffolding.
+
+**Recovery:** one-shot sync PR — branch off `main`, PR back into `staging`, merge. The diff was purely additive on the staging side (main had files staging didn't), so no conflicts. ([PR #122](https://github.com/nous-clawds4/tapestry/pull/122) recorded this for the first occurrence; `deploy-staging.yml` runs but the redeploy is a no-op for running services since only docs/scaffolding moved.)
+
+**Mechanism for prevention:** all changes — *even docs and scaffolding* — should go through the standard `staging → main` flow. The cycle-staging and cycle-prod skills assume parity between the two long-lived branches; landing directly on main breaks that assumption silently. If parity drift is suspected, `git diff --stat origin/main origin/staging` from a fresh checkout reveals it immediately.


### PR DESCRIPTION
## Summary

Four small updates to OPERATIONS.md to reflect work shipped earlier in this session:

1. **§1 Deploy targets** — add row for `feat/pubkey-tagging-target` / `deploy-tags.yml` / `tags.brainstorm.world`; change "three" → "four" throughout; add `TAGS` to secret-naming convention.
2. **§2 Branches** — cross-reference updated to "four deploy-target branches".
3. **§3 CI/CD workflows** — "All three follow" → "All four follow".
4. **§5 Droplets** — new "Sandbox: `tags.brainstorm.world`" subsection.
5. **§8.7** — new operational gotcha documenting the engineering-team scaffolding divergence between main and staging (PR #111 landed direct-to-main; bypassing staging; recovery via the main → staging sync PR #122).

## Changes

One file: `OPERATIONS.md` (+19 / -4).

Doc-only change. Per CLAUDE.md classification table → Implementer + Reviewer only, no story/ADR/test plan needed.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs (no functional change; redeploy is a no-op for running services).
- [ ] `staging.brainstorm.world` stability poll reaches 3 consecutive 200s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)