### PR TITLE
docs: stale node_modules recovery + Playwright install note

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -16,6 +16,15 @@ This bind-mounts the repo at `/usr/local/lib/node_modules/brainstorm` inside the
 docker compose exec tapestry supervisorctl restart brainstorm
 ```
 
+### When a new dep lands
+
+If a teammate adds a dependency to `package.json` and a fresh `docker compose ... up -d` crash-loops brainstorm with `Error: Cannot find module 'X'`, the named volume `tapestry-node-modules` is stale. The dev override bind-mounts the local repo over `/usr/local/lib/node_modules/brainstorm` and then overlays the preserved named volume on its `node_modules/` — so the container sees the new `package.json` from your checkout but an older `node_modules/` from the last container build. Reinstall inside the container against the live `package.json`, then restart:
+
+```bash
+docker exec tapestry bash -c 'cd /usr/local/lib/node_modules/brainstorm && npm install --no-audit --no-fund'
+docker exec tapestry supervisorctl restart brainstorm
+```
+
 ### React UI (Vite dev server)
 
 The frontend lives in `ui/` and uses Vite for development:
@@ -38,6 +47,10 @@ npm run build
 ```
 
 This outputs to `ui/dist/`, which is served by the Express server at `/kg/`.
+
+## Testing
+
+First-time Playwright runs require `npx playwright install` to download the headless browser (~200MB; one-time per machine).
 
 ## Project Structure
 

--- a/engineering-team/roles/tester.md
+++ b/engineering-team/roles/tester.md
@@ -15,6 +15,7 @@ Read the user story and ADR. Design a test plan. Write **failing** tests that, w
 - An ADR from `engineering-team/decisions/<NNNN>-<slug>.md`.
 - The project's testing approach: Node's built-in runner via `npm test` (entry: `test/test.js`); Playwright for browser/e2e flows via `npm run test:playwright`. Test files live under `test/` and `tests/`.
 - Test command: `npm test` (or `npm run test:playwright` for browser flows).
+- First-time Playwright runs require `npx playwright install` to download the headless browser (~200MB; one-time per machine).
 
 ## Your output
 1. A test plan at `engineering-team/stories/<n>-<slug>.test-plan.md` using `engineering-team/templates/test-plan.md`.


### PR DESCRIPTION
## Summary
- Adds a "When a new dep lands" subsection to `docs/DEVELOPMENT.md` explaining the bind-mount + named-volume overlay trap: a new `package.json` dep crash-loops brainstorm with `Cannot find module 'X'` until the container reinstalls against the live `package.json`. Includes the two-line recovery (`docker exec ... npm install` + `supervisorctl restart`).
- Adds a one-line note in `docs/DEVELOPMENT.md` and `engineering-team/roles/tester.md` that first-time Playwright runs need `npx playwright install` (~200MB headless browser; one-time per machine).
- Documentation only — no code changes.

## Test plan
- [ ] Read the new "When a new dep lands" subsection in `docs/DEVELOPMENT.md` — confirm the recovery command matches what unblocked story #4's bring-up.
- [ ] Confirm the Playwright install note is present in both `docs/DEVELOPMENT.md` (Testing section) and `engineering-team/roles/tester.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)