### PR TITLE
sync: main → staging — deploy-communities.yml workflow file

### DIFF
--- a/.github/workflows/deploy-communities.yml
+++ b/.github/workflows/deploy-communities.yml
@@ -1,0 +1,28 @@
+name: Deploy to Communities
+
+on:
+  push:
+    branches: [feat/communities]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        timeout-minutes: 60
+        with:
+          host: ${{ secrets.DEPLOY_HOST_COMMUNITIES }}
+          username: ${{ secrets.DEPLOY_USER_COMMUNITIES }}
+          key: ${{ secrets.DEPLOY_SSH_KEY_COMMUNITIES }}
+          command_timeout: 25m
+          script: |
+            cd /opt/tapestry
+            git checkout -- docker-compose.yml 2>/dev/null
+            git checkout feat/communities 2>/dev/null || git checkout -b feat/communities origin/feat/communities
+            git pull origin feat/communities
+            # Communities droplet uses host nginx on port 80, so Docker must bind to 8080 on localhost only
+            sed -i 's/"80:80"/"127.0.0.1:8080:80"/' docker-compose.yml
+            docker compose up -d --build
+            docker image prune -f


### PR DESCRIPTION
## Summary

One-shot main→staging sync to resolve parity drift surfaced during the OPERATIONS.md docs promotion (PR #145). `deploy-communities.yml` was added directly to main (commit 7f1f0560) without going through the standard `staging → main` flow, leaving staging missing the file.

Same pattern as the §9.7 gotcha (engineering-team scaffolding drift, resolved by PR #122). Diff is purely additive on staging's side, so no conflicts.

## Changes

- `.github/workflows/deploy-communities.yml` — 28 lines added on staging (already present on main and on `feat/communities`)

## Net impact

- `deploy-staging.yml` will run, but the redeploy is a no-op for running services since only a workflow file moved (no app code changes).
- `deploy-communities.yml` itself triggers only on push to `feat/communities`, so adding it to staging doesn't trigger any deploy of communities.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs to completion (no-op redeploy)
- [ ] `git diff --stat origin/main origin/staging` shows zero diff afterward
- [ ] Brief sanity check on `staging.brainstorm.world` (workflow files don't affect served behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)