### PR TITLE
Promote staging → main: docs fix for stale Concept Graph API port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,6 @@ The harness lives in two places:
 
 ## House rules
 
-- The Concept Graph API at `http://localhost:8877` is the authoritative source for domain concepts. Always check there before reading source. See AGENTS.md for the three-call orientation pattern.
-- Reinstall firmware after adding/changing concept definitions: `curl -X POST http://localhost:8877/api/firmware/install`.
+- The Concept Graph API on the local control panel is the authoritative source for domain concepts. Always check there before reading source. See AGENTS.md §1–§3 for the port, TA pubkey, and three-call orientation pattern.
+- Reinstall firmware after adding/changing concept definitions — see AGENTS.md §6 for the exact curl.
 - Don't add new lint or typecheck tooling without an explicit ADR. This project is intentionally JS-without-build.


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`.

## Bundled

- **#132** — docs: fix stale Concept Graph API port reference in CLAUDE.md

## Net production impact

None at runtime — documentation-only change to repo-root `CLAUDE.md`. Future agents loading the file will see the corrected guidance: defer to AGENTS.md §1–§3 and §6 instead of the hardcoded `:8877` port.

## Verification trail

- #132 staging deploy: run [25842385370](https://github.com/nous-clawds4/tapestry/actions/runs/25842385370), 1m22s ✓
- Stability poll: 3/3 streak on first attempts
- Tier 2 sanity: 7 pages + 5 public APIs all 200; search regression returned non-zero hits

## Test plan

- [ ] After merge: deploy-brainstorm.yml runs to completion.
- [ ] Smoke test on brainstorm.world (Tiers 1, 2, 5 — doc-only PR, no Tier 3/4).
- [ ] Confirm prod CLAUDE.md on `origin/main` reflects the corrected guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)