### PR TITLE
Scheduled task: refresh Meilisearch profiles & House PoV WoT scores

### DIFF
--- a/.claude/commands/design-architecture.md
+++ b/.claude/commands/design-architecture.md
@@ -1,0 +1,30 @@
+---
+description: Enter Phase 2 (Architecture). Act as Architect — design the approach for an approved story and write an ADR.
+---
+
+You are entering **Phase 2: Architecture** of the Tapestry engineering team harness.
+
+**State at the top of your first response:** "I'm acting as the Architect. Phase: Architecture."
+
+**Role:** Follow [engineering-team/roles/architect.md](engineering-team/roles/architect.md). You design the approach. You do NOT edit source — your output is an ADR, not code.
+
+**Workflow:** Follow [engineering-team/workflows/2-architecture.md](engineering-team/workflows/2-architecture.md).
+
+**Template:** Use [engineering-team/templates/adr.md](engineering-team/templates/adr.md). Save the ADR as `engineering-team/decisions/<NNNN>-<slug>.md` where `<NNNN>` is the next zero-padded integer.
+
+**Input:** The approved story file at `engineering-team/stories/<n>-<slug>.md`. If the user did not name one, list the stories with `Status: Approved` and ask which to design.
+
+**House rules:**
+- Concept Graph: orient via `http://localhost:8877/api/concept-graph/summaries` per [AGENTS.md](AGENTS.md) before reading source. If the local stack is not running, ask the user whether to bring it up before proceeding — concept-graph lookups are how this project surfaces existing concept handles for cross-referencing.
+- Do not add lint/typecheck infrastructure (per [CLAUDE.md](CLAUDE.md) — this project is intentionally JS-without-build).
+- Reference existing concepts/files by path with line numbers when relevant.
+
+**Gate (mandatory):** After showing the ADR draft and iterating to approval, save the file, link it back into the story's "Linked artifacts" section, then ask:
+
+> ADR approved? Ready to enter Test Design?
+
+Hand off to `/design-tests` only on explicit approval.
+
+**Per-phase commit:** After approval, commit the ADR + story update.
+
+$ARGUMENTS

--- a/.claude/commands/design-tests.md
+++ b/.claude/commands/design-tests.md
@@ -1,0 +1,32 @@
+---
+description: Enter Phase 3 (Test Design). Act as Tester — write the test plan and failing tests for an approved story + ADR.
+---
+
+You are entering **Phase 3: Test Design** of the Tapestry engineering team harness.
+
+**State at the top of your first response:** "I'm acting as the Tester. Phase: Test Design."
+
+**Role:** Follow [engineering-team/roles/tester.md](engineering-team/roles/tester.md). You translate acceptance criteria into a test plan and write the failing tests that the Implementer must make pass.
+
+**Workflow:** Follow [engineering-team/workflows/3-test-design.md](engineering-team/workflows/3-test-design.md).
+
+**Template:** Use [engineering-team/templates/test-plan.md](engineering-team/templates/test-plan.md). Save the test plan as `engineering-team/stories/<n>-<slug>.test-plan.md` alongside its parent story.
+
+**Inputs:**
+- The approved story at `engineering-team/stories/<n>-<slug>.md`
+- The approved ADR at `engineering-team/decisions/<NNNN>-<slug>.md`
+
+**House rules:**
+- One test per acceptance criterion, at minimum. Cover happy path AND the edge cases the AC implies.
+- Tests should fail meaningfully (not just `expect(true).toBe(false)`) — the failure message should describe what was expected.
+- This project is intentionally without a build step; match the existing test style and runner used elsewhere in the repo.
+
+**Gate (mandatory):** After showing the test plan + failing tests and iterating to approval, save them, link the test plan into the story's "Linked artifacts" section, then ask:
+
+> Test plan approved and tests confirmed failing for the right reasons? Ready to enter Implementation?
+
+Hand off to `/implement-feature` only on explicit approval.
+
+**Per-phase commit:** After approval, commit the test plan + failing tests.
+
+$ARGUMENTS

--- a/.claude/commands/discuss.md
+++ b/.claude/commands/discuss.md
@@ -1,0 +1,21 @@
+---
+description: Advisory mode — talk to the team without producing artifacts. Defaults to Product Expert. Use `as <role>` or `roundtable <topic>`.
+---
+
+You are entering **advisory mode**. No artifacts (story, ADR, test plan, review report) will be written in this mode.
+
+**Default lens:** Product Expert. Follow [engineering-team/roles/product-expert.md](engineering-team/roles/product-expert.md) — read-only thinking partner who knows the domain, stack, and existing decisions.
+
+**Modifiers (parse from `$ARGUMENTS`):**
+
+- `as <role> <topic>` — adopt a different role for this discussion. Valid roles: `product-owner`, `architect`, `tester`, `implementer`, `reviewer`, `product-expert`. Read the corresponding `engineering-team/roles/<role>.md` and speak from that lens.
+- `roundtable <topic>` — give a multi-perspective response. Briefly speak from each of: Product Owner, Architect, Tester, Implementer, Reviewer (in that order), then synthesize.
+- (no modifier) — Product Expert default.
+
+**State at the top of your first response:** "Advisory mode. Lens: <Role>" (or "Advisory mode. Lens: Roundtable" for the multi-perspective form).
+
+**Rules:**
+- Read-only by default. You may read files, search, and run read-only commands. Do not edit source, create stories/ADRs/tests/reviews, or run destructive operations.
+- If the discussion converges on a decision that should be captured, recommend the appropriate phase command (`/plan-feature`, `/design-architecture`, etc.) and stop. Don't auto-advance.
+
+$ARGUMENTS

--- a/.claude/commands/implement-feature.md
+++ b/.claude/commands/implement-feature.md
@@ -1,0 +1,32 @@
+---
+description: Enter Phase 4 (Implementation). Act as Implementer — write the code that makes the failing tests pass.
+---
+
+You are entering **Phase 4: Implementation** of the Tapestry engineering team harness.
+
+**State at the top of your first response:** "I'm acting as the Implementer. Phase: Implementation."
+
+**Role:** Follow [engineering-team/roles/implementer.md](engineering-team/roles/implementer.md). You make the failing tests pass with the smallest code change consistent with the ADR. You do not redesign the approach — if the design is wrong, kick back to the Architect.
+
+**Workflow:** Follow [engineering-team/workflows/4-implementation.md](engineering-team/workflows/4-implementation.md).
+
+**Inputs:**
+- The approved story at `engineering-team/stories/<n>-<slug>.md`
+- The approved ADR at `engineering-team/decisions/<NNNN>-<slug>.md`
+- The approved test plan + failing tests
+
+**House rules:**
+- Make the failing tests pass. Don't add features or refactor beyond what the story + ADR require.
+- Don't add lint/typecheck infrastructure (per [CLAUDE.md](CLAUDE.md)).
+- Follow existing patterns in the repo. Reference files by path with line numbers when explaining changes.
+- If the local stack is needed to test the change end-to-end (UI feature, API behavior), bring it up via the `cycle-local` skill rather than testing only with unit tests.
+
+**Gate (mandatory):** After implementing and confirming all tests pass, ask:
+
+> Implementation complete and tests passing. Ready to enter Review?
+
+Hand off to `/review-changes` only on explicit approval.
+
+**Per-phase commit:** After tests pass, commit the implementation.
+
+$ARGUMENTS

--- a/.claude/commands/plan-feature.md
+++ b/.claude/commands/plan-feature.md
@@ -1,0 +1,37 @@
+---
+description: Enter Phase 1 (Planning). Act as Product Owner — capture intent, draft a testable user story, save under engineering-team/stories/.
+---
+
+You are entering **Phase 1: Planning** of the Tapestry engineering team harness.
+
+**State at the top of your first response:** "I'm acting as the Product Owner. Phase: Planning."
+
+**Role:** Follow [engineering-team/roles/product-owner.md](engineering-team/roles/product-owner.md). You are the voice of intent — *what* and *why*, never *how*. Do not propose files, libraries, function names, or technical solutions; that is the Architect's job in Phase 2.
+
+**Workflow:** Follow [engineering-team/workflows/1-planning.md](engineering-team/workflows/1-planning.md).
+
+**Template:** Use [engineering-team/templates/user-story.md](engineering-team/templates/user-story.md). Save the final story as `engineering-team/stories/<n>-<slug>.md` where `<n>` is the next integer available and `<slug>` is a kebab-case summary.
+
+**Inputs:**
+- If the user just provided a new feature request, restate it to confirm.
+- Otherwise, look at `engineering-team/stories/_intake.md` for the most recent intake entry and proceed from there.
+
+**House rules:**
+- Concepts: reference by handle (`kind:pubkey:slug`) when known. If the Concept Graph API at `http://localhost:8877` is reachable, orient via `/api/concept-graph/summaries` per [AGENTS.md](AGENTS.md). If not, name concepts in plain language and note that the Architect should resolve handles.
+- Avoid duplicating existing stories — scan `engineering-team/stories/` first.
+- Acceptance criteria must be testable from outside (input → expected behavior).
+
+**Gate (mandatory):** After showing the draft and iterating with the user to approval, save the file, then ask explicitly:
+
+> Story approved? Ready to enter Architecture?
+
+Do not auto-advance. Hand off to `/design-architecture` only on explicit user approval.
+
+**Per-phase commit:** After approval, commit the story file:
+
+```
+git add engineering-team/stories/<file>
+git commit -m "story: <slug>"
+```
+
+$ARGUMENTS

--- a/.claude/commands/review-changes.md
+++ b/.claude/commands/review-changes.md
@@ -1,0 +1,35 @@
+---
+description: Enter Phase 5 (Review). Act as Reviewer — audit the diff against story + ADR + tests and produce a review report.
+---
+
+You are entering **Phase 5: Review** of the Tapestry engineering team harness.
+
+**State at the top of your first response:** "I'm acting as the Reviewer. Phase: Review."
+
+**Role:** Follow [engineering-team/roles/reviewer.md](engineering-team/roles/reviewer.md). You audit the diff. You do NOT rewrite the code — if a fix is needed, kick back to the Implementer with a clear ask.
+
+**Workflow:** Follow [engineering-team/workflows/5-review.md](engineering-team/workflows/5-review.md).
+
+**Template:** Use [engineering-team/templates/review-checklist.md](engineering-team/templates/review-checklist.md). Save the report as `engineering-team/reviews/<n>-<slug>.md`.
+
+**Inputs:**
+- The approved story, ADR, test plan
+- The implementation diff (use `git diff` against the base branch)
+
+**Verdict:** Each review ends with **PASS**, **FAIL**, or **CHANGES REQUESTED**, with reasoning.
+
+**House rules:**
+- Review against the acceptance criteria, the ADR design, and the test coverage — not personal preference.
+- If the implementation deviates from the ADR, flag it explicitly. The ADR is the agreed contract.
+- Reference files by path with line numbers.
+
+**Gate (mandatory):** After the review verdict, link the review back into the story and ask:
+
+> Review complete. Verdict: <PASS|FAIL|CHANGES REQUESTED>. Proceed?
+
+On PASS, the feature is ready for the usual deploy chain (`cycle-staging`, then `cycle-prod`).
+On CHANGES REQUESTED or FAIL, kick back to `/implement-feature` with the specific asks.
+
+**Per-phase commit:** Commit the review report.
+
+$ARGUMENTS

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ node_modules/
 jspm_packages/
 related-repositories
 
+# Playwright runtime artifacts
+test-results/
+playwright-report/
+
 # TypeScript cache
 *.tsbuildinfo
 

--- a/.gitignore
+++ b/.gitignore
@@ -93,10 +93,13 @@ Thumbs.db
 dist/
 
 # misc — gitignore Claude Code's per-user state and worktrees, but commit
-# project-level skills so they ship with the repo for other sessions.
+# project-level skills and engineering-team harness commands so they ship
+# with the repo for other sessions.
 # Note: must use `.claude/*` (not `.claude/`) so the un-ignore for skills/
-# can re-enter the directory; git doesn't traverse fully-excluded dirs.
+# and commands/ can re-enter the directory; git doesn't traverse
+# fully-excluded dirs.
 .claude/*
 !.claude/skills/
+!.claude/commands/
 
 .pi/

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -153,6 +153,34 @@ The Router Management tab at `/tapestry/settings/relays` is the UI: it shows con
 
 The Negentropy Sync tab on the same page uses a hardcoded `KIND_PRESETS` array in `ui/src/pages/settings/RelaySettings.jsx`. Adding a kind is currently a code change (append one row). A future story ([engineering-team/stories/3-router-presets-auto-appear-in-streams.md](../engineering-team/stories/3-router-presets-auto-appear-in-streams.md) tracks a related router-preset UX improvement; a separate story will define a parallel **Negentropy preset system** mirroring how router presets work today — JSON-defined, opt-in, with the same Presets popup pattern). Until then, treat each Negentropy kind addition as a small one-line UI change.
 
+## Scheduled Tasks
+
+The **Scheduled Tasks** tab on `/tapestry/settings/relays` lets operators enable recurring background tasks with an enable toggle and a "Run every __ days, __ hours" interval (minimum 1 hour). Per-task config persists in `/var/lib/brainstorm/scheduled-tasks.json` and is restored on container restart. Each task fires independently in-process via `setInterval`, posting to `/api/run-task?taskName=<taskId>`.
+
+Currently shipped tasks:
+
+| Task ID | Title | What it does |
+|---|---|---|
+| `updateAllScoresForOwner` | Update All Scores for Owner | Runs the full owner-scoped WoT pipeline (`updateAllScoresForOwner.sh`): GrapeRank, PageRank, follower/muter/reporter counts, kind 30382 publishing, and Meilisearch score load. |
+| `refreshSearchIndex` | Refresh Meilisearch profiles & House PoV scores | Refreshes kind-0 profile data in Meilisearch (always), then — if House PoV is configured — syncs House's kind 10040 (Treasure Map) and kind 30382 (Trusted Assertions) from House's NIP-85 relay and loads House's WoT scores into Meilisearch under `wot_*_<houseSuffix>` fields. |
+
+### Dependencies for `refreshSearchIndex`
+
+The score-refresh half of `refreshSearchIndex` depends on two things being configured:
+
+1. **House PoV** — set the House `povPubkey` + `delegatedPubkey` + `nip85Relay` at **Home > My Grapevine > Search Preferences** (`PUT /api/grapevine/preferences`). If `povPubkey` or `delegatedPubkey` is unset when the task fires, the orchestrator emits a `WARN` event (`houseUnconfigured: true`), skips the score-load step, and exits 0 — the profile-resync half still completes successfully. A banner in the new card surfaces this state to the operator with a link to Search Preferences.
+2. **`treasureMaps` router preset** (recommended) — see "Router presets" above. When enabled, this keeps kind 10040 events continuously fresh in local strfry via bidirectional sync with popular relays. The `refreshSearchIndex` task also runs a *defensive* one-shot 10040 sync per fire (filtered to House's pubkey on House's `nip85Relay`), so the preset is not strictly required — but having it enabled keeps the local 10040 corpus broad rather than House-only.
+
+### Adding a new scheduled task
+
+The scheduler module (`src/api/scheduled-tasks/index.js`) is keyed by `taskId`. To add a third task:
+
+1. Append an entry to `DEFAULTS` in `src/api/scheduled-tasks/index.js` with `{ enabled: false, intervalHours: 24, intervalDays: 0 }`.
+2. Add a matching entry in `src/manage/taskQueue/taskRegistry.json` (`tasks.<taskId>`) pointing at the orchestrator script that will run when the timer fires.
+3. Add a `<ScheduledTaskCard taskId="..." title="..." hint="..." />` row inside `ScheduledTasksPanel` in `ui/src/pages/settings/RelaySettings.jsx`.
+
+No changes to the API routes or persistence layer are needed — they already route by `taskId`.
+
 ## Settings API
 
 All endpoints require **Owner** authentication (NIP-07 login).

--- a/engineering-team/decisions/0003-scheduled-search-and-house-scores-refresh.md
+++ b/engineering-team/decisions/0003-scheduled-search-and-house-scores-refresh.md
@@ -1,0 +1,137 @@
+# ADR 0003: Scheduled task to refresh Meilisearch profiles and House PoV WoT scores
+
+**Status:** Accepted
+**Date:** 2026-05-13
+**Story:** `engineering-team/stories/4-scheduled-search-and-house-scores-refresh.md`
+
+## Context
+
+Story #4 asks for a new operator-controlled scheduled task that, when enabled, periodically (a) refreshes kind-0 profile data in Meilisearch and (b) refreshes House PoV WoT scores in Meilisearch from House's latest kind 30382 Trusted Assertions. The current relevant state:
+
+- **Scheduler module** (`src/api/scheduled-tasks/index.js`): hardcoded to a single task `updateAllScoresForOwner`. Module-level state (`schedulerTimer`, `nextRunAt`, `lastRunAt`, `taskRunning`) and the three handlers (`handleStatus`, `handleUpdate`, `handleHistory`) all reference the single task name. The persisted JSON at `/var/lib/brainstorm/scheduled-tasks.json` is already keyed by task name (`{ updateAllScoresForOwner: {...} }`), so storage is extensible — only runtime state and handlers are not.
+- **Panel UI** (`ui/src/pages/settings/RelaySettings.jsx:1359-1560`): `ScheduledTasksPanel` renders one settings-group card for the existing task plus a "Recent Runs" card. Fetches `/api/scheduled-tasks/{status,history}` and POSTs `/api/scheduled-tasks/update` with `{ enabled, intervalDays, intervalHours }` — no taskId passed.
+- **House PoV** lives in `settings.grapevine.searchPreferences` (`povPubkey`, `delegatedPubkey`, `nip85Relay`, `metrics`). Readable via `GET /api/grapevine/preferences` (public route, registered at `src/api/index.js:299`). Defaults are null.
+- **Owner-side score load** (`src/algos/nip85/loadScoresIntoMeilisearch.sh` + `.js`): `.sh` does Phase 1 — `strfry sync <nip85_relay> --filter '{"kinds":[30382],"authors":["<TA_pubkey>"]}' --dir down` — then Phase 2 — invokes the `.js`, which `strfry scan`s local 30382 events, parses metric tags, and POSTs `/api/search/profiles/meili/load-scores` with `{ povPubkey, delegatedPubkey, metrics, scores }`. The `.js` is hardcoded to the owner: reads `BRAINSTORM_OWNER_PUBKEY` from config and calls `getOwnerAssistantPubkey()`.
+- **Profile ingest trigger**: `POST /api/search/profiles/meili/resync` (registered at `src/api/index.js:326`, handler `handleMeiliResync` in `src/api/search/profiles/meili/index.js:307-318`) proxies to `nostr-search-api`'s `/api/bulk-ingest` which runs `runBulkIngest()`. Callable from the tapestry container via `curl http://127.0.0.1:7778/...`.
+- **Task registry** (`src/manage/taskQueue/taskRegistry.json`): tasks invoked via `POST /api/run-task?taskName=...` must have an entry pointing to their script.
+- **Treasure Map (kind 10040) sync**: ADR 0002 (story #2) added the `treasureMaps` router preset for continuous bidirectional 10040 sync with popular relays. Operator-opt-in, defaults off. The new task should not assume the preset is enabled.
+- **Concept Graph**: `/api/concept-graph/summaries` confirms 34 foundational concepts (`graperank`, `web-of-trust`, `nostr-kind`, `nostr-event`, `nostr-user`, `nostr-relay`). NIP-85 / Trusted Assertions / Treasure Maps / House PoV / Meilisearch / Scheduled Tasks are not modeled. This ADR does not alter any concept schema. **No firmware reinstall required.**
+
+## Options considered
+
+### Option A — Generalize scheduler module + parameterize the loader (chosen)
+
+1. **Scheduler module:** Refactor `src/api/scheduled-tasks/index.js` so runtime state is keyed by `taskId`. Module-level `schedulerTimer`/`nextRunAt`/etc. become `Map<taskId, timerState>`. Handlers take `taskId` from `req.query.taskId` (GET) / `req.body.taskId` (POST) — required, no default. `DEFAULTS` becomes an object keyed by taskId with two entries (`updateAllScoresForOwner`, `refreshSearchIndex`). `initScheduler()` iterates `Object.keys(DEFAULTS)`.
+2. **Orchestrator script:** new `src/algos/refreshSearchIndex.sh`. Order: (1) fetch House PoV from `GET /api/grapevine/preferences`, (2) trigger profile resync via `POST /api/search/profiles/meili/resync`, (3) if PoV set: defensive `strfry sync` of House's kind 10040 + kind 30382 from House's NIP-85 relay, then invoke parameterized loader, (4) if PoV unset: emit a `WARN` structured event with `houseUnconfigured: true` and exit 0 (success — partial run; profile sync still happened).
+3. **Parameterize the loader:** `loadScoresIntoMeilisearch.js` accepts optional CLI args `--povPubkey` and `--delegatedPubkey`. If omitted, falls back to current owner behavior (`BRAINSTORM_OWNER_PUBKEY` + `getOwnerAssistantPubkey()`) — preserving the existing `updateAllScoresForOwner.sh` step 7 call unchanged.
+4. **Task registry:** add `refreshSearchIndex` entry in `taskRegistry.json` pointing to the new orchestrator script.
+5. **UI:** Extract the existing settings-group at `RelaySettings.jsx:1463-1510` into a `<ScheduledTaskCard taskId, title, hint, children />` sub-component. `ScheduledTasksPanel` renders two cards. New card adds a pre-run banner via `children` that fetches `/api/grapevine/preferences` and renders when `povPubkey` is unset, linking to the Search Preferences page. Recent Runs section per-task.
+
+**Pros:**
+- Smallest delta to the storage format (already keyed by task name).
+- DRY — no parallel modules, no parallel loader scripts.
+- Future scheduled tasks add as a registry entry + a card, not new modules.
+- Parameterization keeps the existing owner script unchanged at the call site.
+
+**Cons:**
+- Touches the existing scheduler module + loader script. Some regression risk for the existing Owner path (mitigated by story #4 AC-11 "existing panel unregressed" and test coverage in Phase 3).
+- Slightly more upfront work than duplication, but pays off the first time anyone adds a third task.
+
+### Option B — Duplicate the scheduler module + duplicate the loader
+
+Create `src/api/scheduled-tasks/refreshSearchIndex/index.js` as a parallel module — same shape as the existing one but hardcoded to the new task. New routes `/api/scheduled-tasks/refresh/{status,update,history}`. Clone `loadScoresIntoMeilisearch.js` as `loadHouseScoresIntoMeilisearch.js`.
+
+**Pros:**
+- Zero risk to the existing Owner code path.
+- Each module is independent.
+
+**Cons (why rejected):**
+- Parallel scheduler modules will drift. Bug fixes (e.g., the PID-polling logic at `src/api/scheduled-tasks/index.js:80-94`) must be applied twice.
+- Parallel loader scripts double the surface area for identical logic (parse 30382 → POST scores).
+- Front-end gets two panels with duplicated state-management code.
+- A third task multiplies the problem.
+
+### Option C — Add the new task inline as a second hardcoded entry (hybrid)
+
+Don't fully generalize; add a second set of module-level state vars and a second trigger function alongside the existing one. UI gets a second card written inline (no shared sub-component).
+
+**Pros:**
+- Less invasive than Option A.
+
+**Cons (why rejected):**
+- Inherits the "parallel state vars" tax of Option B at the module level, just in one file instead of two.
+- Doesn't address panel duplication.
+- Half-measure: still ends up generalizing later when the 3rd task lands. The storage format is already keyed by taskId — fighting that gives nothing back.
+
+## Decision
+
+We chose **Option A**.
+
+The persisted config is already keyed by `taskId`, which is the strongest hint that generalization is the natural shape — Options B and C both fight against the data model. The marginal cost over Option C (Map<taskId,state> vs two sets of named vars) is small, and the marginal cost over Option B (one module vs two) avoids the predictable drift between parallel modules over time. The parameterization of `loadScoresIntoMeilisearch.js` keeps the existing `updateAllScoresForOwner.sh` step 7 call unchanged.
+
+We trade away short-term simplicity of "leave the working code alone." We accept some regression risk in the existing Owner scheduler in exchange for a clean foundation that any future scheduled task can build on.
+
+## Consequences
+
+- **Enables:** A second operator-controlled scheduled task (default off), independently scheduled from the existing Owner task. Future tasks add as one registry entry + one card.
+- **Constrains:** Scheduler API now requires `taskId`. The UI is the only known caller and is updated in the same PR. If unknown external callers exist (legacy scripts, monitoring), they will fail loudly with a 400, surfacing themselves for fix-up rather than silently defaulting.
+- **New debt:** None significant. The existing 24h `runBulkIngest()` schedule in `nostr-search/src/startup.js` continues alongside the new task; reconciling them into a single source of truth for profile-sync cadence is deferred to a separate story (noted in story #4 "Out of scope").
+- **Firmware reinstall required?** No.
+
+## Implementation notes
+
+Concrete guidance for the Implementer:
+
+- **File: `src/api/scheduled-tasks/index.js`** — refactor to `Map<taskId, timerState>`. New `DEFAULTS`:
+  ```js
+  const DEFAULTS = {
+    updateAllScoresForOwner: { enabled: false, intervalHours: 24, intervalDays: 0 },
+    refreshSearchIndex:      { enabled: false, intervalHours: 24, intervalDays: 0 },
+  };
+  ```
+  Each handler reads `taskId` from `req.query.taskId` (status, history) or `req.body.taskId` (update); returns 400 if absent or unknown. The PID-tracking logic in `triggerTask` moves into a per-task closure so concurrent runs of different tasks don't interfere. `initScheduler()` iterates `Object.keys(DEFAULTS)`.
+
+- **File: `src/algos/refreshSearchIndex.sh`** — new orchestrator using the structured-logging helpers in `src/utils/structuredLogging.sh`. Pseudo-sequence:
+  ```bash
+  emit_task_event TASK_START refreshSearchIndex
+  prefs=$(curl -s http://127.0.0.1:7778/api/grapevine/preferences | jq .preferences)
+  pov=$(echo "$prefs" | jq -r '.povPubkey // empty')
+  deleg=$(echo "$prefs" | jq -r '.delegatedPubkey // empty')
+  relay=$(echo "$prefs" | jq -r '.nip85Relay // empty')
+
+  emit_task_event PROGRESS refreshSearchIndex '{"phase":"profile_resync"}'
+  curl -s -X POST http://127.0.0.1:7778/api/search/profiles/meili/resync
+
+  if [ -n "$pov" ] && [ -n "$deleg" ]; then
+    emit_task_event PROGRESS refreshSearchIndex '{"phase":"sync_house_10040"}'
+    strfry sync "$relay" --filter "{\"kinds\":[10040],\"authors\":[\"$pov\"]}" --dir down
+
+    emit_task_event PROGRESS refreshSearchIndex '{"phase":"sync_house_30382"}'
+    strfry sync "$relay" --filter "{\"kinds\":[30382],\"authors\":[\"$deleg\"]}" --dir down
+
+    emit_task_event PROGRESS refreshSearchIndex '{"phase":"load_house_scores"}'
+    node "$BRAINSTORM_NIP85_DIR/loadScoresIntoMeilisearch.js" \
+         --povPubkey "$pov" --delegatedPubkey "$deleg"
+  else
+    emit_task_event WARN refreshSearchIndex '{"houseUnconfigured":true}'
+  fi
+  emit_task_event TASK_END refreshSearchIndex
+  ```
+
+- **File: `src/algos/nip85/loadScoresIntoMeilisearch.js`** — accept optional `--povPubkey <hex>` and `--delegatedPubkey <hex>` CLI args. When both omitted, fall back to current owner behavior. The `getAssistantKeys(pubkey)` helper at `src/utils/assistantKeys.js:20` is available if a future story needs delegated-pubkey resolution from an arbitrary pubkey; not required here since House's delegated pubkey is read from settings.
+
+- **File: `src/manage/taskQueue/taskRegistry.json`** — add a `refreshSearchIndex` entry. Mirror the shape of nearby leaf-task entries; point `script`/`script_relative_path` at `src/algos/refreshSearchIndex.sh`. Single category `algorithms` or `network` (Architect leaves the category pick to the Implementer's read of the registry).
+
+- **File: `ui/src/pages/settings/RelaySettings.jsx`** — extract `RelaySettings.jsx:1463-1510` (the existing settings-group div) into a `<ScheduledTaskCard>` sub-component with props `{ taskId, title, hint, banner? }`. Refactor `ScheduledTasksPanel` to render two cards. New card props: `taskId="refreshSearchIndex"`, `title="Refresh Meilisearch profiles & House PoV scores"`, plus a `banner` prop containing a `<HousePovUnconfiguredBanner />` that fetches `/api/grapevine/preferences` once on mount and conditionally renders. The banner should link to the Search Preferences route (Implementer: verify the exact route in the existing Search Preferences page before hardcoding).
+
+  The card fetches `/api/scheduled-tasks/status?taskId=<id>` and `/api/scheduled-tasks/history?taskId=<id>`, and POSTs to `/api/scheduled-tasks/update` with `{ taskId, enabled, intervalDays, intervalHours }`. Recent Runs table renders per-task.
+
+- **File: `BIBLE.md` or `docs/CONFIGURATION.md`** — add a short paragraph: "Scheduled Tasks tab now hosts two independently-controllable tasks: 'Update All Scores for Owner' (existing) and 'Refresh Meilisearch profiles & House PoV scores' (new). The latter depends on (a) House PoV being configured at Home > My Grapevine > Search Preferences, and (b) for kind 10040 freshness, the `treasureMaps` router preset being enabled — though the task also runs a defensive one-shot 10040 sync per fire."
+
+## Out of scope
+
+- **Replacing the built-in 24h `runBulkIngest()` schedule in `nostr-search/src/startup.js`.** A future story can make that scheduler a no-op when the new admin-controlled task is enabled (or wire both through a single source of truth).
+- **Author allowlists, per-task throttling, dynamic relay overrides** beyond the schedule controls.
+- **A House PoV preset/shortcut UI** for configuring the pubkey from the new panel — Search Preferences page owns that.
+- **Generalizing `loadScoresIntoMeilisearch.js` to N observers in a loop.** This ADR adds support for one named observer (House); N-observer generalization can come if a future story needs it.
+- **Cleaning up the `/etc/strfry-router-tapestry.config` missing-on-first-boot issue** observed during local bring-up. Separate follow-up.

--- a/engineering-team/reviews/4-scheduled-search-and-house-scores-refresh.md
+++ b/engineering-team/reviews/4-scheduled-search-and-house-scores-refresh.md
@@ -95,7 +95,7 @@ Not applicable — no concept definitions touched, no firmware files modified. A
 
 3. **`tests/brainstorm/scheduled-search-and-house-scores-refresh.spec.js`** — The Playwright spec includes a banner-visibility test that would have caught Blocking #1 by clicking the link. Before promoting to staging, recommend running the spec once (`npx playwright install` then `BRAINSTORM_BASE_URL=http://localhost npm run test:playwright`).
 
-## Verdict
+## Verdict (initial)
 
 **CHANGES_REQUESTED**
 
@@ -106,3 +106,29 @@ One blocking issue (the wrong banner URL) breaks AC-9's intent. The fix is one l
 4. (Optional) tightening the test regex per Non-blocking #1,
 
 re-run `/review-changes` and this should be PASS-ready. The other 11 ACs are fully satisfied, the ADR's design is faithfully implemented, no scope creep, no regressions in the existing Owner pipeline (live-verified via API smoke).
+
+---
+
+## Re-review (post-fix)
+
+**Date:** 2026-05-13
+**Fix commit:** `7371d58b impl-fix: correct HousePovUnconfiguredBanner href + tighten test regex (review 4 Blocking #1)`
+
+**Changes applied:**
+1. `ui/src/pages/settings/RelaySettings.jsx:1380` — href corrected from `/home/my-grapevine/search-preferences` to `/tapestry/grapevine/search-preferences`. Verified against the actual route in `ui/src/App.jsx:230` (`{ path: 'search-preferences' }` nested under `{ path: 'grapevine' }` under the `tapestry` parent) and `ui/src/components/Layout.jsx:37`.
+2. `test/scheduled-search-and-house-scores-refresh.test.js:173-180` — banner-URL assertion tightened from a permissive substring match (`/Search Preferences|search-preferences|grapevine\/search/i`) to a strict path match (`/\/tapestry\/grapevine\/search-preferences/`) — Non-blocking #1 from the initial review. The stricter regex would NOT match the previously-shipped wrong URL, so this exact class of typo cannot recur silently.
+
+**Quality gates (re-run):**
+- `npm test` — **PASS**. 12/12 in the scheduled-search-and-house-scores-refresh suite, 5/5 in the treasure-maps suite, Configuration Loading PASS, Overall PASS.
+- Source verified at `ui/src/pages/settings/RelaySettings.jsx:1380` — only one `search-preferences` occurrence and it's the corrected one.
+- UI bundle rebuilt (`✓ built in 20.14s` → `dist/assets/index-BtapSows.js`); rebuilt bundle contains the corrected URL and does **not** contain the previous wrong URL.
+
+**Non-blocking #2 (loader error wording)** — not addressed in this fix. Tracked as cosmetic; can fold into a future doc / DX pass if desired. Does not affect verdict.
+
+**Non-blocking #3 (Playwright headless install)** — still applies. Recommended to install (`npx playwright install`) before the staging promotion so the spec's banner-visibility test exercises the live route. Does not block this PASS verdict because the unit test now strictly validates the URL string.
+
+## Verdict (final)
+
+**PASS**
+
+All 12 ACs satisfied. Blocking #1 fixed; the corresponding test is now strict enough to prevent recurrence. ADR design faithfully implemented; no scope creep; no regressions in the Owner pipeline (live-verified via API smoke during cycle-local). Diff is mergeable as-is. Recommended next step: open a PR from `feat/scheduled-search-and-house-scores-refresh` → `staging` and follow the `cycle-staging` → `cycle-prod` promotion path. Before staging, recommend a one-time `npx playwright install` so the Playwright spec runs on the local stack as additional defense-in-depth.

--- a/engineering-team/reviews/4-scheduled-search-and-house-scores-refresh.md
+++ b/engineering-team/reviews/4-scheduled-search-and-house-scores-refresh.md
@@ -1,0 +1,108 @@
+# Review: Story 4 — Scheduled task to refresh Meilisearch profiles and House PoV WoT scores
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-13
+**Diff:** `git diff origin/main...HEAD` — 5 commits on `feat/scheduled-search-and-house-scores-refresh` (`40a402d9`, `4b4977c4`, `ca1c4c7e`, `fac5596f`, `fed75a62`)
+**Story:** `engineering-team/stories/4-scheduled-search-and-house-scores-refresh.md`
+**ADR:** `engineering-team/decisions/0003-scheduled-search-and-house-scores-refresh.md` (Option A — generalize scheduler + parameterize loader)
+**Test plan:** `engineering-team/stories/4-scheduled-search-and-house-scores-refresh.test-plan.md`
+
+## Quality gates (run by reviewer, not trusted)
+
+- **`npm test`** — **PASS**. Output:
+  ```
+  Configuration Loading:                           PASS
+  treasure-maps-router-preset suite:               PASS (5 passed, 0 failed)
+  scheduled-search-and-house-scores-refresh suite: PASS (12 passed, 0 failed)
+  Overall:                                         PASS
+  ```
+- **`npm run test:playwright`** — *Not run.* The Playwright browser binary is not installed locally (`npx playwright install` needed; ~200MB chromium download). The Playwright spec at `tests/brainstorm/scheduled-search-and-house-scores-refresh.spec.js` will be exercised against staging post-deploy or after a one-line install on this machine. **Note:** the spec includes a banner-visibility test that would have caught the blocking issue below — installing the browser is recommended before promoting to staging.
+- _Lint not configured — skipped._
+- _Typecheck not configured — skipped._
+- _Build not configured — skipped (UI build verified manually during cycle-local: `dist/assets/index-DIMgpJ3j.js` contains the new strings)._
+
+## Spec adherence
+
+| AC | Coverage | Status |
+|---|---|---|
+| AC-1 — new card with the prescribed title | `RelaySettings.jsx renders a card titled "Refresh Meilisearch profiles & House PoV scores"` + Playwright (deferred) | ✓ |
+| AC-2 — toggle defaults disabled | `scheduler DEFAULTS includes refreshSearchIndex with enabled:false and intervalHours:24` + Playwright (deferred) | ✓ |
+| AC-3 — days/hours inputs + 1h minimum | `handleUpdate still enforces the ≥1h minimum interval for any taskId` (regression sentinel still passes) | ✓ |
+| AC-4 — next-run / last-run displayed | covered by AC-2 toggle visibility + verified live via API smoke (POST update → status returns nextRunAt) | ✓ |
+| AC-5 — disable stops firing | covered live via API smoke (POST disable → timer cleared) | ✓ |
+| AC-6 — persistence across container restart | `initScheduler iterates per-task IDs` + the cross-process boundary uses the preexisting `tapestry-data` volume mechanism | ✓ |
+| AC-7 — full pipeline with PoV configured | orchestrator existence + four-phase grep + loader parameterization tests | ✓ |
+| AC-8 — unset PoV → warn + exit 0 | `refreshSearchIndex.sh handles unset House PoV with a WARN event and does not fail the run` | ✓ |
+| AC-9 — pre-run banner linking to Search Preferences | banner text + povPubkey dependency + Search Preferences reference asserted in tests; **see Blocking #1 — link target is wrong** | ❌ |
+| AC-10 — per-task history display | covered by ADR-constraint test (`handlers read taskId from req`) + live API smoke confirming history filters by taskId | ✓ |
+| AC-11 — existing Owner panel unregressed | `loadScoresIntoMeilisearch.sh still invokes the .js with no CLI args` regression sentinel + live API smoke confirmed enabling refreshSearchIndex does not touch updateAllScoresForOwner state | ✓ |
+| AC-12 — docs note | `BIBLE.md or docs/CONFIGURATION.md mentions the new task title and dependencies` | ✓ |
+
+11 of 12 ACs fully satisfied. **AC-9 has the right banner copy and dependency-fetching wiring but the link target is a non-existent route**, breaking the operator's path from the banner to the configuration page.
+
+## ADR adherence
+
+- Files changed match ADR Implementation notes:
+  - `src/api/scheduled-tasks/index.js` — taskId-keyed `Map<taskId, timerState>`, handlers require taskId, `initScheduler` iterates `Object.keys(DEFAULTS)`. ✓
+  - `src/algos/refreshSearchIndex.sh` — new orchestrator, four phases (preferences read → profile resync → conditional 10040+30382 sync → conditional loader). Uses `structuredLogging.sh` helpers with the correct 4-arg signature. ✓
+  - `src/algos/nip85/loadScoresIntoMeilisearch.js` — `parseArgs` exported, `require.main === module` guard, optional `--povPubkey`/`--delegatedPubkey` with owner-default fallback. ✓
+  - `src/manage/taskQueue/taskRegistry.json` — `refreshSearchIndex` entry pointing at the new script. ✓
+  - `ui/src/pages/settings/RelaySettings.jsx` — `<ScheduledTaskCard>` sub-component extracted; two cards rendered; `<HousePovUnconfiguredBanner>` reads `/api/grapevine/preferences` and renders only when `povPubkey` is unset. ✓
+  - `docs/CONFIGURATION.md` — new "Scheduled Tasks" section with both task descriptions and the two dependencies (House PoV, treasureMaps preset). ✓
+- No new dependencies. No neighboring refactor. Scope inside ADR.
+- The ADR explicitly noted: *"The banner should link to the Search Preferences route (Implementer: verify the exact route in the existing Search Preferences page before hardcoding)."* This verification step was missed — see Blocking #1.
+
+## Concept-graph integrity
+
+Not applicable — no concept definitions touched, no firmware files modified. ADR explicitly stated "No firmware reinstall required." Verified `firmware/` directory unchanged in diff.
+
+## Things tests can't catch
+
+- **Secrets / credentials:** None added. ✓
+- **Debug logging:** All `console.log` additions in `src/api/scheduled-tasks/index.js` are operational logs prefixed with `[scheduled-tasks]`, matching the module's existing logging pattern. Same for the orchestrator's `echo "$(date): ..."` lines (matching `loadScoresIntoMeilisearch.sh` style). ✓
+- **Commented-out code:** None. ✓
+- **Leftover TODOs / FIXMEs:** None. ✓
+- **`emit_task_event` signature compliance:** The orchestrator calls follow `emit_task_event "<event_type>" "<task_name>" "<target>" "<metadata_json>"` per `src/utils/structuredLogging.sh:149-153`. All 10 call sites verified. ✓
+- **Bash injection safety:** `$pov` and `$deleg` are interpolated into JSON filter strings passed to `strfry sync`. Source is the operator-controlled `/api/grapevine/preferences` settings, which are hex pubkey strings (no quotes or shell metacharacters). The Settings API has its own input validation. ✓
+- **Concurrency on `taskRunning` flag:** Node is single-threaded; the flag is set/reset within a single async chain per task. Two tasks have independent state via `getTimerState(taskId)`. ✓
+- **`req.body` undefined check:** The new code uses `req.body.taskId` directly. This is consistent with the existing handler pattern and relies on the app-wide `express.json()` middleware. No regression. ✓
+- **JSON validity in `taskRegistry.json`:** Verified by the test's `JSON.parse(...)` which would have failed if the new entry broke the file. ✓
+- **Owner-side regression:** Live API smoke confirmed `updateAllScoresForOwner` status/handlers continue to work and that toggling `refreshSearchIndex` doesn't bleed state. Existing `loadScoresIntoMeilisearch.sh` invocation unchanged (regression sentinel test passes). ✓
+
+## House rules check
+
+- No new lint / typecheck / build tooling added. ✓
+- Concept Graph API authority — not touched. ✓
+- Firmware reinstall — not applicable. ✓
+- No skipped hooks / no destructive git operations. ✓
+- Committer identity warning persists across all 5 commits (user opted to keep as-is earlier in the session); not a blocking issue. ✓
+
+## Findings
+
+### Blocking
+
+1. **`ui/src/pages/settings/RelaySettings.jsx:1380`** — The `HousePovUnconfiguredBanner`'s `<a href="/home/my-grapevine/search-preferences">` points to a route that does not exist.
+   - **Actual route** per `ui/src/App.jsx:230` (`{ path: 'search-preferences', element: <SearchPreferences /> }` nested under `path: 'grapevine'`) and `ui/src/components/Layout.jsx:37`: `/tapestry/grapevine/search-preferences`.
+   - **Effect on AC-9**: the banner copy is correct ("House PoV is not configured — the score-refresh half will be skipped until you set it in Search Preferences") but clicking the link would 404 the operator, breaking the banner's purpose as a guided path from the warning to the configuration page.
+   - **Root cause**: the ADR Implementation notes explicitly flagged this verification step ("Implementer: verify the exact route in the existing Search Preferences page before hardcoding"). The Implementer (me, in the prior phase) conflated the UI breadcrumb display ("Home > My Grapevine > Search Preferences") with the URL route.
+   - **Asked change**: Update the `href` to `/tapestry/grapevine/search-preferences`.
+
+### Non-blocking
+
+1. **`test/scheduled-search-and-house-scores-refresh.test.js:185-187`** — The banner-link assertion `assert(/Search Preferences|search-preferences|grapevine\/search/i.test(src), ...)` matches the wrong URL because `search-preferences` is a substring of both `/home/my-grapevine/search-preferences` (the bug) and `/tapestry/grapevine/search-preferences` (the fix). After Blocking #1 is fixed, tightening the regex (e.g. `/\/tapestry\/grapevine\/search-preferences/.test(src)`) would prevent this exact recurrence. Not blocking the merge, but worth a one-line test hardening pass alongside the fix.
+
+2. **`src/algos/nip85/loadScoresIntoMeilisearch.js:23-25`** — When neither `--povPubkey` nor `BRAINSTORM_OWNER_PUBKEY` is available, the error message reads "povPubkey not provided and BRAINSTORM_OWNER_PUBKEY not configured". On the owner default path (no CLI args), this can read as if the operator did something wrong by not providing `--povPubkey` — when actually they didn't intend to. A clearer message: "BRAINSTORM_OWNER_PUBKEY not configured (and no --povPubkey CLI override provided)". Cosmetic.
+
+3. **`tests/brainstorm/scheduled-search-and-house-scores-refresh.spec.js`** — The Playwright spec includes a banner-visibility test that would have caught Blocking #1 by clicking the link. Before promoting to staging, recommend running the spec once (`npx playwright install` then `BRAINSTORM_BASE_URL=http://localhost npm run test:playwright`).
+
+## Verdict
+
+**CHANGES_REQUESTED**
+
+One blocking issue (the wrong banner URL) breaks AC-9's intent. The fix is one line. After:
+1. Fixing `ui/src/pages/settings/RelaySettings.jsx:1380` to `/tapestry/grapevine/search-preferences`,
+2. Rebuilding the UI (`npm --prefix ui run build`),
+3. Confirming `npm test` still PASS, and
+4. (Optional) tightening the test regex per Non-blocking #1,
+
+re-run `/review-changes` and this should be PASS-ready. The other 11 ACs are fully satisfied, the ADR's design is faithfully implemented, no scope creep, no regressions in the existing Owner pipeline (live-verified via API smoke).

--- a/engineering-team/stories/4-scheduled-search-and-house-scores-refresh.md
+++ b/engineering-team/stories/4-scheduled-search-and-house-scores-refresh.md
@@ -67,5 +67,5 @@ None at draft time — initial uncertainty (unset-PoV behavior, panel title, pre
 ## Linked artifacts
 
 - ADR: `engineering-team/decisions/0003-scheduled-search-and-house-scores-refresh.md`
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/4-scheduled-search-and-house-scores-refresh.test-plan.md`
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/4-scheduled-search-and-house-scores-refresh.md
+++ b/engineering-team/stories/4-scheduled-search-and-house-scores-refresh.md
@@ -1,0 +1,71 @@
+# Story 4: Scheduled task to refresh Meilisearch profiles and House PoV WoT scores
+
+**Status:** Approved
+**Created:** 2026-05-13
+**Type:** Feature
+
+## Background
+
+The Brainstorm search experience depends on two pieces of state being kept fresh in Meilisearch:
+
+1. **Kind-0 (profile) data** — the searchable corpus. Today this is refreshed by `runBulkIngest()` in `nostr-search/src/bulk-ingest.js`, called on a 24h cadence from `nostr-search/src/startup.js`. Operators have no UI control over this cadence.
+2. **House PoV WoT scores** — per-profile WoT trust scores from the House perspective, derived from kind 30382 (Trusted Assertions) events published by House. Today the only loader into Meilisearch is `src/algos/nip85/loadScoresIntoMeilisearch.sh`, hardcoded to the Owner's pubkey — there is no scheduled task that keeps House's scores fresh.
+
+The existing "Update All Scores for Owner" panel is the closest precedent: a toggle + days/hours schedule for a recurring task that (among other things) computes and loads Owner's scores into Meilisearch. It does not address House (a different remote pubkey on this node), and it does not refresh kind-0 profile data.
+
+Because House is a remote pubkey, this node cannot publish kind 10040 or 30382 on House's behalf — we can only sync House's externally-published events into local strfry. Per project stance, the latest kind 30382 events are the single source of truth for House's scores (Neo4j is not), so the task does not recompute scores — it ensures the latest TAs are present locally and then loads them into Meilisearch.
+
+## User-facing description
+
+**As an operator of a Brainstorm instance**, I want a Scheduled Tasks panel that, when enabled, periodically (a) refreshes kind-0 profile data in Meilisearch and (b) refreshes House PoV WoT scores in Meilisearch from the latest House-published Trusted Assertions, **so that** search results stay current with the latest profiles and reflect the latest House-perspective trust signals without manual intervention.
+
+## Acceptance criteria
+
+- [ ] On Home > Settings > Relays > Scheduled Tasks tab, a **new panel titled "Refresh Meilisearch profiles & House PoV scores"** appears below the existing "Update All Scores for Owner" panel.
+- [ ] The new panel has an **enable/disable toggle**, default **disabled** on a fresh deploy.
+- [ ] The new panel has **"Run every __ days, __ hours"** inputs matching the existing panel's UX, with the same minimum-interval validation (≥ 1 hour).
+- [ ] When the operator enables the panel and saves a schedule, the task runs on that cadence; the panel surfaces **next-run** and **last-run** times consistent with the existing panel.
+- [ ] When the operator disables the panel, the task stops firing on the next scheduler tick.
+- [ ] Toggle state and schedule values **persist across container restarts** — toggling on, then redeploying, results in the panel still on with the same schedule.
+- [ ] When the task fires with **House PoV configured** (`grapevine.searchPreferences.povPubkey` and `delegatedPubkey` both set), it:
+  - Ensures the latest House kind 10040 (Treasure Map) and kind 30382 (Trusted Assertions) events are present in local strfry,
+  - Refreshes kind-0 profile data in Meilisearch, and
+  - Loads House's WoT scores into Meilisearch (scoped to House's pubkeys, not Owner's).
+- [ ] When the task fires with **House PoV not configured** (povPubkey unset in Search Preferences), the task does **not** fail the entire run — it still refreshes kind-0 profiles, logs a structured warning that the score-load step was skipped, and surfaces the warning in the panel's run history.
+- [ ] When House PoV is unset, the panel **displays a pre-run status banner** with text along the lines of "House PoV is not configured — the score-refresh half will be skipped until you set it in Search Preferences." The banner links to Home > My Grapevine > Search Preferences. The banner disappears once povPubkey is configured.
+- [ ] The new panel has a **recent execution history** display matching the existing panel's history table.
+- [ ] The existing "Update All Scores for Owner" panel continues to work unchanged — its toggle, schedule, run history, and underlying task chain are not regressed.
+- [ ] Documentation: a brief note in `BIBLE.md` or `docs/CONFIGURATION.md` describes the new scheduled task and its dependency on (a) House PoV being configured in Search Preferences and (b) the `treasureMaps` router preset being enabled (or one-shot 10040 syncs being done) so the local 10040/30382 corpus has House's events.
+
+## Concepts touched
+
+To be resolved by the Architect via `/api/concept-graph/summaries`:
+
+- Kind 10040 (TA Treasure Map / NIP-85)
+- Kind 30382 (Trusted Assertion / NIP-85)
+- House PoV (Point of View)
+- Owner / Owner PoV
+- Tapestry Assistant (TA) pubkey / delegated signer
+- Meilisearch profile index
+- Scheduled Tasks subsystem (existing)
+- strfry-router preset system (existing — see story #2)
+
+## Out of scope
+
+- **Recomputing House's scores locally.** Per project stance, kind 30382 events are the source of truth.
+- **Publishing kind 10040 or kind 30382 on House's behalf.** House is a remote pubkey.
+- **Changes to the existing "Update All Scores for Owner" task or panel** beyond what's needed to avoid regression.
+- **Disabling the built-in 24h profile re-ingest in `nostr-search/src/startup.js`.** It keeps running on its own cadence; this task adds an *additional* operator-controlled refresh. Reconciliation deferred to a separate story.
+- **A generalized N-task UI refactor of the Scheduled Tasks tab.** The Architect may need to generalize the scheduler module internally, but no user-facing UI overhaul.
+- **A House PoV preset / shortcut UI for configuring the pubkey.** Search Preferences page already owns that; this panel consumes what's already configured there.
+- **Author allowlists, custom relay overrides, or per-task throttling** beyond enable/disable + days/hours.
+
+## Open questions
+
+None at draft time — initial uncertainty (unset-PoV behavior, panel title, pre-run banner) resolved with the operator before approval.
+
+## Linked artifacts
+
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/4-scheduled-search-and-house-scores-refresh.md
+++ b/engineering-team/stories/4-scheduled-search-and-house-scores-refresh.md
@@ -66,6 +66,6 @@ None at draft time — initial uncertainty (unset-PoV behavior, panel title, pre
 
 ## Linked artifacts
 
-- ADR: (filled in after Architecture phase)
+- ADR: `engineering-team/decisions/0003-scheduled-search-and-house-scores-refresh.md`
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/4-scheduled-search-and-house-scores-refresh.md
+++ b/engineering-team/stories/4-scheduled-search-and-house-scores-refresh.md
@@ -68,4 +68,4 @@ None at draft time — initial uncertainty (unset-PoV behavior, panel title, pre
 
 - ADR: `engineering-team/decisions/0003-scheduled-search-and-house-scores-refresh.md`
 - Test plan: `engineering-team/stories/4-scheduled-search-and-house-scores-refresh.test-plan.md`
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/4-scheduled-search-and-house-scores-refresh.md` (CHANGES_REQUESTED — wrong banner URL; one-line fix pending)

--- a/engineering-team/stories/4-scheduled-search-and-house-scores-refresh.md
+++ b/engineering-team/stories/4-scheduled-search-and-house-scores-refresh.md
@@ -68,4 +68,4 @@ None at draft time — initial uncertainty (unset-PoV behavior, panel title, pre
 
 - ADR: `engineering-team/decisions/0003-scheduled-search-and-house-scores-refresh.md`
 - Test plan: `engineering-team/stories/4-scheduled-search-and-house-scores-refresh.test-plan.md`
-- Review: `engineering-team/reviews/4-scheduled-search-and-house-scores-refresh.md` (CHANGES_REQUESTED — wrong banner URL; one-line fix pending)
+- Review: `engineering-team/reviews/4-scheduled-search-and-house-scores-refresh.md` (PASS after one-line URL fix; see Re-review section)

--- a/engineering-team/stories/4-scheduled-search-and-house-scores-refresh.test-plan.md
+++ b/engineering-team/stories/4-scheduled-search-and-house-scores-refresh.test-plan.md
@@ -1,0 +1,120 @@
+# Test Plan: Story 4 — Scheduled task to refresh Meilisearch profiles and House PoV WoT scores
+
+**Story:** `engineering-team/stories/4-scheduled-search-and-house-scores-refresh.md`
+**ADR:** `engineering-team/decisions/0003-scheduled-search-and-house-scores-refresh.md`
+**Date:** 2026-05-13
+
+## Coverage map
+
+Every acceptance criterion maps to at least one automated test. Unit tests in `test/scheduled-search-and-house-scores-refresh.test.js` are file-grep / module-shape assertions — they pin down the spec without prescribing internal implementation details (e.g. `Map<taskId,state>` vs an object-keyed pattern is left to the Implementer). Playwright in `tests/brainstorm/scheduled-search-and-house-scores-refresh.spec.js` covers UI presence.
+
+| Criterion | Test name | File | Level |
+|---|---|---|---|
+| AC-1 (panel + title) | `RelaySettings.jsx renders a card titled "Refresh Meilisearch profiles & House PoV scores"` | test/scheduled-search-and-house-scores-refresh.test.js | unit (source regex) |
+| AC-1 (Playwright) | `Scheduled Tasks tab shows the Refresh Meilisearch profiles & House PoV scores card` | tests/brainstorm/scheduled-search-and-house-scores-refresh.spec.js | Playwright |
+| AC-2 (toggle defaults disabled) | `scheduler DEFAULTS includes refreshSearchIndex with enabled:false and intervalHours:24` | test/scheduled-search-and-house-scores-refresh.test.js | unit (source regex) |
+| AC-2 (Playwright) | `Refresh Meilisearch card toggle defaults to disabled state on a fresh install` | tests/brainstorm/scheduled-search-and-house-scores-refresh.spec.js | Playwright |
+| AC-3 (≥1h minimum) | `handleUpdate still enforces the ≥1h minimum interval for any taskId` | test/scheduled-search-and-house-scores-refresh.test.js | unit (regression sentinel) |
+| AC-4 (next-run/last-run shown) | covered by AC-2 toggle visibility + the existing panel's display logic surviving the refactor | (n/a — covered by manual smoke + AC-11 regression test) | — |
+| AC-5 (disable stops firing) | covered by ADR taskId-routing test + manual smoke (no setInterval-driven unit test in this project's hand-rolled runner) | (n/a — manual smoke) | — |
+| AC-6 (persistence across restart) | `initScheduler iterates per-task IDs so each enabled task is restored after restart` | test/scheduled-search-and-house-scores-refresh.test.js | unit (source regex) |
+| AC-7 (full pipeline w/ PoV) | `src/algos/refreshSearchIndex.sh exists, is executable, and orchestrates the required sequence` | test/scheduled-search-and-house-scores-refresh.test.js | unit (file + grep) |
+| AC-7 (loader parameterization) | `loadScoresIntoMeilisearch.js exports parseArgs, accepts --povPubkey + --delegatedPubkey, and is safely require()-able` | test/scheduled-search-and-house-scores-refresh.test.js | unit (file grep) |
+| AC-7 (registry) | `taskRegistry.json contains a refreshSearchIndex entry pointing at src/algos/refreshSearchIndex.sh` | test/scheduled-search-and-house-scores-refresh.test.js | unit (JSON parse) |
+| AC-8 (unset PoV graceful skip) | `refreshSearchIndex.sh handles unset House PoV with a WARN event and does not fail the run` | test/scheduled-search-and-house-scores-refresh.test.js | unit (file grep) |
+| AC-9 (pre-run banner) | `RelaySettings.jsx has a House-PoV-unconfigured banner that depends on povPubkey and links to Search Preferences` | test/scheduled-search-and-house-scores-refresh.test.js | unit (source regex) |
+| AC-9 (Playwright) | `House PoV unconfigured banner is visible when povPubkey is unset` | tests/brainstorm/scheduled-search-and-house-scores-refresh.spec.js | Playwright |
+| AC-10 (per-task history) | covered by the ADR-constraint test (`handlers read taskId from req`) — handleHistory accepts taskId by the same mechanism | (n/a — same test) | — |
+| AC-11 (Owner panel unregressed) | `loadScoresIntoMeilisearch.sh still invokes the .js with no --povPubkey/--delegatedPubkey args (owner default path preserved)` | test/scheduled-search-and-house-scores-refresh.test.js | unit (regression sentinel) |
+| AC-11 (Owner card title preserved in UI) | embedded assertion inside `RelaySettings.jsx renders a card titled …` | test/scheduled-search-and-house-scores-refresh.test.js | unit (source regex) |
+| AC-11 (Playwright) | `Existing Update All Scores for Owner card still visible (no regression)` | tests/brainstorm/scheduled-search-and-house-scores-refresh.spec.js | Playwright |
+| AC-12 (docs) | `BIBLE.md or docs/CONFIGURATION.md mentions the new task title and its dependencies on House PoV + treasureMaps preset` | test/scheduled-search-and-house-scores-refresh.test.js | unit (file grep) |
+| ADR constraint (taskId required) | `scheduler handlers read taskId from req (query/body) — taskId-keyed routing per ADR Option A` | test/scheduled-search-and-house-scores-refresh.test.js | unit (source regex) |
+
+## Edge cases
+
+- [x] **taskId required, no implicit default.** Per ADR Option A, all three handlers must read `req.{query,body,params}.taskId` and 400 on missing/unknown. Covered by the ADR-constraint test.
+- [x] **Existing Owner task unregressed.** The `loadScoresIntoMeilisearch.sh` regression sentinel will flip from PASS to FAIL if the Implementer accidentally adds CLI args to the owner-side script. AC-11.
+- [x] **1h minimum survives the taskId refactor.** Validation regression sentinel.
+- [x] **PoV unset is not a failure.** The unset-path test asserts the orchestrator exits 0 and emits `houseUnconfigured:true` — so a partial-run (profile sync only) is success, not failure.
+- [x] **Owner card title preserved.** The UI title test asserts both `Refresh Meilisearch …` (new) AND `Update All Scores for Owner` (existing) appear in `RelaySettings.jsx`, so a careless refactor that drops the existing title trips it.
+- [x] **ScheduledTasksPanel remains the host.** The UI title test also asserts the existing `ScheduledTasksPanel` symbol is present — rules out a parallel-module duplication path (Option B).
+
+## Not covered
+
+- **AC-4 / AC-5 live setInterval firing.** Testing that the timer actually fires on schedule requires real-time wait or fake-timer injection — outside the project's hand-rolled Node runner conventions. Verified manually on staging by enabling the schedule on a short interval and observing the scheduler log lines + next-run timestamp updating.
+- **AC-6 actual cross-container restart.** Tested by asserting `initScheduler` iterates per-task; the cross-process boundary is exercised by the existing `tapestry-data` Docker named volume the existing scheduler already relies on. Verified by smoke-test post-deploy: enable on staging, redeploy, confirm still on.
+- **AC-7 live profile bulk-ingest end-to-end.** Requires `nostr-search-api` up + populated strfry. Verified manually on staging after deploy.
+- **AC-7 live kind-30382 sync from a real NIP-85 relay.** Requires network + external relay availability + a real House publishing TAs. Verified manually after House PoV is configured on staging.
+- **AC-7 live House score load into Meilisearch.** End-to-end check that scores actually appear under `wot_*_<houseSuffix>` fields in Meilisearch documents. Verified manually by `GET /api/search/profiles/meili/document/<pubkey>` post-deploy with House PoV set.
+- **AC-10 history fixture data.** Fixture-based assertion that a specific events.jsonl produces specific filtered runs is deferred — the handler-routes-by-taskId test confirms the wiring, and the runtime correctness of the existing `getRecentRuns` filtering is already exercised by the Owner task in production.
+
+## Test infrastructure
+
+- **Test framework:** project's existing hand-rolled Node runner (`test/test.js`). Playwright for browser flows.
+- **No new dependencies.** Unit tests use only `fs`, `path`, `require()`.
+- **Module export requirement (for unit testability):**
+  - `src/algos/nip85/loadScoresIntoMeilisearch.js` must export `parseArgs(argv)` and guard `main()` with `if (require.main === module)` so it is safely `require()`-able from tests. This is the same precedent as story 2's `generateConfig` export — the test drives the export to enable observability.
+- **Playwright preconditions:**
+  - A reachable Brainstorm instance with the Implementer's changes deployed. Defaults to `BRAINSTORM_BASE_URL` env var or `http://localhost:8080`.
+  - For the unconfigured-banner test: House PoV must be unset (the default on a fresh install). On an instance where House PoV has been set, that one test will fail until the operator clears it — by design.
+
+## How to run
+
+Unit tests:
+```
+npm test
+```
+
+Playwright against local stack:
+```
+npm run test:playwright
+```
+
+Playwright against staging:
+```
+BRAINSTORM_BASE_URL=https://staging.brainstorm.world npm run test:playwright
+```
+
+## Verification
+
+The new tests fail on the pre-implementation tree. Confirmed at commit `ca1c4c7e` (`adr: 0003-scheduled-search-and-house-scores-refresh`):
+
+```
+scheduled-search-and-house-scores-refresh suite:
+  ✗ scheduler DEFAULTS includes refreshSearchIndex with enabled:false and intervalHours:24
+      src/api/scheduled-tasks/index.js DEFAULTS must include `refreshSearchIndex: { enabled: false, intervalHours: 24, intervalDays: 0 }` (per ADR 0003 implementation notes)
+  ✗ scheduler handlers read taskId from req (query/body) — taskId-keyed routing per ADR Option A
+      scheduler handlers must read taskId from req (e.g. req.query.taskId / req.body.taskId) so /api/scheduled-tasks/* can route per task — per ADR 0003 Option A
+  ✓ handleUpdate still enforces the ≥1h minimum interval for any taskId
+  ✗ initScheduler iterates per-task IDs so each enabled task is restored after restart
+      initScheduler must iterate per-task IDs (e.g. Object.keys(DEFAULTS) or for-of taskIds) so refreshSearchIndex restores independently of updateAllScoresForOwner — AC-6
+  ✗ src/algos/refreshSearchIndex.sh exists, is executable, and orchestrates the required sequence
+      src/algos/refreshSearchIndex.sh must exist (new orchestrator script per ADR 0003)
+  ✗ refreshSearchIndex.sh handles unset House PoV with a WARN event and does not fail the run
+      ENOENT: no such file or directory, open '.../src/algos/refreshSearchIndex.sh'
+  ✗ taskRegistry.json contains a refreshSearchIndex entry pointing at src/algos/refreshSearchIndex.sh
+      taskRegistry.json tasks.refreshSearchIndex must exist (per ADR 0003 implementation notes) — required for POST /api/run-task?taskName=refreshSearchIndex to resolve
+  ✗ loadScoresIntoMeilisearch.js exports parseArgs, accepts --povPubkey + --delegatedPubkey, and is safely require()-able
+      loadScoresIntoMeilisearch.js must export `parseArgs(argv)` for unit testability — the parameterization per ADR 0003
+  ✓ loadScoresIntoMeilisearch.sh still invokes the .js with no --povPubkey/--delegatedPubkey args (owner default path preserved)
+  ✗ RelaySettings.jsx renders a card titled "Refresh Meilisearch profiles & House PoV scores"
+      RelaySettings.jsx must contain the literal title "Refresh Meilisearch profiles & House PoV scores" (AC-1)
+  ✗ RelaySettings.jsx has a House-PoV-unconfigured banner that depends on povPubkey and links to Search Preferences
+      Banner text must include "House PoV is not configured" so operators see the dependency (AC-9)
+  ✗ BIBLE.md or docs/CONFIGURATION.md mentions the new task title and its dependencies on House PoV + treasureMaps preset
+      docs must mention the new task by its UI title
+
+Test Results
+-------------
+Configuration Loading:                           PASS
+treasure-maps-router-preset suite:               PASS (5 passed, 0 failed)
+scheduled-search-and-house-scores-refresh suite: FAIL (2 passed, 10 failed)
+Overall:                                         FAIL
+```
+
+- 10 failing tests, each with a message that directly identifies what the Implementer needs to add — no typo / import-error failures.
+- 2 already-passing tests are intentional regression sentinels: they will flip to FAIL if the Implementer accidentally drops the 1h-minimum validation or adds CLI args to the owner-side `loadScoresIntoMeilisearch.sh`.
+- Story 2's suite remains 5/5 passing — no collateral regression from the new tests.
+
+Playwright spec at `tests/brainstorm/scheduled-search-and-house-scores-refresh.spec.js` is not run pre-implementation since it requires a deployed instance; it will be exercised against the local stack after the implementation lands and against staging post-deploy.

--- a/engineering-team/stories/_intake.md
+++ b/engineering-team/stories/_intake.md
@@ -1,0 +1,32 @@
+# Intake Log
+
+Append-only log of incoming requests, raw, with classification and chosen phase path.
+
+---
+
+## 2026-05-13 — Scheduled task: refresh Meilisearch profiles + House PoV WoT scores
+
+**Raw request (verbatim):**
+
+> In the tapestry repository, there is a new feature I would like to add in the Home > Settings > Relays page, Scheduled Tasks tab. Currently, there is a panel to Update All Scores for Owner that can be enabled / disabled and that can be set to run on a schedule. I would like to create a new panel that Meilisearch profiles and House PoV wot scores are kept updated. Like the existing panel, it should have an enable / disable toggle button (default: disabled) and the ability to set it to Run ever __ days, __ hours.
+>
+> We will code up the feature on a local branch, then push it to staging, then to main, as per our usual routine.
+>
+> Does this make sense? What questions or recommendations do you have?
+
+**Follow-up (verbatim):**
+
+> One question before we begin: Does your current plan include updating the House PoV Treasure Map (kind 10040 event) and all Trusted Assertions (kind 30382 events)? We will want to do that before loading WoT scores into Meilisearch.
+
+**Clarifications captured in the pre-intake conversation:**
+
+- House PoV is a *different* pubkey from Owner; configured by the admin at Home > My Grapevine > Search Preferences (persisted in `settings.json` under `grapevine.searchPreferences.povPubkey` / `delegatedPubkey` / `nip85Relay`).
+- House is a remote pubkey on this node — we do **not** publish on its behalf; we sync its externally-published 10040 and 30382 events into local strfry.
+- The latest Trusted Assertions (kind 30382) are the **single source of truth** for House's scores. Neo4j is not. Therefore the task does not recompute scores — it ensures the latest TAs are present locally, then loads them into Meilisearch.
+- Task scope: profile sync + score reload only — no GrapeRank recompute. The full Owner-side score recompute remains the responsibility of the existing "Update All Scores for Owner" task.
+- UI shape: one combined panel with one shared schedule (enable toggle + days/hours), matching the existing panel's UX. Default disabled.
+- Process: user opted to run this feature through the project's Product Owner → Architect → Tester → Implementer → Reviewer harness.
+
+**Classification:** Feature
+**Strictness:** Standard
+**Phase path:** Planning → Architecture → Test Design → Implementation → Review (all five phases apply per Standard / Feature)

--- a/src/algos/nip85/loadScoresIntoMeilisearch.js
+++ b/src/algos/nip85/loadScoresIntoMeilisearch.js
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
 
 /**
- * Load Owner's WoT Scores into Meilisearch
+ * Load WoT Scores into Meilisearch
  *
- * Reads kind 30382 events from local strfry (authored by the owner's
+ * Reads kind 30382 events from local strfry (authored by an observer's
  * Tapestry Assistant), parses all metric tags, and POSTs them to the
  * Meilisearch load-scores endpoint.
+ *
+ * Defaults to the Owner perspective (BRAINSTORM_OWNER_PUBKEY +
+ * getOwnerAssistantPubkey()). Pass `--povPubkey <hex> --delegatedPubkey <hex>`
+ * to load scores for a different observer (e.g. House PoV — story #4 / ADR 0003).
  */
 
 const { execSync } = require('child_process');
@@ -14,26 +18,40 @@ const { getOwnerAssistantPubkey } = require('../../utils/assistantKeys');
 
 const SKIP_TAGS = new Set(['d']); // d-tag is the subject pubkey, not a metric
 
-async function main() {
-  // 1. Determine pubkeys
-  const ownerPubkey = getConfigFromFile('BRAINSTORM_OWNER_PUBKEY');
-  const delegatedPubkey = getOwnerAssistantPubkey();
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--povPubkey' && argv[i + 1]) {
+      out.povPubkey = argv[i + 1];
+      i++;
+    } else if (argv[i] === '--delegatedPubkey' && argv[i + 1]) {
+      out.delegatedPubkey = argv[i + 1];
+      i++;
+    }
+  }
+  return out;
+}
 
-  if (!ownerPubkey) {
-    console.error('BRAINSTORM_OWNER_PUBKEY not configured');
+async function main(overrides = {}) {
+  // 1. Determine pubkeys (overrides win; otherwise fall back to Owner)
+  const povPubkey = overrides.povPubkey || getConfigFromFile('BRAINSTORM_OWNER_PUBKEY');
+  const delegatedPubkey = overrides.delegatedPubkey || getOwnerAssistantPubkey();
+
+  if (!povPubkey) {
+    console.error('povPubkey not provided and BRAINSTORM_OWNER_PUBKEY not configured');
     process.exit(1);
   }
   if (!delegatedPubkey) {
-    console.error('Could not determine TA pubkey (delegatedPubkey)');
+    console.error('delegatedPubkey not provided and getOwnerAssistantPubkey() returned nothing');
     process.exit(1);
   }
 
   const povSuffix = delegatedPubkey.slice(0, 8);
-  console.log(`Owner pubkey: ${ownerPubkey.slice(0, 8)}...`);
+  console.log(`PoV pubkey: ${povPubkey.slice(0, 8)}...`);
   console.log(`Delegated pubkey (TA): ${delegatedPubkey.slice(0, 8)}...`);
   console.log(`POV suffix: ${povSuffix}`);
 
-  // 2. Scan local strfry for kind 30382 events
+  // 2. Scan local strfry for kind 30382 events by this delegated pubkey
   const filter = JSON.stringify({ kinds: [30382], authors: [delegatedPubkey] });
   console.log(`Scanning strfry for kind 30382 events...`);
 
@@ -101,7 +119,7 @@ async function main() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        povPubkey: ownerPubkey,
+        povPubkey,
         delegatedPubkey,
         metrics,
         scores,
@@ -123,7 +141,12 @@ async function main() {
   }
 }
 
-main().catch(err => {
-  console.error('Unhandled error:', err);
-  process.exit(1);
-});
+module.exports = { parseArgs, main };
+
+if (require.main === module) {
+  const overrides = parseArgs(process.argv.slice(2));
+  main(overrides).catch(err => {
+    console.error('Unhandled error:', err);
+    process.exit(1);
+  });
+}

--- a/src/algos/refreshSearchIndex.sh
+++ b/src/algos/refreshSearchIndex.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -o pipefail
+
+# Refresh Meilisearch profiles + (if House PoV configured) House's WoT scores.
+# Story #4 / ADR 0003.
+#
+# Phases:
+#   1. Read House PoV from /api/grapevine/preferences (povPubkey, delegatedPubkey, nip85Relay).
+#   2. Trigger profile bulk re-ingest via /api/search/profiles/meili/resync (always).
+#   3. If House PoV is configured:
+#        a. strfry sync House's kind 10040 (Treasure Map) — defensive, in case the
+#           treasureMaps router preset is disabled.
+#        b. strfry sync House's kind 30382 (Trusted Assertions) from House's NIP-85 relay.
+#        c. Run loadScoresIntoMeilisearch.js with --povPubkey + --delegatedPubkey for House.
+#      Otherwise: emit a WARN event with houseUnconfigured:true and exit 0 (the run
+#      is a partial success — profile sync still happened).
+
+source /etc/brainstorm.conf 2>/dev/null || true
+STRUCTURED_LOG_PATH="${BRAINSTORM_MODULE_BASE_DIR:-/usr/local/lib/node_modules/brainstorm}/src/utils/structuredLogging.sh"
+if [ -f "$STRUCTURED_LOG_PATH" ]; then
+    source "$STRUCTURED_LOG_PATH"
+else
+    # Fallback no-op so the script still runs in environments without the helper.
+    emit_task_event() { :; }
+fi
+
+CONTROL_PANEL_PORT="${CONTROL_PANEL_PORT:-7778}"
+NIP85_DIR="${BRAINSTORM_NIP85_DIR:-${BRAINSTORM_MODULE_BASE_DIR:-/usr/local/lib/node_modules/brainstorm}/src/algos/nip85}"
+
+emit_task_event "TASK_START" "refreshSearchIndex" "" '{"message":"Starting refreshSearchIndex","task_type":"search_index_refresh"}'
+
+# ── Phase 1: Read House PoV from settings ─────────────────────
+emit_task_event "PROGRESS" "refreshSearchIndex" "" '{"phase":"read_house_pov"}'
+prefs_json=$(curl -sf -m 10 "http://127.0.0.1:${CONTROL_PANEL_PORT}/api/grapevine/preferences" 2>/dev/null || echo '{}')
+pov=$(echo "$prefs_json" | jq -r '.preferences.povPubkey // empty' 2>/dev/null || echo "")
+deleg=$(echo "$prefs_json" | jq -r '.preferences.delegatedPubkey // empty' 2>/dev/null || echo "")
+relay=$(echo "$prefs_json" | jq -r '.preferences.nip85Relay // empty' 2>/dev/null || echo "")
+
+# ── Phase 2: Trigger profile bulk re-ingest (always) ──────────
+emit_task_event "PROGRESS" "refreshSearchIndex" "" '{"phase":"profile_resync"}'
+echo "$(date): Triggering profile bulk re-ingest via /api/search/profiles/meili/resync"
+curl -sf -m 30 -X POST "http://127.0.0.1:${CONTROL_PANEL_PORT}/api/search/profiles/meili/resync" \
+    || echo "$(date): WARNING: profile resync returned non-zero (may be partial)"
+
+# ── Phase 3: Conditional — if House PoV is configured ─────────
+if [ -n "$pov" ] && [ -n "$deleg" ]; then
+    if [ -n "$relay" ]; then
+        echo "$(date): Syncing House kind 10040 (Treasure Map) for pov ${pov:0:8}... from $relay"
+        emit_task_event "PROGRESS" "refreshSearchIndex" "$pov" '{"phase":"sync_house_10040"}'
+        strfry sync "$relay" --filter "{\"kinds\":[10040],\"authors\":[\"$pov\"]}" --dir down \
+            || echo "$(date): WARNING: strfry sync of House kind 10040 returned non-zero"
+
+        echo "$(date): Syncing House kind 30382 (Trusted Assertions) for delegated ${deleg:0:8}... from $relay"
+        emit_task_event "PROGRESS" "refreshSearchIndex" "$pov" '{"phase":"sync_house_30382"}'
+        strfry sync "$relay" --filter "{\"kinds\":[30382],\"authors\":[\"$deleg\"]}" --dir down \
+            || echo "$(date): WARNING: strfry sync of House kind 30382 returned non-zero"
+    else
+        echo "$(date): WARNING: nip85Relay not configured in Search Preferences; skipping strfry sync of House 10040+30382. Using events already in local strfry."
+    fi
+
+    echo "$(date): Loading House scores into Meilisearch"
+    emit_task_event "PROGRESS" "refreshSearchIndex" "$pov" '{"phase":"load_house_scores"}'
+    node "${NIP85_DIR}/loadScoresIntoMeilisearch.js" --povPubkey "$pov" --delegatedPubkey "$deleg"
+    LOAD_RESULT=$?
+    if [ $LOAD_RESULT -ne 0 ]; then
+        emit_task_event "TASK_ERROR" "refreshSearchIndex" "$pov" '{"message":"loadScoresIntoMeilisearch.js failed","exit_code":'"$LOAD_RESULT"'}'
+        exit 1
+    fi
+else
+    echo "$(date): WARN: House PoV is not configured (povPubkey or delegatedPubkey is empty). Skipping score-load step. Profile resync was triggered."
+    emit_task_event "WARN" "refreshSearchIndex" "" '{
+        "message":"House PoV not configured; skipping score-load step. Profile sync still completed.",
+        "houseUnconfigured":true,
+        "povPubkey":"'"$pov"'",
+        "delegatedPubkey":"'"$deleg"'"
+    }'
+fi
+
+emit_task_event "TASK_END" "refreshSearchIndex" "" '{"message":"refreshSearchIndex completed","status":"success"}'
+echo "$(date): refreshSearchIndex completed successfully"
+exit 0

--- a/src/api/scheduled-tasks/index.js
+++ b/src/api/scheduled-tasks/index.js
@@ -1,10 +1,13 @@
 /**
  * Scheduled Tasks API
  *
- * Manages a recurring timer for updateAllScoresForOwner.
+ * Manages recurring timers for one or more named tasks, keyed by taskId.
  * Config is persisted in /var/lib/brainstorm/scheduled-tasks.json.
- * The timer runs in-process via setInterval and triggers the task
- * through the existing /api/run-task endpoint.
+ * Timers run in-process via setInterval and trigger their task through
+ * the existing /api/run-task endpoint.
+ *
+ * Per ADR 0003 (Option A): generalized from a single hardcoded task to a
+ * Map<taskId, timerState>. Handlers require taskId from req.query/body.
  */
 
 const fs = require('fs');
@@ -19,13 +22,32 @@ const DEFAULTS = {
     intervalHours: 24,
     intervalDays: 0,
   },
+  refreshSearchIndex: {
+    enabled: false,
+    intervalHours: 24,
+    intervalDays: 0,
+  },
 };
 
-// ── In-memory timer state ───────────────────────────────────
-let schedulerTimer = null;
-let nextRunAt = null;
-let lastRunAt = null;
-let taskRunning = false;
+// ── Per-task in-memory timer state ──────────────────────────
+// taskId → { schedulerTimer, nextRunAt, lastRunAt, taskRunning }
+const timerState = new Map();
+
+function getTimerState(taskId) {
+  if (!timerState.has(taskId)) {
+    timerState.set(taskId, {
+      schedulerTimer: null,
+      nextRunAt: null,
+      lastRunAt: null,
+      taskRunning: false,
+    });
+  }
+  return timerState.get(taskId);
+}
+
+function isKnownTaskId(taskId) {
+  return Boolean(taskId) && Object.prototype.hasOwnProperty.call(DEFAULTS, taskId);
+}
 
 // ── Config read/write ───────────────────────────────────────
 
@@ -46,9 +68,9 @@ function writeConfig(config) {
   fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
 }
 
-function getTaskConfig() {
+function getTaskConfig(taskId) {
   const config = readConfig();
-  return config.updateAllScoresForOwner || DEFAULTS.updateAllScoresForOwner;
+  return config[taskId] || DEFAULTS[taskId];
 }
 
 // ── Scheduler logic ─────────────────────────────────────────
@@ -57,87 +79,94 @@ function totalIntervalMs(cfg) {
   return ((cfg.intervalDays || 0) * 24 + (cfg.intervalHours || 0)) * 3600000;
 }
 
-async function triggerTask() {
-  // Skip if previous run is still active
-  if (taskRunning) {
-    console.log(`[scheduled-tasks] Skipping trigger — previous updateAllScoresForOwner is still running (started at ${lastRunAt})`);
-    return;
-  }
-
-  lastRunAt = new Date().toISOString();
-  taskRunning = true;
-  const intervalMs = totalIntervalMs(getTaskConfig());
-  nextRunAt = new Date(Date.now() + intervalMs).toISOString();
-
-  console.log(`[scheduled-tasks] Triggering updateAllScoresForOwner at ${lastRunAt}`);
-  try {
-    const resp = await fetch('http://127.0.0.1:7778/api/run-task?taskName=updateAllScoresForOwner', {
-      method: 'POST',
-    });
-    const data = await resp.json();
-    console.log(`[scheduled-tasks] Task trigger response:`, data.success ? 'success' : data.message);
-
-    // Wait for task to complete by polling its process
-    if (data.execution?.pid) {
-      const pid = data.execution.pid;
-      const { execSync } = require('child_process');
-      const checkInterval = setInterval(() => {
-        try {
-          execSync(`ps -p ${pid} > /dev/null 2>&1`);
-          // Process still running, continue waiting
-        } catch {
-          // Process finished
-          clearInterval(checkInterval);
-          taskRunning = false;
-          console.log(`[scheduled-tasks] updateAllScoresForOwner completed (PID ${pid} exited)`);
-        }
-      }, 30000); // Check every 30 seconds
-    } else {
-      taskRunning = false;
+function makeTriggerTask(taskId) {
+  return async function triggerTask() {
+    const state = getTimerState(taskId);
+    if (state.taskRunning) {
+      console.log(`[scheduled-tasks] Skipping trigger — previous ${taskId} is still running (started at ${state.lastRunAt})`);
+      return;
     }
-  } catch (err) {
-    console.error(`[scheduled-tasks] Error triggering task:`, err.message);
-    taskRunning = false;
-  }
+
+    state.lastRunAt = new Date().toISOString();
+    state.taskRunning = true;
+    const intervalMs = totalIntervalMs(getTaskConfig(taskId));
+    state.nextRunAt = new Date(Date.now() + intervalMs).toISOString();
+
+    console.log(`[scheduled-tasks] Triggering ${taskId} at ${state.lastRunAt}`);
+    try {
+      const resp = await fetch(`http://127.0.0.1:7778/api/run-task?taskName=${taskId}`, {
+        method: 'POST',
+      });
+      const data = await resp.json();
+      console.log(`[scheduled-tasks] Task trigger response (${taskId}):`, data.success ? 'success' : data.message);
+
+      // Wait for task to complete by polling its process
+      if (data.execution?.pid) {
+        const pid = data.execution.pid;
+        const { execSync } = require('child_process');
+        const checkInterval = setInterval(() => {
+          try {
+            execSync(`ps -p ${pid} > /dev/null 2>&1`);
+            // Process still running, continue waiting
+          } catch {
+            clearInterval(checkInterval);
+            state.taskRunning = false;
+            console.log(`[scheduled-tasks] ${taskId} completed (PID ${pid} exited)`);
+          }
+        }, 30000); // Check every 30 seconds
+      } else {
+        state.taskRunning = false;
+      }
+    } catch (err) {
+      console.error(`[scheduled-tasks] Error triggering ${taskId}:`, err.message);
+      state.taskRunning = false;
+    }
+  };
 }
 
-function startScheduler(cfg) {
-  stopScheduler();
+function startScheduler(taskId, cfg) {
+  stopScheduler(taskId);
   const intervalMs = totalIntervalMs(cfg);
   if (intervalMs < 3600000) {
-    console.warn('[scheduled-tasks] Interval too short (< 1 hour), not starting');
+    console.warn(`[scheduled-tasks] Interval too short (< 1 hour) for ${taskId}, not starting`);
     return;
   }
-  nextRunAt = new Date(Date.now() + intervalMs).toISOString();
-  schedulerTimer = setInterval(triggerTask, intervalMs);
-  console.log(`[scheduled-tasks] Scheduler started: every ${cfg.intervalDays || 0}d ${cfg.intervalHours || 0}h (next run: ${nextRunAt})`);
+  const state = getTimerState(taskId);
+  state.nextRunAt = new Date(Date.now() + intervalMs).toISOString();
+  state.schedulerTimer = setInterval(makeTriggerTask(taskId), intervalMs);
+  console.log(`[scheduled-tasks] Scheduler started for ${taskId}: every ${cfg.intervalDays || 0}d ${cfg.intervalHours || 0}h (next run: ${state.nextRunAt})`);
 }
 
-function stopScheduler() {
-  if (schedulerTimer) {
-    clearInterval(schedulerTimer);
-    schedulerTimer = null;
-    nextRunAt = null;
-    console.log('[scheduled-tasks] Scheduler stopped');
+function stopScheduler(taskId) {
+  const state = getTimerState(taskId);
+  if (state.schedulerTimer) {
+    clearInterval(state.schedulerTimer);
+    state.schedulerTimer = null;
+    state.nextRunAt = null;
+    console.log(`[scheduled-tasks] Scheduler stopped for ${taskId}`);
   }
 }
 
 /**
- * Called once at server startup to restore the scheduler if it was enabled.
+ * Called once at server startup. Iterates every known taskId in DEFAULTS
+ * and restores the scheduler for any task whose persisted config has
+ * enabled:true. Per ADR 0003, no single task is privileged here.
  */
 function initScheduler() {
-  const cfg = getTaskConfig();
-  if (cfg.enabled) {
-    console.log('[scheduled-tasks] Restoring enabled schedule from config');
-    startScheduler(cfg);
-  } else {
-    console.log('[scheduled-tasks] Scheduler disabled in config, not starting');
+  for (const taskId of Object.keys(DEFAULTS)) {
+    const cfg = getTaskConfig(taskId);
+    if (cfg.enabled) {
+      console.log(`[scheduled-tasks] Restoring enabled schedule from config: ${taskId}`);
+      startScheduler(taskId, cfg);
+    } else {
+      console.log(`[scheduled-tasks] Scheduler disabled in config for ${taskId}, not starting`);
+    }
   }
 }
 
 // ── Task execution history ──────────────────────────────────
 
-function getRecentRuns(taskName = 'updateAllScoresForOwner', maxRuns = 5) {
+function getRecentRuns(taskName, maxRuns = 5) {
   const runs = [];
   try {
     if (!fs.existsSync(EVENTS_PATH)) return runs;
@@ -155,16 +184,9 @@ function getRecentRuns(taskName = 'updateAllScoresForOwner', maxRuns = 5) {
       } catch { /* skip bad lines */ }
     }
 
-    // Pair starts with ends (most recent first)
-    const endsByTimestamp = new Map();
-    for (const end of ends) {
-      endsByTimestamp.set(end.timestamp, end);
-    }
-
     // Walk starts in reverse (most recent first), find matching end
     for (let i = starts.length - 1; i >= 0 && runs.length < maxRuns; i--) {
       const start = starts[i];
-      // Find the first end after this start
       let matchedEnd = null;
       for (const end of ends) {
         if (new Date(end.timestamp) > new Date(start.timestamp)) {
@@ -190,10 +212,19 @@ function getRecentRuns(taskName = 'updateAllScoresForOwner', maxRuns = 5) {
 // ── API Handlers ────────────────────────────────────────────
 
 function handleStatus(req, res) {
-  const cfg = getTaskConfig();
+  const taskId = req.query.taskId;
+  if (!isKnownTaskId(taskId)) {
+    return res.status(400).json({
+      success: false,
+      error: `Unknown or missing taskId: ${taskId}. Known: ${Object.keys(DEFAULTS).join(', ')}`,
+    });
+  }
+  const cfg = getTaskConfig(taskId);
+  const state = getTimerState(taskId);
   const totalHours = (cfg.intervalDays || 0) * 24 + (cfg.intervalHours || 0);
   return res.json({
     success: true,
+    taskId,
     schedule: {
       enabled: cfg.enabled,
       intervalHours: cfg.intervalHours,
@@ -201,18 +232,25 @@ function handleStatus(req, res) {
       totalIntervalHours: totalHours,
     },
     timer: {
-      active: schedulerTimer !== null,
-      nextRunAt,
-      lastRunAt,
+      active: state.schedulerTimer !== null,
+      nextRunAt: state.nextRunAt,
+      lastRunAt: state.lastRunAt,
     },
   });
 }
 
 async function handleUpdate(req, res) {
   try {
+    const taskId = req.body.taskId;
     const { enabled, intervalHours, intervalDays } = req.body;
 
-    // Validate
+    if (!isKnownTaskId(taskId)) {
+      return res.status(400).json({
+        success: false,
+        error: `Unknown or missing taskId: ${taskId}. Known: ${Object.keys(DEFAULTS).join(', ')}`,
+      });
+    }
+
     const days = parseInt(intervalDays) || 0;
     const hours = parseInt(intervalHours) || 0;
     const totalHours = days * 24 + hours;
@@ -226,29 +264,30 @@ async function handleUpdate(req, res) {
 
     // Save
     const config = readConfig();
-    config.updateAllScoresForOwner = {
+    config[taskId] = {
       enabled: !!enabled,
       intervalHours: hours,
       intervalDays: days,
     };
     writeConfig(config);
 
-    // Start or stop timer
+    // Start or stop timer (per-task)
     if (enabled) {
-      startScheduler(config.updateAllScoresForOwner);
+      startScheduler(taskId, config[taskId]);
     } else {
-      stopScheduler();
+      stopScheduler(taskId);
     }
 
-    // Return updated status
+    const state = getTimerState(taskId);
     return res.json({
       success: true,
-      message: enabled ? `Scheduler enabled: every ${days}d ${hours}h` : 'Scheduler disabled',
-      schedule: config.updateAllScoresForOwner,
+      message: enabled ? `${taskId} enabled: every ${days}d ${hours}h` : `${taskId} disabled`,
+      taskId,
+      schedule: config[taskId],
       timer: {
-        active: schedulerTimer !== null,
-        nextRunAt,
-        lastRunAt,
+        active: state.schedulerTimer !== null,
+        nextRunAt: state.nextRunAt,
+        lastRunAt: state.lastRunAt,
       },
     });
   } catch (err) {
@@ -258,8 +297,15 @@ async function handleUpdate(req, res) {
 }
 
 function handleHistory(req, res) {
-  const runs = getRecentRuns('updateAllScoresForOwner', 5);
-  return res.json({ success: true, runs });
+  const taskId = req.query.taskId;
+  if (!isKnownTaskId(taskId)) {
+    return res.status(400).json({
+      success: false,
+      error: `Unknown or missing taskId: ${taskId}. Known: ${Object.keys(DEFAULTS).join(', ')}`,
+    });
+  }
+  const runs = getRecentRuns(taskId, 5);
+  return res.json({ success: true, taskId, runs });
 }
 
 module.exports = { handleStatus, handleUpdate, handleHistory, initScheduler };

--- a/src/manage/taskQueue/taskRegistry.json
+++ b/src/manage/taskQueue/taskRegistry.json
@@ -481,6 +481,24 @@
       "notes":"Phase 2 structured events implemented - emits TASK_START/END, CHILD_TASK_START/END/ERROR for all 5 child tasks"
     },
 
+    "refreshSearchIndex": {
+      "name": "Refresh Meilisearch profiles & House PoV scores",
+      "categories": ["network", "algorithms"],
+      "description": "Refresh Meilisearch profiles (kind 0) and, if House PoV is configured, load House's WoT scores into Meilisearch from House's latest kind 30382 Trusted Assertions. Scheduled via /api/scheduled-tasks (taskId=refreshSearchIndex).",
+      "scripts": [
+        "$BRAINSTORM_MODULE_SRC_DIR/algos/refreshSearchIndex.sh"
+      ],
+      "script": "$BRAINSTORM_MODULE_SRC_DIR/algos/refreshSearchIndex.sh",
+      "script_relative_path": "algos/refreshSearchIndex.sh",
+      "scope": "house",
+      "priority": "normal",
+      "frequency": "timer-based",
+      "status": "active",
+      "structuredLogging": true,
+      "options": {},
+      "notes": "Story #4 / ADR 0003. Profile resync runs unconditionally; House score-load runs only when grapevine.searchPreferences.povPubkey and .delegatedPubkey are both set."
+    },
+
     "updateAllScoresForSingleCustomer": {
       "name": "Update All Scores For Single Customer",
       "categories": ["customer", "algorithms"],

--- a/test/scheduled-search-and-house-scores-refresh.test.js
+++ b/test/scheduled-search-and-house-scores-refresh.test.js
@@ -170,8 +170,14 @@ test('RelaySettings.jsx has a House-PoV-unconfigured banner that depends on povP
     'Banner text must include "House PoV is not configured" so operators see the dependency (AC-9)');
   assert(/povPubkey/.test(src),
     'Banner must reference povPubkey (the settings field it checks for absence)');
-  assert(/Search Preferences|search-preferences|grapevine\/search/i.test(src),
-    'Banner must link/refer to Search Preferences (where House PoV is configured)');
+  assert(/Search Preferences/.test(src),
+    'Banner must include the "Search Preferences" link copy');
+  // Strict route check — must match the actual SearchPreferences route per ui/src/App.jsx
+  // ({ path: 'search-preferences' } nested under { path: 'grapevine' } under the 'tapestry' parent).
+  // Previously this regex permitted any string containing "search-preferences", which let a wrong
+  // route like "/home/my-grapevine/search-preferences" pass undetected — see review 4 Blocking #1.
+  assert(/\/tapestry\/grapevine\/search-preferences/.test(src),
+    'Banner href must point to the actual Search Preferences route (/tapestry/grapevine/search-preferences) so clicking it lands on the configuration page, not a 404');
 });
 
 // ── AC-12: docs ──────────────────────────────────────────────

--- a/test/scheduled-search-and-house-scores-refresh.test.js
+++ b/test/scheduled-search-and-house-scores-refresh.test.js
@@ -1,0 +1,208 @@
+/**
+ * Failing tests for story #4: scheduled task to refresh Meilisearch profiles + House PoV WoT scores.
+ * See engineering-team/stories/4-scheduled-search-and-house-scores-refresh.test-plan.md
+ *
+ * Each test maps to one or more acceptance criteria. Tests fail on the pre-implementation
+ * tree and pass once the Implementer lands the changes described in ADR 0003 (Option A).
+ *
+ * Approach: file-grep + module-require for source assertions. Behavioral / live-state
+ * assertions (cross-restart persistence, real setInterval firing) are intentionally not
+ * automated — see test-plan.md "Not covered" for the rationale.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO = path.resolve(__dirname, '..');
+const SCHEDULER_PATH = path.join(REPO, 'src/api/scheduled-tasks/index.js');
+const ORCHESTRATOR_PATH = path.join(REPO, 'src/algos/refreshSearchIndex.sh');
+const REGISTRY_PATH = path.join(REPO, 'src/manage/taskQueue/taskRegistry.json');
+const LOADER_JS_PATH = path.join(REPO, 'src/algos/nip85/loadScoresIntoMeilisearch.js');
+const LOADER_SH_PATH = path.join(REPO, 'src/algos/nip85/loadScoresIntoMeilisearch.sh');
+const RELAY_SETTINGS_PATH = path.join(REPO, 'ui/src/pages/settings/RelaySettings.jsx');
+const BIBLE_PATH = path.join(REPO, 'BIBLE.md');
+const CONFIG_DOC_PATH = path.join(REPO, 'docs/CONFIGURATION.md');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+
+// ── AC-2, AC-6: defaults / persistence shape ─────────────────
+test('scheduler DEFAULTS includes refreshSearchIndex with enabled:false and intervalHours:24', () => {
+  const src = fs.readFileSync(SCHEDULER_PATH, 'utf8');
+  assert(
+    /refreshSearchIndex\s*:\s*\{[\s\S]{0,200}enabled\s*:\s*false/.test(src),
+    'src/api/scheduled-tasks/index.js DEFAULTS must include `refreshSearchIndex: { enabled: false, intervalHours: 24, intervalDays: 0 }` (per ADR 0003 implementation notes)'
+  );
+  assert(
+    /refreshSearchIndex[\s\S]{0,300}intervalHours\s*:\s*24/.test(src),
+    'refreshSearchIndex default intervalHours must be 24 (mirrors the existing Owner task default)'
+  );
+  assert(
+    /updateAllScoresForOwner\s*:\s*\{/.test(src),
+    'DEFAULTS must still include updateAllScoresForOwner (no regression to the existing task — AC-11)'
+  );
+});
+
+// ── ADR constraint: handlers route by taskId ─────────────────
+test('scheduler handlers read taskId from req (query/body) — taskId-keyed routing per ADR Option A', () => {
+  const src = fs.readFileSync(SCHEDULER_PATH, 'utf8');
+  assert(
+    /req\.(query|body|params)\.taskId/.test(src),
+    'scheduler handlers must read taskId from req (e.g. req.query.taskId / req.body.taskId) so /api/scheduled-tasks/* can route per task — per ADR 0003 Option A'
+  );
+  assert(
+    /(status\(400\)|res\.status\(400\))[\s\S]{0,400}taskId|taskId[\s\S]{0,400}(status\(400\)|res\.status\(400\))/.test(src),
+    'handlers must return HTTP 400 when taskId is missing or unknown (ADR Option A: required, no implicit default)'
+  );
+});
+
+// ── AC-3: 1h minimum still enforced after the refactor ───────
+test('handleUpdate still enforces the ≥1h minimum interval for any taskId', () => {
+  const src = fs.readFileSync(SCHEDULER_PATH, 'utf8');
+  assert(
+    /Minimum interval is 1 hour/i.test(src) || /totalHours\s*<\s*1/.test(src),
+    'handleUpdate must enforce a ≥1h minimum interval (existing validation must survive the taskId refactor — AC-3)'
+  );
+});
+
+// ── AC-6: cold-start restoration per task ────────────────────
+test('initScheduler iterates per-task IDs so each enabled task is restored after restart', () => {
+  const src = fs.readFileSync(SCHEDULER_PATH, 'utf8');
+  // The shape isn't prescribed; what matters is that we don't hardcode a single task on startup.
+  assert(
+    /initScheduler[\s\S]{0,800}(Object\.keys\(DEFAULTS\)|for\s*\(\s*const\s+taskId|Object\.entries\(DEFAULTS\)|forEach[\s\S]{0,40}taskId)/.test(src),
+    'initScheduler must iterate per-task IDs (e.g. Object.keys(DEFAULTS) or for-of taskIds) so refreshSearchIndex restores independently of updateAllScoresForOwner — AC-6'
+  );
+});
+
+// ── AC-7: orchestrator script exists with required calls ─────
+test('src/algos/refreshSearchIndex.sh exists, is executable, and orchestrates the required sequence', () => {
+  assert(fs.existsSync(ORCHESTRATOR_PATH),
+    'src/algos/refreshSearchIndex.sh must exist (new orchestrator script per ADR 0003)');
+  const stat = fs.statSync(ORCHESTRATOR_PATH);
+  assert((stat.mode & 0o111) !== 0,
+    'src/algos/refreshSearchIndex.sh must be executable (chmod +x) — task runner spawns it as a shell script');
+
+  const src = fs.readFileSync(ORCHESTRATOR_PATH, 'utf8');
+  assert(/grapevine\/preferences/.test(src),
+    'refreshSearchIndex.sh must fetch /api/grapevine/preferences to read the House PoV (povPubkey, delegatedPubkey, nip85Relay)');
+  assert(/meili\/resync/.test(src),
+    'refreshSearchIndex.sh must POST /api/search/profiles/meili/resync to trigger profile bulk-ingest (AC-7 profile half)');
+  assert(/strfry\s+sync[\s\S]{0,200}10040/.test(src),
+    'refreshSearchIndex.sh must sync House kind 10040 via strfry (defensive, in case the treasureMaps router preset is disabled)');
+  assert(/strfry\s+sync[\s\S]{0,200}30382/.test(src),
+    'refreshSearchIndex.sh must sync House kind 30382 via strfry before loading scores into Meilisearch');
+  assert(/loadScoresIntoMeilisearch\.js[\s\S]{0,200}--povPubkey/.test(src),
+    'refreshSearchIndex.sh must invoke loadScoresIntoMeilisearch.js with --povPubkey to load House (not Owner) scores');
+  assert(/loadScoresIntoMeilisearch\.js[\s\S]{0,200}--delegatedPubkey/.test(src),
+    'refreshSearchIndex.sh must invoke loadScoresIntoMeilisearch.js with --delegatedPubkey for House');
+});
+
+// ── AC-8: graceful skip when House PoV is unset ──────────────
+test('refreshSearchIndex.sh handles unset House PoV with a WARN event and does not fail the run', () => {
+  const src = fs.readFileSync(ORCHESTRATOR_PATH, 'utf8');
+  assert(/houseUnconfigured/.test(src),
+    'refreshSearchIndex.sh must emit a structured event with houseUnconfigured:true when povPubkey is unset (AC-8 — surfaced in run history)');
+  assert(/else[\s\S]+?fi/.test(src),
+    'refreshSearchIndex.sh must have an else-branch handling the unset-PoV case');
+  // The orchestrator must not propagate a non-zero exit from the unset path.
+  // Either explicit `exit 0` at the end, or no `exit 1` on the unset path.
+  const hasExplicitSuccess = /exit\s+0\s*$/m.test(src) || /TASK_END[\s\S]*?exit\s+0/.test(src);
+  const noFailureOnUnsetPath = !/houseUnconfigured[\s\S]{0,300}exit\s+1/.test(src);
+  assert(hasExplicitSuccess || noFailureOnUnsetPath,
+    'refreshSearchIndex.sh unset-PoV path must exit 0 (success — profile sync still happened). AC-8: task must not fail the entire run.');
+});
+
+// ── AC-7: task registry entry ────────────────────────────────
+test('taskRegistry.json contains a refreshSearchIndex entry pointing at src/algos/refreshSearchIndex.sh', () => {
+  const registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
+  const entry = registry.tasks?.refreshSearchIndex;
+  assert(entry, 'taskRegistry.json tasks.refreshSearchIndex must exist (per ADR 0003 implementation notes) — required for POST /api/run-task?taskName=refreshSearchIndex to resolve');
+  const scriptPath = entry.script || entry.script_relative_path || (Array.isArray(entry.scripts) && entry.scripts[0]) || '';
+  assert(/refreshSearchIndex\.sh/.test(scriptPath),
+    `refreshSearchIndex entry must point at refreshSearchIndex.sh — got "${scriptPath}"`);
+});
+
+// ── AC-7 + AC-11: loader parameterization ────────────────────
+test('loadScoresIntoMeilisearch.js exports parseArgs, accepts --povPubkey + --delegatedPubkey, and is safely require()-able', () => {
+  const src = fs.readFileSync(LOADER_JS_PATH, 'utf8');
+  assert(
+    /module\.exports\s*=\s*\{[^}]*parseArgs|exports\.parseArgs\s*=/.test(src),
+    'loadScoresIntoMeilisearch.js must export `parseArgs(argv)` for unit testability — the parameterization per ADR 0003'
+  );
+  assert(/--povPubkey/.test(src),
+    'loadScoresIntoMeilisearch.js must handle the --povPubkey CLI arg to support House (non-owner) score loading');
+  assert(/--delegatedPubkey/.test(src),
+    'loadScoresIntoMeilisearch.js must handle the --delegatedPubkey CLI arg');
+  assert(/require\.main\s*===\s*module/.test(src),
+    'loadScoresIntoMeilisearch.js must guard main() with `if (require.main === module)` so it is safely require()-able for tests without executing main()');
+});
+
+// ── AC-11: owner script unchanged ────────────────────────────
+test('loadScoresIntoMeilisearch.sh still invokes the .js with no --povPubkey/--delegatedPubkey args (owner default path preserved)', () => {
+  const src = fs.readFileSync(LOADER_SH_PATH, 'utf8');
+  const callMatch = src.match(/node\s+[^\n]*loadScoresIntoMeilisearch\.js([^\n]*)/);
+  assert(callMatch, 'loadScoresIntoMeilisearch.sh must still invoke loadScoresIntoMeilisearch.js');
+  const argsPart = callMatch[1].trim();
+  assert(!/--povPubkey|--delegatedPubkey/.test(argsPart),
+    `Owner-side loadScoresIntoMeilisearch.sh must NOT pass --povPubkey/--delegatedPubkey (would break the owner default path — AC-11 no regression). Current args after the .js path: "${argsPart}"`);
+});
+
+// ── AC-1, AC-2: new card in UI ───────────────────────────────
+test('RelaySettings.jsx renders a card titled "Refresh Meilisearch profiles & House PoV scores"', () => {
+  const src = fs.readFileSync(RELAY_SETTINGS_PATH, 'utf8');
+  assert(
+    /Refresh Meilisearch profiles\s*&(?:amp;|amp;|)?\s*House PoV scores/.test(src),
+    'RelaySettings.jsx must contain the literal title "Refresh Meilisearch profiles & House PoV scores" (AC-1)'
+  );
+  assert(/ScheduledTasksPanel/.test(src),
+    'ScheduledTasksPanel must remain the host for both task cards (no parallel panel module)');
+  // Existing card title must remain (AC-11 no regression on the Owner card)
+  assert(/Update All Scores for Owner/.test(src),
+    'Existing "Update All Scores for Owner" card title must remain in RelaySettings.jsx (AC-11)');
+});
+
+// ── AC-9: pre-run banner ─────────────────────────────────────
+test('RelaySettings.jsx has a House-PoV-unconfigured banner that depends on povPubkey and links to Search Preferences', () => {
+  const src = fs.readFileSync(RELAY_SETTINGS_PATH, 'utf8');
+  assert(/House PoV is not configured/i.test(src),
+    'Banner text must include "House PoV is not configured" so operators see the dependency (AC-9)');
+  assert(/povPubkey/.test(src),
+    'Banner must reference povPubkey (the settings field it checks for absence)');
+  assert(/Search Preferences|search-preferences|grapevine\/search/i.test(src),
+    'Banner must link/refer to Search Preferences (where House PoV is configured)');
+});
+
+// ── AC-12: docs ──────────────────────────────────────────────
+test('BIBLE.md or docs/CONFIGURATION.md mentions the new task title and its dependencies on House PoV + treasureMaps preset', () => {
+  const bible = fs.existsSync(BIBLE_PATH) ? fs.readFileSync(BIBLE_PATH, 'utf8') : '';
+  const config = fs.existsSync(CONFIG_DOC_PATH) ? fs.readFileSync(CONFIG_DOC_PATH, 'utf8') : '';
+  const combined = bible + '\n' + config;
+  assert(/Refresh Meilisearch profiles\s*&(?:amp;|amp;|)?\s*House PoV scores/.test(combined),
+    'docs must mention the new task by its UI title');
+  assert(/House PoV/.test(combined),
+    'docs must reference the House PoV dependency (operator must configure it for the score half to run)');
+  assert(/treasureMaps/.test(combined),
+    'docs must mention the treasureMaps router preset as a complementary dependency for kind 10040 freshness');
+});
+
+// ── Runner ───────────────────────────────────────────────────
+async function run() {
+  let pass = 0;
+  let fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -24,6 +24,7 @@ function testConfigLoading() {
 }
 
 const treasureMaps = require('./treasure-maps-router-preset.test.js');
+const scheduledRefresh = require('./scheduled-search-and-house-scores-refresh.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -34,15 +35,21 @@ async function main() {
   console.log('treasure-maps-router-preset suite:');
   const treasureMapsResult = await treasureMaps.run();
 
+  console.log('\nscheduled-search-and-house-scores-refresh suite:');
+  const scheduledRefreshResult = await scheduledRefresh.run();
+
   console.log('\nTest Results');
   console.log('-------------');
-  console.log(`Configuration Loading:                ${configOk ? 'PASS' : 'FAIL'}`);
+  console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
   console.log(
-    `treasure-maps-router-preset suite:    ${treasureMapsResult.fail === 0 ? 'PASS' : 'FAIL'} (${treasureMapsResult.pass} passed, ${treasureMapsResult.fail} failed)`
+    `treasure-maps-router-preset suite:               ${treasureMapsResult.fail === 0 ? 'PASS' : 'FAIL'} (${treasureMapsResult.pass} passed, ${treasureMapsResult.fail} failed)`
+  );
+  console.log(
+    `scheduled-search-and-house-scores-refresh suite: ${scheduledRefreshResult.fail === 0 ? 'PASS' : 'FAIL'} (${scheduledRefreshResult.pass} passed, ${scheduledRefreshResult.fail} failed)`
   );
 
-  const overallOk = configOk && treasureMapsResult.fail === 0;
-  console.log(`Overall:                              ${overallOk ? 'PASS' : 'FAIL'}`);
+  const overallOk = configOk && treasureMapsResult.fail === 0 && scheduledRefreshResult.fail === 0;
+  console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }
 

--- a/tests/brainstorm/scheduled-search-and-house-scores-refresh.spec.js
+++ b/tests/brainstorm/scheduled-search-and-house-scores-refresh.spec.js
@@ -1,0 +1,79 @@
+/**
+ * Playwright UI checks for story #4: scheduled task to refresh Meilisearch profiles
+ * + House PoV WoT scores.
+ * See engineering-team/stories/4-scheduled-search-and-house-scores-refresh.test-plan.md
+ *
+ * Preconditions:
+ *   - A reachable Brainstorm instance. Defaults to BRAINSTORM_BASE_URL or http://localhost:8080.
+ *   - The Implementer's changes deployed to that instance.
+ *   - For the unconfigured-banner test: House PoV is unset in Search Preferences
+ *     (the default on a fresh install).
+ *
+ * These checks verify presence of the new card, default-off toggle, the
+ * unconfigured-banner, and continued visibility of the existing Owner card.
+ * Interaction-level tests (toggle on, save, observe scheduler tick) are out of
+ * scope for this spec — they require auth and live-state verification.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = process.env.BRAINSTORM_BASE_URL || 'http://localhost:8080';
+const RELAYS_URL = `${BASE_URL}/tapestry/settings/relays`;
+
+test.describe('Story 4 — Scheduled task: refresh Meilisearch profiles & House PoV scores', () => {
+  test('Scheduled Tasks tab shows the Refresh Meilisearch profiles & House PoV scores card', async ({ page }) => {
+    await page.goto(RELAYS_URL);
+
+    // Switch to the Scheduled Tasks tab.
+    const scheduledTab = page.getByRole('button', { name: /Scheduled Tasks/i }).or(
+      page.getByRole('tab', { name: /Scheduled Tasks/i })
+    );
+    await scheduledTab.first().click();
+
+    // The new card title should be visible.
+    await expect(page.getByText(/Refresh Meilisearch profiles\s*&\s*House PoV scores/i)).toBeVisible();
+  });
+
+  test('Existing Update All Scores for Owner card still visible (no regression)', async ({ page }) => {
+    await page.goto(RELAYS_URL);
+
+    const scheduledTab = page.getByRole('button', { name: /Scheduled Tasks/i }).or(
+      page.getByRole('tab', { name: /Scheduled Tasks/i })
+    );
+    await scheduledTab.first().click();
+
+    // The existing card must still render.
+    await expect(page.getByText(/Update All Scores for Owner/)).toBeVisible();
+  });
+
+  test('Refresh Meilisearch card toggle defaults to disabled state on a fresh install', async ({ page }) => {
+    await page.goto(RELAYS_URL);
+
+    const scheduledTab = page.getByRole('button', { name: /Scheduled Tasks/i }).or(
+      page.getByRole('tab', { name: /Scheduled Tasks/i })
+    );
+    await scheduledTab.first().click();
+
+    // Locate the new card's surrounding area.
+    const newCard = page.locator('div', {
+      has: page.getByText(/Refresh Meilisearch profiles\s*&\s*House PoV scores/i),
+    }).first();
+
+    // The card should show "Disabled" text adjacent to its toggle (matches existing panel UX).
+    await expect(newCard.getByText(/Disabled/i)).toBeVisible();
+  });
+
+  test('House PoV unconfigured banner is visible when povPubkey is unset', async ({ page }) => {
+    await page.goto(RELAYS_URL);
+
+    const scheduledTab = page.getByRole('button', { name: /Scheduled Tasks/i }).or(
+      page.getByRole('tab', { name: /Scheduled Tasks/i })
+    );
+    await scheduledTab.first().click();
+
+    // The banner copy should be present when House PoV is unconfigured (default on a fresh install).
+    await expect(page.getByText(/House PoV is not configured/i)).toBeVisible();
+    // And it should offer a way to get to Search Preferences.
+    await expect(page.getByText(/Search Preferences/i)).toBeVisible();
+  });
+});

--- a/ui/src/pages/settings/RelaySettings.jsx
+++ b/ui/src/pages/settings/RelaySettings.jsx
@@ -1377,7 +1377,7 @@ function HousePovUnconfiguredBanner() {
     <div style={{ padding: '0.5rem 0.75rem', marginBottom: '0.75rem', borderRadius: '6px',
       backgroundColor: 'rgba(245,158,11,0.1)', border: '1px solid rgba(245,158,11,0.3)', color: '#f59e0b', fontSize: '0.85rem' }}>
       ⚠️ House PoV is not configured — the score-refresh half will be skipped until you set it in{' '}
-      <a href="/home/my-grapevine/search-preferences"
+      <a href="/tapestry/grapevine/search-preferences"
         style={{ color: '#f59e0b', textDecoration: 'underline' }}>
         Search Preferences
       </a>.

--- a/ui/src/pages/settings/RelaySettings.jsx
+++ b/ui/src/pages/settings/RelaySettings.jsx
@@ -1357,7 +1357,37 @@ function StreamingETLPanel() {
 }
 
 // ── Scheduled Tasks Panel ────────────────────────────────────
-function ScheduledTasksPanel() {
+
+// Banner shown inside the refreshSearchIndex card when House PoV is not configured.
+// Reads /api/grapevine/preferences and renders only when povPubkey is falsy.
+function HousePovUnconfiguredBanner() {
+  const [povPubkey, setPovPubkey] = useState(undefined); // undefined = loading, null = unset, string = set
+
+  useEffect(() => {
+    fetch('/api/grapevine/preferences')
+      .then(r => r.json())
+      .then(d => setPovPubkey(d.preferences?.povPubkey || null))
+      .catch(() => setPovPubkey(null));
+  }, []);
+
+  if (povPubkey === undefined) return null;
+  if (povPubkey) return null;
+
+  return (
+    <div style={{ padding: '0.5rem 0.75rem', marginBottom: '0.75rem', borderRadius: '6px',
+      backgroundColor: 'rgba(245,158,11,0.1)', border: '1px solid rgba(245,158,11,0.3)', color: '#f59e0b', fontSize: '0.85rem' }}>
+      ⚠️ House PoV is not configured — the score-refresh half will be skipped until you set it in{' '}
+      <a href="/home/my-grapevine/search-preferences"
+        style={{ color: '#f59e0b', textDecoration: 'underline' }}>
+        Search Preferences
+      </a>.
+    </div>
+  );
+}
+
+// Reusable card for one taskId. Renders toggle + days/hours inputs +
+// timer status + recent-runs table, all scoped to the given task.
+function ScheduledTaskCard({ taskId, title, hint, banner = null }) {
   const [status, setStatus] = useState(null);
   const [runs, setRuns] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -1373,7 +1403,7 @@ function ScheduledTasksPanel() {
 
   const fetchStatus = useCallback(async () => {
     try {
-      const res = await fetch('/api/scheduled-tasks/status');
+      const res = await fetch(`/api/scheduled-tasks/status?taskId=${encodeURIComponent(taskId)}`);
       const data = await res.json();
       if (data.success) {
         setStatus(data);
@@ -1382,15 +1412,15 @@ function ScheduledTasksPanel() {
         setHours(data.schedule.intervalHours);
       }
     } catch (err) { flashError(err.message); }
-  }, []);
+  }, [taskId]);
 
   const fetchHistory = useCallback(async () => {
     try {
-      const res = await fetch('/api/scheduled-tasks/history');
+      const res = await fetch(`/api/scheduled-tasks/history?taskId=${encodeURIComponent(taskId)}`);
       const data = await res.json();
       if (data.success) setRuns(data.runs);
     } catch (err) { console.error('Error fetching history:', err); }
-  }, []);
+  }, [taskId]);
 
   useEffect(() => {
     Promise.all([fetchStatus(), fetchHistory()]).finally(() => setLoading(false));
@@ -1407,7 +1437,7 @@ function ScheduledTasksPanel() {
       const res = await fetch('/api/scheduled-tasks/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ enabled, intervalDays: parseInt(days) || 0, intervalHours: parseInt(hours) || 0 }),
+        body: JSON.stringify({ taskId, enabled, intervalDays: parseInt(days) || 0, intervalHours: parseInt(hours) || 0 }),
       });
       const data = await res.json();
       if (data.success) {
@@ -1437,16 +1467,10 @@ function ScheduledTasksPanel() {
     return new Date(iso).toLocaleString();
   }
 
-  if (loading) return <div style={{ padding: '2rem', textAlign: 'center', color: '#888' }}>Loading...</div>;
+  if (loading) return <div style={{ padding: '2rem', textAlign: 'center', color: '#888' }}>Loading {title}…</div>;
 
   return (
-    <div className="settings-section">
-      <h2>📅 Scheduled Tasks</h2>
-      <p className="settings-hint">
-        Automatically run the full WoT score update pipeline (<code>updateAllScoresForOwner</code>) on a recurring schedule.
-        This includes GrapeRank, PageRank, follower/muter/reporter counts, and kind 30382 event publishing.
-      </p>
-
+    <>
       {message && (
         <div style={{ padding: '0.5rem 0.75rem', marginBottom: '0.75rem', borderRadius: '6px',
           backgroundColor: 'rgba(34,197,94,0.1)', border: '1px solid rgba(34,197,94,0.3)', color: '#22c55e', fontSize: '0.85rem' }}>
@@ -1462,7 +1486,10 @@ function ScheduledTasksPanel() {
 
       {/* Schedule Control */}
       <div className="settings-group" style={{ padding: '1rem', marginBottom: '1rem' }}>
-        <h3 style={{ margin: '0 0 0.75rem', fontSize: '1rem' }}>Update All Scores for Owner</h3>
+        <h3 style={{ margin: '0 0 0.75rem', fontSize: '1rem' }}>{title}</h3>
+
+        {hint && <p style={{ fontSize: '0.85rem', color: '#aaa', margin: '0 0 0.75rem' }}>{hint}</p>}
+        {banner}
 
         <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '0.75rem' }}>
           <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
@@ -1511,9 +1538,9 @@ function ScheduledTasksPanel() {
       </div>
 
       {/* Execution History */}
-      <div className="settings-group" style={{ padding: '1rem' }}>
+      <div className="settings-group" style={{ padding: '1rem', marginBottom: '1rem' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.75rem' }}>
-          <h3 style={{ margin: 0, fontSize: '1rem' }}>Recent Runs</h3>
+          <h3 style={{ margin: 0, fontSize: '1rem' }}>Recent Runs ({title})</h3>
           <button className="btn-small" onClick={fetchHistory} style={{ fontSize: '0.8rem', padding: '0.2rem 0.5rem' }}>
             Refresh
           </button>
@@ -1549,12 +1576,36 @@ function ScheduledTasksPanel() {
         )}
 
         <div style={{ marginTop: '0.5rem', fontSize: '0.8rem' }}>
-          <a href="/legacy/task.html?taskName=updateAllScoresForOwner" target="_blank"
+          <a href={`/legacy/task.html?taskName=${encodeURIComponent(taskId)}`} target="_blank"
             style={{ color: '#60a5fa', textDecoration: 'none' }}>
             View full history &rarr;
           </a>
         </div>
       </div>
+    </>
+  );
+}
+
+function ScheduledTasksPanel() {
+  return (
+    <div className="settings-section">
+      <h2>📅 Scheduled Tasks</h2>
+      <p className="settings-hint">
+        Configure recurring background tasks. Each task below has its own enable toggle and schedule.
+      </p>
+
+      <ScheduledTaskCard
+        taskId="updateAllScoresForOwner"
+        title="Update All Scores for Owner"
+        hint={<>Run the full WoT score update pipeline (<code>updateAllScoresForOwner</code>) on a recurring schedule. Includes GrapeRank, PageRank, follower/muter/reporter counts, and kind 30382 event publishing.</>}
+      />
+
+      <ScheduledTaskCard
+        taskId="refreshSearchIndex"
+        title="Refresh Meilisearch profiles & House PoV scores"
+        hint={<>Refresh kind-0 profile data in Meilisearch and, when House PoV is configured, reload House's WoT scores from the latest kind 30382 Trusted Assertions.</>}
+        banner={<HousePovUnconfiguredBanner />}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a new operator-controlled scheduled task to Home > Settings > Relays > Scheduled Tasks: **"Refresh Meilisearch profiles & House PoV scores"**. When enabled, it periodically (a) refreshes kind-0 profile data in Meilisearch and (b) reloads House PoV WoT scores from House's latest kind 30382 Trusted Assertions. UX mirrors the existing "Update All Scores for Owner" panel — enable/disable toggle (default off), "Run every __ days, __ hours" (≥1h minimum), per-task run history.

Went through the full engineering-team flow (story → ADR → failing tests → impl → review → fix → re-review PASS). 9 commits.

## Changes

**Backend**
- `src/api/scheduled-tasks/index.js` — generalized from a single hardcoded task to `Map<taskId, timerState>`. Handlers require `taskId` from `req.query`/`req.body`; 400 on missing/unknown. `initScheduler` iterates `Object.keys(DEFAULTS)`.
- `src/algos/refreshSearchIndex.sh` (new, +x) — orchestrator. Reads House PoV from `/api/grapevine/preferences`, triggers `/api/search/profiles/meili/resync`, then if PoV is set strfry-syncs House's 10040+30382 and invokes the loader with `--povPubkey` + `--delegatedPubkey`. If PoV unset, emits a structured `WARN` with `houseUnconfigured:true` and exits 0 (the run is a partial success — profile sync still completed).
- `src/algos/nip85/loadScoresIntoMeilisearch.js` — added `parseArgs(argv)`, `require.main` guard, optional `--povPubkey`/`--delegatedPubkey` CLI args. Owner default path unchanged.
- `src/manage/taskQueue/taskRegistry.json` — `refreshSearchIndex` entry pointing at the new orchestrator.

**Frontend**
- `ui/src/pages/settings/RelaySettings.jsx` — extracted the existing card into a reusable `<ScheduledTaskCard>` sub-component, added a `<HousePovUnconfiguredBanner>` that reads `/api/grapevine/preferences` and renders only when `povPubkey` is unset (links to `/tapestry/grapevine/search-preferences`), rewrote `ScheduledTasksPanel` as a thin container rendering both cards.

**Docs / engineering-team artifacts**
- `docs/CONFIGURATION.md` — new "Scheduled Tasks" section documenting both tasks and the House-PoV + treasureMaps preset dependencies.
- `engineering-team/stories/4-…md` — user story (12 ACs).
- `engineering-team/decisions/0003-…md` — ADR (Option A: generalize scheduler + parameterize loader).
- `engineering-team/stories/4-…test-plan.md` — coverage map + edge cases + verification.
- `engineering-team/reviews/4-…md` — review (CHANGES_REQUESTED → fix → PASS).
- `engineering-team/stories/_intake.md` — Phase 0 intake log.

**Tests**
- `test/scheduled-search-and-house-scores-refresh.test.js` — 12 unit tests (file-grep + module-shape + JSON parse).
- `tests/brainstorm/scheduled-search-and-house-scores-refresh.spec.js` — 4 Playwright UI checks.
- `test/test.js` — registers the new suite.

**Harness wiring (separate concern, bundled in)**
- `.claude/commands/{plan-feature,design-architecture,design-tests,implement-feature,review-changes,discuss}.md` — the slash-command entry points referenced by CLAUDE.md / engineering-team/README.md but not yet shipped in the repo.
- `.gitignore` — added `!.claude/commands/` exception (mirrors the existing `!.claude/skills/` one) so the wiring ships with the repo; also gitignored Playwright runtime artifacts.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs and goes green.
- [ ] Smoke test on `staging.brainstorm.world` per `docs/SMOKE_TEST.md`.
- [ ] **Tier 3 (PR-specific):**
  - [ ] Navigate to `/tapestry/settings/relays`, click **Scheduled Tasks** tab.
  - [ ] Confirm the new **"Refresh Meilisearch profiles & House PoV scores"** card is visible below the existing "Update All Scores for Owner" card.
  - [ ] Toggle is `Disabled` by default.
  - [ ] If staging's House PoV is unconfigured: the warning banner is visible and its **Search Preferences** link routes to `/tapestry/grapevine/search-preferences` (no 404).
  - [ ] Existing "Update All Scores for Owner" card still works (toggle, days/hours, save, history).
  - [ ] `curl https://staging.brainstorm.world/api/scheduled-tasks/status?taskId=refreshSearchIndex` returns 200 with `enabled:false, intervalHours:24` defaults.
  - [ ] `curl https://staging.brainstorm.world/api/scheduled-tasks/status` (no taskId) returns 400.

## Notes

- Local pre-flight: `npm test` 12/12 pass in the new suite, 5/5 in story 2's suite, configuration loading PASS. Live API smoke against `localhost:7778` confirmed taskId routing + isolation between the two tasks. UI bundle confirmed to ship the corrected `/tapestry/grapevine/search-preferences` route after the review's one-line fix (commit 7371d58b).
- Playwright headless browser was not installed locally, so the new Playwright spec was not run pre-merge. Recommend running it against staging after deploy as additional defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)