### PR TITLE
fix: per-query Neo4j timeout for /api/get-user-data (story #5)

### DIFF
--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -45,6 +45,8 @@ Confirm the basic surface area is up. All should HTTP 200:
 
 A "known-active" pubkey for the parameter-bearing tests: `04c915daefee38317fa734444acee390a8269fe5810b2241e5e6dd343dfbecc9` (jack).
 
+**Known gotcha (until story #6 lands):** `/api/get-user-data?pubkey=<jack>` is expected to return **HTTP 504 with `{"success":false, "message":"Neo4j query timeout…"}`** within ~15s, not 200. Jack's follow graph is large enough that the current unbounded Cypher in `src/api/export/users/queries/userdata.js` exceeds the per-query `NEO4J_QUERY_TIMEOUT_MS` deadline (story #5 added the deadline; story #6 will rewrite the Cypher to use bounded `size(...)` pattern expressions). For this pubkey on this endpoint, a 504 with a JSON body is the **expected** smoke-test outcome — a hang or a 502 is the real regression to flag. Other pubkeys (and other endpoints for Jack, like `/api/get-user-counts`) should still 200 normally.
+
 ### Tier 3 — PR-specific (depends on what changed)
 
 These are the checks that prove the actual change shipped, not just that the system is up. The cycle-* skills should pick the appropriate ones based on what's in the diff:

--- a/engineering-team/reviews/5-per-query-neo4j-timeout-safety-net.md
+++ b/engineering-team/reviews/5-per-query-neo4j-timeout-safety-net.md
@@ -1,0 +1,100 @@
+# Review: Story 5 — Per-query Neo4j timeout for `/api/get-user-data`
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-14
+**Branch:** `fix/get-user-data-neo4j-timeout` → `staging` (PR pending)
+**Diff:** `git diff origin/staging...HEAD` — three commits ahead:
+- `ab38d595` story: per-query-neo4j-timeout-safety-net
+- `82a4e2f2` test: failing tests for per-query-neo4j-timeout-safety-net (story #5)
+- `181c6596` impl: per-query-neo4j-timeout-safety-net (story #5)
+
+**Classification:** Bug / Standard / Implementer + Tester + Reviewer (Architecture skipped — fix is obvious per CLAUDE.md harness rules for Bug type).
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **PASS**. Four suites + Configuration Loading all green:
+  - Configuration Loading: PASS
+  - treasure-maps-router-preset: 5/5 PASS
+  - scheduled-search-and-house-scores-refresh: 12/12 PASS
+  - strfry-router-first-boot-config: 3/3 PASS
+  - **per-query-neo4j-timeout-safety-net: 8/8 PASS** (T1–T5 driver tests + R1–R3 regression sentinels)
+- [x] `node -c` syntax-check on all three modified JS files — **PASS** (`src/api/export/users/queries/userdata.js`, `test/per-query-neo4j-timeout-safety-net.test.js`, `test/test.js`).
+- [ ] `npm run test:playwright` — skipped. No browser-observable change; story explicitly states no UI surface is altered.
+- [x] _Lint not configured — skipped._
+- [x] _Typecheck not configured — skipped._
+- [x] _Build not configured — skipped._
+
+## Spec adherence (vs. story #5 acceptance criteria)
+
+Every AC has a passing test or a documented manual-smoke deferral:
+
+- [x] **AC-1** (Jack → 504 within 15s with JSON body) — T2 + T3 pin the wiring; live behavior deferred to manual staging smoke per the test plan's "Not covered" section (requires real Neo4j with Jack's graph loaded, not reproducible in local Docker stack).
+- [x] **AC-2** (fast pubkey still 200 with existing shape) — R3 sentinel verifies the `apiResponse` literal still contains `success/isUserInNeo4j/metaData/data`. PASS.
+- [x] **AC-3** (driver-layer timeout) — T2 confirms `session.run(cypherQuery, {}, { timeout: queryTimeoutMs })` at [userdata.js:176](src/api/export/users/queries/userdata.js#L176). The timeout fires inside the Neo4j server via transactionConfig, not via a Node-side Promise.race wrapper.
+- [x] **AC-4** (session/driver close on timeout) — R1 sentinel verifies the `.finally(() => { session.close(); driver.close(); })` at [userdata.js:288](src/api/export/users/queries/userdata.js#L288) is preserved. The 504 `return` at line 276 ensures `.finally` still runs.
+- [x] **AC-5** (config-driven timeout) — T1 confirms `parseInt(getConfigFromFile('NEO4J_QUERY_TIMEOUT_MS', 15000), 10)` at [userdata.js:60](src/api/export/users/queries/userdata.js#L60), matching the existing `NEO4J_URI/USER/PASSWORD` pattern.
+- [x] **AC-6** (JSON 504 distinguishable from nginx 504) — T3 confirms `res.status(504).json({ success: false, message: ... })` at [userdata.js:276](src/api/export/users/queries/userdata.js#L276). Body is JSON, not HTML.
+- [x] **AC-7** (structured timeout log: pubkey + observerPubkey + elapsed) — T4 confirms `console.error('Neo4j query timeout fetching user data:', { pubkey, observerPubkey, elapsedMs, limitMs, code })` at [userdata.js:275](src/api/export/users/queries/userdata.js#L275). Distinct prefix from the generic `'Error fetching user data:'` log makes it grep-able.
+- [x] **AC-8** (existing 500 path unchanged) — R2 sentinel verifies the `res.status(500).json({ success: false, ... })` path at [userdata.js:282-286](src/api/export/users/queries/userdata.js#L282) is preserved. The 504 is additive.
+- [x] **AC-9** (`docs/SMOKE_TEST.md` notes the Jack 504 expectation) — T5 confirms the new paragraph at [docs/SMOKE_TEST.md:48](docs/SMOKE_TEST.md#L48) co-locates "504", "jack", "get-user-data", and "story #6". Smoke runners will now treat the Jack 504 as expected.
+
+No criterion is silently dropped. No behavior added that isn't in the story.
+
+## ADR adherence
+
+- [x] **No ADR required.** Architecture phase intentionally skipped per CLAUDE.md harness rules for Standard-strictness Bug classification (fix is a `transactionConfig` + a 504 branch — obvious). Story's "Linked artifacts" records the skip explicitly.
+- [x] **No new dependencies.** `package.json` and `package-lock.json` untouched (`git diff --stat origin/staging...HEAD` confirms). The change uses the already-imported `neo4j-driver` module's existing `session.run(query, params, transactionConfig)` API surface — no new module imports.
+- [x] **Layering respected.** Change is entirely inside the existing handler function in `src/api/export/users/queries/userdata.js`. No leak into shared `lib/`, `src/utils/`, or driver-level code.
+
+## Concept-graph integrity
+
+- [x] N/A. No concept definitions, schemas, or firmware JSON touched. No `kind:pubkey:slug` handles involved. No firmware reinstall needed.
+
+## Things tests can't catch
+
+- [x] **No secrets in committed files.** `git diff origin/staging...HEAD` contains only the pubkey hex `04c915da…ecc9` (Jack), which is a public Nostr identifier (pubkeys are public by design — that's how Nostr identifies users). Logging `pubkey` and `observerPubkey` on timeout is consistent with the existing `'Error fetching user data:', error` log, which already serializes the request context.
+- [x] **No leftover debug logging or `console.log`.** Two `console.error` calls (one timeout-specific, one generic) — both structured, both intentional per AC-7 and the existing pattern.
+- [x] **No commented-out code.** The three-line comment block at [userdata.js:172-174](src/api/export/users/queries/userdata.js#L172) explains *why* the deadline exists (forward-pointer to story #6 for the underlying Cypher fix) — non-obvious WHY per CLAUDE.md tone rules, not narration.
+- [x] **Error paths handled where it matters.** The `isTimeout` guard at [line 273](src/api/export/users/queries/userdata.js#L273) checks `error && typeof error.code === 'string' && /TransactionTimedOut/i.test(error.code)` — null-safe, string-type-safe, and uses a permissive substring regex that handles both `TransactionTimedOutClientConfiguration` and `TransactionTimedOut` variants the Neo4j server emits across versions.
+- [x] **Concurrency / race conditions considered.** Each request creates its own driver+session pair (pre-existing pattern at [line 62-67](src/api/export/users/queries/userdata.js#L62)); the Promise chain is single-flight per request. No shared mutable state introduced. The `queryStartMs` capture at [line 175](src/api/export/users/queries/userdata.js#L175) closes over a per-request const, no leakage between requests.
+- [x] **Security: no new injection vectors.** The 504 body interpolates only the integers `elapsedMs` and `queryTimeoutMs` — no user input. The console.error log includes `pubkey`/`observerPubkey` but only into the structured-object second arg, not into a format string. Pre-existing Cypher injection via interpolated pubkey at [line 69](src/api/export/users/queries/userdata.js#L69) is **explicitly out of scope** per the story (deferred to story #6 alongside the hex-validation work) — confirmed untouched by this diff.
+
+## House rules check
+
+- [x] **Concept Graph API authority respected** (N/A — no concept code touched).
+- [x] **No new lint/typecheck/build tooling.** `package.json` not modified.
+- [x] **No firmware reinstall needed** (no concept definitions changed).
+
+## Story #6 scope items verified untouched
+
+Reviewed explicitly because the story's "Out of scope" section calls these out:
+
+- [x] **Unbounded `OPTIONAL MATCH` fan-out** at [userdata.js:88-136](src/api/export/users/queries/userdata.js#L88) — confirmed unchanged. `grep "OPTIONAL MATCH"` returns the same 8 unmodified occurrences.
+- [x] **Weak pubkey validation** at [userdata.js:31](src/api/export/users/queries/userdata.js#L31) (`nip19.npubEncode` accepts non-hex input; no `/^[0-9a-f]{64}$/i` check) — confirmed unchanged.
+- [x] **Latent `query` → `cypherQuery` ReferenceError** at [userdata.js:284](src/api/export/users/queries/userdata.js#L284) inside the 500 catch body — confirmed unchanged. Will only fire on the (now-narrowed) generic-error path; still latent.
+
+The Implementer correctly stayed in scope.
+
+## Findings
+
+### Blocking
+
+_None._
+
+### Non-blocking
+
+1. **[src/api/export/users/queries/userdata.js:60](src/api/export/users/queries/userdata.js#L60) — `parseInt` on malformed conf value yields `NaN`.** If `/etc/brainstorm.conf` ever contains a non-numeric `NEO4J_QUERY_TIMEOUT_MS=abc`, `parseInt` returns `NaN` and `session.run(query, {}, { timeout: NaN })` is passed to the driver. Per neo4j-driver-core, `transactionConfig.timeout` is validated as a non-negative integer; `NaN` will likely throw at config-validation time, which falls through to the existing 500 path with a config-error stack trace. Acceptable — the operator gets a clear 500 they can diagnose — but a defensive `Number.isFinite(queryTimeoutMs) && queryTimeoutMs > 0 ? queryTimeoutMs : 15000` would make the misconfiguration self-healing. Skip if you'd rather surface bad config loudly; mention in the next handler-touch.
+
+2. **[src/api/export/users/queries/userdata.js:278](src/api/export/users/queries/userdata.js#L278) — 504 message hardcodes a "story #6" forward-reference.** The client sees `"see story #6 for the planned Cypher fix"` in the response body. Internal story numbers leaking into public API responses is a minor smell — when story #6 lands, the message either becomes stale or needs a coordinated edit. Consider a more durable wording (e.g. *"the query for this pubkey exceeds the time budget; the unbounded expansion is being addressed separately"*). Not a blocker — the existing wording is descriptive and the URL surface isn't externally documented.
+
+3. **[src/api/export/users/queries/userdata.js:60, 65](src/api/export/users/queries/userdata.js#L60) — incidental trailing-whitespace cleanups.** The Implementer's edits inadvertently removed two trailing-whitespace lines from neighbors of the new config-read insertion. Per the Implementer role's "Don't refactor neighboring code" rule, this is a technical scope violation — but it's whitespace-only, 0 semantic effect, no review-time risk. Noted for awareness; not asking for a revert.
+
+4. **`queryStartMs` is wall-clock from before `session.run` returns its first byte, not from when Neo4j actually begins the query.** The `elapsedMs` reported in the log and the 504 body therefore includes the bolt handshake / pool-acquisition time. For operator diagnostics this is fine — and arguably more accurate than the server-side timer, since it reflects what the client experienced — but if anyone reads the log expecting "time spent inside Neo4j," they'll be slightly off. Not in spec, not worth a code change.
+
+5. **Per-request driver instantiation.** Each handler call creates a new `neo4j.driver(...)` and `driver.session()` pair, then closes both in `.finally`. This is a **pre-existing** pattern across the codebase (`profiles.js`, `nip56-profiles.js`, `proximity.js` all do the same), and Story #5 doesn't change it. Pool-sharing across requests would reduce handshake overhead — out of scope here, but worth a future cycle's consideration if the handler-touching budget allows.
+
+## Verdict
+
+**PASS** — diff matches story #5 acceptance criteria (every AC has a passing test or documented manual-smoke deferral), no ADR required by classification, all four test suites green (28/28), no Story #6 scope items touched, no blocking quality concerns. The five non-blocking notes are observations for the next handler-touch (likely Story #6), not change requests.
+
+Recommend the standard deploy chain: `cycle-staging` → manual `curl` against staging for Jack to verify the 504 fires live (per the test plan's "Not covered" curl recipe at the story #5 test-plan §"Not covered") → on confirmation, `cycle-prod` to promote.

--- a/engineering-team/stories/5-per-query-neo4j-timeout-safety-net.md
+++ b/engineering-team/stories/5-per-query-neo4j-timeout-safety-net.md
@@ -1,0 +1,64 @@
+# Story 5: Per-query Neo4j timeout for `/api/get-user-data`
+
+**Status:** Approved
+**Created:** 2026-05-13
+**Type:** Bug
+
+## Background
+
+During the cycle-staging smoke test for PR #127 (story #4), the canonical "known-active" pubkey from `docs/SMOKE_TEST.md:46` — Jack (`04c915daefee38317fa734444acee390a8269fe5810b2241e5e6dd343dfbecc9`) — was found to hang `/api/get-user-data` on both staging and production. Reproduction (May 2026): the request times out at the curl deadline of 20s with zero bytes returned, while the neighboring `/api/get-user-counts?pubkey=$PK` (strfry-backed, not Neo4j) returns 200 in normal time, and the same `/api/get-user-data` endpoint returns 200 in ~400ms for less-connected pubkeys. The hang is specific to the (endpoint, high-fanout-pubkey) combination.
+
+Root cause for the *hang* (separate from the *slow query*): the handler at `src/api/export/users/queries/userdata.js:172` calls `session.run(cypherQuery)` with no transaction config. Neo4j has no server-side deadline, so a runaway query keeps consuming graph resources and the bolt session never returns; the nginx upstream eventually drops the client, but the Node process still has an open session and an open driver until the underlying connection dies. There is no structured error path for "this query is too slow."
+
+The underlying query also has unbounded fan-out — that is the *cause* of the slowness for Jack — but fixing the query is Story #6. **This story scopes only to the safety net**: ensure the endpoint fails fast with a structured response and releases its resources, so that (a) the same pubkey returning slow doesn't black-hole a connection, (b) future high-fanout pubkeys are bounded even if the query itself drifts back into unboundedness, and (c) the smoke test gets a clear failure signal (504 + JSON body) instead of a 20s hang.
+
+Lands the failsafe independently of the query fix, so even if Story #6 slips a cycle, the production endpoint stops hanging.
+
+## User-facing description
+
+**As an operator of a Brainstorm instance**, I want `/api/get-user-data` to return a structured error within a bounded time when its Neo4j query is too slow, **so that** a slow or high-fanout pubkey can never hang the endpoint long enough for the upstream nginx to drop the client, and so that the failure shows up in logs and clients as a real status code instead of a black-holed connection.
+
+## Acceptance criteria
+
+- [ ] Given Jack's pubkey (`04c915daefee38317fa734444acee390a8269fe5810b2241e5e6dd343dfbecc9`), when `/api/get-user-data?pubkey=<jack>` is called, the response returns within the configured timeout window (default ≤ 15s) with **HTTP 504** and a JSON body matching `{ success: false, message: <string mentioning timeout> }`. No more zero-byte hangs.
+- [ ] Given a fast pubkey (e.g. `0f6c85267910c0e49e60b8f4f92db600a47c7c10f711a94182989c9cae5e1313` from the existing repro), when `/api/get-user-data?pubkey=<fast>` is called, the response is HTTP 200 with the existing response shape unchanged — same top-level keys (`success`, `isUserInNeo4j`, `metaData`, `data`), same nested fields. No regression on the happy path.
+- [ ] The timeout is enforced at the Neo4j layer via the driver's `transactionConfig.timeout` (or equivalent), not only at the Node/Express layer, so the Neo4j-side query is actually cancelled and stops consuming graph resources when the deadline fires.
+- [ ] On timeout, both `session.close()` and `driver.close()` still run (the existing `.finally` path must not leak when the rejection comes from the timeout rather than from a query error). Verified by an assertion that no driver/session handles accumulate after N consecutive timed-out requests in the test suite.
+- [ ] The timeout value is read from configuration (via `getConfigFromFile`, matching the existing pattern for `NEO4J_URI` / `NEO4J_USER` / `NEO4J_PASSWORD`), with a sensible default if the config is absent. Operators can tune it without a code change.
+- [ ] The 504 response is distinguishable from an nginx-emitted 504: the response **has a JSON body with `success: false`**, whereas an upstream nginx 504 typically returns an HTML error page. This lets the smoke test and any clients tell a handled timeout from an unhandled one.
+- [ ] On timeout, a structured `console.error` (matching the format of the existing `'Error fetching user data:'` log) is emitted with the pubkey, observerPubkey, and elapsed-time fields, so operators can grep logs for slow pubkeys without needing Neo4j-side tracing.
+- [ ] The existing error path for non-timeout Neo4j errors (`.catch` at `userdata.js:267`) continues to return HTTP 500 with the existing shape — the new timeout path is additive, not a replacement.
+- [ ] `docs/SMOKE_TEST.md:46` is updated with a one-sentence note that the canonical "known-active" pubkey (Jack) currently exercises the high-fanout path and is expected to return a 504 from `/api/get-user-data` until Story #6 lands. A smoke-test run that gets a 504 with `success: false` from this endpoint for Jack should be treated as **expected** (not a regression), while a hang or a 502 should be flagged.
+
+## Concepts touched
+
+To be resolved by the Implementer via `/api/concept-graph/summaries` if uncertain:
+
+- NostrUser (the Neo4j node type the timed-out query traverses)
+- Get-user-data endpoint
+- Owner / Owner PoV (the default `observerPubkey` fallback at `userdata.js:38`)
+- NostrUserWotMetricsCard (the alternate source when `observerPubkey` is set)
+
+## Out of scope
+
+- **The actual Cypher rewrite to bound the fan-out.** That is Story #6. This story explicitly accepts that Jack will keep timing out at 504 until #6 lands; the goal here is *bounded failure*, not *successful response*.
+- **Cypher injection / pubkey hex validation at `userdata.js:69`.** Same handler, but tightly coupled to the query rewrite — lands with Story #6.
+- **Fixing the latent `query` → `cypherQuery` ReferenceError in the `.catch` at `userdata.js:271`.** Same reasoning: bundle with #6.
+- **Applying the same timeout pattern to other Neo4j-backed handlers** (`profiles.js`, `nip56-profiles.js`, `proximity.js`, etc.). If the Implementer extracts a shared helper while doing this story, fine, but the *application* of the helper to other endpoints is a separate decision per endpoint and out of scope here.
+- **Changes to nginx upstream timeout configuration.** This story makes the application-layer deadline come first; nginx config is a separate concern.
+- **Per-pubkey query result caching.** Tempting for Jack specifically, but invalidation is non-trivial and belongs in a later story if at all.
+- **A UI surfacing of the 504.** Clients that consume this endpoint will start seeing 504s — surfacing them in any front-end views is a separate story per consumer.
+
+## Open questions
+
+Resolved with operator at approval time:
+
+- **Default timeout value:** **15s** (15000 ms). Well under the 20s curl deadline observed in the repro and below typical nginx upstream timeouts, so the application-layer 504 is the first deadline to fire.
+- **Config key name:** **`NEO4J_QUERY_TIMEOUT_MS`**, read via `getConfigFromFile` matching the existing pattern for `NEO4J_URI` / `NEO4J_USER` / `NEO4J_PASSWORD`, defaulting to 15000 in code if absent.
+- **Shared helper vs. inline:** **Inline in `userdata.js`** for this story. Story #6 revisits the same handler and is the natural point to factor a shared helper if one is needed elsewhere.
+
+## Linked artifacts
+
+- ADR: skipped (Bug, fix is obvious — per CLAUDE.md harness rules for Standard strictness on Bug type)
+- Test plan: to be filled in after Test Design phase
+- Review: to be filled in after Review phase

--- a/engineering-team/stories/5-per-query-neo4j-timeout-safety-net.md
+++ b/engineering-team/stories/5-per-query-neo4j-timeout-safety-net.md
@@ -61,4 +61,4 @@ Resolved with operator at approval time:
 
 - ADR: skipped (Bug, fix is obvious — per CLAUDE.md harness rules for Standard strictness on Bug type)
 - Test plan: `engineering-team/stories/5-per-query-neo4j-timeout-safety-net.test-plan.md`
-- Review: to be filled in after Review phase
+- Review: `engineering-team/reviews/5-per-query-neo4j-timeout-safety-net.md` (PASS, 5 non-blocking notes)

--- a/engineering-team/stories/5-per-query-neo4j-timeout-safety-net.md
+++ b/engineering-team/stories/5-per-query-neo4j-timeout-safety-net.md
@@ -60,5 +60,5 @@ Resolved with operator at approval time:
 ## Linked artifacts
 
 - ADR: skipped (Bug, fix is obvious — per CLAUDE.md harness rules for Standard strictness on Bug type)
-- Test plan: to be filled in after Test Design phase
+- Test plan: `engineering-team/stories/5-per-query-neo4j-timeout-safety-net.test-plan.md`
 - Review: to be filled in after Review phase

--- a/engineering-team/stories/5-per-query-neo4j-timeout-safety-net.test-plan.md
+++ b/engineering-team/stories/5-per-query-neo4j-timeout-safety-net.test-plan.md
@@ -1,0 +1,108 @@
+# Test Plan: Story 5 — Per-query Neo4j timeout for `/api/get-user-data`
+
+**Story:** `engineering-team/stories/5-per-query-neo4j-timeout-safety-net.md`
+**ADR:** None — Architecture phase intentionally skipped per Standard-strictness Bug classification (see story §"Linked artifacts").
+**Date:** 2026-05-14
+
+## Coverage map
+
+Same testing style as story #4 and the recent `strfry-router-first-boot-config` Bug: failing tests are **source-regex assertions** against `src/api/export/users/queries/userdata.js` and `docs/SMOKE_TEST.md`. They pin what the spec requires (driver-layer timeout, config key name, 504 branch, structured log, docs note) without prescribing **how** the implementer wires it (Promise wrapping, an `executeRead` transaction, a Map of timeouts, etc. — all left open).
+
+Live behavior assertions (Jack actually returns 504 within 15s) are deferred to manual staging smoke since they require real Neo4j + Jack's graph data — not reproducible in the hand-rolled Node runner without infrastructure this project doesn't have an ADR for.
+
+| Criterion | Test name | File | Level |
+|---|---|---|---|
+| AC-1 (Jack → HTTP 504 within 15s with JSON body) | covered indirectly by T2 (driver-layer timeout wired) + T3 (504 branch with success:false + message); live behavior verified by manual staging smoke (`curl -m 20 .../api/get-user-data?pubkey=04c915da…`) | n/a | manual smoke |
+| AC-2 (fast pubkey still returns 200 with existing shape) | R3 `userdata.js still emits the existing 200 response shape (success/isUserInNeo4j/metaData/data)` | test/per-query-neo4j-timeout-safety-net.test.js | unit (regression sentinel) |
+| AC-3 (timeout enforced at Neo4j driver layer, not just Node) | T2 `userdata.js passes a transactionConfig with a numeric timeout to session.run / executeRead / readTransaction` | test/per-query-neo4j-timeout-safety-net.test.js | unit (source regex) |
+| AC-4 (session.close + driver.close run on timeout — no leak) | R1 `userdata.js still closes session and driver in the .finally cleanup path` | test/per-query-neo4j-timeout-safety-net.test.js | unit (regression sentinel) |
+| AC-5 (timeout from `NEO4J_QUERY_TIMEOUT_MS` via getConfigFromFile, default 15000) | T1 `userdata.js reads NEO4J_QUERY_TIMEOUT_MS via getConfigFromFile with a numeric default of 15000` | test/per-query-neo4j-timeout-safety-net.test.js | unit (source regex) |
+| AC-6 (504 distinguishable from nginx 504: JSON body with success:false) | T3 `userdata.js has a 504 response branch with JSON body {success:false} and a message that mentions "timeout"` | test/per-query-neo4j-timeout-safety-net.test.js | unit (source regex) |
+| AC-7 (structured timeout log: pubkey + observerPubkey + elapsed) | T4 `userdata.js logs the timeout with elapsed-time context, distinct from the existing generic error log` | test/per-query-neo4j-timeout-safety-net.test.js | unit (source regex) |
+| AC-8 (existing non-timeout 500 path unchanged) | R2 `userdata.js still has the 500 error path with success:false for non-timeout Neo4j errors` | test/per-query-neo4j-timeout-safety-net.test.js | unit (regression sentinel) |
+| AC-9 (docs/SMOKE_TEST.md notes Jack 504 expectation pending Story #6) | T5 `docs/SMOKE_TEST.md notes the get-user-data 504 expectation for the high-fanout pubkey` | test/per-query-neo4j-timeout-safety-net.test.js | unit (file grep) |
+
+## Edge cases
+
+- [x] **`NEO4J_QUERY_TIMEOUT_MS` unset.** Story §"Open questions" resolved: default in code is 15000 ms. T1 asserts the default literal is present, so an Implementer who reads the config without a default trips the test.
+- [x] **Existing generic Neo4j error path unregressed.** R2 sentinel — if the Implementer accidentally rips out the 500 path while adding the 504 branch, it flips to FAIL.
+- [x] **`.finally` resource cleanup unregressed.** R1 sentinel — if the Implementer adds an `await session.run(...)` with a `try/catch` that bypasses the existing `.finally`, the sentinel flips to FAIL.
+- [x] **Happy-path 200 response shape unregressed.** R3 sentinel — if the Implementer accidentally changes the top-level response keys (`success` / `isUserInNeo4j` / `metaData` / `data`), it flips to FAIL.
+- [x] **Timeout log is distinct from generic Neo4j-error log.** T4 asserts `elapsed` appears in the source AND a `console.error` site mentions timeout — drives a separate log line that's grep-able for operators (per story background: "without needing Neo4j-side tracing").
+- [x] **Cypher rewrite NOT in scope.** No assertion about LIMIT, `size(...)` patterns, parameterized pubkeys, or the `query` → `cypherQuery` ReferenceError at line 271 — those are explicitly Story #6 per the story's "Out of scope" section, and adding tests here would block this safety-net story on the bigger fix.
+
+## Not covered
+
+- **AC-1 live behavior: Jack actually returns 504 within 15s.** Requires real Neo4j with Jack's loaded graph (~hundreds of thousands of follow edges) and the deployed handler. Verified by manual staging smoke after deploy:
+  ```bash
+  PK=04c915daefee38317fa734444acee390a8269fe5810b2241e5e6dd343dfbecc9
+  time curl -m 20 -s -o /tmp/resp.json -w '%{http_code}\n' \
+    "https://staging.brainstorm.world/api/get-user-data?pubkey=$PK"
+  # Expect: 504 within ~15s, /tmp/resp.json contains {"success":false,...}
+  jq '.success, .message' /tmp/resp.json   # success:false, message mentioning timeout
+  ```
+- **AC-2 live behavior: fast pubkey still returns 200 in normal time.** Verified by manual staging smoke alongside AC-1:
+  ```bash
+  PK2=0f6c85267910c0e49e60b8f4f92db600a47c7c10f711a94182989c9cae5e1313
+  time curl -m 20 -s -o /tmp/resp2.json -w '%{http_code}\n' \
+    "https://staging.brainstorm.world/api/get-user-data?pubkey=$PK2"
+  # Expect: 200 within ~0.5s, full response shape intact
+  ```
+- **AC-4 no-handle-accumulation leak under repeated timeouts.** Requires running the server with a debug build and asserting bolt-connection count post-N-requests is bounded. R1 pins the `.finally` cleanup in source; runtime leak verification is deferred to the standard "let staging soak for an hour after deploy" step.
+- **AC-7 log line shape match in production logs.** Verified by `docker logs tapestry | grep -i 'timeout'` against staging after a smoke-test hit on Jack post-deploy.
+- **nginx upstream window confirmed at >15s.** The 15s default was chosen against an assumed nginx upstream timeout ≥20s (the curl repro's deadline). If the deployed nginx config is shorter, the safety-net 504 wouldn't fire first. Pre-implementation check: `grep -r 'proxy_read_timeout\|proxy_send_timeout' docker/ config/` to confirm. Deferred to Implementer as a one-line sanity check, not a test.
+
+## Test infrastructure
+
+- **Test framework:** project's existing hand-rolled Node runner (`test/test.js`). No new dependencies.
+- **No Playwright spec** — the failure mode (a hung HTTP connection on the unbounded Cypher) cannot be reproduced in the local Docker stack without Jack's data loaded. No browser surface is changed.
+- **Fixtures:** none. All assertions read source files via `fs.readFileSync`.
+- **Files asserted against:**
+  - `src/api/export/users/queries/userdata.js` — the handler being patched.
+  - `docs/SMOKE_TEST.md` — the operator-facing smoke doc.
+
+## How to run
+
+```
+npm test
+```
+
+Targeted run of just this suite:
+```
+node -e "require('./test/per-query-neo4j-timeout-safety-net.test.js').run()"
+```
+
+## Verification
+
+The new tests fail on the pre-implementation tree. Confirmed against the working tree at story commit `ab38d595` (`story: per-query-neo4j-timeout-safety-net`), with the failing-tests file and `test/test.js` registration staged on top:
+
+```
+per-query-neo4j-timeout-safety-net suite:
+  ✗ T1: userdata.js reads NEO4J_QUERY_TIMEOUT_MS via getConfigFromFile with a numeric default of 15000
+      userdata.js must read NEO4J_QUERY_TIMEOUT_MS via getConfigFromFile with a numeric default of 15000 (AC-5). Example: `const queryTimeoutMs = parseInt(getConfigFromFile('NEO4J_QUERY_TIMEOUT_MS', 15000));`
+  ✗ T2: userdata.js passes a transactionConfig with a numeric timeout to session.run / executeRead / readTransaction
+      userdata.js must enforce the query timeout at the Neo4j driver layer, not just on the Node side (AC-3). Expected `session.run(cypherQuery, {}, { timeout: queryTimeoutMs })` (or equivalent executeRead/readTransaction call with `{ timeout: ... }`). Current call has no transactionConfig.
+  ✗ T3: userdata.js has a 504 response branch with JSON body {success:false} and a message mentioning "timeout"
+      userdata.js must return HTTP 504 with a JSON body when the Neo4j query times out (AC-1, AC-6). No `.status(504).json(` call found.
+  ✗ T4: userdata.js logs the timeout with elapsed-time context, distinct from the existing generic Neo4j-error log
+      userdata.js must surface elapsed-time on timeout (AC-7) — search for "elapsed" yielded nothing. Suggested: include an `elapsedMs` field in the timeout log.
+  ✗ T5: docs/SMOKE_TEST.md notes the get-user-data 504 expectation for the high-fanout pubkey (Jack)
+      docs/SMOKE_TEST.md must note that /api/get-user-data is expected to return 504 for the high-fanout pubkey (Jack) until story #6 lands (AC-9). No co-located "504" + Jack/get-user-data/story #6 reference found.
+  ✓ R1: userdata.js still closes session and driver in the .finally cleanup path (no resource leak on timeout)
+  ✓ R2: userdata.js still returns 500 with success:false for non-timeout Neo4j errors (existing error path unregressed)
+  ✓ R3: userdata.js still emits the existing 200 response shape (success/isUserInNeo4j/metaData/data)
+
+Test Results
+-------------
+Configuration Loading:                           PASS
+treasure-maps-router-preset suite:               PASS (5 passed, 0 failed)
+scheduled-search-and-house-scores-refresh suite: PASS (12 passed, 0 failed)
+strfry-router-first-boot-config suite:           PASS (3 passed, 0 failed)
+per-query-neo4j-timeout-safety-net suite:        FAIL (3 passed, 5 failed)
+Overall:                                         FAIL
+```
+
+- 5 failing tests (T1–T5), each with a message that directly names what the Implementer needs to add: the config-key read, the driver `transactionConfig.timeout`, the 504 JSON branch, the elapsed-time log, and the docs note.
+- 3 already-passing sentinels (R1–R3): the existing `.finally` cleanup, the existing 500-path body, and the existing 200-response shape. They are intentionally green; if any of them flips to FAIL during Implementation, an existing behavior was broken and the Implementer needs to back out the regressing change.
+- All four other suites stay green — no collateral regression from registering the new file in `test/test.js`.
+- Failures cite the spec by AC number and include the suggested fix snippet, not a typo or import error.

--- a/src/api/export/users/queries/userdata.js
+++ b/src/api/export/users/queries/userdata.js
@@ -57,12 +57,13 @@ function handleGetUserData(req, res) {
     const neo4jUri = getConfigFromFile('NEO4J_URI', 'bolt://localhost:7687');
     const neo4jUser = getConfigFromFile('NEO4J_USER', 'neo4j');
     const neo4jPassword = getConfigFromFile('NEO4J_PASSWORD', 'neo4j');
-    
+    const queryTimeoutMs = parseInt(getConfigFromFile('NEO4J_QUERY_TIMEOUT_MS', 15000), 10);
+
     const driver = neo4j.driver(
       neo4jUri,
       neo4j.auth.basic(neo4jUser, neo4jPassword)
     );
-    
+
     const session = driver.session();
 
     let cypherQuery = `
@@ -168,8 +169,11 @@ function handleGetUserData(req, res) {
     recommendationsFromObserverCount
     `
     
-    // Execute the query
-    session.run(cypherQuery)
+    // Execute the query with a driver-layer deadline so a runaway Cypher
+    // (e.g. high-fanout pubkeys whose follow/follower expansion is unbounded —
+    // see story #6) fails fast with a 504 instead of hanging the nginx upstream.
+    const queryStartMs = Date.now();
+    session.run(cypherQuery, {}, { timeout: queryTimeoutMs })
       .then(result => {
         if (result.records.length === 0) {
           return res.json({
@@ -265,6 +269,15 @@ function handleGetUserData(req, res) {
         res.status(200).json(apiResponse);
       })
       .catch(error => {
+        const elapsedMs = Date.now() - queryStartMs;
+        const isTimeout = error && typeof error.code === 'string' && /TransactionTimedOut/i.test(error.code);
+        if (isTimeout) {
+          console.error('Neo4j query timeout fetching user data:', { pubkey, observerPubkey, elapsedMs, limitMs: queryTimeoutMs, code: error.code });
+          return res.status(504).json({
+            success: false,
+            message: `Neo4j query timeout after ${elapsedMs}ms (limit ${queryTimeoutMs}ms). The user-data query is unbounded for this pubkey; see story #6 for the planned Cypher fix.`
+          });
+        }
         console.error('Error fetching user data:', error);
         res.status(500).json({
           success: false,

--- a/test/per-query-neo4j-timeout-safety-net.test.js
+++ b/test/per-query-neo4j-timeout-safety-net.test.js
@@ -1,0 +1,210 @@
+/**
+ * Story #5: Per-query Neo4j timeout for /api/get-user-data.
+ *
+ * The handler at src/api/export/users/queries/userdata.js calls
+ *   session.run(cypherQuery)
+ * with no transactionConfig, so a runaway Cypher query (e.g. for Jack —
+ * pubkey 04c915daefee38317fa734444acee390a8269fe5810b2241e5e6dd343dfbecc9 —
+ * which fans out across hundreds of thousands of follow edges) hangs until
+ * the nginx upstream drops the client. There's no application-layer
+ * deadline and no structured failure response.
+ *
+ * These tests pin the safety net: a driver-layer timeout (default 15s,
+ * configurable via NEO4J_QUERY_TIMEOUT_MS), a 504 JSON response branch
+ * with success:false, an elapsed-time log distinct from the generic
+ * Neo4j-error log, and a corresponding note in docs/SMOKE_TEST.md so the
+ * smoke runner treats the 504 as expected until story #6 fixes the
+ * underlying Cypher fan-out.
+ *
+ * Tests are intentionally source-regex (matching the project's
+ * scheduled-search-and-house-scores-refresh and strfry-router-first-boot
+ * precedents) so the spec is pinned without prescribing the exact wiring
+ * the Implementer chooses (await/Promise/executeRead, etc.).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const USERDATA_PATH = path.resolve(__dirname, '../src/api/export/users/queries/userdata.js');
+const SMOKE_TEST_PATH = path.resolve(__dirname, '../docs/SMOKE_TEST.md');
+
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'Assertion failed');
+}
+
+// ---------------------------------------------------------------------------
+// Failing tests (T1–T5) — must FAIL pre-implementation, PASS post-implementation.
+// ---------------------------------------------------------------------------
+
+test('T1: userdata.js reads NEO4J_QUERY_TIMEOUT_MS via getConfigFromFile with a numeric default of 15000', () => {
+  const src = fs.readFileSync(USERDATA_PATH, 'utf8');
+
+  // Per story §"Open questions": key is NEO4J_QUERY_TIMEOUT_MS, default in code is 15000 (ms).
+  // Read pattern must match the existing pattern for NEO4J_URI / NEO4J_USER / NEO4J_PASSWORD.
+  const re = /getConfigFromFile\(\s*['"]NEO4J_QUERY_TIMEOUT_MS['"]\s*,\s*15000\b/;
+  assert(
+    re.test(src),
+    'userdata.js must read NEO4J_QUERY_TIMEOUT_MS via getConfigFromFile with a numeric default of 15000 (AC-5). ' +
+      'Example: `const queryTimeoutMs = parseInt(getConfigFromFile(\'NEO4J_QUERY_TIMEOUT_MS\', 15000));`'
+  );
+});
+
+test('T2: userdata.js passes a transactionConfig with a numeric timeout to session.run / executeRead / readTransaction', () => {
+  const src = fs.readFileSync(USERDATA_PATH, 'utf8');
+
+  // The Neo4j driver enforces transaction deadlines via { timeout: N } passed as the third arg
+  // to session.run(query, params, config) or as the second arg to executeRead/readTransaction.
+  // Accept any of those call shapes; reject a bare session.run(cypherQuery) with no config arg.
+  // The check: somewhere in the file, an `{ timeout: <numeric or identifier> }` object appears
+  // within ~400 chars of a session.run / executeRead / readTransaction call.
+  const re = /session\.(run|executeRead|readTransaction|executeWrite|writeTransaction)\s*\([\s\S]{0,400}\btimeout\s*:/;
+  assert(
+    re.test(src),
+    'userdata.js must enforce the query timeout at the Neo4j driver layer, not just on the Node side (AC-3). ' +
+      'Expected `session.run(cypherQuery, {}, { timeout: queryTimeoutMs })` ' +
+      '(or equivalent executeRead/readTransaction call with `{ timeout: ... }`). Current call has no transactionConfig.'
+  );
+});
+
+test('T3: userdata.js has a 504 response branch with JSON body {success:false} and a message mentioning "timeout"', () => {
+  const src = fs.readFileSync(USERDATA_PATH, 'utf8');
+
+  // Must have res.status(504).json(...) somewhere.
+  const statusRe = /\.status\(\s*504\s*\)\s*\.json\(/;
+  assert(
+    statusRe.test(src),
+    'userdata.js must return HTTP 504 with a JSON body when the Neo4j query times out (AC-1, AC-6). ' +
+      'No `.status(504).json(` call found.'
+  );
+
+  // The 504 JSON body must include success: false and a message mentioning timeout/timed out.
+  // Capture a window around the 504 call site for the body assertion.
+  const windowRe = /\.status\(\s*504\s*\)\s*\.json\(\s*\{[\s\S]{0,400}?\}/;
+  const window = src.match(windowRe);
+  assert(window, '504 JSON body must be an object literal — found `.status(504).json(` but could not match a body block');
+  assert(
+    /success\s*:\s*false/.test(window[0]),
+    'The 504 JSON body must include `success: false` so clients can distinguish from a 200/2xx (AC-6). Found body: ' + window[0]
+  );
+  assert(
+    /(timeout|timed[\s-]?out)/i.test(window[0]),
+    'The 504 JSON body must include a message mentioning "timeout" (or "timed out") so the failure is self-describing (AC-1). Found body: ' +
+      window[0]
+  );
+});
+
+test('T4: userdata.js logs the timeout with elapsed-time context, distinct from the existing generic Neo4j-error log', () => {
+  const src = fs.readFileSync(USERDATA_PATH, 'utf8');
+
+  // AC-7: the timeout log must surface elapsed-time so operators can grep slow pubkeys without needing
+  // Neo4j-side tracing. The exact log format is left to the Implementer, but the source must mention
+  // `elapsed` (any casing) AND have a console.error site that references the timeout context.
+  assert(
+    /elapsed/i.test(src),
+    'userdata.js must surface elapsed-time on timeout (AC-7) — search for "elapsed" yielded nothing. ' +
+      'Suggested: include an `elapsedMs` field in the timeout log.'
+  );
+
+  // The timeout log must be distinguishable from the existing "Error fetching user data:" generic log.
+  // Easiest pin: a console.error call site referencing "timeout" or "timed out" exists.
+  const timeoutLogRe = /console\.error\([^)]*?(timeout|timed[\s-]?out)/i;
+  assert(
+    timeoutLogRe.test(src),
+    'userdata.js must have a console.error call site that mentions "timeout" or "timed out" so the timeout failure is grep-able in container logs ' +
+      'distinct from the existing generic `console.error(\'Error fetching user data:\', error)` line (AC-7).'
+  );
+});
+
+test('T5: docs/SMOKE_TEST.md notes the get-user-data 504 expectation for the high-fanout pubkey (Jack)', () => {
+  const src = fs.readFileSync(SMOKE_TEST_PATH, 'utf8');
+
+  // AC-9: the doc must (a) reference 504 and (b) reference the high-fanout pubkey context near it,
+  // so smoke runs treat the 504 as expected until story #6 lands.
+  // Accept any of: explicit "504" mention plus either "Jack", the literal pubkey prefix, or "get-user-data" within ~300 chars.
+  const noteRe = /504[\s\S]{0,300}(jack|04c915da|get-user-data|story\s*#?\s*6)|(?:jack|04c915da|get-user-data|story\s*#?\s*6)[\s\S]{0,300}504/i;
+  assert(
+    noteRe.test(src),
+    'docs/SMOKE_TEST.md must note that /api/get-user-data is expected to return 504 for the high-fanout pubkey (Jack) ' +
+      'until story #6 lands (AC-9). No co-located "504" + Jack/get-user-data/story #6 reference found.'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Regression sentinels (R1–R3) — must PASS pre-implementation AND post-implementation.
+// If they flip to FAIL during Implementation, an existing behavior was broken.
+// ---------------------------------------------------------------------------
+
+test('R1: userdata.js still closes session and driver in the .finally cleanup path (no resource leak on timeout)', () => {
+  const src = fs.readFileSync(USERDATA_PATH, 'utf8');
+
+  // The existing .finally block at userdata.js:275-278 must remain — it's what guarantees that
+  // both the new timeout path and the existing error path release the bolt session and driver.
+  // AC-4 is satisfied by leaving this in place; if the Implementer introduces a try/catch that
+  // bypasses .finally, this sentinel flips to FAIL.
+  const re = /\.finally\(\s*\(\s*\)\s*=>\s*\{[\s\S]*?session\.close\(\)[\s\S]*?driver\.close\(\)/;
+  assert(
+    re.test(src),
+    'userdata.js must keep the `.finally(() => { session.close(); driver.close(); ... })` cleanup so no bolt session leaks ' +
+      'on the new timeout path (AC-4). The sentinel is failing — the existing .finally block was removed or restructured.'
+  );
+});
+
+test('R2: userdata.js still returns 500 with success:false for non-timeout Neo4j errors (existing error path unregressed)', () => {
+  const src = fs.readFileSync(USERDATA_PATH, 'utf8');
+
+  // AC-8: the new 504 branch must be additive, not a replacement. The existing 500 path stays.
+  const re = /\.status\(\s*500\s*\)[\s\S]{0,200}success\s*:\s*false/;
+  assert(
+    re.test(src),
+    'userdata.js must preserve its existing 500 + {success:false} error path for non-timeout Neo4j errors (AC-8). ' +
+      'The sentinel is failing — the generic error branch appears to have been removed or changed.'
+  );
+});
+
+test('R3: userdata.js still emits the existing 200 response shape (success/isUserInNeo4j/metaData/data)', () => {
+  const src = fs.readFileSync(USERDATA_PATH, 'utf8');
+
+  // AC-2: a fast pubkey must still get the same top-level response shape.
+  // Scope the check to the `apiResponse` object literal so we accept both
+  // colon form (`success: true`) and shorthand form (`isUserInNeo4j,`) and don't
+  // false-match the four key names elsewhere in the file.
+  const m = src.match(/const\s+apiResponse\s*=\s*\{[\s\S]*?\};/);
+  assert(
+    m,
+    'userdata.js must construct an `apiResponse` object literal for the 200 response (AC-2). The sentinel cannot find it.'
+  );
+  const block = m[0];
+
+  for (const key of ['success', 'isUserInNeo4j', 'metaData', 'data']) {
+    const re = new RegExp('\\b' + key + '\\b');
+    assert(
+      re.test(block),
+      `userdata.js apiResponse object must still include the \`${key}\` top-level key on the 200 response (AC-2). ` +
+        'The sentinel is failing — the happy-path response shape was changed.'
+    );
+  }
+});
+
+async function run() {
+  let pass = 0;
+  let fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -26,6 +26,7 @@ function testConfigLoading() {
 const treasureMaps = require('./treasure-maps-router-preset.test.js');
 const scheduledRefresh = require('./scheduled-search-and-house-scores-refresh.test.js');
 const strfryRouterFirstBoot = require('./strfry-router-first-boot-config.test.js');
+const perQueryNeo4jTimeout = require('./per-query-neo4j-timeout-safety-net.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -42,6 +43,9 @@ async function main() {
   console.log('\nstrfry-router-first-boot-config suite:');
   const strfryRouterFirstBootResult = await strfryRouterFirstBoot.run();
 
+  console.log('\nper-query-neo4j-timeout-safety-net suite:');
+  const perQueryNeo4jTimeoutResult = await perQueryNeo4jTimeout.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -54,12 +58,16 @@ async function main() {
   console.log(
     `strfry-router-first-boot-config suite:           ${strfryRouterFirstBootResult.fail === 0 ? 'PASS' : 'FAIL'} (${strfryRouterFirstBootResult.pass} passed, ${strfryRouterFirstBootResult.fail} failed)`
   );
+  console.log(
+    `per-query-neo4j-timeout-safety-net suite:        ${perQueryNeo4jTimeoutResult.fail === 0 ? 'PASS' : 'FAIL'} (${perQueryNeo4jTimeoutResult.pass} passed, ${perQueryNeo4jTimeoutResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
     treasureMapsResult.fail === 0 &&
     scheduledRefreshResult.fail === 0 &&
-    strfryRouterFirstBootResult.fail === 0;
+    strfryRouterFirstBootResult.fail === 0 &&
+    perQueryNeo4jTimeoutResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }


### PR DESCRIPTION
## Summary

`/api/get-user-data` currently hangs indefinitely for the canonical smoke-test pubkey Jack (`04c915da…ecc9`) because the handler in `src/api/export/users/queries/userdata.js` calls `session.run(cypherQuery)` with no transactionConfig — a runaway Cypher across Jack's high-fanout follow graph never returns within nginx's upstream window and the client sees zero bytes. This PR lands story #5's **safety net**: a Neo4j-driver-layer deadline (default 15 s, configurable via `NEO4J_QUERY_TIMEOUT_MS`) that fails fast with HTTP 504 + structured JSON instead of hanging. The unbounded-fan-out Cypher rewrite that's the underlying root cause is deliberately deferred to story #6, so this safety net lands independently — even if #6 slips, the production endpoint stops hanging.

Bug classification, Standard strictness: Architecture phase skipped (fix is obvious — a `transactionConfig` + a 504 branch). Full PO → Tester → Implementer → Reviewer harness ran with explicit gates; review verdict is **PASS** with 5 non-blocking notes.

## Changes

- `src/api/export/users/queries/userdata.js` — read `NEO4J_QUERY_TIMEOUT_MS` (default 15000), pass `{ timeout: queryTimeoutMs }` to `session.run`, branch on `/TransactionTimedOut/i` `error.code` to return 504 with a structured `{success:false, message:"Neo4j query timeout after Xms (limit Yms). … see story #6 …"}` body, and a distinct timeout-tagged `console.error` log with `pubkey/observerPubkey/elapsedMs/limitMs/code` for ops grep-ability. The existing `.finally(session.close + driver.close)` cleanup and 500-path for non-timeout errors are preserved.
- `docs/SMOKE_TEST.md` — paragraph noting that `/api/get-user-data` is expected to return **504 with `{"success":false, …}`** for the high-fanout pubkey (Jack) until story #6 lands; hangs/502s remain real regressions.
- `engineering-team/stories/5-per-query-neo4j-timeout-safety-net.md` — Phase 1 (Planning) story, status Approved.
- `engineering-team/stories/5-per-query-neo4j-timeout-safety-net.test-plan.md` — Phase 3 (Test Design) plan: source-regex assertions matching the project's existing `scheduled-search-*` and `strfry-router-first-boot-*` test style; live `Jack → 504` deferred to manual staging smoke (real Neo4j with Jack's graph not reproducible locally).
- `test/per-query-neo4j-timeout-safety-net.test.js` (new) — 8 tests: T1–T5 driving the implementation (config key + numeric default, `transactionConfig.timeout` passed, 504 JSON branch, elapsed-time log, SMOKE_TEST.md note) and R1–R3 regression sentinels (`.finally` cleanup preserved, 500 path preserved, 200 `apiResponse` shape preserved).
- `test/test.js` — registers the new suite.
- `engineering-team/reviews/5-per-query-neo4j-timeout-safety-net.md` — Phase 5 (Review) report, verdict **PASS**.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs cleanly.
- [ ] Tier 1 stability poll on `staging.brainstorm.world` reaches 3-streak.
- [ ] Tier 2 sanity reachability passes (pages, public APIs, search regression).
- [ ] **Tier 3 PR-specific:** the canonical smoke-test pubkey Jack now returns a structured **504** within ~15 s (not a hang, not a 502, not a 500):
  ```bash
  PK=04c915daefee38317fa734444acee390a8269fe5810b2241e5e6dd343dfbecc9
  time curl -m 20 -s -o /tmp/jack.json -w 'HTTP %{http_code} in %{time_total}s\n' \
    "https://staging.brainstorm.world/api/get-user-data?pubkey=$PK"
  jq '.success, .message' /tmp/jack.json
  # Expect: HTTP 504 in ~15s; success=false; message contains "Neo4j query timeout"
  ```
- [ ] **Tier 3 PR-specific:** a fast pubkey still returns 200 in normal time (no regression):
  ```bash
  PK2=0f6c85267910c0e49e60b8f4f92db600a47c7c10f711a94182989c9cae5e1313
  time curl -m 20 -s -o /tmp/fast.json -w 'HTTP %{http_code} in %{time_total}s\n' \
    "https://staging.brainstorm.world/api/get-user-data?pubkey=$PK2"
  # Expect: HTTP 200 in ~0.5s; existing response shape (success/isUserInNeo4j/metaData/data) intact
  ```
- [ ] Tier 4 Chrome visual — skipped (no UI change in this PR).
- [ ] Tier 5 regression sweep: other Neo4j-backed endpoints (`/api/get-profile-scores`, `/api/get-network-proximity`) still respond normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)