### PR TITLE
docs: fix stale Concept Graph API port reference in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,6 @@ The harness lives in two places:
 
 ## House rules
 
-- The Concept Graph API at `http://localhost:8877` is the authoritative source for domain concepts. Always check there before reading source. See AGENTS.md for the three-call orientation pattern.
-- Reinstall firmware after adding/changing concept definitions: `curl -X POST http://localhost:8877/api/firmware/install`.
+- The Concept Graph API on the local control panel is the authoritative source for domain concepts. Always check there before reading source. See AGENTS.md §1–§3 for the port, TA pubkey, and three-call orientation pattern.
+- Reinstall firmware after adding/changing concept definitions — see AGENTS.md §6 for the exact curl.
 - Don't add new lint or typecheck tooling without an explicit ADR. This project is intentionally JS-without-build.


### PR DESCRIPTION
## Summary
- Removes a hardcoded port number for the Concept Graph API from `CLAUDE.md` house rules and redirects readers to `AGENTS.md §1–§3` for the authoritative port, TA pubkey, and three-call orientation pattern.
- Replaces the inline `curl` for firmware reinstall with a reference to `AGENTS.md §6` (same reasoning — keep the canonical recipe in one place).
- Documentation only — no code changes.

## Test plan
- [ ] Read the updated `CLAUDE.md` "House rules" section — confirm no hardcoded port number remains for the Concept Graph API and the AGENTS.md §1–§3 / §6 references are intact.
- [ ] Confirm AGENTS.md §1–§3 and §6 actually contain the referenced details (port, TA pubkey, three-call pattern, firmware curl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)