### PR TITLE
Promote staging → main: NIP-05 checkmark real verification (#151)

### DIFF
--- a/engineering-team/reviews/6-nip05-checkmark-verification.md
+++ b/engineering-team/reviews/6-nip05-checkmark-verification.md
@@ -1,0 +1,97 @@
+# Review: Story 6 — NIP-05 green checkmark must reflect real verification
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-17
+**Branch:** `fix/nip05-verification` → `staging` (PR pending)
+**Diff:** `git diff origin/staging...HEAD` — three commits ahead:
+- `e522d073` story: nip05-checkmark-verification
+- `93c18764` test: failing tests for nip05-checkmark-verification (story #6)
+- `c0a15a61` impl: nip05-checkmark-verification (story #6)
+
+**Classification:** Bug / Standard / Product Owner + Tester + Implementer + Reviewer (Architecture skipped — unambiguous root cause, proven helper pattern already in-repo; recorded in story §"Linked artifacts").
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **PASS**. Five suites + Configuration Loading all green (32/32):
+  - Configuration Loading: PASS
+  - treasure-maps-router-preset: 5/5
+  - scheduled-search-and-house-scores-refresh: 12/12
+  - strfry-router-first-boot-config: 3/3
+  - per-query-neo4j-timeout-safety-net: 8/8
+  - **nip05-checkmark-verification: 4/4** (T1, T2 now pass; R1, R2 sentinels still green)
+- [x] `node -c src/api/nip05.js` — **PASS** (syntax OK).
+- [x] UI build — **PASS**. Production Vite build run during the local cycle compiled the new hook + both edited pages with no JSX/syntax errors; `useNip05Verification` confirmed present in the deployed bundle. (This is the appropriate build-gate evidence for ESM/JSX; `node -c` does not parse JSX.)
+- [x] Local end-to-end cycle — **PASS** on the running stack (container port :7778; the cycle-local skill's `:8080` assumption is stale for this container — noted as a non-blocking skill bug below). `/api/nip05/verify`: genuine match → `{"verified":true}`; wrong pubkey (impersonation) → `{"verified":false}`; name-absent → `false`; unreachable domain → `false`; bad/missing input → `false`. Real outbound HTTPS fetch + pubkey comparison exercised.
+- [x] _Lint not configured — skipped._
+- [x] _Typecheck not configured — skipped._
+- [x] _Build step not configured (Vite invoked manually in the cycle) — n/a._
+
+## Spec adherence (vs. story #6 acceptance criteria)
+
+- [x] **AC-1 (verified → ✅).** `handleNip05Verify` ([src/api/nip05.js:154](src/api/nip05.js#L154)) returns `{verified:true}` only when the domain attests the same pubkey ([line 163](src/api/nip05.js#L163)); the hook prepends `'✅ '` only when `nip05Verified` is true ([UserDetail.jsx:84](ui/src/pages/users/UserDetail.jsx#L84), [BrainstormProfile.jsx:228](ui/src/pages/BrainstormProfile.jsx#L228)). T1/T2 pin the presence-only gate gone; local cycle proved the positive path live.
+- [x] **AC-2 (present but unverified → plain text, no ✅, no warning).** Hook returns `false` for mismatch/absent/malformed/unreachable/timeout (`verifyNip05Identifier` fail-closed catch, [src/api/nip05.js:125](src/api/nip05.js#L125)); JSX renders `{false && '✅ '}` → React renders nothing, leaving the bare `{profile.nip05}` text. No warning glyph added. Local cycle confirmed all four negative cases return `false`.
+- [x] **AC-3 (no nip05 → nothing, unchanged).** The outer `{profile?.nip05 && …}` guard is preserved verbatim on both surfaces — when absent, the whole element short-circuits. Invariant intact; deliberately not pinned in-runner (would over-constrain a refactor — per test plan).
+- [x] **AC-4 (fail-closed, no spinner).** `useState(false)` default ([useNip05Verification.js:16](ui/src/hooks/useNip05Verification.js#L16)); `setVerified(false)` first thing in the effect ([line 20](ui/src/hooks/useNip05Verification.js#L20)) so a previously-verified profile cannot bleed a ✅ onto a new one; `true` only on `res.ok && data?.verified === true` ([line 38](ui/src/hooks/useNip05Verification.js#L38)). No intermediate/spinner UI. Server adds `Cache-Control: no-store`.
+- [x] **AC-5 (both surfaces; search badge unchanged).** Both pages changed identically. R1 green and `git diff --name-only` confirms `BrainstormSearch.jsx` is **not in the diff** — the server-verified pinned badge is untouched.
+- [x] **Concrete #151.** Local strfry/Neo4j has no kind-0 data for the two #151 pubkeys, so the rendered-DOM check is **deferred to staging smoke** per the test plan's "Not covered" (N1) — anticipated, not a gap. The impersonation→`false` mechanism that *is* #151 was proven live at the API layer in the local cycle.
+
+No criterion silently dropped. No behavior added beyond the story (no ⚠️/unverified marker — explicitly out of scope and absent from the diff).
+
+## ADR adherence
+
+- [x] **No ADR required.** Architecture intentionally skipped per CLAUDE.md harness rules for Standard-strictness Bug. Story records the skip.
+- [x] **No new dependencies.** `git diff --name-only origin/staging...HEAD` shows no `package.json`/`package-lock.json`. The endpoint uses global `fetch`/`AbortController` (already used by the existing `verifyNip05` helpers) and React hooks (existing) — no new imports.
+- [x] **Layering respected.** Server logic lives in the module that already owns NIP-05 routes (`src/api/nip05.js`); client logic is a hook in `ui/src/hooks/` mirroring `useProfiles`. No leakage into shared `lib/` or unrelated modules.
+
+## Concept-graph integrity
+
+- [x] N/A. No concept definitions, schemas, firmware JSON, or `kind:pubkey:slug` handles touched. Concept Graph API was unreachable during the cycle but is irrelevant to a UI/API correctness bug. No firmware reinstall needed.
+
+## Things tests can't catch
+
+- [x] **No secrets.** Diff contains only public Nostr pubkeys / a public registry name.
+- [x] **No leftover debug logging.** The single `console.warn('useNip05Verification fetch error:', err)` ([line 44](ui/src/hooks/useNip05Verification.js#L44)) mirrors the existing `useProfiles` error-log pattern — intentional, not cruft.
+- [x] **No commented-out code.** Comments in `src/api/nip05.js` explain the *why* (the deliberate non-dedup decision, the fail-closed contract) per tone rules — not narration.
+- [x] **Error paths.** Fail-closed at every layer: input-type guards + `HEX_PUBKEY_RE` at the boundary ([src/api/nip05.js:158](src/api/nip05.js#L158)), `resp.ok` check, `try/catch → null/false`, `res.ok` check client-side. Verified live.
+- [x] **`{nip05Verified && '✅ '}` is not the `{0 && …}` footgun.** `nip05Verified` is a strict boolean from `useState(false)`, so the falsy branch is `false` (React renders nothing), never a stray `0`.
+- [~] **Concurrency.** Module-level `verificationCache` Map is shared across mounts; same key concurrently → two idempotent fetches writing the same value (no harmful race). The two surfaces are on different routes, never co-mounted. Acceptable; see Non-blocking #2.
+- [~] **Security (SSRF).** Genuine finding — see Blocking analysis below; ruled **non-blocking** for this story with reasoning.
+
+## House rules check
+
+- [x] Concept Graph API authority respected (N/A — no concept code).
+- [x] No new lint/typecheck/build tooling.
+- [x] No firmware reinstall needed (no concept definitions changed).
+- [x] Existing pattern followed (server-side verification, consistent with the trusted meili search path; hook mirrors `useProfiles`).
+
+## Story scope items verified untouched
+
+- [x] **Provider side** (`handleNip05Lookup`, serving our own `.well-known/nostr.json`) — diff hunk shows it as context only; **unchanged**.
+- [x] **Existing `verifyNip05` copies** (`src/api/admin/index.js:18`, `src/api/search/profiles/meili/index.js:26`) — confirmed not in the diff. The Implementer correctly resisted consolidation (out of scope, no ADR).
+- [x] **Search badge + plain-text surfaces** — `BrainstormSearch.jsx` not in diff; R1/R2 green.
+
+## Findings
+
+### Blocking
+
+_None._
+
+### Non-blocking
+
+1. **[src/api/nip05.js:125–142](src/api/nip05.js#L125) — unauthenticated SSRF surface (pre-existing pattern, constrained oracle). Recommend a repo-wide follow-up; not a blocker for this story.**
+   `handleNip05Verify` is registered with no auth middleware ([line 171](src/api/nip05.js#L171)) and `verifyNip05Identifier` fetches `https://<domain>/.well-known/nostr.json` where `domain` comes from `NIP05_LOOKUP_RE` ([line 31](src/api/nip05.js#L31)). That regex's domain group `[\w_-]+(\.[\w_-]+)+` matches IP literals and internal names (`169.254.169.254`, `db.internal`), so an attacker can make the server issue requests to internal/link-local hosts.
+   **Why non-blocking:** (a) scheme is hardcoded `https://` and there's a 5s timeout, so most internal/metadata targets (HTTP-only or invalid TLS) just fail → `false`; (b) the fetched body is **never returned** — the endpoint yields only a boolean derived from a pubkey match, i.e. at most a constrained existence/timing oracle, not content exfiltration; (c) **this is the third instance of an already-deployed, accepted pattern** — byte-identical logic already lives in `src/api/search/profiles/meili/index.js:26` (reachable via *public* search) and `src/api/admin/index.js:18` (owner-gated). This story therefore does **not** raise the system's existing risk posture, and consolidating/guarding the three copies (e.g. block RFC1918/link-local/loopback resolution) is explicitly **out of scope** per the story. Blocking an in-scope, well-tested security *fix* on a pre-existing systemic issue would be miscalibrated. **Action:** filed as a separate follow-up (see handoff) — recommend an SSRF guard applied once across all three call sites, plus a decision on whether `/api/nip05/verify` should be rate-limited given it's unauthenticated.
+
+2. **[ui/src/hooks/useNip05Verification.js:40](ui/src/hooks/useNip05Verification.js#L40) — `false` is cached for the page session.** A transient verify failure (network blip, 5s timeout under load) caches `false` for the lifetime of the page session; a genuinely-verified profile would then show no ✅ until a full reload. This is consistent with the fail-closed spec (never *wrongly* green) and the story left caching to Implementation, so it's acceptable — but a short negative-result TTL (or not caching `false`) would make it self-healing. Optional; mention on the next touch.
+
+3. **No in-flight de-dup in the hook.** Two simultaneous verifications of the same key issue two fetches. The two surfaces are on different routes (never co-mounted), so in practice this is at most one redundant request on a fast re-mount. Not worth code now.
+
+4. **cycle-local skill staleness (not this diff).** The skill's `$WT`/`localhost:8080` assumptions don't match this container (publishes :7778/:80; repo isn't a worktree here). I adapted and verified on the correct port. Worth a one-line skill fix in a future ops touch — flagged for awareness, outside story #6.
+
+## Verdict
+
+**PASS** — the diff matches every story #6 acceptance criterion (each has a passing source test, a green out-of-scope sentinel, or a documented staging-smoke deferral consistent with the approved test plan); no ADR required by classification; reviewer-run `npm test` is 32/32 green; the live local cycle proved the verification logic end-to-end including the impersonation→`false` case that is the core of #151; out-of-scope surfaces (provider side, the two existing helpers, the search badge, plain-text renders) are confirmed untouched; no new dependencies; minimal, on-scope change.
+
+The SSRF finding is real and named precisely, but it is a **pre-existing, systemic, already-deployed pattern** that this story explicitly scoped out of consolidating, and is mitigated here to a constrained boolean oracle — non-blocking, with a repo-wide follow-up filed.
+
+**Recommended next steps:** standard deploy chain — `cycle-staging`, then the test plan's "Not covered" staging smoke (N1: both #151 pubkeys show **no ✅**; N2: a `@brainstorm.world` registry identity shows ✅; N3: no pre-confirmation ✅ flash; N4: no-nip05 profile unchanged) as the **authoritative behavioral gate**, then `cycle-prod`. Close issue #151 when the fix reaches `main` (prod), since the bug reproduces on prod.

--- a/engineering-team/stories/6-nip05-checkmark-verification.md
+++ b/engineering-team/stories/6-nip05-checkmark-verification.md
@@ -1,0 +1,41 @@
+# Story 6: NIP-05 green checkmark must reflect real verification
+
+**Status:** Approved
+**Created:** 2026-05-17
+**Type:** Bug
+
+## Background
+On profile pages, a green ✅ next to a user's NIP-05 identifier signals to viewers that the identifier is verified — i.e. the identifier's domain attests that this pubkey owns `name@domain`. Currently the ✅ is shown solely because the `nip05` field in the user's kind-0 metadata is non-empty. No domain lookup is performed, and the domain-attested pubkey is never compared to the profile's pubkey. Consequently, unverified, misconfigured, stale, or deliberately impersonated identifiers all display as "verified." This misleads every viewer and is an impersonation vector: anyone can set `someone@well-known-brand.com` in their profile and appear verified. Affects all viewers of profile pages on prod (brainstorm.world) and staging. Tracked as GitHub issue #151.
+
+## User-facing description
+As someone viewing another user's profile, I want the green NIP-05 checkmark to appear only when that user's NIP-05 identifier has actually been verified against its domain, so that I can trust the checkmark as a genuine identity signal and not be misled by unverified or impersonated identifiers.
+
+## Acceptance criteria
+Testable from the outside.
+
+- [ ] Given a profile whose `nip05` resolves, at its domain, to **the same pubkey as the profile**, when the profile page renders, then the green ✅ is shown next to the identifier.
+- [ ] Given a profile with a non-empty `nip05` that does **not** verify — name absent at the domain, domain lists a *different* pubkey, malformed response, or domain unreachable/times out — when the profile page renders, then the identifier is shown as **plain text with no ✅ and no warning indicator**.
+- [ ] Given a profile with no `nip05` field, when the profile page renders, then no identifier line and no checkmark is shown (unchanged from today).
+- [ ] While verification is in flight, the ✅ is **not** shown — fail-closed: the checkmark appears only after a confirmed positive match (no spinner/intermediate UI required).
+- [ ] All of the above hold on **both** the `/user/:pubkey` profile detail page **and** the Brainstorm profile page; the existing search-results "✅ NIP-05 Verified" badge is unchanged.
+
+**Concrete verification:** the two pubkeys cited in issue #151 (`b17e0293…` and `ff18165a…`) must display **no checkmark** after the fix.
+
+## Concepts touched
+- NIP-05 identifier verification — per the Nostr NIP-05 spec: `name@domain` is verified only if `https://domain/.well-known/nostr.json?name=<name>` maps `<name>` to the profile's own pubkey. (Concept Graph API was unreachable during planning; a `kind:pubkey:slug` handle can be resolved downstream if one exists.)
+
+## Out of scope
+- The search-results / suggestions "✅ NIP-05 Verified" badge — already gated on real server-side verification; unchanged.
+- Adding any positive "verified" indicator to surfaces that today show NIP-05 as plain text with no checkmark (search list, suggestions, admin view, the Identity-table row) — no false claim there; deferred.
+- An explicit "unverified" / ⚠️ marker, or a distinct "domain unreachable" state — explicitly decided against; unverified renders as neutral plain text.
+- How brainstorm.world publishes *its own* NIP-05 registry (the provider side) — unrelated, unchanged.
+- Caching/performance tuning of the verification lookup — left to Implementation, beyond the fail-closed guarantee above.
+
+## Open questions
+- None blocking. *How* verification is performed (where it runs, reuse of existing logic, caching) is deliberately left to the Implementer; the PO prescribes only observable behavior.
+
+## Linked artifacts
+- GitHub issue: https://github.com/nous-clawds4/tapestry/issues/151 — close when this reaches `main` (prod)
+- ADR: N/A — Architecture phase skipped (Standard bug, unambiguous root cause)
+- Test plan: (filled after Test Design)
+- Review: (filled after Review)

--- a/engineering-team/stories/6-nip05-checkmark-verification.md
+++ b/engineering-team/stories/6-nip05-checkmark-verification.md
@@ -38,4 +38,4 @@ Testable from the outside.
 - GitHub issue: https://github.com/nous-clawds4/tapestry/issues/151 — close when this reaches `main` (prod)
 - ADR: N/A — Architecture phase skipped (Standard bug, unambiguous root cause)
 - Test plan: `engineering-team/stories/6-nip05-checkmark-verification.test-plan.md`
-- Review: (filled after Review)
+- Review: `engineering-team/reviews/6-nip05-checkmark-verification.md` — **PASS** (2026-05-17)

--- a/engineering-team/stories/6-nip05-checkmark-verification.md
+++ b/engineering-team/stories/6-nip05-checkmark-verification.md
@@ -37,5 +37,5 @@ Testable from the outside.
 ## Linked artifacts
 - GitHub issue: https://github.com/nous-clawds4/tapestry/issues/151 — close when this reaches `main` (prod)
 - ADR: N/A — Architecture phase skipped (Standard bug, unambiguous root cause)
-- Test plan: (filled after Test Design)
+- Test plan: `engineering-team/stories/6-nip05-checkmark-verification.test-plan.md`
 - Review: (filled after Review)

--- a/engineering-team/stories/6-nip05-checkmark-verification.test-plan.md
+++ b/engineering-team/stories/6-nip05-checkmark-verification.test-plan.md
@@ -1,0 +1,97 @@
+# Test Plan: Story 6 — NIP-05 green checkmark must reflect real verification
+
+**Story:** `engineering-team/stories/6-nip05-checkmark-verification.md`
+**ADR:** None — Architecture phase intentionally skipped per Standard-strictness Bug classification (see story §"Linked artifacts").
+**Date:** 2026-05-17
+
+## Approach
+
+Same precedent as story #5 and `strfry-router-first-boot-config`: failing tests are **source-regex assertions** against the two scoped components, plus **regression sentinels** for the out-of-scope surfaces. They pin the single thing the spec fixes — *the ✅ next to a profile's NIP-05 must no longer be gated by `nip05`-presence alone* — without prescribing **how** verification is wired (client vs server, reuse of the existing `verifyNip05()` helper, caching). The story explicitly left that to the Implementer.
+
+**Deliberate limitation (read this).** A source test cannot prove the new gate is a *real* pubkey match or that it is fail-closed in flight — a structurally-correct but semantically-fake gate (a hook that returns `true` whenever `nip05` exists) would pass T1/T2. The **authoritative behavioral gate** for AC-1, the positive half of AC-2, and AC-4 is the staging smoke in §"Not covered": the two #151 pubkeys must show **no ✅**, and a known-good identity **must** show ✅. The Reviewer must treat that smoke evidence as required, not optional. This mirrors story #5, where "Jack actually returns 504" was likewise deferred to staging smoke because it is not reproducible in the hand-rolled runner and pinning it in source would over-constrain the Implementer.
+
+## Coverage map
+
+| Criterion | Test / mechanism | File | Level |
+|---|---|---|---|
+| AC-1 (verified → ✅) | **T1/T2** ensure the ✅ is no longer presence-only-gated (necessary condition); the *positive* behavior — a genuinely verified profile actually shows ✅ — is **staging smoke** with a known-good identity (§"Not covered") | test/nip05-checkmark-verification.test.js | source + manual smoke |
+| AC-2 (present but unverified → plain text, no ✅, no warning) | **T1/T2** (presence-only ✅ removed) + **R2** (no warning/indicator added to plain-text surfaces); concrete negative — the two #151 pubkeys still show the nip05 *text* with **no ✅** — is **staging smoke** | test/nip05-checkmark-verification.test.js | source + manual smoke |
+| AC-3 (no `nip05` field → nothing shown, unchanged) | Invariant preserved by any sane fix (cannot verify without a `nip05` to verify). Deliberately **not** pinned in-runner: a structural grep for `profile.nip05` in the page file would false-FAIL a legitimate component-extraction refactor the story did not forbid (Tester role: don't write brittle tests against undescribed implementation). Verified by **staging smoke** (a no-nip05 profile renders no nip05 line, as today). | — | manual smoke |
+| AC-4 (fail-closed; ✅ never shown in flight) | Covered in spirit by **T1/T2** — a ✅ that cannot render from presence alone also cannot render before a positive result. True in-flight *timing* is observation-only (note in §"Not covered"). | test/nip05-checkmark-verification.test.js | source + manual smoke |
+| AC-5 (both surfaces; search badge unchanged) | **T1** (UserDetail) + **T2** (BrainstormProfile) cover "both"; **R1** pins the search-results "✅ NIP-05 Verified" badge unchanged | test/nip05-checkmark-verification.test.js | source (sentinel) |
+| Concrete #151 (`b17e0293…`, `ff18165a…` → no ✅) | **Staging smoke** — exact URLs in §"Not covered" | — | manual smoke |
+
+T1, T2 = FAIL pre-implementation, PASS post. R1, R2 = PASS pre AND post (out-of-scope guards; a flip to FAIL means the Implementer touched something the story put out of scope).
+
+## Edge cases
+
+- [x] **Incidental ✅ in scope files not false-matched.** `UserDetail.jsx:341` (`✅ Active PoV`) and `BrainstormProfile.jsx:41` (`icon: '✅'`) are unrelated. The `PRESENCE_ONLY_CHECKMARK` regex requires a `nip05 &&` guard *immediately* in front of a JSX tag whose content starts with ✅, so neither is matched. Confirmed: pre-implementation only the two real bug lines match.
+- [x] **Identity-table row not false-matched.** `UserDetail.jsx`'s `{profile?.nip05 && ( <tr>…<td>NIP-05</td>… )}` has a `nip05 &&` guard but **no ✅** in the tag — regex correctly does not fire on it, and R2 separately pins it ✅-free.
+- [x] **A correct "presence AND verification" gate passes.** `profile?.nip05 && verified && <p>✅` and `nip05Verified && <p>✅` do **not** match `PRESENCE_ONLY_CHECKMARK` (verified by construction in the test header) — the tests do not force a particular gate expression, only forbid the presence-only one.
+- [x] **Component-extraction refactor not blocked.** If the Implementer extracts a `<Nip05Badge profile=…/>`, the scoped files contain no presence-only ✅ → T1/T2 pass; AC-3/behavior covered by smoke. The tests do not require the ✅ to stay in these files.
+- [x] **Out-of-scope already-correct badge protected.** R1 fails if the search `nip05Result` badge is altered/removed — guards against "fixing" the wrong surface.
+- [x] **Scope creep into plain-text surfaces caught.** R2 fails if a ✅ is added to `bs-result-nip05`, `bs-suggest-nip05`, or the UserDetail Identity row — encodes the "two ✅ sites only" scope decision.
+- [ ] **Semantically-fake verification (gate that always returns true when nip05 exists).** *Not catchable in source* — this is exactly what the staging smoke exists to catch (#151 pubkeys must show no ✅).
+
+## Not covered (deferred to staging smoke — authoritative behavioral gate)
+
+The bug reproduces on staging (confirmed by the reporter), so post-deploy smoke on `staging.brainstorm.world` is the real proof.
+
+**N1 — AC-2 / #151 negative (must show NO ✅):**
+```
+https://staging.brainstorm.world/user/b17e029321ce8ef14d989d964041576151e0a7b87a69e50809ff6ca8ebd795b1?pov=78ed0837
+https://staging.brainstorm.world/user/ff18165afde00852d49a4e1316c981c7af0164c1810c0bc0fe41d361dd7ca7f0?pov=a1420e44
+```
+Expect: NIP-05 string still shown as **plain text**, **no green ✅**, no warning glyph. Repeat on the Brainstorm profile page surface for the same pubkeys.
+
+**N2 — AC-1 positive (must show ✅):** load a profile whose NIP-05 is genuinely valid — i.e. `https://<domain>/.well-known/nostr.json?name=<name>` returns exactly that profile's pubkey. **Most stable fixture: an identifier `<name>@brainstorm.world` registered in our own NIP-05 registry** (we control that `.well-known/nostr.json`, so it is deterministic and not subject to third-party drift). The Implementer/Tester picks a current registered name and its pubkey. Expect: green ✅ shown on both the `/user/:pubkey` and Brainstorm profile surfaces.
+
+**N3 — AC-4 fail-closed timing:** with network throttling, the ✅ must **never flash** before the positive result resolves (it should be absent, then appear only if verified). Observation-only; record whether any pre-confirmation flash is seen.
+
+**N4 — AC-3 no-nip05 invariant:** load a profile with no `nip05` field — no nip05 line, no ✅ (unchanged from today).
+
+## Test infrastructure
+
+- **Test framework:** the project's existing hand-rolled Node runner (`npm test` → `test/test.js`). No new dependencies, no new framework (house rule).
+- **No Playwright spec.** Story #5 precedent: externally-dependent behavior (here, a live `.well-known/nostr.json` fetch to arbitrary third-party domains) is not deterministically reproducible in-runner without mocking infrastructure this project has no ADR for, and intercepting a specific fetch URL would prescribe the client-vs-server approach the story left open. Behavioral proof is staging smoke (above).
+- **Fixtures:** none in-runner — all four tests read source via `fs.readFileSync`. Smoke fixtures: the two #151 pubkeys (negative) and a `@brainstorm.world` registered name (positive).
+- **Files asserted against:** `ui/src/pages/users/UserDetail.jsx`, `ui/src/pages/BrainstormProfile.jsx`, `ui/src/pages/BrainstormSearch.jsx`.
+
+## How to run
+
+```
+npm test
+```
+
+Targeted run of just this suite:
+```
+node -e "require('./test/nip05-checkmark-verification.test.js').run()"
+```
+
+## Verification
+
+The new tests fail on the pre-implementation tree. Confirmed against the working tree at story commit `e522d073` (`story: nip05-checkmark-verification`), with `test/nip05-checkmark-verification.test.js` and the `test/test.js` registration on top:
+
+```
+nip05-checkmark-verification suite:
+  ✗ T1: UserDetail.jsx no longer renders the NIP-05 ✅ gated by nip05-presence alone
+      UserDetail.jsx must not render the green ✅ next to a profile's NIP-05 merely because `profile.nip05` is non-empty (AC-1, AC-2, AC-4). The ✅ must be gated on a verification outcome (domain-attested pubkey === profile pubkey), fail-closed. HOW (client/server, reuse of an existing verifyNip05() helper, caching) is the Implementer's call — only the presence-only gate must go. Found the presence-only pattern still present (currently UserDetail.jsx:84).
+  ✗ T2: BrainstormProfile.jsx no longer renders the NIP-05 ✅ gated by nip05-presence alone
+      BrainstormProfile.jsx must not render the green ✅ next to a profile's NIP-05 merely because `profile.nip05` is non-empty (AC-1, AC-2, AC-4, AC-5 — same fix on both surfaces). The ✅ must be gated on a verification outcome, fail-closed. Found the presence-only pattern still present (currently BrainstormProfile.jsx:228).
+  ✓ R1: BrainstormSearch.jsx keeps the server-verified "✅ NIP-05 Verified" badge gated on nip05Result
+  ✓ R2: plain-text NIP-05 surfaces stay checkmark-free (no positive indicator added where the story deferred it)
+
+Test Results
+-------------
+Configuration Loading:                           PASS
+treasure-maps-router-preset suite:               PASS (5 passed, 0 failed)
+scheduled-search-and-house-scores-refresh suite: PASS (12 passed, 0 failed)
+strfry-router-first-boot-config suite:           PASS (3 passed, 0 failed)
+per-query-neo4j-timeout-safety-net suite:        PASS (8 passed, 0 failed)
+nip05-checkmark-verification suite:              FAIL (2 passed, 2 failed)
+Overall:                                         FAIL
+```
+
+- 2 failing tests (T1, T2), each citing the spec by AC number and stating what must change *without* prescribing the mechanism — not a typo or import error.
+- 2 passing sentinels (R1, R2): the already-correct server-verified search badge, and the plain-text surfaces staying checkmark-free. Intentionally green; a flip to FAIL during Implementation means an out-of-scope surface was touched.
+- All four pre-existing suites stay green — no collateral regression from registering the new file in `test/test.js`.

--- a/src/api/nip05.js
+++ b/src/api/nip05.js
@@ -27,6 +27,8 @@ const { getSettings } = require('../config/settings');
 const NAME_RE = /^[a-z0-9._-]+$/;
 const HEX_PUBKEY_RE = /^[0-9a-f]{64}$/;
 const RELAY_RE = /^wss?:\/\//;
+// NIP-05 identifier: optional `local-part@`, then a dotted domain.
+const NIP05_LOOKUP_RE = /^(?:([\w.+-]+)@)?([\w_-]+(\.[\w_-]+)+)$/;
 
 /**
  * Validate a candidate `nip05` settings sub-object.
@@ -112,12 +114,67 @@ function handleNip05Lookup(req, res) {
   return res.json({ names, relays });
 }
 
+/**
+ * Resolve a NIP-05 identifier against its own domain.
+ * Fetches https://<domain>/.well-known/nostr.json?name=<name> and returns the
+ * hex pubkey the domain attests for that name, or null. 5-second timeout.
+ * (Same shape as the verifyNip05 helpers in src/api/admin and the meili search
+ * proxy — kept local rather than refactored across all three, which is out of
+ * scope for story #6.)
+ */
+async function verifyNip05Identifier(nip05Address) {
+  const match = String(nip05Address || '').match(NIP05_LOOKUP_RE);
+  if (!match) return null;
+  const name = match[1] || '_';
+  const domain = match[2];
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+    const resp = await fetch(
+      `https://${domain}/.well-known/nostr.json?name=${encodeURIComponent(name)}`,
+      { signal: controller.signal }
+    );
+    clearTimeout(timer);
+    if (!resp.ok) return null;
+    const json = await resp.json();
+    const pubkey = json.names?.[name] || json.names?.[name.toLowerCase()];
+    if (!pubkey || !HEX_PUBKEY_RE.test(pubkey)) return null;
+    return pubkey;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * GET /api/nip05/verify?nip05=<addr>&pubkey=<hex>
+ * Returns { verified: true } ONLY if the identifier's domain attests the
+ * SAME pubkey as the one supplied. Fail-closed: any missing input, bad
+ * pubkey, lookup error, timeout, or mismatch yields { verified: false }.
+ */
+async function handleNip05Verify(req, res) {
+  res.set('Cache-Control', 'no-store');
+  const nip05 = typeof req.query.nip05 === 'string' ? req.query.nip05 : '';
+  const pubkey = typeof req.query.pubkey === 'string' ? req.query.pubkey.toLowerCase() : '';
+  if (!nip05 || !HEX_PUBKEY_RE.test(pubkey)) {
+    return res.json({ verified: false });
+  }
+  try {
+    const attested = await verifyNip05Identifier(nip05);
+    return res.json({ verified: !!attested && attested.toLowerCase() === pubkey });
+  } catch {
+    return res.json({ verified: false });
+  }
+}
+
 function registerNip05Routes(app) {
   app.get('/.well-known/nostr.json', handleNip05Lookup);
+  app.get('/api/nip05/verify', handleNip05Verify);
 }
 
 module.exports = {
   registerNip05Routes,
   handleNip05Lookup,
+  handleNip05Verify,
+  verifyNip05Identifier,
   validateNip05,
 };

--- a/test/nip05-checkmark-verification.test.js
+++ b/test/nip05-checkmark-verification.test.js
@@ -1,0 +1,165 @@
+/**
+ * Story #6: NIP-05 green checkmark must reflect real verification.
+ *
+ * Today both profile surfaces render the ✅ purely on presence of the
+ * kind-0 `nip05` string:
+ *
+ *   UserDetail.jsx:84      {profile?.nip05 && <p className="user-nip05">✅ {profile.nip05}</p>}
+ *   BrainstormProfile.jsx  {profile?.nip05 && <div className="bsp-nip05">✅ {profile.nip05}</div>}
+ *
+ * No domain lookup, no pubkey match — so unverified / impersonated
+ * identifiers display as verified (GitHub #151).
+ *
+ * These tests are intentionally source-regex (matching the
+ * per-query-neo4j-timeout-safety-net / strfry-router-first-boot Bug
+ * precedents). They pin the ONE thing the spec fixes — the ✅ next to a
+ * profile's nip05 must no longer be gated by nip05-presence alone — WITHOUT
+ * prescribing how verification is done (client vs server, reuse of an
+ * existing verifyNip05() helper, caching). The story deliberately left that
+ * to the Implementer.
+ *
+ * What source tests CANNOT prove: that the new gate is a *real* match of the
+ * domain-attested pubkey against the profile pubkey, and that it is
+ * fail-closed in flight. A structurally-correct but semantically-fake gate
+ * (e.g. a hook that returns true whenever nip05 exists) would pass T1/T2.
+ * The authoritative behavioral gate for AC-1 / AC-2-positive / AC-4 is the
+ * staging smoke documented in the test plan ("Not covered"): the two #151
+ * pubkeys must show NO ✅, and a known-good identity MUST show ✅. The
+ * Reviewer must treat that smoke evidence as required, not optional.
+ *
+ * T1–T2  : FAIL pre-implementation, PASS post-implementation.
+ * R1–R2  : PASS pre AND post — out-of-scope guards; if they flip to FAIL,
+ *          the Implementer touched something the story put out of scope.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const UI = path.resolve(__dirname, '../ui/src/pages');
+const USERDETAIL_PATH = path.join(UI, 'users/UserDetail.jsx');
+const BRAINSTORMPROFILE_PATH = path.join(UI, 'BrainstormProfile.jsx');
+const BRAINSTORMSEARCH_PATH = path.join(UI, 'BrainstormSearch.jsx');
+
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'Assertion failed');
+}
+
+/**
+ * The bug pattern: a nip05-presence check (`...nip05 &&`) immediately
+ * followed by a single JSX element whose content starts with ✅. Matches
+ * the current line in both files. Does NOT match:
+ *   - `nip05Verified && <p>✅`           (gated on a verification signal)
+ *   - `profile?.nip05 && verified && <p>✅`  (presence AND verification)
+ *   - `<p>✅ Active PoV</p>` / `icon: '✅'`   (no nip05-presence guard in front)
+ *   - the Identity-table row `nip05 && ( <tr><td>NIP-05</td>... )` (no ✅ in the tag)
+ * i.e. it fires ONLY when nip05-presence ALONE renders the checkmark.
+ */
+const PRESENCE_ONLY_CHECKMARK = /nip05\s*&&\s*\(?\s*<[^>]{0,120}>\s*✅/;
+
+// ---------------------------------------------------------------------------
+// Failing tests — must FAIL now, PASS once the ✅ is gated on verification.
+// ---------------------------------------------------------------------------
+
+test('T1: UserDetail.jsx no longer renders the NIP-05 ✅ gated by nip05-presence alone', () => {
+  const src = fs.readFileSync(USERDETAIL_PATH, 'utf8');
+  assert(
+    !PRESENCE_ONLY_CHECKMARK.test(src),
+    'UserDetail.jsx must not render the green ✅ next to a profile\'s NIP-05 ' +
+      'merely because `profile.nip05` is non-empty (AC-1, AC-2, AC-4). The ✅ ' +
+      'must be gated on a verification outcome (domain-attested pubkey === profile pubkey), ' +
+      'fail-closed. HOW (client/server, reuse of an existing verifyNip05() helper, caching) ' +
+      'is the Implementer\'s call — only the presence-only gate must go. ' +
+      'Found the presence-only pattern still present (currently UserDetail.jsx:84).'
+  );
+});
+
+test('T2: BrainstormProfile.jsx no longer renders the NIP-05 ✅ gated by nip05-presence alone', () => {
+  const src = fs.readFileSync(BRAINSTORMPROFILE_PATH, 'utf8');
+  assert(
+    !PRESENCE_ONLY_CHECKMARK.test(src),
+    'BrainstormProfile.jsx must not render the green ✅ next to a profile\'s NIP-05 ' +
+      'merely because `profile.nip05` is non-empty (AC-1, AC-2, AC-4, AC-5 — same fix on ' +
+      'both surfaces). The ✅ must be gated on a verification outcome, fail-closed. ' +
+      'Found the presence-only pattern still present (currently BrainstormProfile.jsx:228).'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Regression sentinels — must PASS now AND post-implementation.
+// ---------------------------------------------------------------------------
+
+test('R1: BrainstormSearch.jsx keeps the server-verified "✅ NIP-05 Verified" badge gated on nip05Result', () => {
+  const src = fs.readFileSync(BRAINSTORMSEARCH_PATH, 'utf8');
+  // Story §"Out of scope": the search-results badge is already gated on real
+  // server-side verification (nip05Result, set only after verifyNip05 resolves).
+  // It must be left untouched (AC-5). If this flips to FAIL the Implementer
+  // changed an out-of-scope, already-correct surface.
+  const re = /nip05Result\s*&&[\s\S]{0,200}?✅\s*NIP-05 Verified/;
+  assert(
+    re.test(src),
+    'BrainstormSearch.jsx must keep its `{nip05Result && ( ... ✅ NIP-05 Verified ... )}` ' +
+      'pinned-result badge unchanged — it is already gated on real server-side verification ' +
+      'and is explicitly OUT OF SCOPE for story #6 (AC-5). The sentinel is failing: this ' +
+      'out-of-scope badge was altered or removed.'
+  );
+});
+
+test('R2: plain-text NIP-05 surfaces stay checkmark-free (no positive indicator added where the story deferred it)', () => {
+  const search = fs.readFileSync(BRAINSTORMSEARCH_PATH, 'utf8');
+  const userDetail = fs.readFileSync(USERDETAIL_PATH, 'utf8');
+
+  // Story §"Out of scope": surfaces that show NIP-05 as PLAIN TEXT today must
+  // not gain a ✅ (adding a positive indicator there is a deferred feature,
+  // not this bug fix). Three stable, high-risk anchors:
+
+  // (a) search results list — className "bs-result-nip05"
+  const resultWin = search.match(/bs-result-nip05[\s\S]{0,80}/);
+  assert(resultWin, 'R2: could not locate the bs-result-nip05 element in BrainstormSearch.jsx (anchor moved?).');
+  assert(
+    !/✅/.test(resultWin[0]),
+    'R2: the search-results NIP-05 (bs-result-nip05) must stay plain text — no ✅ added ' +
+      '(story #6 Out of scope). The sentinel is failing.'
+  );
+
+  // (b) search suggestions — className "bs-suggest-nip05"
+  const suggestWin = search.match(/bs-suggest-nip05[\s\S]{0,80}/);
+  assert(suggestWin, 'R2: could not locate the bs-suggest-nip05 element in BrainstormSearch.jsx (anchor moved?).');
+  assert(
+    !/✅/.test(suggestWin[0]),
+    'R2: the search-suggestion NIP-05 (bs-suggest-nip05) must stay plain text — no ✅ added ' +
+      '(story #6 Out of scope). The sentinel is failing.'
+  );
+
+  // (c) UserDetail Identity-table NIP-05 value cell (same file as the bug —
+  //     highest risk of a collateral edit). Anchor on the label cell.
+  const idxRow = userDetail.match(/NIP-05<\/td>[\s\S]{0,120}/);
+  assert(idxRow, 'R2: could not locate the Identity-table "NIP-05" row in UserDetail.jsx (anchor moved?).');
+  assert(
+    !/✅/.test(idxRow[0]),
+    'R2: the Identity-table NIP-05 row in UserDetail.jsx must stay plain text — the fix ' +
+      'is for the header badge only; the detail row is Out of scope for story #6. The sentinel is failing.'
+  );
+});
+
+async function run() {
+  let pass = 0;
+  let fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -27,6 +27,7 @@ const treasureMaps = require('./treasure-maps-router-preset.test.js');
 const scheduledRefresh = require('./scheduled-search-and-house-scores-refresh.test.js');
 const strfryRouterFirstBoot = require('./strfry-router-first-boot-config.test.js');
 const perQueryNeo4jTimeout = require('./per-query-neo4j-timeout-safety-net.test.js');
+const nip05CheckmarkVerification = require('./nip05-checkmark-verification.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -46,6 +47,9 @@ async function main() {
   console.log('\nper-query-neo4j-timeout-safety-net suite:');
   const perQueryNeo4jTimeoutResult = await perQueryNeo4jTimeout.run();
 
+  console.log('\nnip05-checkmark-verification suite:');
+  const nip05CheckmarkVerificationResult = await nip05CheckmarkVerification.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -61,13 +65,17 @@ async function main() {
   console.log(
     `per-query-neo4j-timeout-safety-net suite:        ${perQueryNeo4jTimeoutResult.fail === 0 ? 'PASS' : 'FAIL'} (${perQueryNeo4jTimeoutResult.pass} passed, ${perQueryNeo4jTimeoutResult.fail} failed)`
   );
+  console.log(
+    `nip05-checkmark-verification suite:              ${nip05CheckmarkVerificationResult.fail === 0 ? 'PASS' : 'FAIL'} (${nip05CheckmarkVerificationResult.pass} passed, ${nip05CheckmarkVerificationResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
     treasureMapsResult.fail === 0 &&
     scheduledRefreshResult.fail === 0 &&
     strfryRouterFirstBootResult.fail === 0 &&
-    perQueryNeo4jTimeoutResult.fail === 0;
+    perQueryNeo4jTimeoutResult.fail === 0 &&
+    nip05CheckmarkVerificationResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/ui/src/hooks/useNip05Verification.js
+++ b/ui/src/hooks/useNip05Verification.js
@@ -1,0 +1,53 @@
+import { useState, useEffect } from 'react';
+
+// Client-side cache keyed by `${pubkey}|${nip05}` (survives across mounts
+// within the same page session).
+const verificationCache = new Map();
+
+/**
+ * Hook: verify a profile's NIP-05 identifier against its domain.
+ *
+ * Returns a boolean. Fail-closed: starts false and only ever becomes true
+ * after the server confirms the identifier's domain attests THIS pubkey.
+ * Missing inputs, lookup errors, timeouts, and mismatches all stay false —
+ * so the caller can safely gate a "verified" checkmark on the return value.
+ */
+export default function useNip05Verification(pubkey, nip05) {
+  const [verified, setVerified] = useState(false);
+
+  useEffect(() => {
+    // Reset first so a previously-verified profile never bleeds onto a new one.
+    setVerified(false);
+
+    if (!pubkey || !nip05) return;
+
+    const cacheKey = `${pubkey}|${nip05}`;
+    if (verificationCache.has(cacheKey)) {
+      setVerified(verificationCache.get(cacheKey));
+      return;
+    }
+
+    let cancelled = false;
+
+    async function check() {
+      try {
+        const res = await fetch(
+          `/api/nip05/verify?nip05=${encodeURIComponent(nip05)}&pubkey=${encodeURIComponent(pubkey)}`
+        );
+        const data = await res.json();
+        const ok = res.ok && data?.verified === true;
+        if (cancelled) return;
+        verificationCache.set(cacheKey, ok);
+        setVerified(ok);
+      } catch (err) {
+        // Fail-closed: leave it false.
+        console.warn('useNip05Verification fetch error:', err);
+      }
+    }
+
+    check();
+    return () => { cancelled = true; };
+  }, [pubkey, nip05]);
+
+  return verified;
+}

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -5,6 +5,7 @@ import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu from '../components/BrainstormUserMenu';
 import { useProfileActions } from '../hooks/useProfileActions';
 import useUserCounts from '../hooks/useUserCounts';
+import useNip05Verification from '../hooks/useNip05Verification';
 import ConfirmDialog from '../components/ConfirmDialog';
 import ReportModal from '../components/ReportModal';
 
@@ -90,6 +91,7 @@ export default function BrainstormProfile() {
   const showActions = user && user.pubkey !== pubkey;
 
   const { data: userCounts, loading: userCountsLoading } = useUserCounts(pubkey);
+  const nip05Verified = useNip05Verification(pubkey, profile?.nip05);
   const followingCount = userCounts?.followingCount ?? null;
   const fmtCount = (n) => (n == null ? '—' : new Intl.NumberFormat().format(n));
 
@@ -225,7 +227,7 @@ export default function BrainstormProfile() {
               )}
               <div className="bsp-header-info">
                 <h1 className="bsp-name">{displayName}</h1>
-                {profile?.nip05 && <div className="bsp-nip05">✅ {profile.nip05}</div>}
+                {profile?.nip05 && <div className="bsp-nip05">{nip05Verified && '✅ '}{profile.nip05}</div>}
                 {profileAge && <span className="bsp-age">Updated {profileAge}</span>}
               </div>
             </div>

--- a/ui/src/pages/users/UserDetail.jsx
+++ b/ui/src/pages/users/UserDetail.jsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, Link } from 'react-router-dom';
 import { nip19 } from 'nostr-tools';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import useProfiles from '../../hooks/useProfiles';
+import useNip05Verification from '../../hooks/useNip05Verification';
 import { useTrust } from '../../context/TrustContext';
 import { useConfig } from '../../context/ConfigContext';
 import { useCypher } from '../../hooks/useCypher';
@@ -52,6 +53,7 @@ export default function UserDetail() {
   const pubkeys = useMemo(() => [pubkey], [pubkey]);
   const profiles = useProfiles(pubkeys);
   const profile = profiles?.[pubkey];
+  const nip05Verified = useNip05Verification(pubkey, profile?.nip05);
 
   const displayName = profile?.display_name || profile?.name || shortPubkey(pubkey);
 
@@ -81,7 +83,7 @@ export default function UserDetail() {
         )}
         <div>
           <h1>{displayName}</h1>
-          {profile?.nip05 && <p className="user-nip05">✅ {profile.nip05}</p>}
+          {profile?.nip05 && <p className="user-nip05">{nip05Verified && '✅ '}{profile.nip05}</p>}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`. Bundle is exactly PR #154 — no other changes are on staging ahead of main.

## Bundled

- **#154** — fix: NIP-05 checkmark must reflect real verification (#151). Story #6, full engineering-team harness (PO → Tester → Implementer → Reviewer; Architecture skipped — Standard bug). Reviewer verdict PASS.

## Net production impact

On profile pages (`/user/:pubkey` → BrainstormProfile, and `/tapestry/users/:pubkey` → UserDetail), the green ✅ next to a user's NIP-05 now appears **only when the identifier genuinely verifies** (the domain's `.well-known/nostr.json` attests the same pubkey). Unverified, misconfigured, or impersonated identifiers show the NIP-05 as plain text with no ✅ and no warning. Additive new endpoint `GET /api/nip05/verify`; fail-closed. No forced sign-out, no data migration, no breaking change. Closes #151.

## Verification trail

- #154 staging deploy run `25999443245` — success, 7m54s.
- `npm test` 32/32 green (reviewer-run).
- Staging API proof on the **exact #151 profiles**: `DavidCharles@ArenaTherapeutics.com`/b17e0293 → `{"verified":false}`; `goldfisthumb1@nostr.land`/ff18165a → `{"verified":false}`; verified fixture `brainstorm@brainstorm.world`/0f6c8526 → `{"verified":true}`; fail-closed on bad/missing input.
- User visual eyeball on staging confirmed.
- One non-blocking pre-existing SSRF noted in review; separate repo-wide follow-up filed.

## Test plan

- [ ] After merge: `deploy-brainstorm.yml` runs to completion.
- [ ] Stability + sanity on brainstorm.world.
- [ ] `GET /api/nip05/verify` — match→`true`, mismatch/bad→`false`; the two #151 pubkeys with their real nip05 → `false`.
- [ ] Regression sweep (`/`, `/search`, `/user/:pk`, `/api/profiles`).
- [ ] Close #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)