### PR TITLE
docs(OPERATIONS): clarify long-lived sandbox branch convention

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -43,6 +43,8 @@ feat/foo (off staging)
     → source feature branch auto-deleted
 ```
 
+**Long-lived sandbox branches** (currently `feature-magic-carpet` and `feat/pubkey-tagging-target`, plus any future additions) follow the same convention: fork from `staging`, deploy to their own droplet via a dedicated `deploy-<name>.yml` workflow, and eventually merge back via the standard `<branch> → staging → main` path. New sandboxes get a row added to the deploy-target table above when they're stood up, plus a row in [§5 "Droplets and empirical measurements"](#5-droplets-and-empirical-measurements).
+
 For Matthias's sandbox: he PRs from his fork's `magic-carpet` branch into our `feature-magic-carpet`. Merging deploys to `magic-carpet.brainstorm.world`. Code on `feature-magic-carpet` is **not** intended for production until promoted via the standard `feature-magic-carpet → staging → main` path.
 
 ---


### PR DESCRIPTION
## Summary

OPERATIONS.md §1 had a promotion-flow diagram for short-lived `feat/*` branches but didn't explicitly call out that long-lived sandbox branches (like `feature-magic-carpet` and `feat/pubkey-tagging-target`) follow the same fork-from-staging convention. Adds one paragraph after the diagram to make this explicit and to nudge contributors to also update the §1 deploy-target table and the §5 droplet list when standing up a new sandbox.

Motivated by an in-session conversation about creating `feat/communities` as a new sandbox — the existing doc didn't say whether to fork from main or staging.

## Changes

One paragraph added to `OPERATIONS.md` (+2 lines).

Doc-only change. Per CLAUDE.md classification table → Implementer + Reviewer only, no story/ADR/test plan needed.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs (no-op for running services; only docs touched).
- [ ] `staging.brainstorm.world` stability poll reaches 3 consecutive 200s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)