### PR TITLE
Promote staging → main: dev docs for stale node_modules + Playwright install

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -16,6 +16,15 @@ This bind-mounts the repo at `/usr/local/lib/node_modules/brainstorm` inside the
 docker compose exec tapestry supervisorctl restart brainstorm
 ```
 
+### When a new dep lands
+
+If a teammate adds a dependency to `package.json` and a fresh `docker compose ... up -d` crash-loops brainstorm with `Error: Cannot find module 'X'`, the named volume `tapestry-node-modules` is stale. The dev override bind-mounts the local repo over `/usr/local/lib/node_modules/brainstorm` and then overlays the preserved named volume on its `node_modules/` — so the container sees the new `package.json` from your checkout but an older `node_modules/` from the last container build. Reinstall inside the container against the live `package.json`, then restart:
+
+```bash
+docker exec tapestry bash -c 'cd /usr/local/lib/node_modules/brainstorm && npm install --no-audit --no-fund'
+docker exec tapestry supervisorctl restart brainstorm
+```
+
 ### React UI (Vite dev server)
 
 The frontend lives in `ui/` and uses Vite for development:
@@ -38,6 +47,10 @@ npm run build
 ```
 
 This outputs to `ui/dist/`, which is served by the Express server at `/kg/`.
+
+## Testing
+
+First-time Playwright runs require `npx playwright install` to download the headless browser (~200MB; one-time per machine).
 
 ## Project Structure
 

--- a/engineering-team/roles/tester.md
+++ b/engineering-team/roles/tester.md
@@ -15,6 +15,7 @@ Read the user story and ADR. Design a test plan. Write **failing** tests that, w
 - An ADR from `engineering-team/decisions/<NNNN>-<slug>.md`.
 - The project's testing approach: Node's built-in runner via `npm test` (entry: `test/test.js`); Playwright for browser/e2e flows via `npm run test:playwright`. Test files live under `test/` and `tests/`.
 - Test command: `npm test` (or `npm run test:playwright` for browser flows).
+- First-time Playwright runs require `npx playwright install` to download the headless browser (~200MB; one-time per machine).
 
 ## Your output
 1. A test plan at `engineering-team/stories/<n>-<slug>.test-plan.md` using `engineering-team/templates/test-plan.md`.


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`.

## Bundled

- **#131** — docs: stale node_modules recovery + Playwright install note

## Net production impact

None at runtime — documentation-only change. Updates `docs/DEVELOPMENT.md` with a "When a new dep lands" subsection (named-volume + bind-mount overlay trap and the two-line recovery) and adds a one-line Playwright `npx playwright install` note to both `docs/DEVELOPMENT.md` (Testing) and `engineering-team/roles/tester.md`.

## Verification trail

- #131 staging deploy: run [25842815027](https://github.com/nous-clawds4/tapestry/actions/runs/25842815027), 1m16s ✓
- Stability poll: 3/3 streak on first attempts
- Tier 2 sanity: post-stability 502 flicker observed once; cleared after a second 3/3 stability cycle (standard one-retry per OPERATIONS §8.5). All 7 pages + 5 public APIs returned 200; search regression returned non-zero hits.

## Test plan

- [ ] After merge: deploy-brainstorm.yml runs to completion.
- [ ] Smoke test on brainstorm.world (Tiers 1, 2, 5 — doc-only PR, no Tier 3/4).
- [ ] Confirm `origin/main:docs/DEVELOPMENT.md` includes the new "When a new dep lands" subsection and Testing note; confirm `engineering-team/roles/tester.md` includes the Playwright install line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)