### PR TITLE
Enforce bounty reward caps

### DIFF
--- a/BIBLE.md
+++ b/BIBLE.md
@@ -1434,10 +1434,10 @@ The bounties subsystem lets a list curator (Alice) offer Lightning sats to any t
 
 ### Model
 
-- **Bounty = a row in SQLite**, not a nostr event. Bounties are app-level metadata (no cross-client coordination needed for a PoC). Schema lives in `src/db/bounties.js`; table is `bounties(id, issuer_pubkey, list_coordinate, amount_sats, criteria, expiration, created_at, status)`. DB file is `/var/lib/brainstorm/bounties.db` in prod (tapestry-data volume) or `./data/bounties.db` in dev.
+- **Bounty = a row in SQLite**, not a nostr event. Bounties are app-level metadata (no cross-client coordination needed for a PoC). Schema lives in `src/db/bounties.js`; table is `bounties(id, issuer_pubkey, list_coordinate, amount_sats, bounty_cap_sats, reward_per_item, max_rewards_per_npub, criteria, expiration, created_at, status)`. DB file is `/var/lib/brainstorm/bounties.db` in prod (tapestry-data volume) or `./data/bounties.db` in dev.
 - **Claim = an ordinary kind-39999 ListItem** on the bountied list, published through tapestry's existing `/tapestry/lists/:id/items/new` flow. No new event kind, no new submission endpoint. Correlation is implicit: claims are items on `bounty.list_coordinate` by pubkeys trusted by the issuer (rank ≥ 2), created after `bounty.created_at`.
 - **Payment = NIP-57 zap** tagging the claim's event id. Client signs kind-9734, posts to the recipient's LNURL callback, gets back an invoice. Kind-9735 receipt (published by the LNURL provider) is the proof of payment.
-- **Fulfilled status = derived**: the bounty is considered `fulfilled` when any kind-9735 receipt exists whose embedded zap request pubkey (parsed from the receipt's `description` tag per NIP-57) equals `bounty.issuer_pubkey`, targeting the bounty's list coordinate.
+- **Fulfilled status = derived**: the bounty is considered `fulfilled` only when issuer zap receipts have consumed the bounty cap. The payout policy grants `amount_sats` per payable reward, up to `floor(bounty_cap_sats / amount_sats)` rewards. By default only one reward per contributor is payable; `reward_per_item=1` allows multiple item rewards, optionally capped by `max_rewards_per_npub`. When unpaid claims exceed remaining reward slots, payable claims are selected deterministically by oldest claim first.
 
 ### Trust check
 
@@ -1449,7 +1449,7 @@ Set `DEV_SKIP_TRUST_CHECK=true` in `.env` to bypass the rank gate for local deve
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/api/bounties` | Create a bounty (session required). Body: `{ listCoordinate, amountSats, criteria, expiration? }`. |
+| POST | `/api/bounties` | Create a bounty (session required). Body: `{ listCoordinate, amountSats, bountyCapSats?, rewardPerItem?, maxRewardsPerNpub?, criteria, expiration? }`. If omitted, `bountyCapSats` defaults to `amountSats`. |
 | GET | `/api/bounties` | List bounties (`?status=open\|all`). Each includes a derived status. |
 | GET | `/api/bounties/eligible?viewer=<hex>` | Bounties whose issuer trusts the viewer at rank ≥ 2. |
 | GET | `/api/bounties/:id` | Single bounty + derived claims + zap receipts. |

--- a/bin/paycode.js
+++ b/bin/paycode.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+/**
+ * paycode — render a Lightning payment code as a QR, exactly as the issuer-side
+ * UI (ui/src/components/PaymentCode.jsx) shows it. The terminal/PNG/HTML output
+ * mirrors that component's label + helper text so a CLI preview is faithful to
+ * what a payer would actually see and scan.
+ *
+ * Accepts a BOLT11 invoice (lnbc…), a BOLT12 offer (lno1…), or a BIP-21/lightning:
+ * URI. Classification matches readBolt12()/PaymentCode's bolt12-vs-bolt11 split.
+ *
+ *   node bin/paycode.js <payload> [--png <path>] [--html <path>] [--no-term] [--json]
+ *   echo "<payload>" | node bin/paycode.js --png /tmp/code.png
+ */
+const fs = require('fs');
+const path = require('path');
+
+function loadDep(name) {
+  const tries = [name, path.join(__dirname, '..', 'ui', 'node_modules', name), `/usr/local/lib/node_modules/brainstorm/node_modules/${name}`];
+  for (const t of tries) { try { return require(t); } catch {} }
+  throw new Error(`cannot load '${name}' — is qrcode installed (ui/node_modules)?`);
+}
+const QRCode = loadDep('qrcode');
+
+// Mirror of PaymentCode.jsx labels.
+function classify(payload) {
+  const s = String(payload).trim();
+  if (/lno1[a-z0-9]{8,}/i.test(s)) {
+    return { type: 'bolt12', label: 'BOLT12 offer (static, reusable)', wallet: 'Scan with Phoenix / Zeus / CLN, or paste into a BOLT12-aware wallet — pay any amount.' };
+  }
+  if (/ln(bc|tb|bcrt)[0-9]/i.test(s)) {
+    return { type: 'bolt11', label: 'BOLT11 invoice (one-time)', wallet: 'Scan or paste into your Lightning wallet to pay this exact amount.' };
+  }
+  return { type: 'unknown', label: 'Payment code', wallet: 'Scan or paste into a Lightning wallet.' };
+}
+
+function parseArgs(argv) {
+  const pos = []; const flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      const k = a.slice(2);
+      if (['no-term', 'json'].includes(k)) { flags[k] = true; continue; }
+      const n = argv[i + 1];
+      if (n === undefined || n.startsWith('--')) flags[k] = true; else { flags[k] = n; i++; }
+    } else pos.push(a);
+  }
+  return { pos, flags };
+}
+
+function readStdin() {
+  try { return fs.readFileSync(0, 'utf8').trim(); } catch { return ''; }
+}
+
+function htmlDoc({ payload, info, dataUrl }) {
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Payment code — ${info.label}</title></head>
+<body style="font-family:system-ui,sans-serif;background:#0d1117;color:#c9d1d9;max-width:560px;margin:2rem auto;padding:0 1rem">
+<header><h1 style="font-size:1.2rem">${info.label}</h1>
+<p style="opacity:.75">${info.wallet}</p></header>
+<section style="text-align:center">
+<img alt="payment QR" src="${dataUrl}" style="width:300px;height:300px;background:#fff;padding:10px;border-radius:8px"/>
+</section>
+<section><p style="opacity:.7;font-size:.85rem">Raw code (copy/paste if you can't scan):</p>
+<pre style="white-space:pre-wrap;word-break:break-all;background:#161b22;border:1px solid #30363d;border-radius:6px;padding:10px;font-size:.7rem">${payload.replace(/[<&]/g, c => ({ '<': '&lt;', '&': '&amp;' }[c]))}</pre></section>
+<footer><p style="opacity:.6;font-size:.8rem">Rendered by <code>bin/paycode.js</code> — a faithful CLI mirror of the app's <code>PaymentCode</code> component. ${info.type === 'bolt11' ? 'One-time invoice: pay exactly once.' : info.type === 'bolt12' ? 'Static offer: reusable, payer chooses the amount (BOLT12-aware wallet required).' : ''}</p></footer>
+</body></html>`;
+}
+
+async function main() {
+  const { pos, flags } = parseArgs(process.argv.slice(2));
+  const payload = (pos[0] || readStdin() || '').trim();
+  if (!payload) {
+    console.error('usage: paycode <bolt11|bolt12|lightning:|bitcoin:?lno=> [--png path] [--html path] [--no-term] [--json]');
+    process.exit(1);
+  }
+  const info = classify(payload);
+
+  if (!flags.json) {
+    console.log(`\n${info.label}`);
+    console.log(`${info.wallet}\n`);
+  }
+  if (!flags['no-term'] && !flags.json) {
+    console.log(await QRCode.toString(payload, { type: 'terminal', small: true }));
+  }
+  if (flags.png) { await QRCode.toFile(flags.png, payload, { width: 512, margin: 2 }); }
+  let dataUrl = null;
+  if (flags.html) {
+    dataUrl = await QRCode.toDataURL(payload, { width: 512, margin: 2 });
+    fs.writeFileSync(flags.html, htmlDoc({ payload, info, dataUrl }));
+  }
+
+  if (flags.json) {
+    console.log(JSON.stringify({ type: info.type, label: info.label, payload, png: flags.png || null, html: flags.html || null }, null, 2));
+  } else {
+    if (flags.png) console.log(`PNG written: ${flags.png}`);
+    if (flags.html) console.log(`HTML written: ${flags.html}`);
+    console.log(`\npayload (${info.type}):\n${payload}`);
+  }
+}
+
+main().catch(e => { console.error('error:', e.message); process.exit(1); });

--- a/bin/receiving.js
+++ b/bin/receiving.js
@@ -1,0 +1,347 @@
+#!/usr/bin/env node
+
+/**
+ * receiving — prove the pick-a-wallet → kind 0 loop from the terminal.
+ *
+ * Subcommands:
+ *   set <method> [value]   set your receiving method on your own kind 0
+ *                          methods: npub-cash | address <lud16> | bolt12 <lno1…> | lnurl <lnurl1…>
+ *   show <pubkey>          resolve the ACTIVE method (bolt12→lud16 precedence),
+ *                          newest across local strfry + profile relays
+ *   resolve <pubkey>       run the issuer-side payout decision headlessly:
+ *                          BOLT12 (untracked) vs BOLT11-via-LNURL (tracked)
+ *
+ * Signing key (set only): --nsec <nsec1…|hex>, else $NOSTR_NSEC. The key is the
+ * user's own, supplied by them, used locally — never logged or persisted.
+ *
+ * Flags:
+ *   --nsec <key>      signing key for `set` (or $NOSTR_NSEC)
+ *   --pubkey <hex>    expected signer pubkey; `set` rejects a mismatch (Finding 6)
+ *   --relays a,b,c    override PROFILE_RELAYS (defaults to settings)
+ *   --no-local        skip local strfry import (set) / skip local scan (show/resolve)
+ *   --no-external     skip external relays (show/resolve)
+ *   --amount <sats>   informational, for `resolve`
+ *   --json            machine-readable output
+ *
+ * Examples:
+ *   node bin/receiving.js set npub-cash --nsec nsec1...
+ *   node bin/receiving.js set address alice@walletofsatoshi.com --nsec nsec1...
+ *   node bin/receiving.js set bolt12 'bitcoin:?lno=lno1...' --nsec nsec1...
+ *   node bin/receiving.js set lnurl lnurl1dp68... --nsec nsec1...
+ *   node bin/receiving.js show <pubkey-hex>
+ *   node bin/receiving.js resolve <pubkey-hex> --amount 1000
+ */
+
+function loadDep(name) {
+  try { return require(name); }
+  catch { return require(`/usr/local/lib/node_modules/brainstorm/node_modules/${name}`); }
+}
+
+const { nip19, getPublicKey, finalizeEvent } = loadDep('nostr-tools');
+
+const { buildReceivingContent } = require('../src/lib/receiving/mergeKind0');
+const { resolveReceivingMethod, resolvePayment } = require('../src/lib/receiving/resolveMethod');
+const { resolveProfile } = require('../src/lib/receiving/resolveProfile');
+const { publishProfileEvent, getProfileRelays } = require('../src/lib/receiving/publish');
+const { WALLET_OPTIONS } = require('../src/lib/receiving/walletOptions');
+const { probeReceiving, trackedVerdict } = require('../src/lib/receiving/probe');
+
+// ---- arg parsing -----------------------------------------------------------
+
+function parseArgs(argv) {
+  const positionals = [];
+  const flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      const key = a.slice(2);
+      const boolFlags = ['no-local', 'no-external', 'json', 'help', 'probe', 'no-probe'];
+      if (boolFlags.includes(key)) { flags[key] = true; continue; }
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) { flags[key] = true; }
+      else { flags[key] = next; i++; }
+    } else {
+      positionals.push(a);
+    }
+  }
+  return { positionals, flags };
+}
+
+function die(msg, code = 1) {
+  console.error(`error: ${msg}`);
+  process.exit(code);
+}
+
+function out(flags, human, obj) {
+  if (flags.json) console.log(JSON.stringify(obj, null, 2));
+  else console.log(human);
+}
+
+function shortPk(hex) { return hex ? `${hex.slice(0, 8)}…${hex.slice(-4)}` : '—'; }
+
+function nowSeconds() { return Math.floor(Date.now() / 1000); }
+
+function relaysFrom(flags) {
+  if (flags.relays) return String(flags.relays).split(',').map(s => s.trim()).filter(Boolean);
+  return getProfileRelays();
+}
+
+// ---- key handling (never log the raw key) ----------------------------------
+
+function loadSigningKey(flags) {
+  const raw = flags.nsec || process.env.NOSTR_NSEC;
+  if (!raw) die('no signing key — pass --nsec <nsec1…|hex> or set $NOSTR_NSEC');
+
+  let hex;
+  if (typeof raw === 'string' && raw.startsWith('nsec1')) {
+    let decoded;
+    try { decoded = nip19.decode(raw); }
+    catch { return die('--nsec is not a valid nsec1… key'); }
+    if (decoded.type !== 'nsec') die(`--nsec decoded to ${decoded.type}, expected nsec`);
+    hex = Buffer.from(decoded.data).toString('hex');
+  } else if (typeof raw === 'string' && /^[0-9a-f]{64}$/i.test(raw)) {
+    hex = raw.toLowerCase();
+  } else {
+    return die('--nsec must be an nsec1… key or 64-char hex');
+  }
+
+  const privBytes = Uint8Array.from(Buffer.from(hex, 'hex'));
+  const pubkey = getPublicKey(privBytes);
+  return { privBytes, pubkey };
+}
+
+// ---- subcommands -----------------------------------------------------------
+
+async function cmdSet(positionals, flags) {
+  const method = positionals[0];
+  const value = positionals[1];
+  if (!method) {
+    die('usage: receiving set <npub-cash|address|bolt12|lnurl> [value] --nsec <key>');
+  }
+
+  const { privBytes, pubkey } = loadSigningKey(flags);
+
+  // Signer-mismatch guard (Finding 6): the key must match the expected target.
+  if (flags.pubkey && flags.pubkey.toLowerCase() !== pubkey) {
+    die(`signer mismatch: --nsec is ${shortPk(pubkey)} but --pubkey expects ${shortPk(String(flags.pubkey).toLowerCase())}`);
+  }
+
+  // Merge into the user's CURRENT profile so we don't drop name/about/etc.
+  if (flags['no-local'] && flags['no-external']) {
+    console.error('warning: --no-local and --no-external both set — merging into an EMPTY profile; any existing name/about/picture will be dropped from the new kind 0.');
+  }
+  let current = null;
+  try {
+    const resolved = await resolveProfile(pubkey, {
+      relays: relaysFrom(flags),
+      includeLocal: !flags['no-local'],
+      includeExternal: !flags['no-external'],
+    });
+    current = resolved.profile;
+  } catch (err) {
+    console.error(`warning: could not read current profile (${err.message}); merging into empty profile`);
+  }
+
+  let built;
+  try {
+    built = buildReceivingContent({ profile: current, method, value, pubkeyHex: pubkey });
+  } catch (err) {
+    return die(err.message);
+  }
+
+  // For LNURL-backed methods (lud16 address or lud06 lnurl1… code), probe the
+  // LNURL so we can tell the user *now* whether it actually works for tracked
+  // zaps (fedimint gateways / static paycodes often don't). Non-fatal: we still
+  // publish — the user may know what they're doing. Skip with --no-probe.
+  let probe = null, verdict = null;
+  if ((built.field === 'lud16' || built.field === 'lud06') && !flags['no-probe']) {
+    probe = await probeReceiving(built.value);
+    verdict = trackedVerdict(probe);
+    if (verdict.tracked !== true) {
+      console.error(`warning: ${built.value}: ${verdict.note}`);
+    }
+  }
+
+  const template = {
+    kind: 0,
+    created_at: nowSeconds(),
+    tags: [],
+    content: JSON.stringify(built.content),
+  };
+  const signed = finalizeEvent(template, privBytes);
+
+  const pub = await publishProfileEvent(signed, {
+    relays: relaysFrom(flags),
+    includeLocal: !flags['no-local'],
+  });
+
+  const relayOk = pub.relays.filter(r => r.success).length;
+  const human = [
+    `set ${built.field} = ${built.value}`,
+    built.cleared.length ? `cleared conflicting fields: ${built.cleared.join(', ')}` : 'no conflicting fields to clear',
+    verdict ? `tracked: ${verdict.tracked === true ? 'yes' : 'no'} — ${verdict.note}` : 'tracked: not probed (--no-probe)',
+    `signer: ${shortPk(pubkey)}  event: ${signed.id.slice(0, 16)}…`,
+    `local strfry: ${pub.local.success ? 'imported' : (pub.local.skipped ? 'skipped' : 'FAILED')} ${pub.local.message ? `(${pub.local.message})` : ''}`,
+    `profile relays: ${relayOk}/${pub.relays.length} accepted`,
+    ...pub.relays.map(r => `  - ${r.relay}: ${r.success ? 'ok' : r.message}`),
+  ].join('\n');
+
+  out(flags, human, {
+    ok: true,
+    method, field: built.field, value: built.value,
+    cleared: built.cleared, replaced: built.replaced,
+    tracked: verdict ? verdict.tracked : null, probe,
+    pubkey, eventId: signed.id,
+    local: pub.local, relays: pub.relays,
+  });
+}
+
+async function cmdShow(positionals, flags) {
+  const pubkey = (positionals[0] || '').toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(pubkey)) die('usage: receiving show <pubkey-hex>');
+
+  const resolved = await resolveProfile(pubkey, {
+    relays: relaysFrom(flags),
+    includeLocal: !flags['no-local'],
+    includeExternal: !flags['no-external'],
+  });
+  const method = resolveReceivingMethod(resolved.profile);
+
+  // With --probe, verify the real tracked-ness of an LNURL-backed method (a
+  // lud16 address or a static lnurl1… code) via its LNURL allowsNostr.
+  let probe = null;
+  const trackedWord = (t) => (t === true ? 'yes' : t === false ? 'no' : 'unknown');
+  let trackedLine = method ? `tracked: ${trackedWord(method.tracked)} — ${method.trackedReason}` : null;
+  if (method && (method.method === 'lud16' || method.method === 'lnurl') && flags.probe) {
+    probe = await probeReceiving(method.value);
+    const v = trackedVerdict(probe);
+    method.tracked = v.tracked;
+    trackedLine = `tracked: ${trackedWord(v.tracked)} — ${v.note} [probed]`;
+  }
+
+  const human = method
+    ? [
+        `active method: ${method.method} (${method.field})`,
+        `value: ${method.value}`,
+        trackedLine,
+        `profile source: ${resolved.source || 'none'} (local ${resolved.sources.local} / external ${resolved.sources.external} kind-0 seen)`,
+        `created_at: ${resolved.createdAt || '—'}`,
+      ].join('\n')
+    : `no receiving method set (local ${resolved.sources.local} / external ${resolved.sources.external} kind-0 seen)`;
+
+  out(flags, human, {
+    ok: true, pubkey,
+    method, probe, source: resolved.source, createdAt: resolved.createdAt, sources: resolved.sources,
+  });
+}
+
+async function cmdResolve(positionals, flags) {
+  const pubkey = (positionals[0] || '').toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(pubkey)) die('usage: receiving resolve <pubkey-hex> [--amount <sats>]');
+
+  const resolved = await resolveProfile(pubkey, {
+    relays: relaysFrom(flags),
+    includeLocal: !flags['no-local'],
+    includeExternal: !flags['no-external'],
+  });
+  const payment = resolvePayment(resolved.profile);
+  const amount = flags.amount ? Number(flags.amount) : null;
+
+  // With --probe, confirm the LNURL is actually payable (reachable + allowsNostr).
+  // The target is a lud16 address or a static lnurl1… code (in payment.source).
+  let probe = null;
+  const payTarget = payment.lud16 || payment.source;
+  if (payment.type === 'bolt11' && payTarget && flags.probe) {
+    probe = await probeReceiving(payTarget);
+    const v = trackedVerdict(probe);
+    payment.tracked = v.tracked;
+    payment.probeNote = v.note;
+    if (v.tracked !== true) payment.payable = false;
+  }
+
+  let human;
+  if (payment.type === 'none') {
+    human = `no payout possible: ${payment.error}`;
+  } else if (payment.type === 'bolt12') {
+    human = [
+      `payout: BOLT12 static offer — UNTRACKED`,
+      `payload: ${payment.payload}`,
+      `note: no zap receipt; a cap-tracked bounty won't auto-mark this paid or free the slot.`,
+      amount ? `amount: ${amount} sats (offer is amountless; payer chooses)` : null,
+    ].filter(Boolean).join('\n');
+  } else {
+    const viaLnurl = payment.via === 'lnurl';
+    let status;
+    if (payment.tracked === true) status = 'TRACKED';
+    else if (probe) status = 'NOT PAYABLE / UNTRACKED';
+    else if (viaLnurl) status = 'UNKNOWN — run --probe (a static LNURL is tracked only if it allows Nostr zaps)';
+    else status = 'TRACKED (assumed; use --probe to verify)';
+    human = [
+      `payout: BOLT11 via LNURL — ${status}`,
+      `${viaLnurl ? 'lnurl' : 'lud16'}: ${payTarget}`,
+      probe ? `probe: ${payment.probeNote}` : `note: issuer UI signs a kind-9734 and fetches a BOLT11; payment yields a kind-9735 receipt — IF the LNURL allows Nostr zaps (run with --probe to confirm).`,
+      amount ? `amount: ${amount} sats` : null,
+    ].filter(Boolean).join('\n');
+  }
+
+  out(flags, human, { ok: true, pubkey, amount, payment, probe, source: resolved.source });
+}
+
+// Catalog `tracked` is tri-state: true (zap receipt), false (never), or
+// 'depends' (an LNURL — only if it allows Nostr; verify with --probe).
+function trackedTag(tracked) {
+  if (tracked === true) return '[tracked]  ';
+  if (tracked === false) return '[untracked]';
+  return '[depends]  ';
+}
+
+function printHelp() {
+  console.log(`receiving — pick-a-wallet → kind 0 (CLI)
+
+usage:
+  receiving set <method> [value] --nsec <nsec1…|hex>
+  receiving show <pubkey-hex>
+  receiving resolve <pubkey-hex> [--amount <sats>]
+
+set methods:
+  npub-cash              derive <npub>@npub.cash (tracked)            → lud16
+  address <lud16>        a name@domain Lightning address              → lud16
+  wos <lud16>            Wallet of Satoshi address (non-U.S./existing) → lud16
+  fedimint <lud16>       a federation-backed Lightning address        → lud16  (NOT a fed11… invite code)
+  bolt12 <lno1…>         a static BOLT12 offer (untracked)            → bolt12
+  lnurl <lnurl1…>        a static LNURL-pay code (e.g. a paycode)      → lud06  (tracked only if it allows Nostr; --probe)
+
+flags:
+  --nsec <key>     signing key for set (or $NOSTR_NSEC); never logged
+  --pubkey <hex>   expected signer pubkey; set rejects a mismatch
+  --relays a,b     override profile relays (default: settings PROFILE_RELAYS)
+  --no-local       skip local strfry
+  --no-external    skip external relays
+  --probe          show/resolve: verify real tracked-ness (lud16 or lnurl) via its LNURL allowsNostr
+  --no-probe       set: skip the default LNURL allowsNostr check
+  --amount <sats>  informational for resolve
+  --json           machine-readable output
+
+curated options:
+${WALLET_OPTIONS.map(o => `  ${o.id.padEnd(10)} ${trackedTag(o.tracked)} ${o.note}`).join('\n')}
+`);
+}
+
+async function main() {
+  const { positionals, flags } = parseArgs(process.argv.slice(2));
+  const cmd = positionals[0];
+  const rest = positionals.slice(1);
+
+  if (!cmd || flags.help || cmd === 'help') { printHelp(); process.exit(cmd ? 0 : 1); }
+
+  switch (cmd) {
+    case 'set': return cmdSet(rest, flags);
+    case 'show': return cmdShow(rest, flags);
+    case 'resolve': return cmdResolve(rest, flags);
+    default: die(`unknown command: ${cmd} (use set | show | resolve)`);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(err => { console.error(`error: ${err.message}`); process.exit(1); });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
   },
   "scripts": {
     "test": "node test/test.js",
+    "test:receiving": "node test/receiving.test.js",
+    "test:receiving:e2e": "node test/receiving.e2e.js",
+    "test:receiving:probe": "node test/receiving.probe.e2e.js",
+    "receiving": "node bin/receiving.js",
+    "paycode": "node bin/paycode.js",
     "test:playwright": "playwright test",
     "test:playwright:ui": "playwright test --ui",
     "test:playwright:headed": "playwright test --headed",

--- a/setup/nostr/node_project/package-lock.json
+++ b/setup/nostr/node_project/package-lock.json
@@ -8,7 +8,7 @@
       "name": "brainstorm-nostr",
       "version": "1.0.0",
       "dependencies": {
-        "nostr-tools": "^2.23.3"
+        "nostr-tools": "^2.23.5"
       }
     },
     "node_modules/@noble/ciphers": {
@@ -87,9 +87,9 @@
       }
     },
     "node_modules/nostr-tools": {
-      "version": "2.23.3",
-      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.23.3.tgz",
-      "integrity": "sha512-AALyt9k8xPdF4UV2mlLJ2mgCn4kpTB0DZ8t2r6wjdUh6anfx2cTVBsHUlo9U0EY/cKC5wcNyiMAmRJV5OVEalA==",
+      "version": "2.23.5",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.23.5.tgz",
+      "integrity": "sha512-Fa7ZlUdjfUW1P4E7H3yBexhOHYi18XNyvd2n7eNHkYR085xADX6Y8V8Vm7nT/XQajaFOBrptXmVIGkJ2E4vfVw==",
       "license": "Unlicense",
       "dependencies": {
         "@noble/ciphers": "2.1.1",

--- a/setup/nostr/node_project/package.json
+++ b/setup/nostr/node_project/package.json
@@ -1,1 +1,1 @@
-{"name":"brainstorm-nostr","version":"1.0.0","private":true,"dependencies":{"nostr-tools":"^2.23.3"}}
+{"name":"brainstorm-nostr","version":"1.0.0","private":true,"dependencies":{"nostr-tools":"^2.23.5"}}

--- a/src/api/bounties.js
+++ b/src/api/bounties.js
@@ -8,12 +8,16 @@ const {
   listAllBounties,
   getBounty,
   bountiesByIssuer,
-  bountiesByListCoordinates,
   markFulfilled,
 } = require('../db/bounties');
 const { rank } = require('../lib/trust-rank');
-
-const COORDINATE_RE = /^(\d+):([0-9a-f]{64}):(.+)$/;
+const { normalizeBountyCreatePayload } = require('../lib/bounty-fields');
+const {
+  annotateClaimsWithPaymentState,
+  calculateBountyPaymentState,
+  canAcceptNewClaimFrom,
+  publicPaymentState,
+} = require('../lib/bounty-policy');
 
 function requireAuthed(req, res, next) {
   if (!req.session?.authenticated || !req.session?.pubkey) {
@@ -46,18 +50,28 @@ function parseZapRequestPubkey(receipt) {
   try { return JSON.parse(description).pubkey ?? null; } catch { return null; }
 }
 
-async function isBountyFulfilled(bounty) {
-  const receipts = await scanStrfry({
-    kinds: [9735],
-    '#a': [bounty.list_coordinate],
-  });
-  return receipts.some(r => parseZapRequestPubkey(r) === bounty.issuer_pubkey);
-}
-
-function deriveStatus(bounty, { fulfilled = false, now = Math.floor(Date.now() / 1000) } = {}) {
-  if (fulfilled) return 'fulfilled';
+function deriveStatus(bounty, { paymentState = null, now = Math.floor(Date.now() / 1000) } = {}) {
+  if (paymentState?.fulfilled) return 'fulfilled';
   if (bounty.expiration && bounty.expiration < now) return 'expired';
   return bounty.status;
+}
+
+function bountyForClient(bounty, paymentState, { now = Math.floor(Date.now() / 1000), extra = {} } = {}) {
+  const derivedStatus = deriveStatus(bounty, { paymentState, now });
+  return {
+    ...bounty,
+    ...extra,
+    derivedStatus,
+    paymentState: publicPaymentState(paymentState),
+  };
+}
+
+async function paymentStateForBounty(bounty, options = {}) {
+  const claims = await listClaimsFor(bounty, options);
+  return {
+    claims,
+    paymentState: calculateBountyPaymentState(bounty, claims),
+  };
 }
 
 async function listClaimsFor(bounty, { trustFilter = true } = {}) {
@@ -74,39 +88,23 @@ async function listClaimsFor(bounty, { trustFilter = true } = {}) {
       if (r < 2) continue;
     }
     const receipts = await scanStrfry({ kinds: [9735], '#e': [item.id] });
-    const zapReceipt = receipts.find(r => parseZapRequestPubkey(r) === bounty.issuer_pubkey) ?? receipts[0] ?? null;
+    const zapReceipt = receipts.find(r => parseZapRequestPubkey(r) === bounty.issuer_pubkey) ?? null;
     results.push({ event: item, zapReceipt });
   }
   return results;
 }
 
 async function handleCreateBounty(req, res) {
-  const { listCoordinate, amountSats, criteria, expiration } = req.body || {};
-
-  if (!listCoordinate || !COORDINATE_RE.test(listCoordinate)) {
-    return res.status(400).json({ success: false, error: 'listCoordinate must be <kind>:<pubkey>:<dtag>' });
-  }
-  const amt = Number(amountSats);
-  if (!Number.isInteger(amt) || amt <= 0) {
-    return res.status(400).json({ success: false, error: 'amountSats must be a positive integer' });
-  }
-  if (typeof criteria !== 'string' || !criteria.trim()) {
-    return res.status(400).json({ success: false, error: 'criteria is required' });
-  }
-  let exp = null;
-  if (expiration !== undefined && expiration !== null && expiration !== '') {
-    exp = Number(expiration);
-    if (!Number.isInteger(exp) || exp <= 0) {
-      return res.status(400).json({ success: false, error: 'expiration must be a unix timestamp' });
-    }
+  let payload;
+  try {
+    payload = normalizeBountyCreatePayload(req.body || {});
+  } catch (err) {
+    return res.status(err.statusCode || 400).json({ success: false, error: err.message });
   }
 
   const row = createBounty({
     issuerPubkey: req.session.pubkey,
-    listCoordinate,
-    amountSats: amt,
-    criteria: criteria.trim(),
-    expiration: exp,
+    ...payload,
   });
   res.json({ success: true, bounty: row });
 }
@@ -118,10 +116,15 @@ async function handleListBounties(req, res) {
   const now = Math.floor(Date.now() / 1000);
 
   const enriched = await Promise.all(rows.map(async b => {
-    const fulfilled = await isBountyFulfilled(b);
-    return { ...b, derivedStatus: deriveStatus(b, { fulfilled, now }) };
+    const { paymentState } = await paymentStateForBounty(b, { trustFilter: true });
+    const derivedStatus = deriveStatus(b, { paymentState, now });
+    if (derivedStatus === 'fulfilled' && b.status !== 'fulfilled') markFulfilled(b.id);
+    return bountyForClient(b, paymentState, { now });
   }));
-  res.json({ success: true, bounties: enriched });
+  const filtered = statusFilter === 'open'
+    ? enriched.filter(b => b.derivedStatus === 'open')
+    : enriched;
+  res.json({ success: true, bounties: filtered });
 }
 
 async function handleEligibleBounties(req, res) {
@@ -134,13 +137,21 @@ async function handleEligibleBounties(req, res) {
   }
 
   const open = listOpenBounties({ limit: 500 });
+  const now = Math.floor(Date.now() / 1000);
   const checked = await Promise.all(open.map(async b => {
     const issuerRank = await rank(b.issuer_pubkey, viewer);
-    return { bounty: b, issuerRank };
+    if (issuerRank < 2) return null;
+    const { paymentState } = await paymentStateForBounty(b, { trustFilter: true });
+    const bounty = bountyForClient(b, paymentState, { now, extra: { issuerRank } });
+    if (bounty.derivedStatus === 'fulfilled' && b.status !== 'fulfilled') markFulfilled(b.id);
+    return {
+      bounty,
+      canClaim: bounty.derivedStatus === 'open' && canAcceptNewClaimFrom(paymentState, viewer),
+    };
   }));
   const eligible = checked
-    .filter(({ issuerRank }) => issuerRank >= 2)
-    .map(({ bounty, issuerRank }) => ({ ...bounty, issuerRank }));
+    .filter(result => result?.canClaim)
+    .map(({ bounty }) => bounty);
   res.json({ success: true, bounties: eligible });
 }
 
@@ -148,24 +159,29 @@ async function handleGetBounty(req, res) {
   const b = getBounty(req.params.id);
   if (!b) return res.status(404).json({ success: false, error: 'bounty not found' });
 
-  const fulfilled = await isBountyFulfilled(b);
-  if (fulfilled && b.status !== 'fulfilled') markFulfilled(b.id);
-  const claims = await listClaimsFor(b, { trustFilter: true });
+  const { claims, paymentState } = await paymentStateForBounty(b, { trustFilter: true });
+  const derivedStatus = deriveStatus(b, { paymentState });
+  if (derivedStatus === 'fulfilled' && b.status !== 'fulfilled') markFulfilled(b.id);
   res.json({
     success: true,
-    bounty: { ...b, derivedStatus: deriveStatus(b, { fulfilled }) },
-    claims,
+    bounty: bountyForClient(b, paymentState),
+    claims: annotateClaimsWithPaymentState(claims, paymentState),
   });
 }
 
 async function handlePaymentsDue(req, res) {
   const mine = bountiesByIssuer(req.session.pubkey);
-  const open = mine.filter(b => b.status !== 'expired');
+  const now = Math.floor(Date.now() / 1000);
   const result = [];
-  for (const b of open) {
-    const claims = await listClaimsFor(b, { trustFilter: true });
-    const pending = claims.filter(c => !c.zapReceipt);
-    if (pending.length > 0) result.push({ bounty: b, pendingClaims: pending });
+  for (const b of mine) {
+    const { paymentState } = await paymentStateForBounty(b, { trustFilter: true });
+    const derivedStatus = deriveStatus(b, { paymentState, now });
+    if (derivedStatus === 'fulfilled' && b.status !== 'fulfilled') markFulfilled(b.id);
+    if (derivedStatus !== 'open') continue;
+    const pending = paymentState.payableClaims;
+    if (pending.length > 0) {
+      result.push({ bounty: bountyForClient(b, paymentState, { now }), pendingClaims: pending });
+    }
   }
   res.json({ success: true, items: result });
 }
@@ -219,36 +235,43 @@ async function handlePaymentsToMe(req, res) {
   const trustedPairs = candidatePairs.filter((_, i) => ranks[i] >= 2);
   if (!trustedPairs.length) return res.json(empty);
 
-  // Per-claim receipt scans + per-bounty fulfilled checks. We need both: the
-  // per-claim receipt tells us if THIS user got paid; isBountyFulfilled tells
-  // us if SOME OTHER claim was paid (so the bounty is closed, not pending).
   const uniqueBountiesById = new Map();
   for (const p of trustedPairs) uniqueBountiesById.set(p.bounty.id, p.bounty);
   const uniqueBounties = [...uniqueBountiesById.values()];
 
-  const [receiptResults, fulfilledChecks] = await Promise.all([
-    Promise.all(trustedPairs.map(p => scanStrfry({ kinds: [9735], '#e': [p.claim.id] }))),
-    Promise.all(uniqueBounties.map(b => isBountyFulfilled(b))),
-  ]);
-  const fulfilledByBountyId = new Map(uniqueBounties.map((b, i) => [b.id, fulfilledChecks[i]]));
-
   const now = Math.floor(Date.now() / 1000);
+  const bountyStateEntries = await Promise.all(uniqueBounties.map(async bounty => {
+    const { claims, paymentState } = await paymentStateForBounty(bounty, { trustFilter: true });
+    const derivedStatus = deriveStatus(bounty, { paymentState, now });
+    if (derivedStatus === 'fulfilled' && bounty.status !== 'fulfilled') markFulfilled(bounty.id);
+    const annotatedClaims = annotateClaimsWithPaymentState(claims, paymentState);
+    return [bounty.id, {
+      bounty: bountyForClient(bounty, paymentState, { now }),
+      claimsById: new Map(annotatedClaims.map(claim => [claim.event.id, claim])),
+    }];
+  }));
+  const bountyStates = new Map(bountyStateEntries);
+
   const pastDue = [];
   const pending = [];
   const paid = [];
   const closed = [];
 
-  for (let i = 0; i < trustedPairs.length; i++) {
-    const { bounty, claim } = trustedPairs[i];
-    const receipts = receiptResults[i];
-    const zap = receipts.find(r => parseZapRequestPubkey(r) === bounty.issuer_pubkey) ?? null;
-    const ds = deriveStatus(bounty, { fulfilled: fulfilledByBountyId.get(bounty.id), now });
-    const row = { bounty, claim: { event: claim, zapReceipt: zap } };
+  for (const { bounty, claim } of trustedPairs) {
+    const state = bountyStates.get(bounty.id);
+    if (!state) continue;
+    const annotatedClaim = state.claimsById.get(claim.id) ?? {
+      event: claim,
+      zapReceipt: null,
+      paymentStatus: 'closed',
+      closedReason: 'cap',
+    };
+    const row = { bounty: state.bounty, claim: annotatedClaim };
 
-    if (zap) paid.push(row);
-    else if (ds === 'fulfilled') closed.push(row);
-    else if (ds === 'expired') pastDue.push(row);
-    else pending.push(row);
+    if (annotatedClaim.zapReceipt || annotatedClaim.paymentStatus === 'paid') paid.push(row);
+    else if (state.bounty.derivedStatus === 'expired') pastDue.push(row);
+    else if (annotatedClaim.paymentStatus === 'payable') pending.push(row);
+    else closed.push(row);
   }
 
   const byClaimAgeDesc = (a, b) => b.claim.event.created_at - a.claim.event.created_at;

--- a/src/api/profiles/fetchProfiles.js
+++ b/src/api/profiles/fetchProfiles.js
@@ -1,10 +1,13 @@
 /**
  * Profile fetch endpoint with in-memory cache.
  *
- * GET /api/profiles?pubkeys=hex1,hex2,...
+ * GET /api/profiles?pubkeys=hex1,hex2,...[&fresh=1]
  *
- * Fetches kind:0 profiles from PROFILE_RELAYS (defaults.conf),
- * caches in memory with 1-hour TTL.
+ * Fetches kind:0 profiles from PROFILE_RELAYS AND the local strfry store, then
+ * keeps the newest by created_at per pubkey (rev. 2, Finding 1 — local writes
+ * must not be masked by a stale external profile). Caches in memory (5-min TTL).
+ * `?fresh=1` bypasses the cache; invalidateProfileCache() lets the kind-0 save
+ * path drop a stale entry the moment a profile is republished.
  */
 
 const NOSTR_TOOLS_PATH = '/usr/local/lib/node_modules/brainstorm/node_modules/nostr-tools';
@@ -17,6 +20,7 @@ if (typeof globalThis.WebSocket === 'undefined') {
 
 const { SimplePool } = require(NOSTR_TOOLS_PATH);
 const { getSettings } = require('../../config/settings');
+const { mergeNewestByPubkey } = require('../../lib/receiving/newest');
 
 // --- Config ---
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
@@ -40,94 +44,107 @@ function getProfileRelays() {
 }
 
 /**
+ * Gather kind:0 events for the given pubkeys from BOTH the local strfry store
+ * and the external profile relays. Local is collected first so it wins ties
+ * (it's the source of truth for a just-published profile); a genuinely newer
+ * external profile still wins on a strictly-greater created_at. Best-effort:
+ * a failure of either source is logged, not thrown.
+ * Returns a flat array of events.
+ */
+async function collectKind0Events(needed) {
+  const events = [];
+
+  // Local strfry store (always — newest-wins decides, not "missing only").
+  try {
+    const { execSync } = require('child_process');
+    const filter = JSON.stringify({ kinds: [0], authors: needed });
+    // strfry scan takes a nostr filter as a CLI argument and outputs matching events as JSONL
+    const raw = execSync(`strfry scan '${filter.replace(/'/g, "\\'")}'`, {
+      timeout: 5000, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    for (const line of raw.trim().split('\n').filter(Boolean)) {
+      try {
+        const ev = JSON.parse(line);
+        if (ev && ev.kind === 0 && needed.includes(ev.pubkey)) events.push(ev);
+      } catch {}
+    }
+  } catch (localErr) {
+    console.warn('fetchProfiles: local strfry scan error:', localErr.message);
+  }
+
+  // External profile relays.
+  const profileRelays = getProfileRelays();
+  const pool = new SimplePool();
+  try {
+    const ext = await Promise.race([
+      pool.querySync(profileRelays, { kinds: [0], authors: needed }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), FETCH_TIMEOUT_MS)),
+    ]);
+    if (Array.isArray(ext)) {
+      for (const ev of ext) if (ev && ev.kind === 0 && needed.includes(ev.pubkey)) events.push(ev);
+    }
+  } catch (err) {
+    console.warn('fetchProfiles: relay fetch error:', err.message);
+  } finally {
+    try { pool.close(profileRelays); } catch {}
+  }
+
+  return events;
+}
+
+/**
  * Fetch profiles for a list of pubkeys, using cache where possible.
+ * @param {string[]} pubkeys
+ * @param {object} [opts]
+ * @param {boolean} [opts.bypassCache=false] skip the read-through cache (?fresh=1)
  * Returns Map<pubkey, profileObj>.
  */
-async function getProfiles(pubkeys) {
+async function getProfiles(pubkeys, { bypassCache = false } = {}) {
   const now = Date.now();
   const results = new Map();
   const needed = [];
 
   for (const pk of pubkeys) {
-    const cached = cache.get(pk);
-    if (cached && (now - cached.fetchedAt) < CACHE_TTL_MS) {
-      results.set(pk, cached.profile);
-    } else {
-      needed.push(pk);
+    if (!bypassCache) {
+      const cached = cache.get(pk);
+      if (cached && (now - cached.fetchedAt) < CACHE_TTL_MS) {
+        results.set(pk, cached.profile);
+        continue;
+      }
     }
+    needed.push(pk);
   }
 
   if (needed.length === 0) return results;
 
-  // Fetch from relays
-  const profileRelays = getProfileRelays();
-  const pool = new SimplePool();
-  try {
-    const events = await Promise.race([
-      pool.querySync(profileRelays, { kinds: [0], authors: needed }),
-      new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), FETCH_TIMEOUT_MS)),
-    ]);
+  const events = await collectKind0Events(needed);
+  const latest = mergeNewestByPubkey(events); // pubkey -> newest kind:0 event across both sources
 
-    // Keep only the latest kind:0 per pubkey
-    const latest = new Map();
-    for (const ev of events) {
-      const prev = latest.get(ev.pubkey);
-      if (!prev || ev.created_at > prev.created_at) {
-        latest.set(ev.pubkey, ev);
-      }
-    }
+  for (const [pk, ev] of latest) {
+    let profile = {};
+    try { profile = JSON.parse(ev.content); } catch {}
+    cache.set(pk, { profile, fetchedAt: now });
+    results.set(pk, profile);
+  }
 
-    for (const [pk, ev] of latest) {
-      let profile = {};
-      try { profile = JSON.parse(ev.content); } catch {}
-      cache.set(pk, { profile, fetchedAt: now });
-      results.set(pk, profile);
+  // Cache misses as empty (so we don't re-fetch constantly)
+  for (const pk of needed) {
+    if (!results.has(pk)) {
+      cache.set(pk, { profile: null, fetchedAt: now });
+      results.set(pk, null);
     }
-
-    // For any still-missing pubkeys, try local strfry via CLI scan with proper filter
-    const stillMissing = needed.filter(pk => !results.has(pk));
-    if (stillMissing.length > 0) {
-      try {
-        const { execSync } = require('child_process');
-        const filter = JSON.stringify({ kinds: [0], authors: stillMissing });
-        // strfry scan takes a nostr filter as a CLI argument and outputs matching events as JSONL
-        const raw = execSync(`strfry scan '${filter.replace(/'/g, "\\'")}'`, {
-          timeout: 5000, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
-        });
-        const lines = raw.trim().split('\n').filter(Boolean);
-        for (const line of lines) {
-          try {
-            const ev = JSON.parse(line);
-            if (ev.kind === 0 && stillMissing.includes(ev.pubkey)) {
-              let profile = {};
-              try { profile = JSON.parse(ev.content); } catch {}
-              if (!results.has(ev.pubkey)) {
-                cache.set(ev.pubkey, { profile, fetchedAt: now });
-                results.set(ev.pubkey, profile);
-              }
-            }
-          } catch {}
-        }
-      } catch (localErr) {
-        console.warn('fetchProfiles: local strfry scan fallback error:', localErr.message);
-      }
-    }
-
-    // Cache misses as empty (so we don't re-fetch constantly)
-    for (const pk of needed) {
-      if (!results.has(pk)) {
-        cache.set(pk, { profile: null, fetchedAt: now });
-        results.set(pk, null);
-      }
-    }
-  } catch (err) {
-    console.warn('fetchProfiles: relay fetch error:', err.message);
-    // Return what we have from cache; don't cache failures
-  } finally {
-    pool.close(profileRelays);
   }
 
   return results;
+}
+
+/**
+ * Drop cached profiles for the given pubkey(s). Called by the kind-0 save path
+ * so a freshly-published profile is re-read on the next request (Finding 1).
+ */
+function invalidateProfileCache(pubkeys) {
+  const list = Array.isArray(pubkeys) ? pubkeys : [pubkeys];
+  for (const pk of list) if (pk) cache.delete(pk);
 }
 
 /**
@@ -149,8 +166,11 @@ async function handleFetchProfiles(req, res) {
     return res.status(400).json({ success: false, error: 'max 50 pubkeys per request' });
   }
 
+  // ?fresh=1 (or true) bypasses the cache — used right after a profile save.
+  const bypassCache = req.query.fresh === '1' || req.query.fresh === 'true';
+
   try {
-    const profileMap = await getProfiles(pubkeys);
+    const profileMap = await getProfiles(pubkeys, { bypassCache });
     const profiles = {};
     for (const [pk, p] of profileMap) {
       profiles[pk] = p;
@@ -162,4 +182,4 @@ async function handleFetchProfiles(req, res) {
   }
 }
 
-module.exports = { handleFetchProfiles };
+module.exports = { handleFetchProfiles, getProfiles, invalidateProfileCache };

--- a/src/api/strfry/commands/publishEvent.js
+++ b/src/api/strfry/commands/publishEvent.js
@@ -7,6 +7,8 @@
  */
 const { exec } = require('child_process');
 const { getOwnerAssistantKeys } = require('../../../utils/assistantKeys');
+const { publishToRelays, getProfileRelays } = require('../../../lib/receiving/publish');
+const { invalidateProfileCache } = require('../../profiles/fetchProfiles');
 
 // Lazy-load nostr-tools (ESM-friendly path inside Docker)
 let _nt = null;
@@ -59,12 +61,31 @@ async function handlePublishEvent(req, res) {
     // Publish to local strfry via stdin import
     const eventJson = JSON.stringify(signedEvent);
     
-    const child = exec('strfry import', { timeout: 10000 }, (error, stdout, stderr) => {
+    const child = exec('strfry import', { timeout: 10000 }, async (error, stdout, stderr) => {
       if (error) {
         console.error('strfry import error:', error.message, stderr);
         return res.json({ success: false, error: `strfry import failed: ${error.message}` });
       }
       console.log('Published event to strfry:', signedEvent.id?.slice(0, 16));
+
+      // A kind-0 profile must also reach the external PROFILE_RELAYS that
+      // /api/profiles reads, and the read cache must drop its stale copy —
+      // otherwise an issuer keeps seeing the old receiving method (Finding 1).
+      if (signedEvent.kind === 0) {
+        try {
+          invalidateProfileCache([signedEvent.pubkey]);
+          const profileRelays = getProfileRelays();
+          const relayResults = await publishToRelays(signedEvent, profileRelays);
+          const accepted = relayResults.filter(r => r.success).length;
+          console.log(`kind-0 fan-out: ${accepted}/${relayResults.length} profile relays accepted ${signedEvent.id?.slice(0, 16)}`);
+          return res.json({ success: true, event: signedEvent, profileRelays: relayResults });
+        } catch (fanErr) {
+          // Local import already succeeded — report success, surface the fan-out error.
+          console.warn('kind-0 profile-relay fan-out error:', fanErr.message);
+          return res.json({ success: true, event: signedEvent, profileRelays: { error: fanErr.message } });
+        }
+      }
+
       return res.json({ success: true, event: signedEvent });
     });
     

--- a/src/db/bounties.js
+++ b/src/db/bounties.js
@@ -28,6 +28,9 @@ db.exec(`
     issuer_pubkey   TEXT NOT NULL,
     list_coordinate TEXT NOT NULL,
     amount_sats     INTEGER NOT NULL CHECK (amount_sats > 0),
+    bounty_cap_sats INTEGER NOT NULL CHECK (bounty_cap_sats > 0),
+    reward_per_item INTEGER NOT NULL DEFAULT 0 CHECK (reward_per_item IN (0,1)),
+    max_rewards_per_npub INTEGER CHECK (max_rewards_per_npub IS NULL OR max_rewards_per_npub > 0),
     criteria        TEXT NOT NULL,
     expiration      INTEGER,
     created_at      INTEGER NOT NULL,
@@ -38,9 +41,25 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_bounties_status ON bounties(status);
 `);
 
+function ensureBountyColumn(name, alterSql) {
+  const columns = db.prepare('PRAGMA table_info(bounties)').all();
+  if (!columns.some(c => c.name === name)) db.exec(alterSql);
+}
+
+ensureBountyColumn('bounty_cap_sats', 'ALTER TABLE bounties ADD COLUMN bounty_cap_sats INTEGER');
+ensureBountyColumn('reward_per_item', 'ALTER TABLE bounties ADD COLUMN reward_per_item INTEGER NOT NULL DEFAULT 0');
+ensureBountyColumn('max_rewards_per_npub', 'ALTER TABLE bounties ADD COLUMN max_rewards_per_npub INTEGER');
+db.exec('UPDATE bounties SET bounty_cap_sats = amount_sats WHERE bounty_cap_sats IS NULL');
+
 const insertStmt = db.prepare(`
-  INSERT INTO bounties (id, issuer_pubkey, list_coordinate, amount_sats, criteria, expiration, created_at, status)
-  VALUES (@id, @issuer_pubkey, @list_coordinate, @amount_sats, @criteria, @expiration, @created_at, 'open')
+  INSERT INTO bounties (
+    id, issuer_pubkey, list_coordinate, amount_sats, bounty_cap_sats,
+    reward_per_item, max_rewards_per_npub, criteria, expiration, created_at, status
+  )
+  VALUES (
+    @id, @issuer_pubkey, @list_coordinate, @amount_sats, @bounty_cap_sats,
+    @reward_per_item, @max_rewards_per_npub, @criteria, @expiration, @created_at, 'open'
+  )
 `);
 const selectOpenStmt = db.prepare(`
   SELECT * FROM bounties
@@ -53,13 +72,25 @@ const selectByIdStmt = db.prepare(`SELECT * FROM bounties WHERE id = ?`);
 const selectByIssuerStmt = db.prepare(`SELECT * FROM bounties WHERE issuer_pubkey = ? ORDER BY created_at DESC`);
 const markFulfilledStmt = db.prepare(`UPDATE bounties SET status = 'fulfilled' WHERE id = ?`);
 
-function createBounty({ issuerPubkey, listCoordinate, amountSats, criteria, expiration }) {
+function createBounty({
+  issuerPubkey,
+  listCoordinate,
+  amountSats,
+  bountyCapSats,
+  rewardPerItem = false,
+  maxRewardsPerNpub = null,
+  criteria,
+  expiration,
+}) {
   const id = uuidv4();
   const row = {
     id,
     issuer_pubkey: issuerPubkey,
     list_coordinate: listCoordinate,
     amount_sats: amountSats,
+    bounty_cap_sats: bountyCapSats ?? amountSats,
+    reward_per_item: rewardPerItem ? 1 : 0,
+    max_rewards_per_npub: rewardPerItem ? maxRewardsPerNpub : null,
     criteria,
     expiration: expiration ?? null,
     created_at: Math.floor(Date.now() / 1000),

--- a/src/lib/bounty-fields.js
+++ b/src/lib/bounty-fields.js
@@ -1,0 +1,93 @@
+const COORDINATE_RE = /^(\d+):([0-9a-f]{64}):(.+)$/;
+
+class BountyValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'BountyValidationError';
+    this.statusCode = 400;
+  }
+}
+
+function readField(body, camelName, snakeName = camelName) {
+  return body[camelName] ?? body[snakeName];
+}
+
+function requiredPositiveInteger(value, fieldName) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new BountyValidationError(`${fieldName} must be a positive integer`);
+  }
+  return n;
+}
+
+function optionalPositiveInteger(value, fieldName) {
+  if (value === undefined || value === null || value === '') return null;
+  return requiredPositiveInteger(value, fieldName);
+}
+
+function optionalUnixTimestamp(value) {
+  if (value === undefined || value === null || value === '') return null;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new BountyValidationError('expiration must be a unix timestamp');
+  }
+  return n;
+}
+
+function optionalBoolean(value, fieldName, defaultValue = false) {
+  if (value === undefined || value === null || value === '') return defaultValue;
+  if (value === true || value === false) return value;
+  if (value === 1 || value === '1' || value === 'true') return true;
+  if (value === 0 || value === '0' || value === 'false') return false;
+  throw new BountyValidationError(`${fieldName} must be a boolean`);
+}
+
+function normalizeBountyCreatePayload(body = {}) {
+  const listCoordinate = readField(body, 'listCoordinate', 'list_coordinate');
+  if (!listCoordinate || !COORDINATE_RE.test(listCoordinate)) {
+    throw new BountyValidationError('listCoordinate must be <kind>:<pubkey>:<dtag>');
+  }
+
+  const amountSats = requiredPositiveInteger(
+    readField(body, 'amountSats', 'amount_sats'),
+    'amountSats'
+  );
+  const rawCap = readField(body, 'bountyCapSats', 'bounty_cap_sats');
+  const bountyCapSats = rawCap === undefined || rawCap === null || rawCap === ''
+    ? amountSats
+    : requiredPositiveInteger(rawCap, 'bountyCapSats');
+  if (bountyCapSats < amountSats) {
+    throw new BountyValidationError('bountyCapSats must be greater than or equal to amountSats');
+  }
+
+  const rewardPerItem = optionalBoolean(
+    readField(body, 'rewardPerItem', 'reward_per_item'),
+    'rewardPerItem',
+    false
+  );
+  const rawMaxRewards = readField(body, 'maxRewardsPerNpub', 'max_rewards_per_npub');
+  const maxRewardsPerNpub = optionalPositiveInteger(rawMaxRewards, 'maxRewardsPerNpub');
+  if (!rewardPerItem && maxRewardsPerNpub !== null) {
+    throw new BountyValidationError('maxRewardsPerNpub only applies when rewardPerItem is true');
+  }
+
+  const criteria = body.criteria;
+  if (typeof criteria !== 'string' || !criteria.trim()) {
+    throw new BountyValidationError('criteria is required');
+  }
+
+  return {
+    listCoordinate,
+    amountSats,
+    bountyCapSats,
+    rewardPerItem,
+    maxRewardsPerNpub,
+    criteria: criteria.trim(),
+    expiration: optionalUnixTimestamp(body.expiration),
+  };
+}
+
+module.exports = {
+  BountyValidationError,
+  normalizeBountyCreatePayload,
+};

--- a/src/lib/bounty-policy.js
+++ b/src/lib/bounty-policy.js
@@ -1,0 +1,170 @@
+function positiveIntegerOr(value, fallback) {
+  const n = Number(value);
+  return Number.isInteger(n) && n > 0 ? n : fallback;
+}
+
+function isRewardPerItem(bounty) {
+  const value = bounty?.reward_per_item ?? bounty?.rewardPerItem ?? false;
+  return value === true || value === 1 || value === '1' || value === 'true';
+}
+
+function bountyPolicy(bounty = {}) {
+  const amountSats = positiveIntegerOr(bounty.amount_sats ?? bounty.amountSats, 0);
+  const bountyCapSats = positiveIntegerOr(
+    bounty.bounty_cap_sats ?? bounty.bountyCapSats,
+    amountSats
+  );
+  const totalRewardSlots = amountSats > 0
+    ? Math.max(1, Math.floor(bountyCapSats / amountSats))
+    : 0;
+  const rewardPerItem = isRewardPerItem(bounty);
+  const maxRewardsPerNpub = rewardPerItem
+    ? positiveIntegerOr(
+      bounty.max_rewards_per_npub ?? bounty.maxRewardsPerNpub,
+      Infinity
+    )
+    : 1;
+
+  return {
+    amountSats,
+    bountyCapSats,
+    rewardPerItem,
+    maxRewardsPerNpub,
+    totalRewardSlots,
+  };
+}
+
+function claimId(claim) {
+  return claim?.event?.id ?? '';
+}
+
+function claimPubkey(claim) {
+  return (claim?.event?.pubkey ?? '').toLowerCase();
+}
+
+function claimCreatedAt(claim) {
+  return Number(claim?.event?.created_at) || 0;
+}
+
+function compareClaims(a, b) {
+  const byCreatedAt = claimCreatedAt(a) - claimCreatedAt(b);
+  if (byCreatedAt !== 0) return byCreatedAt;
+  return claimId(a).localeCompare(claimId(b));
+}
+
+function increment(map, key) {
+  map.set(key, (map.get(key) || 0) + 1);
+}
+
+function publicPaymentState(state) {
+  return {
+    rewardAmountSats: state.rewardAmountSats,
+    bountyCapSats: state.bountyCapSats,
+    rewardPerItem: state.rewardPerItem,
+    maxRewardsPerNpub: Number.isFinite(state.maxRewardsPerNpub) ? state.maxRewardsPerNpub : null,
+    totalRewardSlots: state.totalRewardSlots,
+    paidRewardCount: state.paidRewardCount,
+    remainingRewardSlots: state.remainingRewardSlots,
+    payableRewardCount: state.payableClaims.length,
+    openRewardSlots: state.openRewardSlots,
+    fulfilled: state.fulfilled,
+  };
+}
+
+function calculateBountyPaymentState(bounty, claims = []) {
+  const policy = bountyPolicy(bounty);
+  const sortedClaims = [...claims].sort(compareClaims);
+  const paidClaims = [];
+  const unpaidClaims = [];
+  const paidByPubkey = new Map();
+
+  for (const claim of sortedClaims) {
+    if (claim.zapReceipt) {
+      paidClaims.push(claim);
+      increment(paidByPubkey, claimPubkey(claim));
+    } else {
+      unpaidClaims.push(claim);
+    }
+  }
+
+  const paidRewardCount = paidClaims.length;
+  const remainingRewardSlots = Math.max(0, policy.totalRewardSlots - paidRewardCount);
+  let openRewardSlots = remainingRewardSlots;
+  const reservedByPubkey = new Map(paidByPubkey);
+  const payableClaims = [];
+  const closedClaims = [];
+
+  for (const claim of unpaidClaims) {
+    const pubkey = claimPubkey(claim);
+    const pubkeyReserved = reservedByPubkey.get(pubkey) || 0;
+
+    if (openRewardSlots <= 0) {
+      closedClaims.push({ ...claim, closedReason: 'cap' });
+      continue;
+    }
+    if (pubkeyReserved >= policy.maxRewardsPerNpub) {
+      closedClaims.push({ ...claim, closedReason: 'contributor' });
+      continue;
+    }
+
+    payableClaims.push({
+      ...claim,
+      paymentStatus: 'payable',
+      paymentAmountSats: policy.amountSats,
+    });
+    increment(reservedByPubkey, pubkey);
+    openRewardSlots -= 1;
+  }
+
+  return {
+    rewardAmountSats: policy.amountSats,
+    bountyCapSats: policy.bountyCapSats,
+    rewardPerItem: policy.rewardPerItem,
+    maxRewardsPerNpub: policy.maxRewardsPerNpub,
+    totalRewardSlots: policy.totalRewardSlots,
+    paidRewardCount,
+    remainingRewardSlots,
+    openRewardSlots,
+    fulfilled: policy.totalRewardSlots > 0 && paidRewardCount >= policy.totalRewardSlots,
+    paidClaims,
+    payableClaims,
+    closedClaims,
+    paidByPubkey,
+    reservedByPubkey,
+  };
+}
+
+function annotateClaimsWithPaymentState(claims = [], state) {
+  const payableById = new Map(state.payableClaims.map(claim => [claimId(claim), claim]));
+  const closedById = new Map(state.closedClaims.map(claim => [claimId(claim), claim]));
+
+  return claims.map(claim => {
+    const id = claimId(claim);
+    if (claim.zapReceipt) {
+      return { ...claim, paymentStatus: 'paid', paymentAmountSats: state.rewardAmountSats };
+    }
+    const payable = payableById.get(id);
+    if (payable) return payable;
+    const closed = closedById.get(id);
+    return {
+      ...claim,
+      paymentStatus: 'closed',
+      paymentAmountSats: state.rewardAmountSats,
+      closedReason: closed?.closedReason ?? 'cap',
+    };
+  });
+}
+
+function canAcceptNewClaimFrom(state, pubkey) {
+  if (!state || state.fulfilled || state.openRewardSlots <= 0) return false;
+  const key = (pubkey ?? '').toLowerCase();
+  return (state.reservedByPubkey.get(key) || 0) < state.maxRewardsPerNpub;
+}
+
+module.exports = {
+  annotateClaimsWithPaymentState,
+  bountyPolicy,
+  calculateBountyPaymentState,
+  canAcceptNewClaimFrom,
+  publicPaymentState,
+};

--- a/src/lib/receiving/index.js
+++ b/src/lib/receiving/index.js
@@ -1,0 +1,19 @@
+/**
+ * Framework-free "receiving setup" core.
+ *
+ * Pure modules (walletOptions, mergeKind0, newest, resolveMethod) carry the
+ * hard logic — option catalog, validators, kind-0 REPLACE merge, newest-wins
+ * selection, bolt12→lud16 precedence. I/O modules (publish, resolveProfile)
+ * wrap relays + local strfry. The CLI (bin/receiving.js) drives all of it; the
+ * web UI is meant to import the same modules later (Phase 2).
+ */
+
+module.exports = {
+  ...require('./walletOptions'),
+  ...require('./mergeKind0'),
+  ...require('./newest'),
+  ...require('./resolveMethod'),
+  ...require('./publish'),
+  ...require('./resolveProfile'),
+  ...require('./probe'),
+};

--- a/src/lib/receiving/mergeKind0.js
+++ b/src/lib/receiving/mergeKind0.js
@@ -1,0 +1,101 @@
+/**
+ * kind-0 profile merge with REPLACE semantics.
+ *
+ * Pure (no I/O). Given an existing profile content object and a chosen
+ * receiving method, produce the new profile content to publish:
+ *
+ *   - preserve every non-receiving field (name, about, picture, nip05, …)
+ *   - clear ALL receiving fields across both families (rev. 2, Finding 2)
+ *   - write exactly one receiving field (the chosen method's `field`)
+ *   - strip server-derived event metadata that must never live in content
+ *
+ * This guarantees that after a switch there is exactly one active receiving
+ * identifier, so a lingering BOLT12 can't shadow a freshly-set Lightning
+ * address (zap.js reads bolt12 before lud16).
+ */
+
+const {
+  ALL_RECEIVING_FIELDS,
+  getOption,
+  validateLud16,
+  extractBolt12,
+  extractLnurl,
+  npubCashAddress,
+} = require('./walletOptions');
+
+// kind-0 content is profile metadata; these are event-level / server-derived
+// and must never be republished inside content. Stripped defensively.
+const SERVER_DERIVED_FIELDS = ['pubkey', 'created_at', 'id', 'sig', 'kind', 'tags'];
+
+/**
+ * Low-level merge: clear every receiving field, then set `field`=`value`.
+ * @param {object|null} existingProfile parsed kind-0 content
+ * @param {string} field receiving field to write (e.g. 'lud16' | 'bolt12')
+ * @param {string} value value to write
+ * @returns {object} new content object
+ */
+function mergeReceivingField(existingProfile, field, value) {
+  const next = { ...(existingProfile || {}) };
+  for (const f of SERVER_DERIVED_FIELDS) delete next[f];
+  for (const f of ALL_RECEIVING_FIELDS) delete next[f];
+  next[field] = value;
+  return next;
+}
+
+/**
+ * High-level builder used by both the CLI and (later) the web picker.
+ *
+ * @param {object} args
+ * @param {object|null} args.profile existing parsed kind-0 content
+ * @param {string} args.method option id: 'npub-cash' | 'address' | 'wos' | 'bolt12' | 'fedimint'
+ * @param {string} [args.value] user-supplied value (lud16 or lno1… offer); ignored for derived methods
+ * @param {string} args.pubkeyHex target pubkey hex (used to derive npub.cash)
+ * @returns {{ content: object, field: string, value: string, cleared: string[], replaced: boolean }}
+ * @throws if the method is unknown or the value is missing/invalid
+ */
+function buildReceivingContent({ profile, method, value, pubkeyHex }) {
+  const option = getOption(method);
+  if (!option) {
+    throw new Error(`Unknown receiving method: ${method}. Use one of: npub-cash, address, wos, fedimint, bolt12, lnurl.`);
+  }
+
+  let field = option.field;
+  let finalValue;
+
+  if (option.derivesFromPubkey) {
+    if (!pubkeyHex) throw new Error(`${method} requires a target pubkey to derive the address`);
+    finalValue = npubCashAddress(pubkeyHex);
+  } else if (field === 'bolt12') {
+    const offer = extractBolt12(value);
+    if (!offer) {
+      throw new Error('Expected a BOLT12 offer (lno1…, lightning:lno1…, or bitcoin:?lno=lno1…)');
+    }
+    finalValue = offer;
+  } else if (field === 'lud06') {
+    // LNURL-pay code (lnurl1…). Stored bech32 in lud06 (NIP convention).
+    const lnurl = extractLnurl(value);
+    if (!lnurl) {
+      throw new Error('Expected an LNURL-pay code (lnurl1… or lightning:lnurl1…)');
+    }
+    finalValue = lnurl;
+  } else {
+    // lud16-family methods (address, wos, fedimint)
+    const check = validateLud16(value);
+    if (!check.valid) throw new Error(check.error);
+    finalValue = check.value;
+  }
+
+  // Which receiving fields carried a value before, for reporting.
+  const before = ALL_RECEIVING_FIELDS.filter(f => profile && profile[f]);
+  const cleared = before.filter(f => f !== field);
+  const replaced = before.includes(field) && profile[field] !== finalValue;
+
+  const content = mergeReceivingField(profile, field, finalValue);
+  return { content, field, value: finalValue, cleared, replaced };
+}
+
+module.exports = {
+  SERVER_DERIVED_FIELDS,
+  mergeReceivingField,
+  buildReceivingContent,
+};

--- a/src/lib/receiving/newest.js
+++ b/src/lib/receiving/newest.js
@@ -1,0 +1,44 @@
+/**
+ * Newest-by-created_at selection for kind-0 events (rev. 2, Finding 1).
+ *
+ * Pure (no I/O). The bug: /api/profiles queried external PROFILE_RELAYS first
+ * and only fell back to local strfry for *missing* pubkeys, so a fresh local
+ * write was masked by a stale external profile. The fix is to gather kind-0
+ * events from BOTH sources and keep the one with the greatest created_at.
+ *
+ * Ties (equal created_at) keep the first-seen event; callers should pass local
+ * events first when local should win a tie, but in practice created_at differs.
+ */
+
+/**
+ * @param {Array<{created_at:number}>} events
+ * @returns {object|null} the event with the greatest created_at, or null
+ */
+function pickNewestEvent(events) {
+  let best = null;
+  for (const ev of events || []) {
+    if (!ev) continue;
+    const ts = Number(ev.created_at) || 0;
+    if (!best || ts > (Number(best.created_at) || 0)) best = ev;
+  }
+  return best;
+}
+
+/**
+ * Group events by pubkey, keeping the newest per pubkey.
+ * @param {Array<{pubkey:string, created_at:number}>} events
+ * @returns {Map<string, object>} pubkey -> newest event
+ */
+function mergeNewestByPubkey(events) {
+  const latest = new Map();
+  for (const ev of events || []) {
+    if (!ev || !ev.pubkey) continue;
+    const prev = latest.get(ev.pubkey);
+    if (!prev || (Number(ev.created_at) || 0) > (Number(prev.created_at) || 0)) {
+      latest.set(ev.pubkey, ev);
+    }
+  }
+  return latest;
+}
+
+module.exports = { pickNewestEvent, mergeNewestByPubkey };

--- a/src/lib/receiving/probe.js
+++ b/src/lib/receiving/probe.js
@@ -1,0 +1,105 @@
+/**
+ * LNURL-pay probe — verify a Lightning address (lud16) is actually reachable
+ * and whether it allows Nostr zaps (NIP-57). This is what makes "tracked"
+ * honest: a lud16 only yields a kind-9735 zap receipt if its LNURL endpoint
+ * returns allowsNostr:true. Fedimint gateway addresses frequently DON'T, and
+ * zap.js throws on such an address — so probing at set-time tells the user
+ * immediately whether the address will work, instead of failing at payout.
+ *
+ * I/O module (uses global fetch, Node 18+). Kept out of the pure core. The
+ * server never calls this; only the CLI does, about the key owner's own
+ * address — so no SSRF surface is added server-side. `allowInsecureLocalhost`
+ * is a test-only affordance (https everywhere in real use).
+ */
+
+const { decodeLnurl, isLnurl } = require('./walletOptions');
+
+const DEFAULT_TIMEOUT_MS = 6000;
+
+/** Split "name@domain" → { user, domain } or null. */
+function parseLud16(lud16) {
+  const s = String(lud16 || '').trim();
+  const at = s.indexOf('@');
+  if (at <= 0 || at === s.length - 1 || s.indexOf('@', at + 1) !== -1) return null;
+  return { user: s.slice(0, at), domain: s.slice(at + 1) };
+}
+
+/**
+ * @returns {Promise<{ok:boolean, reachable:boolean, allowsNostr?:boolean, callback?:string|null,
+ *                     minSendable?:number|null, maxSendable?:number|null, status?:number, error?:string}>}
+ */
+/**
+ * GET an LNURL-pay endpoint and map its JSON to the common probe shape. Shared
+ * by probeLud16 (which builds the URL from name@domain) and probeLnurl (which
+ * bech32-decodes the URL out of the code).
+ */
+async function fetchLnurlp(url, timeoutMs) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const resp = await fetch(url, { signal: ctrl.signal });
+    if (!resp.ok) return { ok: false, reachable: true, status: resp.status, error: `LNURL endpoint returned ${resp.status}` };
+    let data;
+    try { data = await resp.json(); } catch { return { ok: false, reachable: true, error: 'LNURL returned invalid JSON' }; }
+    return {
+      ok: true,
+      reachable: true,
+      allowsNostr: data.allowsNostr === true,
+      callback: data.callback || null,
+      minSendable: data.minSendable ?? null,
+      maxSendable: data.maxSendable ?? null,
+    };
+  } catch (e) {
+    return { ok: false, reachable: false, error: e.name === 'AbortError' ? 'timeout' : e.message };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function probeLud16(lud16, { timeoutMs = DEFAULT_TIMEOUT_MS, allowInsecureLocalhost = false } = {}) {
+  const parts = parseLud16(lud16);
+  if (!parts) return { ok: false, reachable: false, error: 'malformed lud16 (expected name@domain)' };
+
+  const isLocal = /^(127\.0\.0\.1|localhost)(:\d+)?$/.test(parts.domain);
+  const scheme = (allowInsecureLocalhost && isLocal) ? 'http' : 'https';
+  const url = `${scheme}://${parts.domain}/.well-known/lnurlp/${encodeURIComponent(parts.user)}`;
+  return fetchLnurlp(url, timeoutMs);
+}
+
+/**
+ * Probe a static LNURL-pay code (lnurl1…): bech32-decode it to its URL, then GET
+ * that endpoint. The scheme is whatever the code encodes (https in real use; a
+ * test code may encode http://127.0.0.1 — see allowInsecureLocalhost note below).
+ *
+ * @returns {Promise<{ok:boolean, reachable:boolean, allowsNostr?:boolean, callback?:string|null,
+ *                     minSendable?:number|null, maxSendable?:number|null, url?:string, status?:number, error?:string}>}
+ */
+async function probeLnurl(lnurl, { timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  const url = decodeLnurl(lnurl);
+  if (!url) return { ok: false, reachable: false, error: 'malformed LNURL (not a valid lnurl1… code)' };
+  const result = await fetchLnurlp(url, timeoutMs);
+  return { ...result, url };
+}
+
+/**
+ * Dispatch a receiving identifier to the right probe: an lnurl1… code goes to
+ * probeLnurl; a name@domain to probeLud16. Both yield the same result shape, so
+ * trackedVerdict() interprets either.
+ */
+async function probeReceiving(value, opts = {}) {
+  if (isLnurl(value)) return probeLnurl(value, opts);
+  return probeLud16(value, opts);
+}
+
+/**
+ * Interpret a probe result into a tracked verdict + human note. Pure given a probe.
+ */
+function trackedVerdict(probe) {
+  if (!probe) return { tracked: null, note: 'not probed' };
+  if (!probe.reachable) return { tracked: false, note: `LNURL unreachable (${probe.error}) — can't confirm payable/tracked` };
+  if (!probe.ok) return { tracked: false, note: `LNURL error (${probe.error}) — not payable via zap` };
+  if (probe.allowsNostr) return { tracked: true, note: 'LNURL allows Nostr zaps → tracked (kind-9735 receipt)' };
+  return { tracked: false, note: 'LNURL reachable but does NOT allow Nostr zaps → the zap button will fail; not tracked' };
+}
+
+module.exports = { probeLud16, probeLnurl, probeReceiving, parseLud16, trackedVerdict };

--- a/src/lib/receiving/publish.js
+++ b/src/lib/receiving/publish.js
@@ -1,0 +1,157 @@
+/**
+ * Publishing helpers — local strfry import + multi-relay fan-out.
+ *
+ * This is the I/O half of the core. The WebSocket publisher is lifted from
+ * bin/brainstorm-create-and-publish-kind10040.js (publishEventToRelay) and the
+ * local-import path from src/api/strfry/commands/publishEvent.js. Both the CLI
+ * and the server's kind-0 save path use these so a freshly-set profile lands on
+ * the same PROFILE_RELAYS that /api/profiles reads (rev. 2, Finding 1).
+ *
+ * CommonJS, dependency-loader tolerant of the Docker install path.
+ */
+
+const { exec } = require('child_process');
+
+function loadDep(name) {
+  try {
+    return require(name);
+  } catch {
+    return require(`/usr/local/lib/node_modules/brainstorm/node_modules/${name}`);
+  }
+}
+
+const WebSocket = loadDep('ws');
+
+const DEFAULT_RELAY_TIMEOUT_MS = 10000;
+const FALLBACK_PROFILE_RELAYS = ['wss://purplepag.es', 'wss://profiles.nostr1.com'];
+
+/**
+ * Resolve PROFILE_RELAYS from merged settings (same source /api/profiles uses),
+ * re-read each call so overrides take effect immediately.
+ */
+function getProfileRelays() {
+  try {
+    const { getSettings } = require('../../config/settings');
+    const relays = getSettings()?.aRelays?.aProfileRelays;
+    if (Array.isArray(relays) && relays.length > 0) return relays;
+  } catch {
+    /* settings not available (e.g. CLI off-instance) — fall through */
+  }
+  return [...FALLBACK_PROFILE_RELAYS];
+}
+
+/**
+ * Publish a signed event to one relay over a short-lived WebSocket.
+ * Resolves { success, message } — never rejects.
+ */
+function publishEventToRelay(event, relayUrl, { timeoutMs = DEFAULT_RELAY_TIMEOUT_MS } = {}) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer = null;
+    const done = (result) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      try { ws.close(); } catch {}
+      resolve({ relay: relayUrl, ...result });
+    };
+
+    let ws;
+    try {
+      ws = new WebSocket(relayUrl);
+    } catch (err) {
+      return resolve({ relay: relayUrl, success: false, message: `connect error: ${err.message}` });
+    }
+
+    timer = setTimeout(() => done({ success: false, message: 'timeout: no relay response in 10s' }), timeoutMs);
+
+    ws.on('open', () => {
+      try { ws.send(JSON.stringify(['EVENT', event])); }
+      catch (err) { done({ success: false, message: `send error: ${err.message}` }); }
+    });
+    ws.on('message', (data) => {
+      try {
+        const res = JSON.parse(data.toString());
+        if (res[0] === 'OK' && res[1] === event.id) {
+          done(res[2] === true
+            ? { success: true, message: 'accepted' }
+            : { success: false, message: res[3] || 'rejected by relay' });
+        }
+      } catch { /* ignore non-OK frames */ }
+    });
+    ws.on('error', (err) => done({ success: false, message: `ws error: ${err.message}` }));
+    ws.on('close', () => done({ success: false, message: 'closed without confirmation' }));
+  });
+}
+
+/**
+ * Fan a signed event out to a list of relays. Resolves an array of per-relay
+ * results; best-effort (individual failures don't reject the batch).
+ */
+async function publishToRelays(event, relays, opts = {}) {
+  const list = Array.isArray(relays) ? relays.filter(Boolean) : [];
+  if (list.length === 0) return [];
+  return Promise.all(list.map(r => publishEventToRelay(event, r, opts)));
+}
+
+/**
+ * Import a signed event into the local strfry store via `strfry import` (stdin).
+ * Resolves { success, skipped?, message }. If the strfry binary is unavailable
+ * (CLI run off-instance) it resolves { success:false, skipped:true } rather
+ * than throwing, so the caller can still publish to relays.
+ */
+function importToLocalStrfry(event, { timeoutMs = 10000 } = {}) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (r) => { if (!settled) { settled = true; resolve(r); } };
+
+    let child;
+    try {
+      child = exec('strfry import', { timeout: timeoutMs }, (error, _stdout, stderr) => {
+        if (error) {
+          const missing = /not found|ENOENT|command not found/i.test(`${error.message} ${stderr}`);
+          return finish({
+            success: false,
+            skipped: missing,
+            message: missing ? 'strfry binary not found — skipped local import' : `strfry import failed: ${error.message}`,
+          });
+        }
+        finish({ success: true, message: 'imported to local strfry' });
+      });
+    } catch (err) {
+      return finish({ success: false, skipped: true, message: `strfry spawn error: ${err.message}` });
+    }
+
+    child.on('error', (err) => {
+      const missing = err.code === 'ENOENT';
+      finish({ success: false, skipped: missing, message: missing ? 'strfry binary not found — skipped local import' : err.message });
+    });
+    try {
+      child.stdin.write(JSON.stringify(event) + '\n');
+      child.stdin.end();
+    } catch (err) {
+      finish({ success: false, skipped: true, message: `stdin error: ${err.message}` });
+    }
+  });
+}
+
+/**
+ * Publish a signed kind-0 (or any) event to local strfry AND the profile
+ * relays. Returns { local, relays } result detail.
+ */
+async function publishProfileEvent(event, { relays, includeLocal = true } = {}) {
+  const relayList = relays || getProfileRelays();
+  const [local, relayResults] = await Promise.all([
+    includeLocal ? importToLocalStrfry(event) : Promise.resolve({ success: false, skipped: true, message: 'local import disabled' }),
+    publishToRelays(event, relayList),
+  ]);
+  return { local, relays: relayResults };
+}
+
+module.exports = {
+  getProfileRelays,
+  publishEventToRelay,
+  publishToRelays,
+  importToLocalStrfry,
+  publishProfileEvent,
+};

--- a/src/lib/receiving/resolveMethod.js
+++ b/src/lib/receiving/resolveMethod.js
@@ -1,0 +1,123 @@
+/**
+ * Active receiving-method resolution — the issuer-side payout decision.
+ *
+ * Pure (no I/O). Mirrors the precedence in ui/src/utils/zap.js exactly:
+ * a BOLT12 offer (bolt12 / lud12 / lightning_offer) wins over a Lightning
+ * address (lud16 / lud06). The point of proving this in the CLI is that
+ * `receiving resolve` makes the *same* decision the issuer UI's zap button
+ * makes — including reporting whether the result is tracked.
+ *
+ * "tracked" = produces a NIP-57 zap receipt (kind 9735) the bounty cap logic
+ * can key off (bounty-policy.js). BOLT12 static offers do not, so they are
+ * reported untracked (rev. 2, Finding 3).
+ */
+
+const { extractBolt12, extractLnurl, isLnurl, BOLT12_FIELDS, LUD16_FIELDS } = require('./walletOptions');
+
+function readBolt12(profile) {
+  if (!profile) return null;
+  for (const f of BOLT12_FIELDS) {
+    const offer = extractBolt12(profile[f]);
+    if (offer) return { field: f, value: offer };
+  }
+  return null;
+}
+
+/**
+ * A Lightning *address* (name@domain) in either lud16 or lud06. Skips values
+ * that are actually LNURL codes — those resolve as method 'lnurl' below.
+ */
+function readLud16Address(profile) {
+  if (!profile) return null;
+  for (const f of LUD16_FIELDS) {
+    const v = profile[f];
+    if (v && typeof v === 'string' && !isLnurl(v)) return { field: f, value: v.trim() };
+  }
+  return null;
+}
+
+/**
+ * A static LNURL-pay code (lnurl1…) wherever it sits — conventionally lud06,
+ * but tolerate a mis-placed lud16. Returned canonicalized (lowercased).
+ */
+function readLnurl(profile) {
+  if (!profile) return null;
+  for (const f of LUD16_FIELDS) {
+    const lnurl = extractLnurl(profile[f]);
+    if (lnurl) return { field: f, value: lnurl };
+  }
+  return null;
+}
+
+/**
+ * @param {object|null} profile parsed kind-0 content
+ * @returns {{method:'bolt12'|'lud16'|'lnurl', field:string, value:string, tracked:boolean|null, trackedReason:string} | null}
+ */
+function resolveReceivingMethod(profile) {
+  const bolt12 = readBolt12(profile);
+  if (bolt12) {
+    return {
+      method: 'bolt12',
+      field: bolt12.field,
+      value: bolt12.value,
+      tracked: false,
+      trackedReason: 'static BOLT12 offer — no zap receipt; cap slot won\'t auto-free',
+    };
+  }
+  // Precedence: a real Lightning address beats a static LNURL code (an address's
+  // LNURL is fetched fresh per-payment and usually allows Nostr; a static code
+  // like a Fedimint paycode usually does not).
+  const lud16 = readLud16Address(profile);
+  if (lud16) {
+    return {
+      method: 'lud16',
+      field: lud16.field,
+      value: lud16.value,
+      // Structural assumption only: a lud16 is tracked *iff* its LNURL allows
+      // Nostr zaps. Confirm with an LNURL probe (CLI --probe / set-time check),
+      // which fedimint gateway addresses in particular may fail.
+      tracked: true,
+      trackedReason: 'LNURL zaps — tracked only if the address allows Nostr (verify via probe)',
+    };
+  }
+  const lnurl = readLnurl(profile);
+  if (lnurl) {
+    return {
+      method: 'lnurl',
+      field: lnurl.field,
+      value: lnurl.value,
+      // Unknown until probed — a static LNURL is tracked only if its endpoint
+      // advertises allowsNostr, which we cannot tell from the code alone.
+      tracked: null,
+      trackedReason: 'static LNURL-pay code — tracked only if its LNURL allows Nostr zaps (verify via probe)',
+    };
+  }
+  return null;
+}
+
+/**
+ * Describe what a payout to this profile would produce, without performing the
+ * LNURL fetch or signing (those need a live network / NIP-07 signer). This is
+ * the framework-free half of zapContributor()'s branch decision.
+ *
+ * @param {object|null} profile
+ * @returns {{type:'bolt12'|'bolt11'|'none', tracked:boolean|null, payload?:string, lud16?:string, via?:string, source?:string, static?:boolean, error?:string}}
+ */
+function resolvePayment(profile) {
+  const resolved = resolveReceivingMethod(profile);
+  if (!resolved) {
+    return { type: 'none', tracked: false, error: 'Recipient has no Lightning address, LNURL code, or BOLT12 offer' };
+  }
+  if (resolved.method === 'bolt12') {
+    return { type: 'bolt12', payload: resolved.value, static: true, tracked: false };
+  }
+  if (resolved.method === 'lnurl') {
+    // A static LNURL: decode → fetch → request an invoice. Without allowsNostr it
+    // yields a plain BOLT11 (no zap receipt), so tracked is unknown until probed.
+    return { type: 'bolt11', via: 'lnurl', source: resolved.value, tracked: null };
+  }
+  // lud16 → the issuer UI would run LNURL pay + sign a 9734 and get a BOLT11.
+  return { type: 'bolt11', lud16: resolved.value, tracked: true };
+}
+
+module.exports = { resolveReceivingMethod, resolvePayment };

--- a/src/lib/receiving/resolveProfile.js
+++ b/src/lib/receiving/resolveProfile.js
@@ -1,0 +1,123 @@
+/**
+ * Newest-wins profile resolver (rev. 2, Finding 1).
+ *
+ * Gathers a pubkey's kind-0 events from BOTH the external PROFILE_RELAYS and
+ * the local strfry store, then keeps the one with the greatest created_at. This
+ * is the resolution `/api/profiles` should perform and that the CLI's
+ * `show` / `resolve` commands use to confirm a just-published method actually
+ * wins over a stale external copy.
+ *
+ * I/O module (SimplePool + strfry scan). Dependency loader tolerant of the
+ * Docker install path; injects a WebSocket global for SimplePool.
+ */
+
+const { execSync } = require('child_process');
+const { pickNewestEvent } = require('./newest');
+const { getProfileRelays } = require('./publish');
+
+function loadDep(name) {
+  try {
+    return require(name);
+  } catch {
+    return require(`/usr/local/lib/node_modules/brainstorm/node_modules/${name}`);
+  }
+}
+
+// nostr-tools' SimplePool needs a global WebSocket (Node has none until v21+).
+if (typeof globalThis.WebSocket === 'undefined') {
+  globalThis.WebSocket = loadDep('ws');
+}
+
+const { SimplePool } = loadDep('nostr-tools');
+
+const DEFAULT_TIMEOUT_MS = 6000;
+
+/**
+ * Query external profile relays for a pubkey's kind-0 events.
+ * Returns an array of events (possibly empty); never throws.
+ */
+async function queryExternal(pubkeyHex, relays, timeoutMs) {
+  const pool = new SimplePool();
+  try {
+    const events = await Promise.race([
+      pool.querySync(relays, { kinds: [0], authors: [pubkeyHex] }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), timeoutMs)),
+    ]);
+    return Array.isArray(events) ? events : [];
+  } catch {
+    return [];
+  } finally {
+    try { pool.close(relays); } catch {}
+  }
+}
+
+/**
+ * Scan the local strfry store for a pubkey's kind-0 events.
+ * Returns an array of events (possibly empty); never throws.
+ */
+function scanLocal(pubkeyHex) {
+  try {
+    const filter = JSON.stringify({ kinds: [0], authors: [pubkeyHex] });
+    const raw = execSync(`strfry scan '${filter.replace(/'/g, "\\'")}'`, {
+      timeout: 5000, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return raw.trim().split('\n').filter(Boolean).map(line => {
+      try { return JSON.parse(line); } catch { return null; }
+    }).filter(ev => ev && ev.kind === 0 && ev.pubkey === pubkeyHex);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Resolve a single pubkey's active kind-0 profile, newest across local + external.
+ *
+ * @param {string} pubkeyHex
+ * @param {object} [opts]
+ * @param {string[]} [opts.relays] override profile relays
+ * @param {boolean} [opts.includeLocal=true]
+ * @param {boolean} [opts.includeExternal=true]
+ * @param {number} [opts.timeoutMs]
+ * @returns {Promise<{event:object|null, profile:object|null, createdAt:number|null, source:'local'|'external'|null, sources:{local:number,external:number}}>}
+ */
+async function resolveProfile(pubkeyHex, opts = {}) {
+  if (!/^[0-9a-f]{64}$/i.test(pubkeyHex)) {
+    throw new Error('resolveProfile: pubkeyHex must be 64-char hex');
+  }
+  const {
+    relays = getProfileRelays(),
+    includeLocal = true,
+    includeExternal = true,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  } = opts;
+
+  const externalEvents = includeExternal ? await queryExternal(pubkeyHex, relays, timeoutMs) : [];
+  const localEvents = includeLocal ? scanLocal(pubkeyHex) : [];
+
+  // Tag each event with its origin so we can report which source won.
+  const tagged = [
+    ...externalEvents.map(ev => ({ ev, source: 'external' })),
+    ...localEvents.map(ev => ({ ev, source: 'local' })),
+  ];
+
+  const newestTagged = pickNewestEvent(tagged.map(t => ({ ...t.ev, __source: t.source })));
+  if (!newestTagged) {
+    return { event: null, profile: null, createdAt: null, source: null, sources: { local: localEvents.length, external: externalEvents.length } };
+  }
+
+  let profile = {};
+  try { profile = JSON.parse(newestTagged.content); } catch { profile = {}; }
+  const source = newestTagged.__source;
+  const event = { ...newestTagged };
+  delete event.__source;
+
+  return {
+    event,
+    profile,
+    createdAt: Number(newestTagged.created_at) || null,
+    source,
+    sources: { local: localEvents.length, external: externalEvents.length },
+  };
+}
+
+module.exports = { resolveProfile, queryExternal, scanLocal };

--- a/src/lib/receiving/walletOptions.js
+++ b/src/lib/receiving/walletOptions.js
@@ -1,0 +1,238 @@
+/**
+ * Receiving-method catalog and pure validators.
+ *
+ * Framework-free (CommonJS, no I/O) so it can be driven from the CLI
+ * (bin/receiving.js) today and imported by the web UI later. The only
+ * dependency is nostr-tools' nip19 codec for npub.cash derivation, which is
+ * pure bech32 — no network.
+ *
+ * A kind-0 profile can carry receiving identifiers under several historical
+ * field names. We group them into two mutually-exclusive *families*:
+ *
+ *   BOLT12 family: bolt12 / lud12 / lightning_offer   (static offer, untracked)
+ *   LUD16  family: lud16  / lud06                      (Lightning address, tracked)
+ *
+ * "Replace semantics" (rev. 2, Finding 2): setting a method writes exactly one
+ * field and clears every other receiving field across BOTH families, so a
+ * stale BOLT12 can never shadow a freshly-set Lightning address (zap.js reads
+ * bolt12 before lud16).
+ */
+
+// Tolerant nostr-tools loader: plain require resolves from the repo's
+// node_modules locally; the absolute path is the Docker install location used
+// elsewhere in the server (see fetchProfiles.js).
+function loadNostrTools() {
+  try {
+    return require('nostr-tools');
+  } catch {
+    return require('/usr/local/lib/node_modules/brainstorm/node_modules/nostr-tools');
+  }
+}
+
+// @scure/base is a transitive dep of nostr-tools (present at the repo root and in
+// the Docker install). We only need its bech32 codec to decode an LNURL string.
+function loadBech32() {
+  const tries = [
+    '@scure/base',
+    '/usr/local/lib/node_modules/brainstorm/node_modules/@scure/base',
+    '/usr/local/lib/node_modules/brainstorm/node_modules/nostr-tools/node_modules/@scure/base',
+  ];
+  for (const t of tries) {
+    try { return require(t).bech32; } catch {}
+  }
+  throw new Error("cannot load '@scure/base' bech32 — needed to decode LNURL codes");
+}
+
+const BOLT12_FIELDS = ['bolt12', 'lud12', 'lightning_offer'];
+// lud16 (Lightning address) and lud06 (LNURL-pay code) share the "address-ish"
+// family. lud06 conventionally carries a bech32 lnurl1… code; lud16 carries
+// name@domain. We disambiguate by value, not by field name (see resolveMethod).
+const LUD16_FIELDS = ['lud16', 'lud06'];
+const ALL_RECEIVING_FIELDS = [...BOLT12_FIELDS, ...LUD16_FIELDS];
+
+const BOLT12_RE = /lno1[a-z0-9]{8,}/i;
+// name@domain.tld — no whitespace, exactly one @, a dotted domain.
+const LUD16_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// A bech32 lnurl1… code, optionally lightning:-prefixed. Charset is permissive
+// here — bech32.decode() does the real validation (checksum + charset).
+const LNURL_RE = /^lnurl1[0-9a-z]+$/;
+// LNURLs routinely exceed the 90-char bech32 default; pass a generous cap so the
+// checksum still guards integrity without rejecting long codes.
+const LNURL_BECH32_LIMIT = 2000;
+
+/**
+ * Accept bare offers, `lightning:` prefixes, and BIP-21 unified URIs
+ * (`bitcoin:?lno=lno1...`, as Phoenix exports). Returns the *original* trimmed
+ * string when it contains a valid offer so the QR/profile stores whatever form
+ * the user pasted (the unified URI is recognized by the broadest wallet set).
+ * Mirrors readBolt12() in ui/src/utils/zap.js.
+ */
+function extractBolt12(value) {
+  if (!value || typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!BOLT12_RE.test(trimmed)) return null;
+  return trimmed;
+}
+
+function isBolt12(value) {
+  return extractBolt12(value) !== null;
+}
+
+/**
+ * Canonicalize an LNURL-pay input to a bare lowercase `lnurl1…` string, or null
+ * if it isn't shaped like one. Accepts a `lightning:` scheme prefix and any
+ * letter case (bech32 is case-insensitive but must be uniform; we store lower).
+ * This is a *shape* check only — decodeLnurl() verifies the bech32 checksum.
+ */
+function normalizeLnurl(value) {
+  if (!value || typeof value !== 'string') return null;
+  const s = value.trim().replace(/^lightning:/i, '').trim().toLowerCase();
+  return LNURL_RE.test(s) ? s : null;
+}
+
+/**
+ * Decode an LNURL-pay code to its underlying https URL, or null if it is not a
+ * valid `lnurl1…` wrapping an http(s) URL. Pure (bech32 only, no network).
+ */
+function decodeLnurl(value) {
+  const ln = normalizeLnurl(value);
+  if (!ln) return null;
+  try {
+    const bech32 = loadBech32();
+    const { prefix, words } = bech32.decode(ln, LNURL_BECH32_LIMIT);
+    if (prefix !== 'lnurl') return null;
+    const url = new TextDecoder().decode(bech32.fromWords(words));
+    return /^https?:\/\//i.test(url) ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate + canonicalize an LNURL-pay code. Returns the bare lowercase
+ * `lnurl1…` to store in lud06 when the code decodes to an http(s) URL, else
+ * null. Mirrors extractBolt12()'s "return the storable form or null" contract.
+ */
+function extractLnurl(value) {
+  return decodeLnurl(value) ? normalizeLnurl(value) : null;
+}
+
+function isLnurl(value) {
+  return extractLnurl(value) !== null;
+}
+
+/**
+ * Validate a Lightning address (lud16). Returns { valid, value?, error? }.
+ */
+function validateLud16(value) {
+  if (!value || typeof value !== 'string') {
+    return { valid: false, error: 'Lightning address is required' };
+  }
+  const trimmed = value.trim();
+  if (!LUD16_RE.test(trimmed)) {
+    return { valid: false, error: `Not a Lightning address (expected name@domain): ${trimmed}` };
+  }
+  return { valid: true, value: trimmed };
+}
+
+/**
+ * Derive a deterministic npub.cash Lightning address from a pubkey.
+ * Accepts hex or an npub1… string. npub.cash addresses are `<npub>@npub.cash`.
+ */
+function npubCashAddress(pubkeyHexOrNpub) {
+  if (!pubkeyHexOrNpub || typeof pubkeyHexOrNpub !== 'string') {
+    throw new Error('npubCashAddress: pubkey required');
+  }
+  let npub = pubkeyHexOrNpub.trim();
+  if (/^[0-9a-f]{64}$/i.test(npub)) {
+    const { nip19 } = loadNostrTools();
+    npub = nip19.npubEncode(npub.toLowerCase());
+  } else if (!npub.startsWith('npub1')) {
+    throw new Error(`npubCashAddress: expected hex pubkey or npub1…, got: ${npub.slice(0, 12)}…`);
+  }
+  return `${npub}@npub.cash`;
+}
+
+/**
+ * Curated option catalog (revised copy from the plan). `field` is the kind-0
+ * field a chosen option writes. `tracked` reflects whether payments yield a
+ * NIP-57 zap receipt (kind 9735) — BOLT12 static offers do not, so a
+ * cap-tracked bounty won't auto-mark them paid (rev. 2, Finding 3).
+ *
+ * The CLI exposes three set-methods directly (npub-cash, address, bolt12);
+ * `wos` and `fedimint` are address sources documented here for the UI.
+ */
+const WALLET_OPTIONS = [
+  {
+    id: 'npub-cash',
+    label: 'npub.cash',
+    field: 'lud16',
+    tracked: true,
+    isDefault: true,
+    derivesFromPubkey: true,
+    needsValue: false,
+    note: 'Deterministic from your npub, no signup. External Cashu mint — not custody by us, but a mint trust model.',
+  },
+  {
+    id: 'address',
+    label: 'Lightning address',
+    field: 'lud16',
+    tracked: true,
+    needsValue: true,
+    note: 'Any name@domain whose LNURL allows Nostr zaps.',
+  },
+  {
+    id: 'wos',
+    label: 'Wallet of Satoshi',
+    field: 'lud16',
+    tracked: true,
+    needsValue: true,
+    note: 'Non-U.S. / existing users only (exited U.S. 2023). Custodial, not by us.',
+  },
+  {
+    id: 'bolt12',
+    label: 'BOLT12 offer (untracked)',
+    field: 'bolt12',
+    tracked: false,
+    needsValue: true,
+    note: 'Static lno1… offer. Self-custodial. No zap receipt — manual / untracked, won\'t auto-free a cap slot.',
+  },
+  {
+    id: 'lnurl',
+    label: 'LNURL-pay code',
+    field: 'lud06',
+    // 'depends': a static lnurl1… is tracked only if its LNURL endpoint advertises
+    // allowsNostr — verified by the probe, not assumable from the code alone.
+    tracked: 'depends',
+    needsValue: true,
+    note: 'Static lnurl1… pay code (e.g. a Fedimint paycode). Tracked only if its LNURL allows Nostr zaps (verify with --probe); otherwise manual / untracked.',
+  },
+  {
+    id: 'fedimint',
+    label: 'Fedimint federation address',
+    field: 'lud16',
+    tracked: true,
+    needsValue: true,
+    note: 'Paste a federation-backed Lightning address (Fedi app / self-hosted gateway). Not a fed11… invite code.',
+  },
+];
+
+function getOption(id) {
+  return WALLET_OPTIONS.find(o => o.id === id) || null;
+}
+
+module.exports = {
+  BOLT12_FIELDS,
+  LUD16_FIELDS,
+  ALL_RECEIVING_FIELDS,
+  extractBolt12,
+  isBolt12,
+  normalizeLnurl,
+  decodeLnurl,
+  extractLnurl,
+  isLnurl,
+  validateLud16,
+  npubCashAddress,
+  WALLET_OPTIONS,
+  getOption,
+};

--- a/test/receiving.e2e.js
+++ b/test/receiving.e2e.js
@@ -1,0 +1,195 @@
+/**
+ * CLI end-to-end test for bin/receiving.js — the proof the plan's "CLI-first"
+ * approach is meant to give: drive the actual binary through the full
+ * sign → publish → read-back → resolve loop and assert every rev. 2 finding.
+ *
+ * Hermetic: a local mock relay (test/support/mock-relay.js) stands in for the
+ * profile relays and verifies signatures on the way in. `--no-local` skips the
+ * strfry binary (not installed in CI / dev), so the loop runs entirely over a
+ * controlled WebSocket. Each scenario spawns bin/receiving.js as a child
+ * process — the same way a human or a script would run it.
+ *
+ * Run: `npm run test:receiving:e2e` (or `node test/receiving.e2e.js`).
+ */
+
+const assert = require('assert');
+const path = require('path');
+const { spawn } = require('child_process');
+const { generateSecretKey, getPublicKey, finalizeEvent } = require('nostr-tools');
+const { startMockRelay } = require('./support/mock-relay');
+
+const CLI = path.join(__dirname, '..', 'bin', 'receiving.js');
+
+// Canonical LUD-01 LNURL example (decodes to an https URL). Used to prove the
+// `set lnurl` → kind-0 lud06 → resolve-as-lnurl loop end-to-end. --no-probe
+// keeps it hermetic (no real LNURL fetch against service.com).
+const GOOD_LNURL = 'lnurl1dp68gurn8ghj7um9wfmxjcm99e3k7mf0v9cxj0m385ekvcenxc6r2c35xvukxefcv5mkvv34x5ekzd3ev56nyd3hxqurzepexejxxepnxscrvwfnv9nxzcn9xq6xyefhvgcxxcmyxymnserxfq5fns';
+
+function hex(sk) { return Buffer.from(sk).toString('hex'); }
+
+/**
+ * Run the CLI as a child process. ASYNC on purpose: the mock relay runs in this
+ * same process, so we must keep the event loop free (spawnSync would block it
+ * and the relay could never answer the child). Returns { code, stdout, stderr, json }.
+ */
+function runCli(args) {
+  return new Promise((resolve) => {
+    const child = spawn('node', [CLI, ...args]);
+    let stdout = '', stderr = '';
+    child.stdout.on('data', d => { stdout += d; });
+    child.stderr.on('data', d => { stderr += d; });
+    child.on('close', (code) => {
+      let json = null;
+      if (stdout.trim().startsWith('{')) { try { json = JSON.parse(stdout); } catch {} }
+      resolve({ code, stdout, stderr, json });
+    });
+  });
+}
+
+/** Build a signed kind-0 with explicit content + created_at (to seed stale events). */
+function signKind0(skHex, content, createdAt) {
+  const sk = Uint8Array.from(Buffer.from(skHex, 'hex'));
+  return finalizeEvent({ kind: 0, created_at: createdAt, tags: [], content: JSON.stringify(content) }, sk);
+}
+
+let passed = 0, failed = 0;
+function check(name, fn) {
+  return Promise.resolve().then(fn)
+    .then(() => { console.log(`  ✓ ${name}`); passed++; })
+    .catch(err => { console.error(`  ✗ ${name}\n      ${err.message}`); failed++; });
+}
+
+async function main() {
+  const NOW = Math.floor(Date.now() / 1000);
+
+  // A pubkey with a STALE bolt12-only profile already on the relay (created_at in the past),
+  // plus an unrelated profile, to prove newest-wins + that a switch is not masked.
+  const skA = hex(generateSecretKey());
+  const pkA = getPublicKey(Uint8Array.from(Buffer.from(skA, 'hex')));
+  const staleA = signKind0(skA, { name: 'Alice', bolt12: 'lno1stalestalestalestale' }, NOW - 100000);
+
+  const relay = await startMockRelay({ seedEvents: [staleA] });
+  console.log(`mock relay listening at ${relay.url} (seeded 1 stale kind-0 for ${pkA.slice(0, 8)}…)\n`);
+
+  // --no-probe keeps `set` hermetic (no real LNURL fetch); show/resolve ignore it unless --probe.
+  const R = ['--relays', relay.url, '--no-local', '--no-probe'];
+
+  console.log('CLI end-to-end (bin/receiving.js over a live relay):\n');
+
+  // 1) set npub-cash → published to the relay (sig verified by relay) → show round-trips it.
+  await check('set npub-cash publishes a valid kind-0 the relay accepts', async () => {
+    const r = await runCli(['set', 'npub-cash', '--nsec', skA, ...R, '--json']);
+    assert.strictEqual(r.code, 0, `exit ${r.code}; stderr=${r.stderr}`);
+    assert.ok(r.json && r.json.ok, 'expected ok json');
+    assert.strictEqual(r.json.field, 'lud16');
+    assert.ok(r.json.value.endsWith('@npub.cash'), `value=${r.json.value}`);
+    const accepted = r.json.relays.filter(x => x.success).length;
+    assert.ok(accepted >= 1, `expected >=1 relay to accept; got ${JSON.stringify(r.json.relays)}`);
+  });
+
+  // 2) Finding 1: relay now holds BOTH the stale bolt12 event and the fresh lud16 event
+  //    for pkA. `show` must return the FRESH lud16 (newest-wins), not the stale bolt12.
+  await check('show resolves NEWEST profile, not the stale bolt12 (Finding 1)', async () => {
+    const r = await runCli(['show', pkA, ...R, '--json']);
+    assert.strictEqual(r.code, 0, `exit ${r.code}; stderr=${r.stderr}`);
+    assert.ok(r.json.method, 'expected a resolved method');
+    assert.strictEqual(r.json.method.method, 'lud16', `got ${r.json.method && r.json.method.method} — stale bolt12 masked the fresh write`);
+    assert.strictEqual(r.json.method.tracked, true);
+    assert.ok(r.json.createdAt > NOW - 100000, 'resolved event should be the fresh one');
+  });
+
+  // 3) Finding 2: switch BOLT12 → address sticks even though the old offer event lingers on the relay.
+  const skB = hex(generateSecretKey());
+  const pkB = getPublicKey(Uint8Array.from(Buffer.from(skB, 'hex')));
+  await check('set bolt12 then show reports it untracked (Finding 3)', async () => {
+    const set = await runCli(['set', 'bolt12', 'bitcoin:?lno=lno1pqps7sjqpgtyzm3qv4uxzmtsd3jjqer9wd3hy6tsw35k7msjz', '--nsec', skB, ...R, '--json']);
+    assert.strictEqual(set.code, 0, `set bolt12 exit ${set.code}; stderr=${set.stderr}`);
+    assert.strictEqual(set.json.field, 'bolt12');
+    const show = await runCli(['show', pkB, ...R, '--json']);
+    assert.strictEqual(show.json.method.method, 'bolt12');
+    assert.strictEqual(show.json.method.tracked, false, 'bolt12 must report untracked');
+  });
+
+  // A fresh key with a STALE bolt12 already lingering on the relay (older created_at),
+  // then a newer `set address`. The new lud16 must win over the lingering offer.
+  const skD = hex(generateSecretKey());
+  const pkD = getPublicKey(Uint8Array.from(Buffer.from(skD, 'hex')));
+  relay.events.push(signKind0(skD, { name: 'Dana', bolt12: 'lno1lingeringoldofferxxxx' }, NOW - 50000));
+  await check('switching to address beats a lingering older bolt12 (Findings 1+2)', async () => {
+    const set = await runCli(['set', 'address', 'dana@walletofsatoshi.com', '--nsec', skD, ...R, '--json']);
+    assert.strictEqual(set.code, 0, `set address exit ${set.code}; stderr=${set.stderr}`);
+    assert.strictEqual(set.json.field, 'lud16');
+    const show = await runCli(['show', pkD, ...R, '--json']);
+    assert.strictEqual(show.json.method.method, 'lud16', 'lingering older bolt12 must NOT win after the newer address set');
+    assert.strictEqual(show.json.method.value, 'dana@walletofsatoshi.com');
+    assert.strictEqual(show.json.method.tracked, true);
+  });
+
+  // 3b) set lnurl → kind-0 lud06 → show resolves it as method 'lnurl' (tracked
+  //     unknown until probed), and resolve reports a bolt11-via-lnurl payout.
+  const skE = hex(generateSecretKey());
+  const pkE = getPublicKey(Uint8Array.from(Buffer.from(skE, 'hex')));
+  await check('set lnurl writes lud06 and show resolves it as lnurl (untracked-until-probed)', async () => {
+    const set = await runCli(['set', 'lnurl', GOOD_LNURL, '--nsec', skE, ...R, '--json']);
+    assert.strictEqual(set.code, 0, `set lnurl exit ${set.code}; stderr=${set.stderr}`);
+    assert.strictEqual(set.json.field, 'lud06');
+    assert.strictEqual(set.json.value, GOOD_LNURL);
+
+    const show = await runCli(['show', pkE, ...R, '--json']);
+    assert.strictEqual(show.json.method.method, 'lnurl');
+    assert.strictEqual(show.json.method.field, 'lud06');
+    assert.strictEqual(show.json.method.value, GOOD_LNURL);
+    assert.strictEqual(show.json.method.tracked, null, 'lnurl tracked must be unknown until probed');
+
+    const res = await runCli(['resolve', pkE, ...R, '--json']);
+    assert.strictEqual(res.json.payment.type, 'bolt11');
+    assert.strictEqual(res.json.payment.via, 'lnurl');
+    assert.strictEqual(res.json.payment.source, GOOD_LNURL);
+    assert.strictEqual(res.json.payment.tracked, null);
+  });
+
+  // (Switching lnurl → another method clearing lud06 is covered as pure logic in
+  //  receiving.test.js — "setting bolt12 later clears a prior lud06 LNURL" — so we
+  //  don't re-set the same key here, which would collide on created_at within the
+  //  same wall-clock second and make newest-wins ambiguous.)
+
+  // 4) resolve mirrors the issuer-side payout decision.
+  await check('resolve reports BOLT12 untracked and BOLT11/LNURL tracked (Finding 3)', async () => {
+    const rA = await runCli(['resolve', pkA, '--amount', '1000', ...R, '--json']);
+    assert.strictEqual(rA.json.payment.type, 'bolt11', 'pkA set npub-cash → lud16 → bolt11');
+    assert.strictEqual(rA.json.payment.tracked, true);
+
+    const skC = hex(generateSecretKey());
+    const pkC = getPublicKey(Uint8Array.from(Buffer.from(skC, 'hex')));
+    await runCli(['set', 'bolt12', 'lno1pqps7sjqpgtyzm3qv4uxzmtsd3jjqer9wd3hy', '--nsec', skC, ...R, '--json']);
+    const rC = await runCli(['resolve', pkC, ...R, '--json']);
+    assert.strictEqual(rC.json.payment.type, 'bolt12');
+    assert.strictEqual(rC.json.payment.tracked, false, 'bolt12 payout must be untracked');
+  });
+
+  // 5) Finding 6: a --nsec whose pubkey ≠ --pubkey is rejected before publishing.
+  await check('wrong-key set is rejected (Finding 6 — signer guard)', async () => {
+    const wrong = '0'.repeat(64);
+    const r = await runCli(['set', 'npub-cash', '--nsec', skA, '--pubkey', wrong, ...R]);
+    assert.notStrictEqual(r.code, 0, 'expected non-zero exit on signer mismatch');
+    assert.ok(/signer mismatch/i.test(r.stderr), `expected signer-mismatch error; stderr=${r.stderr}`);
+  });
+
+  // 6) Every event the relay stored verified — the relay rejects bad sigs, so the
+  //    accepted events prove finalizeEvent produced valid signatures.
+  await check('relay only ever stored signature-valid events', () => {
+    const { verifyEvent } = require('nostr-tools');
+    assert.ok(relay.events.length >= 4, `expected several stored events; got ${relay.events.length}`);
+    for (const ev of relay.events) {
+      assert.ok(verifyEvent(ev), `stored event ${ev.id?.slice(0, 8)} failed verification`);
+    }
+  });
+
+  await relay.close();
+
+  console.log('\n-------------');
+  console.log(`E2E: ${passed} passed, ${failed} failed → ${failed === 0 ? 'PASS' : 'FAIL'}`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch(err => { console.error('e2e harness error:', err); process.exit(1); });

--- a/test/receiving.probe.e2e.js
+++ b/test/receiving.probe.e2e.js
@@ -1,0 +1,128 @@
+/**
+ * LNURL-probe verification (the "is this address actually payable/tracked?" check).
+ *
+ * Hermetic: a local HTTP server stands in for an LNURL-pay endpoint. Exercises
+ * probeLud16 over a real fetch for the cases that matter — especially the
+ * fedimint-gateway case where the LNURL is reachable but does NOT advertise
+ * allowsNostr, so payments are NOT tracked (and zap.js would refuse).
+ *
+ * Run: `npm run test:receiving:probe` (or `node test/receiving.probe.e2e.js`).
+ */
+const assert = require('assert');
+const http = require('http');
+const { bech32 } = require('@scure/base');
+const { probeLud16, probeLnurl, probeReceiving, trackedVerdict, parseLud16 } = require('../src/lib/receiving/probe');
+
+// Encode an http(s) URL as a static lnurl1… code (the inverse of decodeLnurl).
+// Used to point a test LNURL at the ephemeral local server.
+function encodeLnurl(url) {
+  return bech32.encode('lnurl', bech32.toWords(new TextEncoder().encode(url)), 2000);
+}
+
+let passed = 0, failed = 0;
+function check(name, fn) {
+  return Promise.resolve().then(fn)
+    .then(() => { console.log(`  ✓ ${name}`); passed++; })
+    .catch(err => { console.error(`  ✗ ${name}\n      ${err.message}`); failed++; });
+}
+
+function startLnurlServer() {
+  return new Promise((resolve) => {
+    const srv = http.createServer((req, res) => {
+      const m = req.url.match(/^\/\.well-known\/lnurlp\/(.+)$/);
+      const user = m ? decodeURIComponent(m[1]) : null;
+      if (user === 'good') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ tag: 'payRequest', callback: 'https://x/cb', minSendable: 1000, maxSendable: 1e8, allowsNostr: true }));
+      } else if (user === 'nonostr') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ tag: 'payRequest', callback: 'https://x/cb', minSendable: 1000, maxSendable: 1e8 }));
+      } else {
+        res.writeHead(404); res.end('not found');
+      }
+    });
+    srv.listen(0, '127.0.0.1', () => resolve({ port: srv.address().port, close: () => new Promise(r => srv.close(r)) }));
+  });
+}
+
+(async () => {
+  const srv = await startLnurlServer();
+  const D = `127.0.0.1:${srv.port}`;
+  const OPT = { allowInsecureLocalhost: true, timeoutMs: 3000 };
+  console.log(`lnurl test server at http://${D}\n\nLNURL probe:\n`);
+
+  await check('parseLud16 splits/validates', () => {
+    assert.deepStrictEqual(parseLud16('a@b.com'), { user: 'a', domain: 'b.com' });
+    assert.strictEqual(parseLud16('nope'), null);
+    assert.strictEqual(parseLud16('a@b@c'), null);
+  });
+
+  await check('allowsNostr:true → ok + tracked', async () => {
+    const p = await probeLud16(`good@${D}`, OPT);
+    assert.ok(p.ok && p.reachable && p.allowsNostr === true, JSON.stringify(p));
+    assert.strictEqual(trackedVerdict(p).tracked, true);
+  });
+
+  await check('reachable but no allowsNostr → NOT tracked (the fedimint-gateway case)', async () => {
+    const p = await probeLud16(`nonostr@${D}`, OPT);
+    assert.ok(p.ok && p.allowsNostr === false, JSON.stringify(p));
+    assert.strictEqual(trackedVerdict(p).tracked, false);
+  });
+
+  await check('404 → not ok, reachable, not tracked', async () => {
+    const p = await probeLud16(`missing@${D}`, OPT);
+    assert.ok(!p.ok && p.reachable && p.status === 404, JSON.stringify(p));
+    assert.strictEqual(trackedVerdict(p).tracked, false);
+  });
+
+  await check('unreachable host → reachable:false, not tracked', async () => {
+    const p = await probeLud16('x@127.0.0.1:1', { allowInsecureLocalhost: true, timeoutMs: 2000 });
+    assert.strictEqual(p.reachable, false, JSON.stringify(p));
+    assert.strictEqual(trackedVerdict(p).tracked, false);
+  });
+
+  await check('malformed lud16 → error', async () => {
+    const p = await probeLud16('notanaddress', OPT);
+    assert.ok(!p.ok && /malformed/.test(p.error), JSON.stringify(p));
+  });
+
+  // ---- LNURL-pay code (lud06): bech32-decode → fetch the same endpoints ----
+  const lnGood = encodeLnurl(`http://${D}/.well-known/lnurlp/good`);
+  const lnNoNostr = encodeLnurl(`http://${D}/.well-known/lnurlp/nonostr`);
+  const lnMissing = encodeLnurl(`http://${D}/.well-known/lnurlp/missing`);
+
+  await check('probeLnurl: allowsNostr:true → ok + tracked, exposes decoded url', async () => {
+    const p = await probeLnurl(lnGood, { timeoutMs: 3000 });
+    assert.ok(p.ok && p.reachable && p.allowsNostr === true, JSON.stringify(p));
+    assert.ok(p.url && p.url.endsWith('/good'), `expected decoded url; got ${p.url}`);
+    assert.strictEqual(trackedVerdict(p).tracked, true);
+  });
+
+  await check('probeLnurl: reachable but no allowsNostr → NOT tracked (the paycode case)', async () => {
+    const p = await probeLnurl(lnNoNostr, { timeoutMs: 3000 });
+    assert.ok(p.ok && p.allowsNostr === false, JSON.stringify(p));
+    assert.strictEqual(trackedVerdict(p).tracked, false);
+  });
+
+  await check('probeLnurl: 404 → not ok, reachable, not tracked', async () => {
+    const p = await probeLnurl(lnMissing, { timeoutMs: 3000 });
+    assert.ok(!p.ok && p.reachable && p.status === 404, JSON.stringify(p));
+    assert.strictEqual(trackedVerdict(p).tracked, false);
+  });
+
+  await check('probeLnurl: malformed lnurl → error', async () => {
+    const p = await probeLnurl('lnurl1notvalidchecksum', { timeoutMs: 3000 });
+    assert.ok(!p.ok && /malformed LNURL/.test(p.error), JSON.stringify(p));
+  });
+
+  await check('probeReceiving dispatches: lnurl1… → LNURL probe, name@domain → lud16 probe', async () => {
+    const a = await probeReceiving(lnGood, { timeoutMs: 3000 });
+    assert.ok(a.ok && a.allowsNostr === true && a.url, `lnurl path: ${JSON.stringify(a)}`);
+    const b = await probeReceiving(`good@${D}`, OPT);
+    assert.ok(b.ok && b.allowsNostr === true && !b.url, `lud16 path: ${JSON.stringify(b)}`);
+  });
+
+  await srv.close();
+  console.log(`\n-------------\nPROBE E2E: ${passed} passed, ${failed} failed → ${failed === 0 ? 'PASS' : 'FAIL'}`);
+  process.exit(failed === 0 ? 0 : 1);
+})().catch(e => { console.error('probe harness error:', e); process.exit(1); });

--- a/test/receiving.test.js
+++ b/test/receiving.test.js
@@ -1,0 +1,394 @@
+/**
+ * Unit tests for the framework-free "receiving setup" core (Phase 1).
+ *
+ * Matches the repo's existing test style (node + assert, PASS/FAIL summary,
+ * exit code). Run with `npm run test:receiving` or `node test/receiving.test.js`.
+ *
+ * Covers the rev. 2 review findings as pure-logic assertions:
+ *   - validators (lud16 format, bolt12 extraction incl. unified URIs)
+ *   - npub→npub.cash derivation
+ *   - alias-clearing / REPLACE semantics (Finding 2)
+ *   - bolt12→lud16 precedence + tracked/untracked (Findings 3)
+ *   - newest-by-created_at merge (Finding 1)
+ */
+
+const assert = require('assert');
+
+const {
+  extractBolt12, isBolt12, validateLud16, npubCashAddress,
+  extractLnurl, isLnurl, decodeLnurl, normalizeLnurl,
+  WALLET_OPTIONS, getOption,
+} = require('../src/lib/receiving/walletOptions');
+const { buildReceivingContent, mergeReceivingField } = require('../src/lib/receiving/mergeKind0');
+const { resolveReceivingMethod, resolvePayment } = require('../src/lib/receiving/resolveMethod');
+const { pickNewestEvent, mergeNewestByPubkey } = require('../src/lib/receiving/newest');
+
+const A = 'a'.repeat(64);
+
+// LNURL fixtures (deterministic, no network):
+//   GOOD   — the canonical LUD-01 example, decodes to https://service.com/api?q=…
+//   NONURL — a valid lnurl1… that decodes to plain text (must be rejected: not http)
+//   BROKEN — GOOD with its last data char flipped (busted bech32 checksum)
+const GOOD_LNURL = 'lnurl1dp68gurn8ghj7um9wfmxjcm99e3k7mf0v9cxj0m385ekvcenxc6r2c35xvukxefcv5mkvv34x5ekzd3ev56nyd3hxqurzepexejxxepnxscrvwfnv9nxzcn9xq6xyefhvgcxxcmyxymnserxfq5fns';
+const NONURL_LNURL = 'lnurl1df6hxapqwdhk6efqw3jhsapvyphx7apqvys82unv52hlxj';
+const BROKEN_LNURL = 'lnurl1dp68gurn8ghj7um9wfmxjcm99e3k7mf0v9cxj0m385ekvcenxc6r2c35xvukxefcv5mkvv34x5ekzd3ev56nyd3hxqurzepexejxxepnxscrvwfnv9nxzcn9xq6xyefhvgcxxcmyxymnserxfq5fnq';
+
+function run(name, fn) {
+  try { fn(); console.log(`  ✓ ${name}`); return true; }
+  catch (err) { console.error(`  ✗ ${name}\n      ${err.message}`); return false; }
+}
+
+// ---- validators ------------------------------------------------------------
+
+function testValidators() {
+  let ok = true;
+  ok = run('extractBolt12 accepts bare lno1…', () => {
+    assert.strictEqual(extractBolt12('lno1pqps7sjqpgtyzm3qv4uxzmtsd3jjqer9wd3hy6tsw35k7msjzfppz'),
+      'lno1pqps7sjqpgtyzm3qv4uxzmtsd3jjqer9wd3hy6tsw35k7msjzfppz');
+  }) && ok;
+  ok = run('extractBolt12 accepts bitcoin:?lno= unified URI, returns original form', () => {
+    const uri = 'bitcoin:?lno=lno1pqps7sjqpgtyzm3qv4uxzmtsd3jjqer9wd3hy6tsw35k7msjzfppz';
+    assert.strictEqual(extractBolt12(uri), uri);
+  }) && ok;
+  ok = run('extractBolt12 trims whitespace', () => {
+    assert.strictEqual(extractBolt12('  lno1pqps7sjqpgtyzm3q  '), 'lno1pqps7sjqpgtyzm3q');
+  }) && ok;
+  ok = run('extractBolt12 rejects non-offers', () => {
+    assert.strictEqual(extractBolt12('alice@example.com'), null);
+    assert.strictEqual(extractBolt12(''), null);
+    assert.strictEqual(extractBolt12(null), null);
+    assert.strictEqual(isBolt12('nope'), false);
+  }) && ok;
+  ok = run('validateLud16 accepts name@domain.tld', () => {
+    const r = validateLud16('alice@walletofsatoshi.com');
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.value, 'alice@walletofsatoshi.com');
+  }) && ok;
+  ok = run('validateLud16 rejects malformed', () => {
+    assert.strictEqual(validateLud16('alice').valid, false);
+    assert.strictEqual(validateLud16('alice@localhost').valid, false); // no dotted domain
+    assert.strictEqual(validateLud16('a b@x.com').valid, false);       // whitespace
+    assert.strictEqual(validateLud16('').valid, false);
+  }) && ok;
+  return ok;
+}
+
+// ---- LNURL (lud06) decode + validation -------------------------------------
+
+function testLnurl() {
+  let ok = true;
+  ok = run('extractLnurl accepts lnurl1…, lightning:, and UPPER, returns bare lowercase', () => {
+    assert.strictEqual(extractLnurl(GOOD_LNURL), GOOD_LNURL);
+    assert.strictEqual(extractLnurl(GOOD_LNURL.toUpperCase()), GOOD_LNURL);
+    assert.strictEqual(extractLnurl('lightning:' + GOOD_LNURL), GOOD_LNURL);
+    assert.strictEqual(extractLnurl('LIGHTNING:' + GOOD_LNURL.toUpperCase()), GOOD_LNURL);
+    assert.strictEqual(extractLnurl('  ' + GOOD_LNURL + '  '), GOOD_LNURL);
+    assert.strictEqual(isLnurl(GOOD_LNURL), true);
+  }) && ok;
+  ok = run('decodeLnurl returns the underlying https URL', () => {
+    assert.strictEqual(decodeLnurl(GOOD_LNURL), 'https://service.com/api?q=3fc3645b439ce8e7f2553a69e5267081d96dcd340693afabe04be7b0ccd178df');
+  }) && ok;
+  ok = run('extractLnurl rejects a code that decodes to a non-URL', () => {
+    assert.strictEqual(extractLnurl(NONURL_LNURL), null);
+    assert.strictEqual(decodeLnurl(NONURL_LNURL), null);
+    assert.strictEqual(isLnurl(NONURL_LNURL), false);
+  }) && ok;
+  ok = run('extractLnurl rejects a busted-checksum code', () => {
+    assert.strictEqual(extractLnurl(BROKEN_LNURL), null);
+  }) && ok;
+  ok = run('extractLnurl rejects addresses, offers, junk, empty', () => {
+    assert.strictEqual(extractLnurl('alice@walletofsatoshi.com'), null);
+    assert.strictEqual(extractLnurl('lno1pqps7sjqpgtyzm3q'), null);
+    assert.strictEqual(extractLnurl('not-an-lnurl'), null);
+    assert.strictEqual(extractLnurl(''), null);
+    assert.strictEqual(extractLnurl(null), null);
+  }) && ok;
+  ok = run('normalizeLnurl strips prefix/case without decoding', () => {
+    assert.strictEqual(normalizeLnurl('LIGHTNING:LNURL1ABC'), 'lnurl1abc');
+    assert.strictEqual(normalizeLnurl('nope'), null);
+  }) && ok;
+  return ok;
+}
+
+// ---- npub.cash derivation --------------------------------------------------
+
+function testNpubCash() {
+  let ok = true;
+  ok = run('npubCashAddress derives <npub>@npub.cash from hex', () => {
+    const addr = npubCashAddress(A);
+    assert.ok(addr.startsWith('npub1'), `expected npub1… got ${addr}`);
+    assert.ok(addr.endsWith('@npub.cash'), `expected @npub.cash got ${addr}`);
+    // deterministic
+    assert.strictEqual(npubCashAddress(A), addr);
+  }) && ok;
+  ok = run('npubCashAddress passes through an npub1… as-is', () => {
+    const npub = npubCashAddress(A).split('@')[0];
+    assert.strictEqual(npubCashAddress(npub), `${npub}@npub.cash`);
+  }) && ok;
+  ok = run('npubCashAddress rejects garbage', () => {
+    assert.throws(() => npubCashAddress('not-a-key'));
+    assert.throws(() => npubCashAddress(''));
+  }) && ok;
+  return ok;
+}
+
+// ---- alias-clearing / REPLACE semantics (Finding 2) ------------------------
+
+function testReplaceSemantics() {
+  let ok = true;
+
+  ok = run('setting lud16 clears bolt12/lud12/lightning_offer, preserves other fields', () => {
+    const existing = {
+      name: 'Alice', about: 'hi', nip05: 'alice@x.com',
+      bolt12: 'lno1abcdefghij', lud12: 'lno1zzzzzzzzzz', lightning_offer: 'lno1qqqqqqqqqq',
+    };
+    const { content, field, value, cleared } = buildReceivingContent({
+      profile: existing, method: 'address', value: 'alice@walletofsatoshi.com', pubkeyHex: A,
+    });
+    assert.strictEqual(field, 'lud16');
+    assert.strictEqual(value, 'alice@walletofsatoshi.com');
+    assert.strictEqual(content.lud16, 'alice@walletofsatoshi.com');
+    assert.strictEqual(content.bolt12, undefined);
+    assert.strictEqual(content.lud12, undefined);
+    assert.strictEqual(content.lightning_offer, undefined);
+    // non-receiving fields survive
+    assert.strictEqual(content.name, 'Alice');
+    assert.strictEqual(content.about, 'hi');
+    assert.strictEqual(content.nip05, 'alice@x.com');
+    assert.deepStrictEqual(cleared.sort(), ['bolt12', 'lightning_offer', 'lud12']);
+  }) && ok;
+
+  ok = run('setting bolt12 clears lud16/lud06 (and vice versa)', () => {
+    const existing = { lud16: 'alice@x.com', lud06: 'LNURL...', picture: 'http://img' };
+    const { content, field, cleared } = buildReceivingContent({
+      profile: existing, method: 'bolt12', value: 'lno1pqps7sjqpgtyzm3q', pubkeyHex: A,
+    });
+    assert.strictEqual(field, 'bolt12');
+    assert.strictEqual(content.bolt12, 'lno1pqps7sjqpgtyzm3q');
+    assert.strictEqual(content.lud16, undefined);
+    assert.strictEqual(content.lud06, undefined);
+    assert.strictEqual(content.picture, 'http://img');
+    assert.deepStrictEqual(cleared.sort(), ['lud06', 'lud16']);
+  }) && ok;
+
+  ok = run('npub-cash derives lud16 and clears any prior bolt12', () => {
+    const { content, field, value } = buildReceivingContent({
+      profile: { bolt12: 'lno1abcdefghij' }, method: 'npub-cash', pubkeyHex: A,
+    });
+    assert.strictEqual(field, 'lud16');
+    assert.ok(value.endsWith('@npub.cash'));
+    assert.strictEqual(content.lud16, value);
+    assert.strictEqual(content.bolt12, undefined);
+  }) && ok;
+
+  ok = run('strips server-derived fields from content', () => {
+    const out = mergeReceivingField(
+      { name: 'A', pubkey: A, created_at: 123, id: 'eventid', sig: 'sig', kind: 0, tags: [] },
+      'lud16', 'a@b.com',
+    );
+    assert.strictEqual(out.name, 'A');
+    for (const f of ['pubkey', 'created_at', 'id', 'sig', 'kind', 'tags']) {
+      assert.strictEqual(out[f], undefined, `${f} should be stripped`);
+    }
+  }) && ok;
+
+  ok = run('handles null/empty existing profile', () => {
+    const { content, field } = buildReceivingContent({ profile: null, method: 'npub-cash', pubkeyHex: A });
+    assert.strictEqual(field, 'lud16');
+    assert.ok(content.lud16.endsWith('@npub.cash'));
+  }) && ok;
+
+  ok = run('unknown method / invalid value throw', () => {
+    assert.throws(() => buildReceivingContent({ profile: {}, method: 'nope', pubkeyHex: A }));
+    assert.throws(() => buildReceivingContent({ profile: {}, method: 'address', value: 'bad', pubkeyHex: A }));
+    assert.throws(() => buildReceivingContent({ profile: {}, method: 'bolt12', value: 'notanoffer', pubkeyHex: A }));
+  }) && ok;
+
+  return ok;
+}
+
+// ---- fedimint: it's just a lud16 address; reject fed11… invite codes --------
+
+function testFedimint() {
+  let ok = true;
+  ok = run("fedimint option writes the lud16 field (it's an address, not a protocol)", () => {
+    assert.strictEqual(getOption('fedimint').field, 'lud16');
+    const { content, field } = buildReceivingContent({
+      profile: {}, method: 'fedimint', value: 'alice@fedi.example.com', pubkeyHex: A,
+    });
+    assert.strictEqual(field, 'lud16');
+    assert.strictEqual(content.lud16, 'alice@fedi.example.com');
+  }) && ok;
+  ok = run('a federation INVITE CODE (fed11…) is rejected by fedimint and address', () => {
+    const fed11 = 'fed11qgqzc2nhwden5te0vejkg6tdd9h8gepwvejkg6tdd9h8garhduhx6at5d9h8jmn9wshxxmmd';
+    assert.throws(() => buildReceivingContent({ profile: {}, method: 'fedimint', value: fed11, pubkeyHex: A }), /Lightning address/);
+    assert.throws(() => buildReceivingContent({ profile: {}, method: 'address', value: fed11, pubkeyHex: A }), /Lightning address/);
+  }) && ok;
+  ok = run('switching fedimint→ keeps replace semantics (clears a prior bolt12)', () => {
+    const { content } = buildReceivingContent({
+      profile: { bolt12: 'lno1abcdefghij' }, method: 'fedimint', value: 'gw@fedimint.example.org', pubkeyHex: A,
+    });
+    assert.strictEqual(content.lud16, 'gw@fedimint.example.org');
+    assert.strictEqual(content.bolt12, undefined);
+  }) && ok;
+  return ok;
+}
+
+// ---- precedence + tracked/untracked (Finding 3) ----------------------------
+
+function testPrecedence() {
+  let ok = true;
+  ok = run('bolt12 wins over lud16 (matches zap.js), reported untracked', () => {
+    const m = resolveReceivingMethod({ bolt12: 'lno1pqps7sjqpgtyzm3q', lud16: 'a@b.com' });
+    assert.strictEqual(m.method, 'bolt12');
+    assert.strictEqual(m.tracked, false);
+  }) && ok;
+  ok = run('lud16 alone resolves tracked', () => {
+    const m = resolveReceivingMethod({ lud16: 'a@b.com' });
+    assert.strictEqual(m.method, 'lud16');
+    assert.strictEqual(m.tracked, true);
+  }) && ok;
+  ok = run('no method resolves null', () => {
+    assert.strictEqual(resolveReceivingMethod({ name: 'x' }), null);
+    assert.strictEqual(resolveReceivingMethod(null), null);
+  }) && ok;
+  ok = run('resolvePayment mirrors the issuer decision', () => {
+    assert.deepStrictEqual(resolvePayment({ bolt12: 'lno1pqps7sjqpgtyzm3q' }),
+      { type: 'bolt12', payload: 'lno1pqps7sjqpgtyzm3q', static: true, tracked: false });
+    assert.deepStrictEqual(resolvePayment({ lud16: 'a@b.com' }),
+      { type: 'bolt11', lud16: 'a@b.com', tracked: true });
+    assert.strictEqual(resolvePayment({}).type, 'none');
+  }) && ok;
+  return ok;
+}
+
+// ---- LNURL as a receiving method: build → resolve → precedence -------------
+
+function testLnurlReceiving() {
+  let ok = true;
+
+  ok = run('build lnurl writes lud06 (bare lnurl1…) and clears bolt12/lud16', () => {
+    const existing = { name: 'Carol', bolt12: 'lno1abcdefghij', lud16: 'carol@x.com' };
+    const { content, field, value, cleared } = buildReceivingContent({
+      profile: existing, method: 'lnurl', value: 'lightning:' + GOOD_LNURL.toUpperCase(), pubkeyHex: A,
+    });
+    assert.strictEqual(field, 'lud06');
+    assert.strictEqual(value, GOOD_LNURL);           // normalized: prefix stripped, lowercased
+    assert.strictEqual(content.lud06, GOOD_LNURL);
+    assert.strictEqual(content.bolt12, undefined);
+    assert.strictEqual(content.lud16, undefined);
+    assert.strictEqual(content.name, 'Carol');       // non-receiving field survives
+    assert.deepStrictEqual(cleared.sort(), ['bolt12', 'lud16']);
+  }) && ok;
+
+  ok = run('build lnurl rejects a malformed code', () => {
+    assert.throws(() => buildReceivingContent({ profile: {}, method: 'lnurl', value: BROKEN_LNURL, pubkeyHex: A }), /LNURL-pay code/);
+    assert.throws(() => buildReceivingContent({ profile: {}, method: 'lnurl', value: 'alice@x.com', pubkeyHex: A }), /LNURL-pay code/);
+  }) && ok;
+
+  ok = run('setting bolt12 later clears a prior lud06 LNURL', () => {
+    const { content, cleared } = buildReceivingContent({
+      profile: { lud06: GOOD_LNURL }, method: 'bolt12', value: 'lno1pqps7sjqpgtyzm3q', pubkeyHex: A,
+    });
+    assert.strictEqual(content.bolt12, 'lno1pqps7sjqpgtyzm3q');
+    assert.strictEqual(content.lud06, undefined);
+    assert.ok(cleared.includes('lud06'));
+  }) && ok;
+
+  ok = run("resolveReceivingMethod reports 'lnurl' (tracked unknown until probed)", () => {
+    const m = resolveReceivingMethod({ lud06: GOOD_LNURL });
+    assert.strictEqual(m.method, 'lnurl');
+    assert.strictEqual(m.field, 'lud06');
+    assert.strictEqual(m.value, GOOD_LNURL);
+    assert.strictEqual(m.tracked, null);             // not assumable from the code alone
+  }) && ok;
+
+  ok = run('precedence: bolt12 wins over an LNURL', () => {
+    const m = resolveReceivingMethod({ bolt12: 'lno1pqps7sjqpgtyzm3q', lud06: GOOD_LNURL });
+    assert.strictEqual(m.method, 'bolt12');
+  }) && ok;
+
+  ok = run('precedence: a real lud16 address wins over an LNURL in lud06', () => {
+    const m = resolveReceivingMethod({ lud16: 'alice@walletofsatoshi.com', lud06: GOOD_LNURL });
+    assert.strictEqual(m.method, 'lud16');
+    assert.strictEqual(m.value, 'alice@walletofsatoshi.com');
+  }) && ok;
+
+  ok = run('an LNURL mis-placed in lud16 still resolves as lnurl', () => {
+    const m = resolveReceivingMethod({ lud16: GOOD_LNURL });
+    assert.strictEqual(m.method, 'lnurl');
+    assert.strictEqual(m.field, 'lud16');
+  }) && ok;
+
+  ok = run('resolvePayment for an LNURL → bolt11 via lnurl, tracked unknown', () => {
+    assert.deepStrictEqual(resolvePayment({ lud06: GOOD_LNURL }),
+      { type: 'bolt11', via: 'lnurl', source: GOOD_LNURL, tracked: null });
+  }) && ok;
+
+  return ok;
+}
+
+// ---- newest-by-created_at merge (Finding 1) --------------------------------
+
+function testNewest() {
+  let ok = true;
+  ok = run('pickNewestEvent returns greatest created_at', () => {
+    const ev = pickNewestEvent([
+      { id: 'old', created_at: 100 },
+      { id: 'new', created_at: 300 },
+      { id: 'mid', created_at: 200 },
+    ]);
+    assert.strictEqual(ev.id, 'new');
+    assert.strictEqual(pickNewestEvent([]), null);
+  }) && ok;
+  ok = run('mergeNewestByPubkey: fresh local beats stale external per pubkey', () => {
+    const B = 'b'.repeat(64);
+    const latest = mergeNewestByPubkey([
+      { pubkey: A, created_at: 100, content: '{"bolt12":"stale"}' },   // stale external
+      { pubkey: A, created_at: 500, content: '{"lud16":"fresh@x"}' },  // fresh local
+      { pubkey: B, created_at: 50, content: '{"name":"bob"}' },
+    ]);
+    assert.strictEqual(latest.get(A).created_at, 500);
+    assert.strictEqual(latest.get(A).content, '{"lud16":"fresh@x"}');
+    assert.strictEqual(latest.get(B).created_at, 50);
+  }) && ok;
+  return ok;
+}
+
+// ---- catalog sanity --------------------------------------------------------
+
+function testCatalog() {
+  let ok = true;
+  ok = run('catalog: exactly one default; bolt12 untracked; npub-cash tracked', () => {
+    assert.strictEqual(WALLET_OPTIONS.filter(o => o.isDefault).length, 1);
+    assert.strictEqual(getOption('bolt12').tracked, false);
+    assert.strictEqual(getOption('npub-cash').tracked, true);
+    assert.strictEqual(getOption('npub-cash').isDefault, true);
+  }) && ok;
+  return ok;
+}
+
+console.log('Running receiving (Phase 1) tests…\n');
+const suites = [
+  ['Validators', testValidators],
+  ['LNURL (lud06) decode + validation', testLnurl],
+  ['npub.cash derivation', testNpubCash],
+  ['Replace semantics (Finding 2)', testReplaceSemantics],
+  ['Fedimint = lud16; reject fed11…', testFedimint],
+  ['Precedence + tracked (Finding 3)', testPrecedence],
+  ['LNURL receiving: build → resolve → precedence', testLnurlReceiving],
+  ['Newest-by-created_at (Finding 1)', testNewest],
+  ['Option catalog', testCatalog],
+];
+
+let allPass = true;
+for (const [title, fn] of suites) {
+  console.log(title + ':');
+  const pass = fn();
+  allPass = allPass && pass;
+  console.log('');
+}
+
+console.log('-------------');
+console.log(`Overall: ${allPass ? 'PASS' : 'FAIL'}`);
+process.exit(allPass ? 0 : 1);

--- a/test/support/fetchprofiles-strfry.e2e.js
+++ b/test/support/fetchprofiles-strfry.e2e.js
@@ -1,0 +1,52 @@
+/**
+ * Verify the edited /api/profiles read path (src/api/profiles/fetchProfiles.js)
+ * against the REAL strfry store — the server half of Finding 1.
+ *
+ * Runs INSIDE the tapestry container (requires nostr-tools at the Docker path).
+ * Uses a throwaway strfry config + temp LMDB so the dev DB is untouched. Imports
+ * kind-0 events via the real `strfry import`, then calls the exported getProfiles()
+ * and asserts it reads them back (and that a newer import wins after cache invalidation).
+ *
+ *   docker exec tapestry node /usr/local/lib/node_modules/brainstorm/test/support/fetchprofiles-strfry.e2e.js
+ */
+const { execSync } = require('child_process');
+
+const DB = '/tmp/fp-e2e-db';
+const CONF = '/tmp/fp-e2e.conf';
+process.env.STRFRY_CONFIG = CONF;
+execSync(`rm -rf ${DB} && mkdir -p ${DB} && cp /etc/strfry.conf ${CONF} && sed -i 's|^db = .*|db = "${DB}/"|' ${CONF}`);
+
+const { generateSecretKey, getPublicKey, finalizeEvent } = require('nostr-tools');
+const { getProfiles, invalidateProfileCache } = require('/usr/local/lib/node_modules/brainstorm/src/api/profiles/fetchProfiles');
+
+const sk = generateSecretKey();
+const pk = getPublicKey(sk);
+const nowS = Math.floor(Date.now() / 1000);
+
+function importEvent(ev) { execSync('strfry import', { input: JSON.stringify(ev) + '\n', stdio: ['pipe', 'ignore', 'ignore'] }); }
+function kind0(content, createdAt) { return finalizeEvent({ kind: 0, created_at: createdAt, tags: [], content: JSON.stringify(content) }, sk); }
+
+(async () => {
+  // 1) import a profile, getProfiles reads it back from real strfry
+  importEvent(kind0({ name: 'Eve', lud16: 'eve-old@example.com' }, nowS - 100));
+  let m = await getProfiles([pk], { bypassCache: true });
+  let p = m.get(pk);
+  console.log('getProfiles read-back:', JSON.stringify(p));
+  if (!p || p.lud16 !== 'eve-old@example.com') throw new Error('getProfiles did not read the imported profile from strfry');
+
+  // 2) a newer import + cache invalidation → newest-wins returns the fresh one
+  importEvent(kind0({ name: 'Eve', lud16: 'eve-new@example.com' }, nowS + 5));
+  invalidateProfileCache([pk]);
+  m = await getProfiles([pk], { bypassCache: true });
+  p = m.get(pk);
+  console.log('after newer import:', JSON.stringify(p));
+  if (!p || p.lud16 !== 'eve-new@example.com') throw new Error('newest-wins failed: stale profile returned');
+
+  // 3) cache hit: without invalidation/bypass, a subsequent older-content import is NOT seen
+  m = await getProfiles([pk]); // cached from step 2
+  if (m.get(pk).lud16 !== 'eve-new@example.com') throw new Error('cache did not serve the last result');
+
+  execSync(`rm -rf ${DB} ${CONF}`);
+  console.log('FETCHPROFILES-STRFRY E2E: PASS');
+  process.exit(0);
+})().catch(e => { console.error('FAIL:', e.message); process.exit(1); });

--- a/test/support/http-integration.e2e.js
+++ b/test/support/http-integration.e2e.js
@@ -1,0 +1,87 @@
+/**
+ * Full HTTP integration for the server-side Finding-1 edits, against the LIVE
+ * brainstorm server in the tapestry container:
+ *   POST /api/strfry/publish  (publishEvent.js — kind-0 fan-out + cache bust)
+ *   GET  /api/profiles        (fetchProfiles.js — newest-wins + ?fresh + invalidate)
+ *
+ * Prereqs handled by the caller: profile relays are temporarily pointed at the
+ * local strfry relay (ws://127.0.0.1:7777) so the fan-out never reaches public
+ * relays, and brainstorm has been restarted to load the edited modules.
+ *
+ * Self-cleaning: deletes the throwaway pubkey's events from /var/lib/strfry at
+ * the end via `strfry delete`, so the dev store is left as it was.
+ *
+ *   docker exec tapestry node /usr/local/lib/node_modules/brainstorm/test/support/http-integration.e2e.js
+ */
+const assert = require('assert');
+const { execSync } = require('child_process');
+const { generateSecretKey, getPublicKey, finalizeEvent } = require('nostr-tools');
+
+const BASE = process.env.API_BASE || 'http://127.0.0.1:7778';
+const sk = generateSecretKey();
+const pk = getPublicKey(sk);
+const nowS = Math.floor(Date.now() / 1000);
+
+function kind0(content, createdAt) {
+  return finalizeEvent({ kind: 0, created_at: createdAt, tags: [], content: JSON.stringify(content) }, sk);
+}
+
+async function publish(ev) {
+  const r = await fetch(`${BASE}/api/strfry/publish`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ event: ev, signAs: 'client' }),
+  });
+  return { status: r.status, body: await r.json() };
+}
+
+async function getProfile(fresh) {
+  const r = await fetch(`${BASE}/api/profiles?pubkeys=${pk}${fresh ? '&fresh=1' : ''}`);
+  const j = await r.json();
+  return j.profiles ? j.profiles[pk] : undefined;
+}
+
+function cleanup() {
+  try {
+    process.env.STRFRY_CONFIG = '/etc/strfry.conf';
+    execSync(`strfry delete --filter '{"authors":["${pk}"]}'`, { stdio: ['pipe', 'ignore', 'ignore'] });
+  } catch (e) { console.warn('cleanup warning:', e.message); }
+}
+
+(async () => {
+  console.log(`server: ${BASE}  throwaway pubkey: ${pk.slice(0, 12)}…\n`);
+
+  // 1) Publish a kind-0 with an lud16 (client-signed). Edited handler must fan out + report it.
+  const ev1 = kind0({ name: 'HTTPTest', lud16: 'http-a@example.com' }, nowS);
+  const p1 = await publish(ev1);
+  assert.strictEqual(p1.status, 200, `publish 1 status ${p1.status}: ${JSON.stringify(p1.body)}`);
+  assert.ok(p1.body.success, `publish 1 not success: ${JSON.stringify(p1.body)}`);
+  assert.ok(Array.isArray(p1.body.profileRelays), `kind-0 publish must include profileRelays fan-out results: ${JSON.stringify(p1.body)}`);
+  console.log('1) publish lud16 → success; fan-out:', JSON.stringify(p1.body.profileRelays));
+
+  // 2) ?fresh=1 read returns the just-published lud16 (read from local strfry after import).
+  const prof1 = await getProfile(true);
+  assert.ok(prof1 && prof1.lud16 === 'http-a@example.com', `fresh read mismatch: ${JSON.stringify(prof1)}`);
+  console.log('2) GET ?fresh=1 →', JSON.stringify(prof1));
+
+  // 3) Plain read (no ?fresh) — populates the 5-min cache with this value.
+  const profCached = await getProfile(false);
+  assert.strictEqual(profCached.lud16, 'http-a@example.com', 'cache-populate read mismatch');
+  console.log('3) GET (no fresh) populates cache →', JSON.stringify(profCached));
+
+  // 4) Publish a NEWER kind-0 switching to bolt12 (REPLACE). The handler must invalidate the cache.
+  const ev2 = kind0({ name: 'HTTPTest', bolt12: 'lno1pqps7sjqpgtyzm3qv4uxzmtsd3jjqer9wd3hy' }, nowS + 5);
+  const p2 = await publish(ev2);
+  assert.ok(p2.body.success, `publish 2 not success: ${JSON.stringify(p2.body)}`);
+  console.log('4) publish bolt12 (newer) → success; fan-out:', JSON.stringify(p2.body.profileRelays));
+
+  // 5) THE key assertion: a plain read (no ?fresh) now returns the NEW profile (bolt12, no lud16).
+  //    If the publish handler had NOT busted the cache, step-3's cached lud16 would still return.
+  const prof2 = await getProfile(false);
+  assert.ok(prof2 && prof2.bolt12 && !prof2.lud16,
+    `cache-bust failed — expected bolt12 & no lud16 on a NON-fresh read, got ${JSON.stringify(prof2)}`);
+  console.log('5) GET (no fresh) after switch → cache was busted →', JSON.stringify(prof2));
+
+  cleanup();
+  console.log('\nHTTP-INTEGRATION E2E: PASS');
+  process.exit(0);
+})().catch(e => { console.error('FAIL:', e.message); cleanup(); process.exit(1); });

--- a/test/support/mock-relay.js
+++ b/test/support/mock-relay.js
@@ -1,0 +1,74 @@
+/**
+ * Minimal in-process nostr relay for CLI end-to-end tests.
+ *
+ * Speaks just enough NIP-01 to exercise bin/receiving.js over a real
+ * WebSocket: it accepts EVENT (verifying the signature — so "accepted" proves
+ * the CLI signed correctly), answers REQ with matching stored events + EOSE,
+ * and handles CLOSE. It is deliberately *store-all* (NOT replaceable-event
+ * collapsing) so a test can seed a stale kind-0 and a fresh one for the same
+ * pubkey and confirm the CLI's newest-wins resolution picks the fresh one.
+ */
+
+const { WebSocketServer } = require('ws');
+const { verifyEvent } = require('nostr-tools');
+
+function matches(filter, ev) {
+  if (filter.kinds && !filter.kinds.includes(ev.kind)) return false;
+  if (filter.authors && !filter.authors.includes(ev.pubkey)) return false;
+  if (filter.ids && !filter.ids.includes(ev.id)) return false;
+  return true;
+}
+
+/**
+ * @param {object} [opts]
+ * @param {object[]} [opts.seedEvents] signed events to pre-store
+ * @returns {Promise<{url:string, port:number, events:object[], close:()=>Promise<void>}>}
+ */
+function startMockRelay({ seedEvents = [] } = {}) {
+  return new Promise((resolve) => {
+    const events = [...seedEvents];
+    const wss = new WebSocketServer({ host: '127.0.0.1', port: 0 }, () => {
+      const port = wss.address().port;
+      resolve({
+        url: `ws://127.0.0.1:${port}`,
+        port,
+        events,
+        close: () => new Promise(r => wss.close(r)),
+      });
+    });
+
+    wss.on('connection', (ws) => {
+      ws.on('message', (raw) => {
+        let msg;
+        try { msg = JSON.parse(raw.toString()); } catch { return; }
+        const [type] = msg;
+
+        if (type === 'EVENT') {
+          const ev = msg[1];
+          const ok = (() => { try { return verifyEvent(ev); } catch { return false; } })();
+          if (ok) events.push(ev);
+          ws.send(JSON.stringify(['OK', ev?.id, ok, ok ? '' : 'invalid: signature verification failed']));
+          return;
+        }
+
+        if (type === 'REQ') {
+          const subId = msg[1];
+          const filters = msg.slice(2);
+          for (const ev of events) {
+            if (filters.some(f => matches(f, ev))) {
+              ws.send(JSON.stringify(['EVENT', subId, ev]));
+            }
+          }
+          ws.send(JSON.stringify(['EOSE', subId]));
+          return;
+        }
+
+        if (type === 'CLOSE') {
+          ws.send(JSON.stringify(['CLOSED', msg[1], '']));
+        }
+      });
+    });
+  });
+}
+
+module.exports = { startMockRelay };

--- a/test/support/strfry-local-e2e.sh
+++ b/test/support/strfry-local-e2e.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Real-strfry end-to-end for the CLI's LOCAL path (strfry import + strfry scan).
+#
+# Meant to run INSIDE the tapestry container, where the patched strfry binary
+# and config live. Uses a throwaway strfry config pointing at a temp LMDB dir so
+# it never touches the dev DB at /var/lib/strfry. Drives bin/receiving.js through
+# set (local import only) → show/resolve (local scan only) and asserts the event
+# round-trips through the real store.
+#
+# Run from the host:
+#   docker exec tapestry bash /usr/local/lib/node_modules/brainstorm/test/support/strfry-local-e2e.sh
+set -euo pipefail
+
+DBDIR=/tmp/strfry-e2e-db
+CONF=/tmp/strfry-e2e.conf
+export STRFRY_CONFIG="$CONF"
+
+rm -rf "$DBDIR"; mkdir -p "$DBDIR"
+cp /etc/strfry.conf "$CONF"
+sed -i "s|^db = .*|db = \"$DBDIR/\"|" "$CONF"
+
+cd /usr/local/lib/node_modules/brainstorm
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+count() { strfry scan --count "$1" 2>/dev/null; }
+
+echo "strfry: $(which strfry)  config: $STRFRY_CONFIG  db: $DBDIR"
+INITIAL=$(count '{"kinds":[0]}')
+echo "initial kind-0 count in temp db: $INITIAL"
+[ "$INITIAL" = "0" ] || fail "temp db not empty ($INITIAL)"
+
+PRIV=$(node -e "const {generateSecretKey}=require('nostr-tools');process.stdout.write(Buffer.from(generateSecretKey()).toString('hex'))")
+PUB=$(node -e "const {getPublicKey}=require('nostr-tools');process.stdout.write(getPublicKey(Uint8Array.from(Buffer.from('$PRIV','hex'))))")
+echo "throwaway pubkey: ${PUB:0:12}…"
+
+echo ""
+echo "--- set npub-cash (empty relays → ONLY the real 'strfry import' runs) ---"
+SET_JSON=$(node bin/receiving.js set npub-cash --nsec "$PRIV" --relays ',' --no-external --no-probe --json)
+echo "$SET_JSON" | node -e 'const o=JSON.parse(require("fs").readFileSync(0));console.log("  field:",o.field,"value:",o.value);console.log("  local import:",JSON.stringify(o.local));process.exit(o.local&&o.local.success?0:1)' \
+  || fail "local strfry import did not report success"
+
+POST=$(count '{"kinds":[0]}')
+echo "post-import kind-0 count: $POST"
+[ "$POST" = "1" ] || fail "expected 1 event in strfry after import, got $POST"
+
+echo ""
+echo "--- show (──no-external → ONLY the real 'strfry scan' reads it back) ---"
+SHOW_JSON=$(node bin/receiving.js show "$PUB" --no-external --json)
+echo "$SHOW_JSON" | node -e '
+const o=JSON.parse(require("fs").readFileSync(0));
+const m=o.method;
+console.log("  resolved:",m&&m.method,"value:",m&&m.value,"source:",o.source,"tracked:",m&&m.tracked);
+if(!m||m.method!=="lud16") { console.error("  expected lud16 from local strfry"); process.exit(1); }
+if(o.source!=="local") { console.error("  expected source=local, got "+o.source); process.exit(1); }
+if(!String(m.value).endsWith("@npub.cash")) { console.error("  expected npub.cash address"); process.exit(1); }
+' || fail "show did not read the imported profile back from strfry"
+
+echo ""
+echo "--- resolve (--no-external → real local scan → payout decision) ---"
+node bin/receiving.js resolve "$PUB" --amount 1000 --no-external --json \
+  | node -e 'const o=JSON.parse(require("fs").readFileSync(0));console.log("  payment:",JSON.stringify(o.payment));process.exit(o.payment.type==="bolt11"&&o.payment.tracked?0:1)' \
+  || fail "resolve did not produce a tracked bolt11 decision"
+
+echo ""
+echo "--- switch: import a newer bolt12; strfry replaces the kind-0 (replaceable), offer wins ---"
+sleep 1.1   # ensure a strictly-greater created_at so the new event wins (no same-second tie)
+node bin/receiving.js set bolt12 'bitcoin:?lno=lno1pqps7sjqpgtyzm3qv4uxzmtsd3jjqer9wd3hy6tsw35k7msjz' --nsec "$PRIV" --relays ',' --no-external --no-probe --json >/dev/null
+POST2=$(count '{"kinds":[0]}')
+echo "kind-0 count after second import (replaceable → stays 1): $POST2"
+SHOW2=$(node bin/receiving.js show "$PUB" --no-external --json)
+echo "$SHOW2" | node -e 'const o=JSON.parse(require("fs").readFileSync(0));const m=o.method;console.log("  resolved now:",m&&m.method,"tracked:",m&&m.tracked);process.exit(m&&m.method==="bolt12"&&m.tracked===false?0:1)' \
+  || fail "after importing a newer bolt12, show should resolve bolt12 (untracked)"
+
+# cleanup temp db
+rm -rf "$DBDIR" "$CONF"
+echo ""
+echo "STRFRY-LOCAL E2E: PASS"

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,13 @@
  * In a real-world scenario, you would use a testing framework like Jest or Mocha.
  */
 
+const assert = require('assert');
 const { loadConfig } = require('../lib/config');
+const { normalizeBountyCreatePayload } = require('../src/lib/bounty-fields');
+const {
+  calculateBountyPaymentState,
+  canAcceptNewClaimFrom,
+} = require('../src/lib/bounty-policy');
 
 // Mock environment variables for testing
 process.env.BRAINSTORM_RELAY_URL = 'wss://test-relay.com';
@@ -23,14 +29,129 @@ function testConfigLoading() {
   }
 }
 
+function testBountyFieldValidation() {
+  const listCoordinate = `39998:${'a'.repeat(64)}:sleepy-dwarfs`;
+  try {
+    const base = normalizeBountyCreatePayload({
+      listCoordinate,
+      amountSats: 1000,
+      criteria: 'Useful list items',
+    });
+    assert.strictEqual(base.bountyCapSats, 1000);
+    assert.strictEqual(base.rewardPerItem, false);
+    assert.strictEqual(base.maxRewardsPerNpub, null);
+
+    const perItem = normalizeBountyCreatePayload({
+      listCoordinate,
+      amountSats: 1000,
+      bountyCapSats: 5000,
+      rewardPerItem: true,
+      maxRewardsPerNpub: 3,
+      criteria: 'Useful list items',
+    });
+    assert.strictEqual(perItem.rewardPerItem, true);
+    assert.strictEqual(perItem.maxRewardsPerNpub, 3);
+
+    assert.throws(() => normalizeBountyCreatePayload({
+      listCoordinate,
+      amountSats: 1000,
+      bountyCapSats: 999,
+      criteria: 'Cap below base reward',
+    }), /greater than or equal/);
+    assert.throws(() => normalizeBountyCreatePayload({
+      listCoordinate,
+      amountSats: 1000,
+      bountyCapSats: 5000,
+      rewardPerItem: false,
+      maxRewardsPerNpub: 3,
+      criteria: 'Misplaced per-item cap',
+    }), /only applies/);
+    return true;
+  } catch (error) {
+    console.error('Bounty field validation failed:', error.message);
+    return false;
+  }
+}
+
+function claim(id, pubkey, createdAt, paid = false) {
+  return {
+    event: { id, pubkey, created_at: createdAt },
+    zapReceipt: paid ? { id: `zap-${id}` } : null,
+  };
+}
+
+function testBountyPaymentPolicy() {
+  try {
+    const alice = 'a'.repeat(64);
+    const bob = 'b'.repeat(64);
+    const carol = 'c'.repeat(64);
+    const dave = 'd'.repeat(64);
+
+    const onePerContributor = {
+      amount_sats: 1000,
+      bounty_cap_sats: 3000,
+      reward_per_item: 0,
+    };
+    const state = calculateBountyPaymentState(onePerContributor, [
+      claim('a1', alice, 1, true),
+      claim('a2', alice, 2),
+      claim('b1', bob, 3),
+      claim('c1', carol, 4),
+      claim('d1', dave, 5),
+    ]);
+    assert.strictEqual(state.fulfilled, false);
+    assert.strictEqual(state.paidRewardCount, 1);
+    assert.deepStrictEqual(state.payableClaims.map(c => c.event.id), ['b1', 'c1']);
+    assert.deepStrictEqual(state.closedClaims.map(c => [c.event.id, c.closedReason]), [
+      ['a2', 'contributor'],
+      ['d1', 'cap'],
+    ]);
+    assert.strictEqual(canAcceptNewClaimFrom(state, bob), false);
+
+    const fulfilled = calculateBountyPaymentState(onePerContributor, [
+      claim('a1', alice, 1, true),
+      claim('b1', bob, 2, true),
+      claim('c1', carol, 3, true),
+      claim('d1', dave, 4),
+    ]);
+    assert.strictEqual(fulfilled.fulfilled, true);
+    assert.strictEqual(fulfilled.payableClaims.length, 0);
+    assert.strictEqual(fulfilled.closedClaims[0].closedReason, 'cap');
+
+    const perItem = calculateBountyPaymentState({
+      amount_sats: 1000,
+      bounty_cap_sats: 5000,
+      reward_per_item: 1,
+      max_rewards_per_npub: 2,
+    }, [
+      claim('a1', alice, 1, true),
+      claim('a2', alice, 2),
+      claim('a3', alice, 3),
+      claim('b1', bob, 4),
+    ]);
+    assert.deepStrictEqual(perItem.payableClaims.map(c => c.event.id), ['a2', 'b1']);
+    assert.deepStrictEqual(perItem.closedClaims.map(c => [c.event.id, c.closedReason]), [
+      ['a3', 'contributor'],
+    ]);
+    return true;
+  } catch (error) {
+    console.error('Bounty payment policy failed:', error.message);
+    return false;
+  }
+}
+
 // Run tests
 console.log('Running Brainstorm tests...');
 const configTest = testConfigLoading();
+const bountyFieldsTest = testBountyFieldValidation();
+const bountyPolicyTest = testBountyPaymentPolicy();
 
 console.log('\nTest Results:');
 console.log('-------------');
 console.log(`Configuration Loading: ${configTest ? 'PASS' : 'FAIL'}`);
-console.log(`Overall: ${configTest ? 'PASS' : 'FAIL'}`);
+console.log(`Bounty Field Validation: ${bountyFieldsTest ? 'PASS' : 'FAIL'}`);
+console.log(`Bounty Payment Policy: ${bountyPolicyTest ? 'PASS' : 'FAIL'}`);
+console.log(`Overall: ${configTest && bountyFieldsTest && bountyPolicyTest ? 'PASS' : 'FAIL'}`);
 
 // Exit with appropriate code
-process.exit(configTest ? 0 : 1);
+process.exit(configTest && bountyFieldsTest && bountyPolicyTest ? 0 : 1);

--- a/ui/src/api/bounties.js
+++ b/ui/src/api/bounties.js
@@ -16,12 +16,28 @@ export async function getBounty(id) {
   return parseJsonOrThrow(resp);
 }
 
-export async function createBounty({ listCoordinate, amountSats, criteria, expiration }) {
+export async function createBounty({
+  listCoordinate,
+  amountSats,
+  bountyCapSats,
+  rewardPerItem,
+  maxRewardsPerNpub,
+  criteria,
+  expiration,
+}) {
   const resp = await fetch('/api/bounties', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
-    body: JSON.stringify({ listCoordinate, amountSats, criteria, expiration }),
+    body: JSON.stringify({
+      listCoordinate,
+      amountSats,
+      bountyCapSats,
+      rewardPerItem,
+      maxRewardsPerNpub,
+      criteria,
+      expiration,
+    }),
   });
   return (await parseJsonOrThrow(resp)).bounty;
 }

--- a/ui/src/pages/bounties/BountyDetail.jsx
+++ b/ui/src/pages/bounties/BountyDetail.jsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import PaymentCode from '../../components/PaymentCode';
 import { getBounty } from '../../api/bounties';
 import { zapContributor } from '../../utils/zap';
+import { capText, closedReasonText, formatSats, maxRewardsText, remainingRewardsText, rewardScopeLabel } from '../../utils/bountyTerms';
 
 function short(pk) { return pk ? pk.slice(0, 8) + '…' : '—'; }
 function age(ts) {
@@ -26,19 +27,22 @@ function titleFromClaim(event) {
   return getTag(event, 'name') || event.id?.slice(0, 12) || '(untitled)';
 }
 
-function ClaimRow({ claim, bountyAmount, onZap }) {
+function ClaimRow({ claim, bounty, onZap }) {
   const [busy, setBusy] = useState(false);
   const [payment, setPayment] = useState(null);
   const [error, setError] = useState(null);
 
-  const paid = !!claim.zapReceipt;
+  const paymentStatus = claim.paymentStatus || (claim.zapReceipt ? 'paid' : 'payable');
+  const paid = paymentStatus === 'paid' || !!claim.zapReceipt;
+  const payable = paymentStatus === 'payable';
+  const bountyAmount = claim.paymentAmountSats ?? bounty.amount_sats;
 
   async function handleZap() {
-    if (paid) return;
+    if (!payable || paid) return;
     setBusy(true);
     setError(null);
     try {
-      const result = await onZap(claim.event.pubkey, claim.event.id);
+      const result = await onZap(claim.event.pubkey, claim.event.id, bountyAmount);
       setPayment(result);
     } catch (err) {
       setError(err.message);
@@ -64,14 +68,18 @@ function ClaimRow({ claim, bountyAmount, onZap }) {
             <span style={{ background: '#2ea043', color: '#fff', padding: '0.2rem 0.5rem', borderRadius: 3, fontSize: '0.75rem' }}>
               Paid
             </span>
-          ) : (
+          ) : payable ? (
             <button
               onClick={handleZap}
               disabled={busy}
               style={{ padding: '0.4rem 0.9rem', background: '#f2a134', color: '#0d1117', border: 'none', borderRadius: 4, fontWeight: 700, cursor: busy ? 'wait' : 'pointer' }}
             >
-              {busy ? 'Zapping…' : `Zap ${bountyAmount} sats`}
+              {busy ? 'Zapping…' : `Zap ${formatSats(bountyAmount)} sats`}
             </button>
+          ) : (
+            <span style={{ background: '#30363d', color: '#c9d1d9', padding: '0.2rem 0.5rem', borderRadius: 3, fontSize: '0.75rem' }}>
+              {closedReasonText(claim.closedReason)}
+            </span>
           )}
         </div>
       </div>
@@ -87,7 +95,7 @@ export default function BountyDetail() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  async function refresh() {
+  const refresh = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -98,9 +106,9 @@ export default function BountyDetail() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [id]);
 
-  useEffect(() => { refresh(); }, [id]);
+  useEffect(() => { refresh(); }, [refresh]);
 
   if (loading) return <div className="page"><Breadcrumbs /><p>Loading bounty…</p></div>;
   if (error) return <div className="page"><Breadcrumbs /><p className="error">Error: {error}</p></div>;
@@ -109,8 +117,13 @@ export default function BountyDetail() {
   const { bounty, claims = [] } = data;
   const derived = bounty.derivedStatus || bounty.status;
 
-  async function onZap(recipientPubkeyHex, claimEventId) {
-    return zapContributor({ recipientPubkeyHex, amountSats: bounty.amount_sats, claimEventId });
+  async function onZap(recipientPubkeyHex, claimEventId, amountSats) {
+    return zapContributor({
+      recipientPubkeyHex,
+      amountSats,
+      claimEventId,
+      listCoordinate: bounty.list_coordinate,
+    });
   }
 
   const listHref = `/tapestry/lists/${encodeURIComponent(bounty.list_coordinate)}`;
@@ -121,11 +134,16 @@ export default function BountyDetail() {
       <div style={{ marginBottom: '1.5rem' }}>
         <div style={{ fontSize: '0.8rem', opacity: 0.55, letterSpacing: '0.08em', textTransform: 'uppercase' }}>Bounty</div>
         <h1 style={{ margin: '0.2rem 0 0.4rem', color: '#f2a134' }}>
-          {bounty.amount_sats.toLocaleString()} sats
+          {formatSats(bounty.amount_sats)} sats
           <span style={{ fontSize: '0.8rem', marginLeft: '0.8rem', padding: '0.2rem 0.5rem', background: derived === 'open' ? '#2ea043' : '#8b949e', color: '#fff', borderRadius: 3, verticalAlign: 'middle' }}>
             {derived}
           </span>
         </h1>
+        <div style={{ fontSize: '0.85rem', opacity: 0.75, marginBottom: '0.35rem' }}>
+          {rewardScopeLabel(bounty)} / {capText(bounty)}
+          {remainingRewardsText(bounty) && <span> / {remainingRewardsText(bounty)}</span>}
+          {maxRewardsText(bounty) && <span> / {maxRewardsText(bounty)}</span>}
+        </div>
         <div style={{ fontSize: '0.9rem', opacity: 0.85 }}>{bounty.criteria}</div>
         <div style={{ fontSize: '0.8rem', opacity: 0.6, marginTop: '0.4rem' }}>
           issued by <code>{short(bounty.issuer_pubkey)}</code> · {age(bounty.created_at)}
@@ -140,7 +158,7 @@ export default function BountyDetail() {
         <p style={{ opacity: 0.6 }}>No claims yet. Trusted contributors submitting list items will appear here.</p>
       )}
       {claims.map(c => (
-        <ClaimRow key={c.event.id} claim={c} bountyAmount={bounty.amount_sats} onZap={onZap} />
+        <ClaimRow key={c.event.id} claim={c} bounty={bounty} onZap={onZap} />
       ))}
     </div>
   );

--- a/ui/src/pages/bounties/BountyList.jsx
+++ b/ui/src/pages/bounties/BountyList.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import { listBounties } from '../../api/bounties';
+import { capText, formatSats, maxRewardsText, remainingRewardsText, rewardScopeLabel } from '../../utils/bountyTerms';
 
 function short(pk) { return pk ? pk.slice(0, 8) + '…' : '—'; }
 function age(ts) {
@@ -69,8 +70,11 @@ export default function BountyList() {
                 </div>
               </div>
               <div style={{ textAlign: 'right' }}>
-                <div style={{ color: '#f2a134', fontSize: '1.4rem', fontWeight: 700 }}>{b.amount_sats.toLocaleString()}</div>
-                <div style={{ fontSize: '0.7rem', opacity: 0.6, letterSpacing: '0.05em' }}>SATS</div>
+                <div style={{ color: '#f2a134', fontSize: '1.4rem', fontWeight: 700 }}>{formatSats(b.amount_sats)}</div>
+                <div style={{ fontSize: '0.7rem', opacity: 0.6, letterSpacing: '0.05em' }}>{rewardScopeLabel(b).toUpperCase()}</div>
+                <div style={{ fontSize: '0.75rem', opacity: 0.65, marginTop: '0.25rem' }}>{capText(b)}</div>
+                {remainingRewardsText(b) && <div style={{ fontSize: '0.75rem', opacity: 0.65 }}>{remainingRewardsText(b)}</div>}
+                {maxRewardsText(b) && <div style={{ fontSize: '0.75rem', opacity: 0.65 }}>{maxRewardsText(b)}</div>}
                 <div style={{ marginTop: '0.4rem' }}>
                   <StatusBadge status={b.derivedStatus || b.status} />
                 </div>

--- a/ui/src/pages/bounties/BountyNew.jsx
+++ b/ui/src/pages/bounties/BountyNew.jsx
@@ -13,6 +13,9 @@ export default function BountyNew() {
 
   const [listCoordinate, setListCoordinate] = useState(params.get('concept') || '');
   const [amountSats, setAmountSats] = useState(1000);
+  const [bountyCapSats, setBountyCapSats] = useState(1000);
+  const [rewardPerItem, setRewardPerItem] = useState(false);
+  const [maxRewardsPerNpub, setMaxRewardsPerNpub] = useState('');
   const [criteria, setCriteria] = useState('');
   const [expiration, setExpiration] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -24,9 +27,23 @@ export default function BountyNew() {
     }
   }, [authLoading, user, navigate]);
 
+  const amount = Number(amountSats);
+  const cap = Number(bountyCapSats);
+  const maxRewards = Number(maxRewardsPerNpub);
   const valid = COORDINATE_RE.test(listCoordinate)
-    && Number.isInteger(Number(amountSats)) && Number(amountSats) > 0
+    && Number.isInteger(amount) && amount > 0
+    && Number.isInteger(cap) && cap >= amount
+    && (!rewardPerItem || maxRewardsPerNpub === '' || (Number.isInteger(maxRewards) && maxRewards > 0))
     && criteria.trim().length > 0;
+
+  function handleAmountChange(value) {
+    setAmountSats(value);
+    const nextAmount = Number(value);
+    const currentCap = Number(bountyCapSats);
+    if (Number.isInteger(nextAmount) && nextAmount > 0 && Number.isInteger(currentCap) && currentCap < nextAmount) {
+      setBountyCapSats(value);
+    }
+  }
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -36,7 +53,10 @@ export default function BountyNew() {
     try {
       const row = await createBounty({
         listCoordinate,
-        amountSats: Number(amountSats),
+        amountSats: amount,
+        bountyCapSats: cap,
+        rewardPerItem,
+        maxRewardsPerNpub: rewardPerItem && maxRewardsPerNpub !== '' ? maxRewards : undefined,
         criteria: criteria.trim(),
         expiration: expiration ? Math.floor(new Date(expiration).getTime() / 1000) : undefined,
       });
@@ -71,17 +91,58 @@ export default function BountyNew() {
         </label>
 
         <label>
-          <div style={{ marginBottom: 4, fontWeight: 600 }}>Reward (sats)</div>
+          <div style={{ marginBottom: 4, fontWeight: 600 }}>Base reward (sats)</div>
           <input
             type="number"
             min={1}
             step={1}
             value={amountSats}
-            onChange={e => setAmountSats(e.target.value)}
+            onChange={e => handleAmountChange(e.target.value)}
             required
             style={{ width: '100%', padding: '0.5rem', background: '#0d1117', border: '1px solid #30363d', borderRadius: 4, color: '#c9d1d9' }}
           />
         </label>
+
+        <label>
+          <div style={{ marginBottom: 4, fontWeight: 600 }}>Bounty cap (sats)</div>
+          <input
+            type="number"
+            min={amount || 1}
+            step={1}
+            value={bountyCapSats}
+            onChange={e => setBountyCapSats(e.target.value)}
+            required
+            style={{ width: '100%', padding: '0.5rem', background: '#0d1117', border: '1px solid #30363d', borderRadius: 4, color: '#c9d1d9' }}
+          />
+          <small style={{ opacity: 0.6 }}>Total sats available before this bounty closes.</small>
+        </label>
+
+        <label style={{ display: 'flex', gap: '0.6rem', alignItems: 'flex-start' }}>
+          <input
+            type="checkbox"
+            checked={rewardPerItem}
+            onChange={e => setRewardPerItem(e.target.checked)}
+            style={{ marginTop: '0.2rem' }}
+          />
+          <span>
+            <span style={{ display: 'block', fontWeight: 600 }}>Reward each item</span>
+            <small style={{ opacity: 0.6 }}>Off means at most one base reward per contributor.</small>
+          </span>
+        </label>
+
+        {rewardPerItem && (
+          <label>
+            <div style={{ marginBottom: 4, fontWeight: 600 }}>Max rewards per contributor (optional)</div>
+            <input
+              type="number"
+              min={1}
+              step={1}
+              value={maxRewardsPerNpub}
+              onChange={e => setMaxRewardsPerNpub(e.target.value)}
+              style={{ width: '100%', padding: '0.5rem', background: '#0d1117', border: '1px solid #30363d', borderRadius: 4, color: '#c9d1d9' }}
+            />
+          </label>
+        )}
 
         <label>
           <div style={{ marginBottom: 4, fontWeight: 600 }}>Criteria</div>

--- a/ui/src/pages/bounties/Eligibility.jsx
+++ b/ui/src/pages/bounties/Eligibility.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import { useAuth } from '../../context/AuthContext';
 import { getEligible } from '../../api/bounties';
+import { capText, formatSats, maxRewardsText, remainingRewardsText, rewardScopeLabel } from '../../utils/bountyTerms';
 
 function short(pk) { return pk ? pk.slice(0, 8) + '…' : '—'; }
 function age(ts) {
@@ -22,7 +23,7 @@ export default function Eligibility() {
 
   useEffect(() => {
     if (authLoading) return;
-    if (!user?.pubkey) { setLoading(false); return; }
+    if (!user?.pubkey) return;
     let cancelled = false;
     getEligible(user.pubkey)
       .then(bs => { if (!cancelled) setBounties(bs); })
@@ -68,6 +69,7 @@ export default function Eligibility() {
       <div style={{ display: 'grid', gap: '0.75rem' }}>
         {bounties.map(b => {
           const claimHref = `/tapestry/lists/${encodeURIComponent(b.list_coordinate)}/items/new?bounty=${encodeURIComponent(b.id)}`;
+          const maxText = maxRewardsText(b);
           return (
             <div key={b.id} style={{ padding: '1rem', background: '#161b22', border: '1px solid #30363d', borderRadius: 6 }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '1rem' }}>
@@ -84,8 +86,12 @@ export default function Eligibility() {
                   </div>
                 </div>
                 <div style={{ textAlign: 'right', minWidth: 140 }}>
-                  <div style={{ color: '#f2a134', fontSize: '1.4rem', fontWeight: 700 }}>{b.amount_sats.toLocaleString()}</div>
-                  <div style={{ fontSize: '0.7rem', opacity: 0.6, letterSpacing: '0.05em', marginBottom: '0.5rem' }}>SATS</div>
+                  <div style={{ color: '#f2a134', fontSize: '1.4rem', fontWeight: 700 }}>{formatSats(b.amount_sats)}</div>
+                  <div style={{ fontSize: '0.7rem', opacity: 0.6, letterSpacing: '0.05em' }}>{rewardScopeLabel(b).toUpperCase()}</div>
+                  <div style={{ fontSize: '0.75rem', opacity: 0.65, marginTop: '0.25rem' }}>{capText(b)}</div>
+                  {remainingRewardsText(b) && <div style={{ fontSize: '0.75rem', opacity: 0.65 }}>{remainingRewardsText(b)}</div>}
+                  {maxText && <div style={{ fontSize: '0.75rem', opacity: 0.65 }}>{maxText}</div>}
+                  <div style={{ marginBottom: '0.5rem' }} />
                   <Link
                     to={claimHref}
                     style={{ display: 'inline-block', padding: '0.4rem 0.9rem', background: '#2ea043', color: '#fff', borderRadius: 4, textDecoration: 'none', fontWeight: 600 }}

--- a/ui/src/pages/bounties/PaymentsDue.jsx
+++ b/ui/src/pages/bounties/PaymentsDue.jsx
@@ -1,17 +1,19 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import PaymentCode from '../../components/PaymentCode';
 import { useAuth } from '../../context/AuthContext';
 import { getPaymentsDue } from '../../api/bounties';
 import { zapContributor } from '../../utils/zap';
+import { capText, formatSats, maxRewardsText, remainingRewardsText, rewardScopeLabel } from '../../utils/bountyTerms';
 
 function short(pk) { return pk ? pk.slice(0, 8) + '…' : '—'; }
 
-function PendingClaimRow({ claim, bountyAmount }) {
+function PendingClaimRow({ claim, bounty }) {
   const [busy, setBusy] = useState(false);
   const [payment, setPayment] = useState(null);
   const [error, setError] = useState(null);
+  const bountyAmount = claim.paymentAmountSats ?? bounty.amount_sats;
 
   async function handleZap() {
     setBusy(true);
@@ -21,6 +23,7 @@ function PendingClaimRow({ claim, bountyAmount }) {
         recipientPubkeyHex: claim.event.pubkey,
         amountSats: bountyAmount,
         claimEventId: claim.event.id,
+        listCoordinate: bounty.list_coordinate,
       });
       setPayment(result);
     } catch (err) {
@@ -42,7 +45,7 @@ function PendingClaimRow({ claim, bountyAmount }) {
           disabled={busy}
           style={{ padding: '0.35rem 0.8rem', background: '#f2a134', color: '#0d1117', border: 'none', borderRadius: 4, fontWeight: 700, cursor: busy ? 'wait' : 'pointer' }}
         >
-          {busy ? 'Loading…' : `Zap ${bountyAmount}`}
+          {busy ? 'Loading…' : `Zap ${formatSats(bountyAmount)} sats`}
         </button>
       </div>
       {payment && <PaymentCode payment={payment} />}
@@ -57,18 +60,15 @@ export default function PaymentsDue() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const refresh = useCallback(() => {
-    setLoading(true);
-    getPaymentsDue()
-      .then(setItems)
-      .catch(e => setError(e.message))
-      .finally(() => setLoading(false));
-  }, []);
-
   useEffect(() => {
     if (authLoading || !user?.pubkey) return;
-    refresh();
-  }, [authLoading, user?.pubkey, refresh]);
+    let cancelled = false;
+    getPaymentsDue()
+      .then(nextItems => { if (!cancelled) setItems(nextItems); })
+      .catch(e => { if (!cancelled) setError(e.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [authLoading, user?.pubkey]);
 
   if (authLoading) return <div className="page"><Breadcrumbs /><p>Loading…</p></div>;
   if (!user?.pubkey) {
@@ -96,10 +96,18 @@ export default function PaymentsDue() {
               </Link>
               <div style={{ fontSize: '0.8rem', opacity: 0.6, fontFamily: 'monospace' }}>{bounty.list_coordinate}</div>
             </div>
-            <div style={{ color: '#f2a134', fontWeight: 700 }}>{bounty.amount_sats.toLocaleString()} sats</div>
+            <div style={{ color: '#f2a134', fontWeight: 700, textAlign: 'right' }}>
+              <div>{formatSats(bounty.amount_sats)} sats</div>
+              <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>{rewardScopeLabel(bounty)}</div>
+            </div>
+          </div>
+          <div style={{ fontSize: '0.8rem', opacity: 0.7, marginBottom: '0.5rem' }}>
+            {capText(bounty)}
+            {remainingRewardsText(bounty) && <span> / {remainingRewardsText(bounty)}</span>}
+            {maxRewardsText(bounty) && <span> / {maxRewardsText(bounty)}</span>}
           </div>
           {pendingClaims.map(c => (
-            <PendingClaimRow key={c.event.id} claim={c} bountyAmount={bounty.amount_sats} />
+            <PendingClaimRow key={c.event.id} claim={c} bounty={bounty} />
           ))}
         </div>
       ))}

--- a/ui/src/pages/bounties/PaymentsToMe.jsx
+++ b/ui/src/pages/bounties/PaymentsToMe.jsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import Bolt12Setup from '../../components/Bolt12Setup';
 import { useAuth } from '../../context/AuthContext';
 import { getPaymentsToMe } from '../../api/bounties';
+import { capText, closedReasonText, formatSats, maxRewardsText, remainingRewardsText, rewardScopeLabel } from '../../utils/bountyTerms';
 
 function short(pk) { return pk ? pk.slice(0, 8) + '…' : '—'; }
 function age(ts) {
@@ -89,7 +90,7 @@ function Row({ entry, kind }) {
           <div style={{ marginTop: '0.4rem' }}>
             {kind === 'pastDue' && <span style={TAG_PAST_DUE}>expired without payment</span>}
             {kind === 'paid' && <span style={TAG_PAID}>paid</span>}
-            {kind === 'closed' && <span style={TAG_CLOSED}>bounty paid to another contributor</span>}
+            {kind === 'closed' && <span style={TAG_CLOSED}>{closedReasonText(claim.closedReason)}</span>}
             {kind === 'paid' && claim.zapReceipt?.id && (
               <span style={{ marginLeft: '0.5rem' }}>
                 <PaidReceiptCopy eventId={claim.zapReceipt.id} />
@@ -97,8 +98,12 @@ function Row({ entry, kind }) {
             )}
           </div>
         </div>
-        <div style={{ color: '#f2a134', fontWeight: 700, whiteSpace: 'nowrap' }}>
-          {bounty.amount_sats.toLocaleString()} sats
+        <div style={{ color: '#f2a134', fontWeight: 700, whiteSpace: 'nowrap', textAlign: 'right' }}>
+          <div>{formatSats(claim.paymentAmountSats ?? bounty.amount_sats)} sats</div>
+          <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>{rewardScopeLabel(bounty)}</div>
+          <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>{capText(bounty)}</div>
+          {remainingRewardsText(bounty) && <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>{remainingRewardsText(bounty)}</div>}
+          {maxRewardsText(bounty) && <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>{maxRewardsText(bounty)}</div>}
         </div>
       </div>
     </div>
@@ -126,18 +131,15 @@ export default function PaymentsToMe() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const refresh = useCallback(() => {
-    setLoading(true);
-    getPaymentsToMe()
-      .then(setData)
-      .catch(e => setError(e.message))
-      .finally(() => setLoading(false));
-  }, []);
-
   useEffect(() => {
     if (authLoading || !user?.pubkey) return;
-    refresh();
-  }, [authLoading, user?.pubkey, refresh]);
+    let cancelled = false;
+    getPaymentsToMe()
+      .then(nextData => { if (!cancelled) setData(nextData); })
+      .catch(e => { if (!cancelled) setError(e.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [authLoading, user?.pubkey]);
 
   if (authLoading) return <div className="page"><Breadcrumbs /><p>Loading…</p></div>;
   if (!user?.pubkey) {
@@ -188,8 +190,8 @@ export default function PaymentsToMe() {
             emptyText="No payments yet."
           />
           <Section
-            title="Closed (paid to someone else)"
-            description="Bounties that were paid to a different contributor; your claim wasn't selected."
+            title="Closed"
+            description="Claims that are no longer payable because the bounty cap or contributor limit was reached."
             kind="closed"
             items={closed}
             emptyText="No closed bounties."

--- a/ui/src/pages/lists/NewDListItem.jsx
+++ b/ui/src/pages/lists/NewDListItem.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../../context/AuthContext';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import { childDTag, randomDTag } from '../../utils/dtag';
 import { getBounty } from '../../api/bounties';
+import { capText, maxRewardsText, rewardText } from '../../utils/bountyTerms';
 
 function getTag(event, name, index = 1) {
   const tag = event.tags?.find(t => t[0] === name);
@@ -218,7 +219,10 @@ export default function NewDListItem() {
           <div style={{ fontSize: '0.85rem', opacity: 0.8 }}>
             Issuer: <code>{bountyInfo.bounty.issuer_pubkey.slice(0, 8)}…</code>
             {' · '}
-            Reward: <strong style={{ color: '#f2a134' }}>{bountyInfo.bounty.amount_sats.toLocaleString()} sats</strong>
+            Reward: <strong style={{ color: '#f2a134' }}>{rewardText(bountyInfo.bounty)}</strong>
+            {' · '}
+            {capText(bountyInfo.bounty)}
+            {maxRewardsText(bountyInfo.bounty) && ` / ${maxRewardsText(bountyInfo.bounty)}`}
             {' · '}
             The issuer (or anyone) may zap you if they approve your submission.
           </div>

--- a/ui/src/utils/bountyTerms.js
+++ b/ui/src/utils/bountyTerms.js
@@ -1,0 +1,39 @@
+export function formatSats(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n.toLocaleString() : '0';
+}
+
+export function bountyCapSats(bounty) {
+  return bounty?.bounty_cap_sats ?? bounty?.paymentState?.bountyCapSats ?? bounty?.amount_sats ?? 0;
+}
+
+export function rewardScopeLabel(bounty) {
+  return bounty?.reward_per_item || bounty?.paymentState?.rewardPerItem ? 'per item' : 'per contributor';
+}
+
+export function rewardText(bounty) {
+  return `${formatSats(bounty?.amount_sats)} sats ${rewardScopeLabel(bounty)}`;
+}
+
+export function capText(bounty) {
+  return `${formatSats(bountyCapSats(bounty))} sats cap`;
+}
+
+export function maxRewardsText(bounty) {
+  const rewardPerItem = bounty?.reward_per_item || bounty?.paymentState?.rewardPerItem;
+  const maxRewards = bounty?.max_rewards_per_npub ?? bounty?.paymentState?.maxRewardsPerNpub;
+  if (!rewardPerItem || !maxRewards) return null;
+  return `max ${maxRewards} rewards per contributor`;
+}
+
+export function remainingRewardsText(bounty) {
+  const remaining = bounty?.paymentState?.remainingRewardSlots;
+  if (!Number.isInteger(remaining)) return null;
+  return `${remaining} reward${remaining === 1 ? '' : 's'} remaining`;
+}
+
+export function closedReasonText(reason) {
+  if (reason === 'contributor') return 'Contributor limit reached';
+  if (reason === 'cap') return 'Bounty cap reached';
+  return 'Not payable';
+}

--- a/ui/src/utils/zap.js
+++ b/ui/src/utils/zap.js
@@ -1,7 +1,7 @@
 /**
  * Client-side zap flow with BOLT12 + NIP-57 (BOLT11/LNURL) support.
  *
- * zapContributor({ recipientPubkeyHex, amountSats, claimEventId })
+ * zapContributor({ recipientPubkeyHex, amountSats, claimEventId, listCoordinate })
  *   -> { type: 'bolt12', payload: '<lno1...>', static: true }
  *      or { type: 'bolt11', payload: '<lnbc1...>' }
  *
@@ -65,7 +65,7 @@ async function fetchRelayList(recipientPubkeyHex) {
   } catch { return []; }
 }
 
-export async function zapContributor({ recipientPubkeyHex, amountSats, claimEventId }) {
+export async function zapContributor({ recipientPubkeyHex, amountSats, claimEventId, listCoordinate }) {
   if (!/^[0-9a-f]{64}$/i.test(recipientPubkeyHex)) throw new Error('recipientPubkeyHex must be hex');
   if (!Number.isInteger(amountSats) || amountSats <= 0) throw new Error('amountSats must be a positive integer');
 
@@ -101,6 +101,7 @@ export async function zapContributor({ recipientPubkeyHex, amountSats, claimEven
     tags: [
       ['p', recipientPubkeyHex],
       ['e', claimEventId],
+      ...(listCoordinate ? [['a', listCoordinate]] : []),
       ['amount', String(amountMsats)],
       relayTag,
     ],


### PR DESCRIPTION
## Summary
- add cap/reward validation and SQLite migration fields for bounties
- derive bounty/payment status from issuer zap receipts, cap exhaustion, per-contributor limits, and oldest-claim-first payable slots
- update bounty/payment UI copy and zap requests to use the cap-aware payment state

## Verification
- npm test
- npx eslint src/api/bounties.js src/pages/bounties/BountyDetail.jsx src/pages/bounties/BountyList.jsx src/pages/bounties/BountyNew.jsx src/pages/bounties/Eligibility.jsx src/pages/bounties/PaymentsDue.jsx src/pages/bounties/PaymentsToMe.jsx src/pages/lists/NewDListItem.jsx src/utils/bountyTerms.js src/utils/zap.js
- npm run build
- env BOUNTIES_DB_PATH=/private/tmp/magic-carpet-bounties-pr-smoke.db volta run --node 24.14.1 node -e "const db = require('./src/db/bounties'); const row = db.createBounty({ issuerPubkey: 'a'.repeat(64), listCoordinate: '39998:' + 'b'.repeat(64) + ':x', amountSats: 1000, bountyCapSats: 3000, rewardPerItem: true, maxRewardsPerNpub: 2, criteria: 'smoke' }); console.log(row.amount_sats, row.bounty_cap_sats, row.reward_per_item, row.max_rewards_per_npub);"