### PR TITLE
Promote staging → main: OPERATIONS §1 long-lived sandbox convention

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -43,6 +43,8 @@ feat/foo (off staging)
     → source feature branch auto-deleted
 ```
 
+**Long-lived sandbox branches** (currently `feature-magic-carpet` and `feat/pubkey-tagging-target`, plus any future additions) follow the same convention: fork from `staging`, deploy to their own droplet via a dedicated `deploy-<name>.yml` workflow, and eventually merge back via the standard `<branch> → staging → main` path. New sandboxes get a row added to the deploy-target table above when they're stood up, plus a row in [§5 "Droplets and empirical measurements"](#5-droplets-and-empirical-measurements).
+
 For Matthias's sandbox: he PRs from his fork's `magic-carpet` branch into our `feature-magic-carpet`. Merging deploys to `magic-carpet.brainstorm.world`. Code on `feature-magic-carpet` is **not** intended for production until promoted via the standard `feature-magic-carpet → staging → main` path.
 
 ---


### PR DESCRIPTION
## Summary

Promotes staging to main. Docs-only change.

## Bundled

- **[#129](https://github.com/nous-clawds4/tapestry/pull/129)** — Adds one paragraph to OPERATIONS.md §1 explicitly stating that long-lived sandbox branches (`feature-magic-carpet`, `feat/pubkey-tagging-target`, future additions like `feat/communities`) follow the same fork-from-staging convention as short-lived feat branches, and nudging contributors to also update the §1 deploy-target table + §5 droplet list when standing up a new sandbox.

## Net production impact

None. Single-paragraph docs addition (`OPERATIONS.md` only, +2 lines). No code paths touched. Production redeploy is a no-op for running services.

## Verification trail

- Staging deploy of #129: [run 25837713262](https://github.com/nous-clawds4/tapestry/actions/runs/25837713262) — completed in 1m19s.
- Stability poll on `staging.brainstorm.world/api/auth/status` reached 3 consecutive 200s on attempts 1–3.

## Test plan

- [ ] After merge: `deploy-brainstorm.yml` runs to completion.
- [ ] Tier 1 stability poll on `brainstorm.world` reaches 3 consecutive 200s.
- [ ] Tier 2 sanity: standard endpoints 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)