### PR TITLE
Promote staging → main: OPERATIONS.md new-droplet runbook + SSH-hardening gotcha

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -3,7 +3,7 @@
 > **Audience:** the active team running this fork at `brainstorm.world`.
 > **Prerequisite reading:** [BIBLE.md](./BIBLE.md) — what tapestry *is* and how it works. This file documents the specifics of *our* deployment that aren't useful to other operators forking the codebase.
 
-**Last updated:** 2026-04-26
+**Last updated:** 2026-05-14
 
 ---
 
@@ -14,9 +14,10 @@
 3. [CI/CD workflows](#3-cicd-workflows)
 4. [Branch protection ruleset](#4-branch-protection-ruleset)
 5. [Droplets and empirical measurements](#5-droplets-and-empirical-measurements)
-6. [Active team and branch ownership](#6-active-team-and-branch-ownership)
-7. [Active tracking issues](#7-active-tracking-issues)
-8. [Operational gotchas we've hit](#8-operational-gotchas-weve-hit)
+6. [Spinning up a new sandbox droplet](#6-spinning-up-a-new-sandbox-droplet)
+7. [Active team and branch ownership](#7-active-team-and-branch-ownership)
+8. [Active tracking issues](#8-active-tracking-issues)
+9. [Operational gotchas we've hit](#9-operational-gotchas-weve-hit)
 
 ---
 
@@ -131,7 +132,126 @@ The dynamic allocation formula in `docker/entrypoint.sh` is universal — see [B
 
 ---
 
-## 6. Active team and branch ownership
+## 6. Spinning up a new sandbox droplet
+
+End-to-end procedure for adding a new long-lived sandbox to the deploy fleet. The reference walk-through is `feat/communities` → `communities.brainstorm.world` on 2026-05-14; sub-sections call out gotchas hit during that run.
+
+### 6.1. Pre-flight (off-droplet)
+
+1. **DNS** — add an `A` record for `<name>.brainstorm.world` → droplet IP **first**. Certbot won't issue until the name resolves, and propagation can take minutes.
+2. **Branch** — the long-lived branch you'll deploy from should already exist on origin, forked from `staging` per §1.
+3. **Droplet** — provision the DO instance. Size to purpose: sandboxes that load the full WoT graph need ~32 GB; lightweight feature work can run smaller. Ubuntu 24.04 LTS.
+
+### 6.2. GitHub setup
+
+1. **Workflow file** — add `.github/workflows/deploy-<name>.yml` on the target branch. Mirror `deploy-tags.yml` and substitute the branch name, secret suffix, and droplet-name comment. Do **not** push yet — pushing triggers the first deploy, which fails until secrets are set and the droplet is ready.
+2. **Repo secrets** — prepare three placeholders in Settings → Secrets (values filled in from the droplet in §6.3 step 2):
+   - `DEPLOY_HOST_<NAME>` — droplet IP or hostname
+   - `DEPLOY_USER_<NAME>` — typically `root`
+   - `DEPLOY_SSH_KEY_<NAME>` — the **private** key generated on the droplet
+
+### 6.3. On the droplet
+
+1. **System packages.** Use Docker's official `docker-ce` only — **do not** also install Ubuntu's `docker.io`. Mixing the two breaks Docker daemon DNS in unpredictable ways (symptoms: `EAI_AGAIN` on npm installs inside containers, `sudo: unable to resolve host <container-id>`).
+   ```bash
+   apt update && apt upgrade -y
+   install -m 0755 -d /etc/apt/keyrings
+   curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+   chmod a+r /etc/apt/keyrings/docker.asc
+   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list
+   apt update
+   apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin nginx certbot python3-certbot-nginx git
+   ```
+
+2. **SSH hardening.** Do this **before** generating the deploy key. Within minutes of a fresh droplet booting, brute-force bots find port 22 and start saturating sshd. Default `MaxStartups 10:30:100` then randomly drops new unauth'd connections — including legitimate ones from GitHub Actions deploys (see §9.9).
+   ```bash
+   # Disable password auth (deploys and humans both use keys)
+   cat > /etc/ssh/sshd_config.d/99-disable-password.conf <<'EOF'
+   PasswordAuthentication no
+   KbdInteractiveAuthentication no
+   EOF
+   sshd -t && systemctl reload ssh
+
+   # Install fail2ban with a basic SSH jail
+   apt install -y fail2ban
+   cat > /etc/fail2ban/jail.d/sshd.local <<'EOF'
+   [sshd]
+   enabled = true
+   port = 22
+   maxretry = 5
+   findtime = 10m
+   bantime = 1h
+   EOF
+   systemctl enable --now fail2ban
+   ```
+
+3. **Deploy SSH key.**
+   ```bash
+   ssh-keygen -t ed25519 -f ~/.ssh/tapestry_<name> -N ""
+   cat ~/.ssh/tapestry_<name>.pub >> ~/.ssh/authorized_keys
+   cat ~/.ssh/tapestry_<name>       # paste into DEPLOY_SSH_KEY_<NAME>
+   ```
+   Now fill in the three `DEPLOY_*_<NAME>` secrets in GitHub.
+
+4. **Clone and check out the target branch.**
+   ```bash
+   git clone https://github.com/nous-clawds4/tapestry.git /opt/tapestry
+   cd /opt/tapestry
+   git checkout <branch>
+   ```
+
+5. **`.env` file** — all three vars from `.env.example` are required. Skipping any of them causes silent runtime failures rather than a hard stop:
+   ```
+   OWNER_PUBKEY=<your_hex_pubkey>
+   NEO4J_PASSWORD=<strong_password>
+   ADMIN_PUBKEYS=<your_hex_pubkey>     # same as OWNER_PUBKEY by convention
+   DOMAIN_NAME=<name>.brainstorm.world
+   ```
+   `ADMIN_PUBKEYS` only emits a `WARN` from docker-compose when missing — don't take that as benign.
+
+6. **Nginx + SSL.**
+   ```bash
+   cat > /etc/nginx/sites-available/<name>.brainstorm.world <<'EOF'
+   server {
+       listen 80;
+       server_name <name>.brainstorm.world;
+       location / {
+           proxy_pass http://127.0.0.1:8080;
+           proxy_set_header Host $host;
+           proxy_set_header X-Real-IP $remote_addr;
+           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+           proxy_set_header X-Forwarded-Proto $scheme;
+       }
+   }
+   EOF
+   ln -sf /etc/nginx/sites-available/<name>.brainstorm.world /etc/nginx/sites-enabled/
+   rm -f /etc/nginx/sites-enabled/default
+   nginx -t && systemctl reload nginx
+   certbot --nginx -d <name>.brainstorm.world
+   ```
+
+7. **Port remap, then first start.** The `sed` is **required** before the first `docker compose up`. Nginx already owns `:80`, so without the remap Docker can't bind and containers stay in "Created" state — neo4j and brainstorm never start, nginx returns 502. The CI/CD workflow runs this `sed` on every deploy (idempotent), but the first manual bring-up is on you:
+   ```bash
+   sed -i 's/"80:80"/"127.0.0.1:8080:80"/' docker-compose.yml
+   docker compose up -d --build
+   ```
+   First build takes 5–15 minutes (strfry's C++/Redis patch compiles from scratch). Subsequent CI/CD deploys warm-cache to ~80 seconds.
+
+### 6.4. Verify and finalize
+
+1. **Service health.** All four services should report `Up`:
+   ```bash
+   docker compose ps                            # tapestry, tapestry-redis, nostr-search-meili, nostr-search-api
+   curl -sI https://<name>.brainstorm.world     # expect 200, briefly 502 if Express is still booting — see §9.5
+   ```
+
+2. **Push the workflow.** `deploy-<name>.yml` lives only on the target branch (Actions on non-default branches only run for pushes to that branch). Pushing the workflow file *is* a push to the branch, which triggers the first CI/CD deploy. That run is the validation: it should idempotently re-pull, re-`sed`, and reach the same healthy state in ~80 seconds.
+
+3. **Update this document.** Add rows to §1 (deploy targets) and §5 (droplets and empirical measurements). Per §1's note this is a documented convention.
+
+---
+
+## 7. Active team and branch ownership
 
 | Person | GitHub | Role | Active branches |
 |--------|--------|------|-----------------|
@@ -143,15 +263,15 @@ Universal credits and contributor list lives in [BIBLE.md §20 "People"](./BIBLE
 
 ---
 
-## 7. Active tracking issues
+## 8. Active tracking issues
 
 - **#63 — Meilisearch upgrade.** Currently pinned at `getmeili/meilisearch:v1.12` (v1.12.8). Panics on certain queries (`q=primal`, `q=prima`) due to a milli interner u16 overflow. Workaround in place at `nostr-search/src/search.js` (catches the panic and returns a friendly notice in place of a 500). Real fix is a Meilisearch upgrade — verify index compatibility, plan a reindex from strfry, and remove the workaround. Deferred until time for the Docker rebuild and reindex window.
 
 ---
 
-## 8. Operational gotchas we've hit
+## 9. Operational gotchas we've hit
 
-### 8.1. `gh` CLI defaults to the upstream fork
+### 9.1. `gh` CLI defaults to the upstream fork
 
 This local checkout has two remotes:
 - `origin` → `nous-clawds4/tapestry` (our fork — what we actually push to)
@@ -161,7 +281,7 @@ This local checkout has two remotes:
 
 **Fix:** always pass `--repo nous-clawds4/tapestry` to every `gh` command, or run `gh repo set-default nous-clawds4/tapestry` once to fix it permanently.
 
-### 8.2. 2026-04-24: auto-delete-head-branches deleted `staging`
+### 9.2. 2026-04-24: auto-delete-head-branches deleted `staging`
 
 After merging a `staging → main` promotion PR, GitHub's "Automatically delete head branches" setting kicked in and deleted `staging` (the PR's head branch).
 
@@ -169,7 +289,7 @@ After merging a `staging → main` promotion PR, GitHub's "Automatically delete 
 
 **Permanent fix:** the `restrict-deletions` ruleset added in the same session (see §4 above) prevents recurrence on long-lived branches. Even with auto-delete enabled at the repo level, GitHub honors the ruleset.
 
-### 8.3. 2026-04-25: NIP-05 prod registration confused volume vs. host filesystem
+### 9.3. 2026-04-25: NIP-05 prod registration confused volume vs. host filesystem
 
 When first registering `brainstorm@brainstorm.world` via the NIP-05 endpoint added in PR #50/#51, David edited `/var/lib/brainstorm/settings.json` *on the droplet host* — but the brainstorm process inside the container reads from the `tapestry-data` Docker named volume mounted at `/var/lib/brainstorm/` *inside the container*. Different filesystems entirely.
 
@@ -177,7 +297,7 @@ When first registering `brainstorm@brainstorm.world` via the NIP-05 endpoint add
 
 **Documented for future maintainers:** [BIBLE.md §15 "Editing settings.json on a deployed droplet"](./BIBLE.md#editing-settingsjson-on-a-deployed-droplet) was added in response to this incident — the gotcha pattern is universal even though we hit it specifically while registering `brainstorm@brainstorm.world`.
 
-### 8.4. GitHub PR head-ref stuck state after retargeting base
+### 9.4. GitHub PR head-ref stuck state after retargeting base
 
 After retargeting a PR's base branch via `gh pr edit --base <new>`, subsequent pushes to the head branch can fail to sync with the PR — GitHub's `refs/pull/<N>/head` stays at the pre-retarget SHA. Symptoms: branch ref on origin updates correctly, but `gh api pulls/<N>` shows stale `head.sha`, `mergeable=false`, `mergeable_state=dirty`. No `synchronize` events fire in the PR timeline. `gh pr update-branch`, close/reopen, retargeting again — none of these recover it.
 
@@ -185,7 +305,7 @@ After retargeting a PR's base branch via `gh pr edit --base <new>`, subsequent p
 
 Hit this on PR #29 → replaced with PR #35 on 2026-04-19.
 
-### 8.5. Post-deploy 502 flicker until brainstorm Express binds
+### 9.5. Post-deploy 502 flicker until brainstorm Express binds
 
 Both `deploy-staging.yml` and `deploy-brainstorm.yml` run `docker compose up -d --build` and exit as soon as the compose command returns. That means CI reports "deploy succeeded" the moment the **container** starts — not when the brainstorm Node process inside it has finished booting (Neo4j driver init, Redis connection, Express middleware, etc., add a few seconds).
 
@@ -209,7 +329,7 @@ For human users hitting the site immediately after a deploy: refresh once or twi
 
 **Long-term fix candidate:** the deploy script could `curl --retry` an API endpoint as a final step before exiting, so CI doesn't report success until brainstorm is actually serving. Not yet done — left as a separate operational improvement.
 
-### 8.6. 2026-05-03: SESSION_SECRET rotated on every container start, invalidating all cookies
+### 9.6. 2026-05-03: SESSION_SECRET rotated on every container start, invalidating all cookies
 
 While verifying the Redis-backed session store landed in #90, we noticed users were still being logged out on every deploy — even though Redis correctly persisted session data across container rebuilds. The actual root cause: `docker/entrypoint.sh` regenerated `SESSION_SECRET="$(openssl rand -hex 32)"` unconditionally on every container start. Each `docker compose up -d --build` recreates the brainstorm container; `entrypoint.sh` re-ran; secret rotated; every existing user cookie failed signed-validation; express-session treated cookies as absent → users logged out, despite Redis still holding the session data.
 
@@ -217,7 +337,7 @@ While verifying the Redis-backed session store landed in #90, we noticed users w
 
 **Lesson:** when fixing a "session persistence" UX, both the *store* (where data lives) and the *secret* (which validates cookies referencing that data) need to survive container rebuilds. Either alone is insufficient.
 
-### 8.7. 2026-05-13: engineering-team scaffolding on main but not on staging
+### 9.7. 2026-05-13: engineering-team scaffolding on main but not on staging
 
 While preparing a new 5-phase engineering-team flow off `staging`, we discovered `engineering-team/` (templates, roles, workflows, README), `AGENTS.md`, and the engineering-team section of `CLAUDE.md` existed on `main` but not on `staging` — about 850 lines of agent-workflow scaffolding silently absent from the pre-production branch. Tracing it back: [PR #111](https://github.com/nous-clawds4/tapestry/pull/111) (commit `4acbe321` — "Add claude 'engineering team' concept") was merged directly to `main`, bypassing staging. All subsequent `staging → main` promotions carried staging's diff *into* main but never the reverse direction — git merges are one-way — so the two branches drifted by exactly that scaffolding.
 
@@ -225,7 +345,7 @@ While preparing a new 5-phase engineering-team flow off `staging`, we discovered
 
 **Mechanism for prevention:** all changes — *even docs and scaffolding* — should go through the standard `staging → main` flow. The cycle-staging and cycle-prod skills assume parity between the two long-lived branches; landing directly on main breaks that assumption silently. If parity drift is suspected, `git diff --stat origin/main origin/staging` from a fresh checkout reveals it immediately.
 
-### 8.8. 2026-05-14: sandbox instance had list headers but no items
+### 9.8. 2026-05-14: sandbox instance had list headers but no items
 
 On `tags.brainstorm.world` we noticed the DLists/Concepts for `tag` and `nostr-user-tag` (kind 39998 headers) were present, but no elements (kind 39999) — the UI showed empty lists. The droplet had run firmware install (so headers were correct), but element events published from users on *other* instances (`brainstorm.world`, local dev, etc.) never reached this droplet's strfry.
 
@@ -236,3 +356,38 @@ On `tags.brainstorm.world` we noticed the DLists/Concepts for `tag` and `nostr-u
 - Continuous: enable the `dcosl` router preset in `/tapestry/settings/relays` (both-direction, kinds 9998/9999/39998/39999).
 
 **Mental model:** see [BIBLE.md §14 "Router Presets"](./BIBLE.md#router-presets). `dcosl.brainstorm.world` is *not* a canonical pool — it's just another instance's public-facing relay that's a convenient pull target if you want shared list state across our deployments.
+
+### 9.9. 2026-05-15: SSH brute-force bots starved CI/CD on the new communities droplet
+
+Avi's first push to `feat/communities` triggered the deploy workflow, but `appleboy/ssh-action` failed at the SSH handshake with `read: connection reset by peer`. Not an auth failure — the connection was being **reset by sshd before authentication ran**.
+
+The droplet was being swarmed by SSH brute-force bots from minutes after boot. With sshd's default `MaxStartups 10:30:100`, once 10 unauthenticated connections are in-flight, sshd starts dropping new ones randomly. The auth log was full of `Invalid user dbus-helper`, `Invalid user pakchoi`, `Connection reset by authenticating user root`, plus repeated `error: beginning MaxStartups throttling` / `drop connection #N from [...] past MaxStartups`. Fail2ban was not installed (`systemctl is-active fail2ban` returned `inactive`). The GitHub Actions deploy connection had the bad luck of arriving during a throttle window and was dropped.
+
+**Recovery for this droplet:** install fail2ban, disable password auth — the same steps now baked into [§6.3 step 2](#63-on-the-droplet). Within minutes fail2ban's banlist grew, MaxStartups throttling stopped firing, and the next deploy ran cleanly.
+
+**Lesson:** any droplet on the public internet on port 22 will be swarmed within minutes of boot. Manual `ssh` retries hide the problem (a person retries until they get lucky); CI/CD has no retry, so it surfaces it. Hardening must happen **before** the deploy SSH key is generated, not after — otherwise the first CI/CD run after key setup is the lottery ticket. The other deploy droplets (prod, staging, magic-carpet, tags) escaped this so far either because they were stood up before the current bot pressure, or because they had hardening applied ad-hoc; the audit checklist below confirms which.
+
+**Audit checklist for existing droplets.** Run this once across all four existing deploy droplets (`brainstorm.world`, `staging.brainstorm.world`, `magic-carpet.brainstorm.world`, `tags.brainstorm.world`) to catch any that are missing the hardening now baked into §6.3 step 2.
+
+On each droplet:
+
+```bash
+# 1. Status check — three signals, all should pass
+echo "=== $(hostname) ==="
+echo "fail2ban: $(systemctl is-active fail2ban 2>/dev/null)"
+sshd -T | grep -E "^(passwordauthentication|kbdinteractiveauthentication)"
+echo "Recent SSH abuse signals (last 1 hour):"
+journalctl -u ssh --since "1 hour ago" --no-pager 2>/dev/null \
+  | grep -cE "MaxStartups|Invalid user" || true
+```
+
+A droplet passes if:
+- `fail2ban: active`
+- `passwordauthentication no` and `kbdinteractiveauthentication no`
+- The MaxStartups/Invalid-user count is low (single digits/hour is background noise; hundreds/hour means the droplet is currently saturated)
+
+If a droplet **fails** one of the first two checks, apply the hardening from §6.3 step 2 — the exact same commands work on a running droplet (they take effect on `systemctl reload ssh` and `systemctl enable --now fail2ban`). No reboot or downtime needed. Verify with the same script afterward.
+
+If a droplet shows high abuse counts in the third check but the first two pass, fail2ban is doing its job — the abuse traffic is being banned faster than it can saturate sshd. No action needed.
+
+**Tracking:** add a row to §8 "Active tracking issues" when starting the audit; remove it once all four droplets pass. The audit doesn't need to be scheduled — it's a one-time backfill; new droplets are protected by §6.3 step 2 going forward.


### PR DESCRIPTION
## Summary

Promotes the OPERATIONS.md docs update from staging to main after staging verification.

## Bundled

- **#144** — `docs: OPERATIONS.md — new-droplet runbook + SSH-hardening gotcha` (adds §6 runbook + §9.9 incident with audit checklist; renumbers §6/§7/§8 → §7/§8/§9)

## Net production impact

Documentation only. The `deploy-brainstorm.yml` run will rebuild and restart the brainstorm container on `brainstorm.world`, but no served behavior changes. Users may see a brief 502 flicker during the post-deploy Express bind window (per §9.5 in the new doc) — that's expected and self-resolving.

## Verification trail

- PR #144 staging deploy: [run 25898176416](https://github.com/nous-clawds4/tapestry/actions/runs/25898176416), 1m23s, ✅
- Stability poll: stable after 3×2s polls (3 consecutive 200s on first attempt)
- Tier 2 sanity: 7 pages + 5 APIs all 200, search returned hits with `success:true`
- Tier 3 PR-specific: OPERATIONS.md on `staging` branch verified to have the 23 expected section headings

## Test plan

- [ ] After merge: `deploy-brainstorm.yml` runs to completion
- [ ] Smoke test on `brainstorm.world` — same tiers as staging
- [ ] Verify `OPERATIONS.md` is browsable on the `main` branch on github.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)