### PR TITLE
Promote staging → main: community-reference stub + concept export (#156)

### DIFF
--- a/engineering-team/decisions/0004-publish-export-a-concept.md
+++ b/engineering-team/decisions/0004-publish-export-a-concept.md
@@ -1,6 +1,6 @@
 # ADR 0004: Publish/export a concept — Concept-Graph-rooted
 
-**Status:** Accepted
+**Status:** Accepted (revised 2026-05-18 — see Revision 1)
 **Date:** 2026-05-17
 **Story:** `engineering-team/stories/9-publish-export-a-concept.md`
 
@@ -44,3 +44,17 @@ Wrap the whole concept in one event. **Cons:** breaks a-tag addressing and the c
 
 ## Out of scope
 Privacy-tiered export; Header→ConceptGraph protocol tag; server-side headless export; concepts beyond `nostr-relay` for verification.
+
+---
+
+## Revision 1 (2026-05-18) — restricted DList relay target
+
+**Trigger:** Review of stories #8/#9 (`engineering-team/reviews/8-community-reference-and-export.md`, CHANGES_REQUESTED) + an explicit owner relay-policy decision: concept export must publish **only to `wss://dcosl.brainstorm.world`**, not to the general-purpose `PUBLISH_RELAYS` set (purplepag.es / primal / damus / nos.lol / wot.grapevine.network).
+
+**What changes:**
+- The original Decision's "**No change to `nostrPublish.js` — reuse as-is**" and the implicit `publishEverywhere → PUBLISH_RELAYS` target are **superseded**. `publishEverywhere` is parameterized: `publishEverywhere(signedEvent, relays = PUBLISH_RELAYS)`. The default is unchanged, so every existing caller (profile follow/mute/report via `useProfileActions`) is byte-for-byte unaffected. The concept-export action passes `['wss://dcosl.brainstorm.world']`.
+- Still ADR-0004 Option A in spirit: the browser primitive is reused (not a new server-side publisher); only its relay target is now an argument. Sentinels: **TE1** stays valid (the concept-export UI still calls `publishEverywhere`); **RE1** stays valid (`publishEverywhere` + `PUBLISH_RELAYS` still exported; no server-side `SimplePool.publish`).
+
+**Rationale:** (a) avoid polluting general-purpose relays with concept/DList events; (b) `wss://dcosl.brainstorm.world` is the purpose-built DList relay — the `dcosl` router preset already mirrors kinds 9998/9999/39998/39999; (c) **export target and import `relayHints` must be the same relay set or the round-trip cannot close** — see ADR 0005 Revision 1. Junk-tolerance on the import side is the real robustness mechanism (owner's explicit framing); the restricted publish target is pollution-minimisation courtesy, not correctness.
+
+**Consequences / follow-ups:** Implementer re-cycle: parameterize `publishEverywhere`; concept-export passes the dcosl set. No re-architecture. Reviewer finding #2 (`install.js:1141` misleading IMPORT log) is folded into the same Implementer pass (it is an Implementer fix, not an ADR change — referenced here only for chain coherence).

--- a/engineering-team/decisions/0004-publish-export-a-concept.md
+++ b/engineering-team/decisions/0004-publish-export-a-concept.md
@@ -1,0 +1,46 @@
+# ADR 0004: Publish/export a concept — Concept-Graph-rooted
+
+**Status:** Accepted
+**Date:** 2026-05-17
+**Story:** `engineering-team/stories/9-publish-export-a-concept.md`
+
+## Context
+Export is the producer; the Story 8 import contract conforms to whatever this emits. Decided default: **Full, Concept-Graph-rooted, own-authored TA-signed events only, Header always included**.
+
+Mechanism facts (verified):
+- The concept's events already exist **signed in local strfry** (TA-signed, addressed `39998/39999:<TA>:<d-tag>`). Export = re-publish an existing event set outward; no serialization/transform except `graphContext` is stripped on share (BIBLE.md:1527).
+- Per-event publish to **external** relays is **browser-side**: `publishEverywhere` → local strfry + `PUBLISH_RELAYS` (ui/src/utils/nostrPublish.js:95). `/api/strfry/publish` is local-only; `/api/relay/external` is fetch-only. No server-side external publisher exists.
+- Concept enumeration is a Neo4j traversal from the Header via class-thread + core-node wiring; concept-graph API exists (`/api/concept-graph/node/:handle/neighbors`, `/subgraph/:handle`) — src/api/concept-graph/index.js:194.
+- Concept Graph node handle: `39999:<TA>:nostr-relay-concept-graph` — the transitive root (imports subsets/elements + property-tree-graph + core-nodes-graph), confirmed live via `/neighbors`.
+- Derived edges (HAS_ELEMENT/IS_A_SUPERSET_OF) are implicit — the importer re-derives them; they are not published.
+
+## Options considered
+
+### Option A — Server enumerates the own-authored set; UI loops existing `publishEverywhere` (chosen)
+New owner-only endpoint returns the concept's **TA-authored** constituent events (traversal seeded at the Header, including the Concept Graph node and its closure, filtered to `pubkey == TA`). The existing concept-detail UI action loops the existing browser-side `publishEverywhere` over that set.
+**Pros:** reuses the exact existing signer/publish path used for all other UGC; no new server-side relay-publish infra; idempotent (replaceable events); own-authored filter enforces the provenance principle for free; matches the decided default exactly.
+**Cons:** export driven from an owner browser session (not a headless server job); large concepts → many sequential publishes (needs batching + partial-failure reporting).
+
+### Option B — Server-side concept publisher
+Add a server-side external-relay publisher; export runs entirely server-side.
+**Pros:** headless; no browser needed. **Cons:** new external-publish infra duplicating the established browser path; diverges from how every other event is published today; larger blast radius for a producer stub. Rejected — not justified yet.
+
+### Option C — Single bundled archive event
+Wrap the whole concept in one event. **Cons:** breaks a-tag addressing and the class-thread model; importer can't address sub-nodes. Rejected.
+
+## Decision
+**Option A** — smallest design that produces exactly the event set Story 8 consumes, reusing the established publish/signer model, with the provenance filter built in.
+
+## Consequences
+- **Enables:** a deterministic "Publish concept" producing the import-side contract; graceful degradation (Header alone is valid); generalizes to any concept.
+- **Constrains:** large concepts need batching + per-event/per-relay partial-failure reporting (not transactional). Re-publish = re-broadcast (consistent with existing firmware-header behavior). Full Concept-Graph-rooted *retrieval* on the import side needs the deferred Header→ConceptGraph tag (plan item (1)); **export is unaffected** — importers degrade to the Header floor until then.
+- **Follow-ups:** Header→ConceptGraph tag ADR (1); privacy-tiered export; export progress UX.
+- **Firmware reinstall required?** **No** — operator action over existing graph/events; no firmware/manifest change. (Contrast ADR 0005/import, which does require reinstall.)
+
+## Implementation notes
+- **New endpoint** (owner-guarded, like Settings): `GET /api/concept/:handle/export-set` → resolves `39998:<TA>:<slug>`, Cypher-traverses `IS_THE_CONCEPT_FOR | IS_A_SUPERSET_OF | HAS_ELEMENT | IS_THE_*_FOR` from the Header (incl. the Concept Graph node + closure), `WHERE node.pubkey = <TA pubkey>`, returns the raw signed events (graphContext stripped via the existing share path). New handler under `src/api/concept/` (or extend `src/api/concept-graph/`); reuse traversal helpers in src/api/concept-graph/index.js.
+- **UI:** add a "Publish concept" action on the concept detail/actions surface (owner-only) that calls the endpoint then loops the existing `publishEverywhere` (ui/src/utils/nostrPublish.js:95), accumulating per-event `{successes, failures}` for a summary. Batch sequentially.
+- **No change** to `nostrPublish.js`, `/api/strfry/publish`, or `PUBLISH_RELAYS` — reuse as-is.
+
+## Out of scope
+Privacy-tiered export; Header→ConceptGraph protocol tag; server-side headless export; concepts beyond `nostr-relay` for verification.

--- a/engineering-team/decisions/0005-community-reference-nostr-relay-stub.md
+++ b/engineering-team/decisions/0005-community-reference-nostr-relay-stub.md
@@ -1,6 +1,6 @@
 # ADR 0005: Community-reference pointer — Nostr Relay stub
 
-**Status:** Accepted
+**Status:** Accepted (revised 2026-05-18 — see Revision 1)
 **Date:** 2026-05-17
 **Story:** `engineering-team/stories/8-community-reference-nostr-relay-stub.md`
 **Depends on:** ADR 0004 (export contract)
@@ -41,3 +41,17 @@ No linkage ⇒ defeats purpose. Rejected.
 
 ## Out of scope
 Community Superset/sets/elements/schema retrieval; materialization; Header→ConceptGraph tag; signed IMPORT/firmware rel-type; privacy tiers; concepts beyond `nostr-relay`.
+
+---
+
+## Revision 1 (2026-05-18) — relayHints aligned to the DList relay
+
+**Trigger:** Consequence of ADR 0004 Revision 1 (concept export now publishes **only** to `wss://dcosl.brainstorm.world`). The Context's "`communityReference.relayHints` defaults to that PUBLISH_RELAYS set per ADR 0004" is **superseded**: import must look where export actually publishes, or the round-trip cannot close by construction.
+
+**What changes:**
+- Shipped `communityReference.relayHints` becomes **`["wss://dcosl.brainstorm.world"]`** (replacing the 5 popular relays in the implemented manifest — an Implementer re-cycle task).
+- Sentinel **TI1** stays valid: it asserts `relayHints` is a non-empty array of `ws(s)://` URLs — a single dcosl URL satisfies it. `headerATag` (`39998:919ba08a…:nostr-relay`) is unchanged.
+
+**Rationale:** export ⇄ import relay-set consistency (ADR 0004 Rev 1 rationale (c)); concept/DList events belong on the purpose-built DList relay (the `dcosl` preset mirrors 39998/39999), not general-purpose relays.
+
+**Consequences:** The export↔import chicken-and-egg closes only once brainstorm.world's TA (`919ba08a…`) has actually run concept export to `wss://dcosl.brainstorm.world` (the stepwise-to-prod plan). Until then, import graceful-degrades — the correct, intended behaviour (ADR 0005 AC-3). Reviewer non-blocking item (AC-4 dormant) is unaffected by this revision.

--- a/engineering-team/decisions/0005-community-reference-nostr-relay-stub.md
+++ b/engineering-team/decisions/0005-community-reference-nostr-relay-stub.md
@@ -1,0 +1,43 @@
+# ADR 0005: Community-reference pointer — Nostr Relay stub
+
+**Status:** Accepted
+**Date:** 2026-05-17
+**Story:** `engineering-team/stories/8-community-reference-nostr-relay-stub.md`
+**Depends on:** ADR 0004 (export contract)
+
+## Context
+Establish a deferred placeholder from the local `nostr-relay` concept to the community-curated one at firmware install. Minimum unit = kind 39998 Header; graceful degradation; `nostr-relay` only. Flaw A and registry-as-DList accepted/deferred.
+
+**Consumes ADR 0004:** a published community concept's Header is a TA-signed `39998:<curator>:nostr-relay` event re-published to `PUBLISH_RELAYS` (purplepag.es, wot.grapevine.network, relay.primal.net, nos.lol, relay.damus.io) with `graphContext` stripped. Therefore `communityReference.relayHints` **defaults to that PUBLISH_RELAYS set**, and the fetch filter `{kinds:[39998],authors:[curatorPk],"#d":["nostr-relay"]}` matches the exported Header exactly. No ADR conflict: 0005 depends on 0004; independent of 0002/0003.
+
+Codebase constraints (verified): firmware install is multi-pass, server-side via internal Express bridge, iterates `manifest.concepts` (src/firmware/install.js); server-side relay fetch `GET /api/relay/external` (src/api/relay/fetchEvents.js); reuse path `POST /api/strfry/publish` then derive via `POST /api/tapestry-key/derive-all/:label` (src/api/tapestry-key/index.js:467); uuids distinct (`39998:<TA>` vs `39998:<curator>`); in-file MERGE pattern at src/firmware/install.js:470; **no IMPORT relationship-type in firmware**, no signed-IMPORT path in `src`.
+
+## Options considered
+
+### Option A — Minimal: imported community Header node + Neo4j-only IMPORT edge, manifest-driven (chosen)
+Fetch the community Header via `/api/relay/external`, publish to local strfry (no re-signing — curator's event), let Pass-3 derive it, `MERGE (localHeader)-[:IMPORT]->(communityHeader)`.
+**Pros:** smallest blast radius, reuses every primitive, idempotent, reversible, unbundled.
+**Cons:** IMPORT edge is Neo4j-only — documented Rule-6 deviation, tracked debt for plan item (1).
+
+### Option B — protocol-correct signed IMPORT event + firmware relationship-type
+Rule-6 correct but broad blast radius (firmware reinstall + BIBLE across instances), pre-empts deferred ADR-(1). Rejected for the stub.
+
+### Option C — import Header node, no edge
+No linkage ⇒ defeats purpose. Rejected.
+
+## Decision
+**Option A** — delivers the stated minimum with the smallest reversible footprint; Rule-6 deviation explicitly tracked for plan item (1).
+
+## Consequences
+- **Enables:** firmware-time deferred local→community linkage; foundation for later edge-walking materialization; generalizes via more `communityReference` entries.
+- **Constrains:** IMPORT edge Neo4j-only until ADR-(1); foreign curator 39998 nodes live in the graph (distinguishable by pubkey). `relayHints` default = `PUBLISH_RELAYS` per ADR 0004 — if the export relay set changes, update both.
+- **Follow-ups (→ plan item (1)/future):** signed IMPORT + firmware rel-type; Header→ConceptGraph tag; superset/element materialization; registry-as-DList; flaw A.
+- **Firmware reinstall required?** **Yes** — `manifest.json` gains a field + new sub-pass; effective only on `POST /api/firmware/install`.
+
+## Implementation notes
+- **`firmware/active/manifest.json`** (edit versioned `versions/v1.0.0/manifest.json`) — add to the `nostr-relay` entry: `"communityReference": { "headerATag": "39998:<curator-pubkey>:nostr-relay", "relayHints": [<PUBLISH_RELAYS>], "knownGoodEventId": "<optional hex>" }`.
+- **`src/firmware/install.js`** — add `async function pass_communityReferences(opts)`, invoked from `install()` after `pass1_bootstrap`, before the Pass-3 derive block. Per concept with `communityReference`: build filter (`ids:[knownGoodEventId]` if set, else `{kinds:[39998],authors:[curatorPk],"#d":[dTag]}`) → `apiGet('/api/relay/external', …)` → no event / id-mismatch ⇒ log miss + `continue` → `apiPost('/api/strfry/publish', { event })` passthrough (no re-sign) → `runCypherApi('MATCH (a {uuid:$from}),(b {uuid:$to}) MERGE (a)-[:IMPORT]->(b)', { from:'39998:'+TA+':'+slug, to:headerATag })`. Per-concept try/catch; never throw.
+- No source change to `fetchEvents.js` / `publishEvent.js` / `tapestry-key/index.js`.
+
+## Out of scope
+Community Superset/sets/elements/schema retrieval; materialization; Header→ConceptGraph tag; signed IMPORT/firmware rel-type; privacy tiers; concepts beyond `nostr-relay`.

--- a/engineering-team/reviews/8-community-reference-and-export.md
+++ b/engineering-team/reviews/8-community-reference-and-export.md
@@ -1,0 +1,63 @@
+# Review: Stories #8 & #9 — Community-reference stub + concept export
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-18
+**Diff:** `git diff 24460033..c1b96499` (impl commit `c1b96499`)
+**Covers:** Story #8 (`engineering-team/stories/8-community-reference-nostr-relay-stub.md`, ADR 0005) and Story #9 (`engineering-team/stories/9-publish-export-a-concept.md`, ADR 0004) — implemented in one coupled diff.
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **PASS**. TE1/TE2/TI1/TI2 green, RE1/RI1/RI2 scope guards green, all 6 pre-existing suites green, Overall PASS. Re-run by reviewer.
+- [ ] `npm run test:playwright` — n/a (no browser spec; per test plans, behavior is smoke-gated).
+- [x] _Lint / typecheck / build — not configured; skipped per role._
+
+## Spec adherence
+
+| AC | Status | Note |
+|---|---|---|
+| #8 AC-1 fetch+import distinct node | structural ✓ / behavioral ⧗ | TI1/TI2 pin it; round-trip is smoke M1 — **not run** |
+| #8 AC-2 placeholder edge | structural ✓ / behavioral ⧗ | post-derive MERGE present; smoke M1 — **not run** |
+| #8 AC-3 graceful | ✓ | per-concept try/catch, miss logs+continues, never throws — code-correct |
+| #8 AC-4 knownGoodEventId | ✓ implemented / dormant | mismatch→skip implemented; shipped manifest omits the field (ADR-optional) — path unexercised |
+| #8 AC-5 idempotent | ✓ | MERGE ⇒ idempotent |
+| #9 AC-1 full export | structural ✓ / behavioral ⧗ | endpoint+UI loop; smoke N1 — **not run** |
+| #9 AC-2 own-authored only | ✓ | `WHERE n.pubkey = $taPubkey` — provenance filter correct |
+| #9 AC-3 graphContext stripped | ✓ | events read from strfry (portable signed form); sound |
+| #9 AC-4 idempotent | ✓ | replaceable events |
+| #9 AC-5 partial failure no abort | ✓ | UI loop per-event try/catch + tally |
+| #9 AC-6 owner-only | ✓ | `requireOwner` on the route |
+
+No criterion silently dropped; no behavior beyond the stories.
+
+## ADR adherence
+
+- ADR 0004 Option A: server enumerates own-authored set; UI reuses `publishEverywhere`; no server-side external publisher. ✓ (RE1 green; `nostrPublish.js`/`PUBLISH_RELAYS` untouched.)
+- ADR 0005 Option A: manifest field + install sub-pass (fetch `/api/relay/external` → publish `/api/strfry/publish` no re-sign → Neo4j-only `IMPORT` MERGE); idempotent; graceful; before Pass-3 derive. ✓
+- **Flagged ADR-prose deviation (non-blocking, correct):** ADR 0005's Implementation notes lump the `IMPORT` MERGE into the pre-derive sub-pass. The implementation correctly **splits** it — fetch/publish pre-derive, MERGE post-derive ([src/firmware/install.js:1135](src/firmware/install.js)) — because the community node does not exist until Pass-3 derive. This honors the ADR's stated *intent* ("publish before derive so it becomes a node; then MERGE") and is the only correct sequencing. Recommend annotating ADR 0005 so the artifact matches reality.
+- No new dependencies. Concept handles in `kind:pubkey:slug` form. Firmware reinstall correctly called out (ADR 0005 Consequences) — see findings re: not yet performed.
+
+## Things tests can't catch
+
+- **No secrets.** The committed `919ba08a…` is a public nostr pubkey (brainstorm.world TA), not a secret. OK.
+- **Logging/style:** new install.js logging matches the file's existing emoji/`console.log` house style; `exportSet.js` `console.error` matches `concept-graph/index.js`. Not debug cruft.
+- **Shell exec:** `exportSet.js` `strfryScan` uses `exec(\`strfry scan '${JSON.stringify(filter)...}'\`)` — identical to the established pattern in `io.js`/`eventSync.js`/`admin/index.js`; `filter` is built from Neo4j-derived hex ids, `handle` is a parameterized Cypher param (never shelled). No new injection vector. Acceptable.
+- No commented-out code, no dead code, no race conditions (sequential install + sequential export loop).
+
+## Findings
+
+### Blocking
+
+1. **Authoritative behavioral gate not executed.** The approved test plans state the local/staging smoke is **Reviewer-required, not optional** (the structural sentinels deliberately cannot prove the relay/Neo4j round-trip). It has not been run. Per role ("approve when in doubt → don't"), I cannot PASS the behavioral ACs (#8 AC-1/AC-2, #9 AC-1) on structural evidence alone. **Asked:** run `cycle-local` to evidence export E2E (N1/N2), import **graceful** (M2), and re-install **idempotency** (M4) before this proceeds.
+2. **[src/firmware/install.js:1141](src/firmware/install.js)** — the post-derive step logs `✅ ${slug}: IMPORT → ${to}` whenever the Cypher call succeeds, but `MATCH (a),(b) MERGE …` creates **no edge and errors not** when the community node `b` is absent (curator hasn't published / derive didn't pick up the foreign 39998). This yields a **false-positive "✅ IMPORT" in smoke output** — directly undermining the M1 evidence the Reviewer must rely on. **Asked (small, Implementer):** return/inspect a created-count (e.g. `… MERGE (a)-[:IMPORT]->(b) RETURN count(*)`) and log success only when the edge was actually created; otherwise log a distinct "community node not present yet — IMPORT deferred".
+
+### Non-blocking
+
+1. **Export↔import chicken-and-egg (track explicitly).** Import-positive M1/M3 is structurally unprovable locally until the reference curator (brainstorm.world TA `919ba08a…`) has itself run the new export. Not an implementation defect — but #8 AC-1/AC-2 must NOT be marked proven until a staging run (where brainstorm.world has exported) or a deliberate fixture (hand-publish a 39998 under a test key + temp `communityReference`). Recommend recording as a staging acceptance item on Story #8.
+2. **#8 AC-4 dormant.** `knownGoodEventId` handling is implemented but the shipped manifest omits the field, so the mismatch path is unexercised by default config (ADR-optional). Acceptable; note for the smoke that AC-4 needs a deliberate fixture to exercise.
+3. **ADR 0005 prose** should be annotated to reflect the (correct) pre/post-derive split — see ADR adherence.
+
+## Verdict
+
+**CHANGES_REQUESTED.**
+
+The code is clean, in-scope, ADR-conformant, and the full `npm test` gate is green — there are no architecture/spec/scope defects. But (1) the approved test plans make the behavioral smoke a **required** gate and it has not been run, and (2) the post-derive success log is misleading in exactly the output that smoke relies on. Both asks are small and precise. Route: fix finding #2 via `/implement-feature` (one-function change), run the finding #1 smoke (`cycle-local`), then re-review — no re-architecture, no scope change.

--- a/engineering-team/reviews/8-community-reference-and-export.md
+++ b/engineering-team/reviews/8-community-reference-and-export.md
@@ -61,3 +61,22 @@ No criterion silently dropped; no behavior beyond the stories.
 **CHANGES_REQUESTED.**
 
 The code is clean, in-scope, ADR-conformant, and the full `npm test` gate is green — there are no architecture/spec/scope defects. But (1) the approved test plans make the behavioral smoke a **required** gate and it has not been run, and (2) the post-derive success log is misleading in exactly the output that smoke relies on. Both asks are small and precise. Route: fix finding #2 via `/implement-feature` (one-function change), run the finding #1 smoke (`cycle-local`), then re-review — no re-architecture, no scope change.
+
+---
+
+## Re-review (2026-05-18) — after ADR 0004/0005 Revision 1 + fixes
+
+**Diff re-audited:** ADR-revision commit `d37f1587` + re-implementation (parameterized `publishEverywhere`, dcosl-only concept publish, `relayHints` → `["wss://dcosl.brainstorm.world"]`, install.js IMPORT-log fix) + Tester consistency notes.
+
+**Quality gate (re-run by reviewer):** `npm test` → **Overall PASS**. All 7 suites + config green; TE1/RE1 still green under the parameterized `publishEverywhere` (primitive + `PUBLISH_RELAYS` still present; export still calls it; no server-side `SimplePool.publish`), TI1 still green (`relayHints` non-empty `ws(s)://` array). `manifest.json` valid JSON.
+
+**Blocking #2 (install.js misleading IMPORT log) — RESOLVED.** [src/firmware/install.js:1144](src/firmware/install.js) now does a `count(b)` presence check before MERGE; logs `✅ IMPORT →` only when the community node exists, else `⏭️ … IMPORT deferred (graceful)`. Smoke output is now trustworthy as M1 evidence.
+
+**ADR adherence (revised):** matches ADR 0004 Rev 1 (relay-parameterized `publishEverywhere`, default arg unchanged ⇒ profile/follow/mute callers byte-identical; concept-export passes the dcosl set) and ADR 0005 Rev 1 (`relayHints` aligned to `wss://dcosl.brainstorm.world`). Export ⇄ import relay sets are now consistent. No scope creep; no new deps.
+
+**Blocking #1 (Reviewer-required behavioral smoke) — code-cleared, behavior gated.** All *code* blockers are resolved; the authoritative behavioral proof is now the **explicitly-authorized stepwise deploy**: `cycle-local` (export→import round-trip on dcosl, local fixture) → `cycle-staging` → `cycle-prod`, then run "Publish concept" for `nostr-relay` on brainstorm.world (TA `919ba08a…`, dcosl-only) so the shipped pointer resolves for real. Per the harness, **PASS ⇒ deploy chain**; the smoke executes there and remains a hard precondition to prod.
+
+**Non-blocking carried forward:** export↔import chicken-and-egg now closes *by plan* at the prod export step (no longer an open risk, just a sequenced action); AC-4 (`knownGoodEventId`) still dormant by default config — exercise via fixture in smoke; ADR pre/post-derive split now documented (Rev 1). 
+
+### Verdict (Re-review)
+**PASS (code/ADR/scope).** Behavioral acceptance gate = the stepwise `cycle-local → cycle-staging → cycle-prod` smoke that is the immediate next planned step. #8 AC-1/AC-2 and #9 AC-1 are **not** to be marked proven until the export→import round-trip is observed on dcosl (cycle-local first, then the real prod-curator export). No further code changes required to proceed.

--- a/engineering-team/stories/8-community-reference-nostr-relay-stub.md
+++ b/engineering-team/stories/8-community-reference-nostr-relay-stub.md
@@ -42,5 +42,5 @@ None blocking — resolved in Discovery. Noted: the placeholder edge is Neo4j-on
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/0005-community-reference-nostr-relay-stub.md` (Accepted; depends on ADR 0004)
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/8-community-reference-nostr-relay-stub.test-plan.md` (4 sentinels; behavioral AC-1…AC-5 deferred to local/staging smoke — authoritative, Reviewer-required)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/8-community-reference-nostr-relay-stub.md
+++ b/engineering-team/stories/8-community-reference-nostr-relay-stub.md
@@ -1,0 +1,46 @@
+# Story 8: Community-reference pointer — Nostr Relay stub
+
+**Status:** Approved
+**Created:** 2026-05-17
+**Type:** Feature
+
+## Background
+A firmware concept is a *local* definition authored by this instance's Tapestry Assistant. The community also curates definitions of the same concepts (e.g. "Nostr Relay"). We want firmware to carry a pointer to the community-curated definition so a fresh install can establish a **deferred placeholder link** to it — without importing the full class thread now, and without re-deciding at install time what "the community's definition" is.
+
+Accepted-and-deferred (recorded here, resolved in plan item (1), NOT this story):
+- **Flaw A** — a firmware-baked pointer is dev-curated, not Grapevine-selected. Inherent to firmware; to be addressed when firmware itself is community-curated.
+- **Registry-as-DList** — the per-concept pointer should eventually be a community-curated DList; hardcoded for now.
+
+Design decided in Discovery: the **minimum a community curator must publish** is the kind 39998 Concept Header (graceful degradation — if nothing else is reachable, we still anchor the concept). Scope is limited to **one concept: `nostr-relay`**.
+
+**Depends on:** Story 9 (Publish/export a concept). The import contract here *consumes* the export contract defined there — export is the producer. The ADR for this story is renumbered **0005** and is finalized only after the export ADR (**0004**) is accepted.
+
+## User-facing description
+As a Tapestry operator, when I install firmware, I want my local `nostr-relay` Concept Header linked (as a deferred placeholder) to the community-curated `nostr-relay` Concept Header, so the community's curation can later be materialized without re-deciding what the community's definition is.
+
+## Acceptance criteria
+- [ ] Given a firmware concept with a `communityReference` (`headerATag`, `relayHints[]`, optional `knownGoodEventId`), when firmware install runs, then the community Concept Header (kind 39998) is fetched from the relay hints and imported as a Neo4j node whose uuid is its own a-tag (distinct from the local TA header).
+- [ ] Given the community Header was imported, when install completes, then a placeholder edge exists from the local `nostr-relay` Concept Header to the community `nostr-relay` Concept Header.
+- [ ] Given the community Header cannot be fetched (no relay carries it / timeout), when install runs, then the miss is logged, install continues, and the local firmware concept is created/updated exactly as before (graceful degradation — no install failure).
+- [ ] Given `knownGoodEventId` is set, when fetching, then the fetched event's id is verified against it; a mismatch is treated as a miss (graceful + logged).
+- [ ] Given firmware install is re-run, when it runs again, then no duplicate community node and no duplicate placeholder edge are created (idempotent).
+
+## Concepts touched
+- `39998:<TA-pubkey>:nostr-relay` — local Concept Header for Nostr Relay (gains one outgoing placeholder edge).
+- `39998:<curator-pubkey>:nostr-relay` — community Concept Header, newly imported as a distinct foreign node.
+
+## Out of scope
+- Fetching/wiring the community Superset, sets, elements, or JSON Schema.
+- Element/superset materialization (the placeholder edge *is* the deferral).
+- The Concept-Header → Concept-Graph nostr-event-tag protocol change (separate ratifiable ADR under plan item (1); prerequisite for single-event full retrieval, not for this stub).
+- Promoting the placeholder to a protocol-correct signed IMPORT relationship event + a first-class firmware IMPORT relationship-type (deferred to (1)).
+- The three-tier privacy model.
+- Any concept other than `nostr-relay`.
+
+## Open questions
+None blocking — resolved in Discovery. Noted: the placeholder edge is Neo4j-only for this stub (a documented deviation from "explicit relationships are nostr events" / Normalization Rule 6), tracked as debt for plan item (1).
+
+## Linked artifacts
+- ADR: `engineering-team/decisions/0005-community-reference-nostr-relay-stub.md` (Accepted; depends on ADR 0004)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/8-community-reference-nostr-relay-stub.md
+++ b/engineering-team/stories/8-community-reference-nostr-relay-stub.md
@@ -43,4 +43,4 @@ None blocking — resolved in Discovery. Noted: the placeholder edge is Neo4j-on
 ## Linked artifacts
 - ADR: `engineering-team/decisions/0005-community-reference-nostr-relay-stub.md` (Accepted; depends on ADR 0004)
 - Test plan: `engineering-team/stories/8-community-reference-nostr-relay-stub.test-plan.md` (4 sentinels; behavioral AC-1…AC-5 deferred to local/staging smoke — authoritative, Reviewer-required)
-- Review: `engineering-team/reviews/8-community-reference-and-export.md` — **CHANGES_REQUESTED** (npm test green & in-scope; blocking: Reviewer-required smoke not run + misleading post-derive IMPORT log)
+- Review: `engineering-team/reviews/8-community-reference-and-export.md` — re-review **PASS (code/ADR/scope)** after ADR 0004/0005 Rev 1; behavioral acceptance gated on the stepwise cycle-local→staging→prod smoke

--- a/engineering-team/stories/8-community-reference-nostr-relay-stub.md
+++ b/engineering-team/stories/8-community-reference-nostr-relay-stub.md
@@ -43,4 +43,4 @@ None blocking — resolved in Discovery. Noted: the placeholder edge is Neo4j-on
 ## Linked artifacts
 - ADR: `engineering-team/decisions/0005-community-reference-nostr-relay-stub.md` (Accepted; depends on ADR 0004)
 - Test plan: `engineering-team/stories/8-community-reference-nostr-relay-stub.test-plan.md` (4 sentinels; behavioral AC-1…AC-5 deferred to local/staging smoke — authoritative, Reviewer-required)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/8-community-reference-and-export.md` — **CHANGES_REQUESTED** (npm test green & in-scope; blocking: Reviewer-required smoke not run + misleading post-derive IMPORT log)

--- a/engineering-team/stories/8-community-reference-nostr-relay-stub.test-plan.md
+++ b/engineering-team/stories/8-community-reference-nostr-relay-stub.test-plan.md
@@ -1,0 +1,79 @@
+# Test Plan: Story 8 — Community-reference pointer (Nostr Relay stub)
+
+**Story:** `engineering-team/stories/8-community-reference-nostr-relay-stub.md`
+**ADR:** `engineering-team/decisions/0005-community-reference-nostr-relay-stub.md` (depends on ADR 0004)
+**Date:** 2026-05-17
+
+## Approach
+
+Precedent: stories #5 / #6. The behavioral core — a real community kind-39998 Header fetched off a relay, imported as a **distinct foreign node**, the Neo4j `IMPORT` placeholder edge created, graceful skip when no relay carries it, `knownGoodEventId` mismatch handling, and re-install idempotency — needs a live firmware install + relays + Neo4j and is **not reproducible in the hand-rolled Node runner**. The in-runner suite pins the **stable contract** (the manifest data shape + the install wiring/ordering/graceful contract ADR 0005 fixed); the behavioral proof is the **authoritative local/staging smoke** below.
+
+**Deliberate limitation (read this).** Source sentinels prove the manifest field exists and that install.js *references* the fetch/publish/IMPORT/ordering contract — they cannot prove the edge is actually created against the right foreign node, that a relay miss truly degrades gracefully, or that re-install is idempotent. The authoritative gate for AC-1…AC-5 is the §"Not covered" smoke. **The Reviewer must treat that smoke evidence as required, not optional.**
+
+## Coverage map
+
+| Criterion | Test / mechanism | File | Level |
+|---|---|---|---|
+| AC-1 (fetch community Header → import as distinct node) | **TI1** (manifest `communityReference` well-formed) + **TI2** (install fetches via `/api/relay/external`, publishes via `/api/strfry/publish`); the node actually appearing distinct from the local TA header is **smoke M1** | test/community-reference-nostr-relay-stub.test.js | source + smoke |
+| AC-2 (placeholder edge local→community Header) | **TI2** pins an `[:IMPORT]` MERGE in install; the edge actually present post-install is **smoke M1** | test/community-reference-nostr-relay-stub.test.js | source + smoke |
+| AC-3 (Header unreachable ⇒ graceful, local concept unaffected) | **TI2** pins try/catch in the sub-pass region (never throws out of install); real graceful skip is **smoke M2** | test/community-reference-nostr-relay-stub.test.js | source + smoke |
+| AC-4 (knownGoodEventId verified; mismatch = miss) | **TI1** pins the field is 64-hex when present; mismatch→miss behavior is **smoke M3** | test/community-reference-nostr-relay-stub.test.js | source + smoke |
+| AC-5 (re-run idempotent) | MERGE semantics pinned by **TI2** (`[:IMPORT]` via MERGE); no-duplicate proof is **smoke M4** | test/community-reference-nostr-relay-stub.test.js | source + smoke |
+
+TI1, TI2 = FAIL pre-implementation, PASS post. RI1, RI2 = PASS pre AND post (scope guards: RI1 flips if Implementer drifts to ADR Option B = a first-class IMPORT firmware relationship-type; RI2 flips if a "No source change" file gains community-reference logic).
+
+## Edge cases
+
+- [x] **Option-A vs Option-B enforced.** RI1 fails if `manifest.relationshipTypes` ≠ the known 11 or any entry references IMPORT — encodes "the IMPORT edge is Neo4j-only" (ADR 0005 Decision).
+- [x] **Scope creep into reused files caught.** RI2 fails if `fetchEvents.js` / `publishEvent.js` / `tapestry-key/index.js` gains `communityReference` logic (ADR 0005 "No source change" — feature lives only in install.js + manifest).
+- [x] **Ordering pinned.** TI2 asserts the `/api/relay/external` call precedes the Pass-3 `/api/tapestry-key/derive-all/` marker — the community Header must be published before derive so it becomes a node.
+- [x] **No re-signing.** TI2's message states the foreign event is passed through `/api/strfry/publish` without re-signing (you cannot sign someone else's event); the actual passthrough param is the Implementer's to confirm (smoke M1 proves the node is the curator's pubkey, not the TA's).
+- [ ] **Edge points at the right foreign node / true idempotency / true graceful skip.** Not catchable in source — smoke M1/M2/M4.
+
+## Not covered (deferred to local/staging smoke — authoritative behavioral gate)
+
+Run on the local docker stack (`cycle-local`, `http://localhost:8080`) or `staging.brainstorm.world`. **Precondition:** `POST /api/firmware/install` is the action under test; `communityReference` must be populated with a real curator pubkey + a relay that carries that Header.
+
+**M1 — AC-1/AC-2 (import + placeholder edge):** publish a community `nostr-relay` Header (kind 39998, a curator pubkey ≠ local TA) to a relay in `relayHints` — strongest via Story #9 export from another instance; minimally via a hand-signed 39998. Run `POST /api/firmware/install`. Via `/api/concept-graph/node/39998:<localTA>:nostr-relay/neighbors`, expect an **`IMPORT`** edge to a **distinct** node whose handle is `39998:<curator>:nostr-relay` (different pubkey segment from the local TA header).
+
+**M2 — AC-3 (graceful):** set `relayHints` to a relay that does NOT carry the Header (or unreachable). Run install. Expect install completes, logs the miss, **no `IMPORT` edge**, and the local `nostr-relay` concept is created/normalized exactly as before (no failure).
+
+**M3 — AC-4 (knownGoodEventId):** set `knownGoodEventId` to a wrong id → expect miss (no edge), logged. Set it to the correct id → expect edge created.
+
+**M4 — AC-5 (idempotent):** run `POST /api/firmware/install` twice. Expect exactly **one** community node and **one** `IMPORT` edge (MERGE — no duplicates).
+
+## Test infrastructure
+
+- **Framework:** existing hand-rolled Node runner (`npm test` → `test/test.js`). No new deps/framework (house rule). Registered: `communityReferenceStub` in `test/test.js`.
+- **Files asserted against:** `firmware/active/manifest.json` (versioned `versions/v1.0.0`), `src/firmware/install.js`, and the three ADR-0005 "no source change" files for RI2.
+- **No Playwright spec.** Firmware-install + relay + Neo4j round-trip is not deterministically reproducible in-runner; behavioral proof is the smoke above.
+- **Smoke fixtures:** a community `nostr-relay` 39998 Header on a `relayHints` relay (Story #9 export or hand-signed); local docker stack or staging.
+
+## How to run
+
+```
+npm test
+```
+
+Targeted:
+```
+node -e "require('./test/community-reference-nostr-relay-stub.test.js').run()"
+```
+
+## Verification
+
+New tests fail on the pre-implementation tree (working tree atop story/ADR commit `b416c938`):
+
+```
+community-reference-nostr-relay-stub suite:
+  ✗ TI1: firmware manifest carries a well-formed `communityReference` on the nostr-relay concept (AC-1, ADR 0005)
+  ✗ TI2: install.js has a graceful community-reference sub-pass, wired before Pass-3 derive (AC-1/AC-3/AC-5, ADR 0005)
+  ✓ RI1: no first-class IMPORT firmware relationship-type added (ADR 0005 chose Option A, rejected Option B)
+  ✓ RI2: ADR-0005 "No source change" files stay free of community-reference logic
+community-reference-nostr-relay-stub suite:      FAIL (2 passed, 2 failed)
+Overall:                                         FAIL
+```
+
+- TI1, TI2 fail citing AC + ADR, describing the missing contract without prescribing the ADR-open function name — not a typo/import error (suite loaded and ran).
+- RI1, RI2 pass (intentional scope guards; a flip to FAIL during Implementation = Option-B drift or edits to "No source change" files).
+- All 6 pre-existing suites stay green — no collateral regression from registering the new suite.

--- a/engineering-team/stories/8-community-reference-nostr-relay-stub.test-plan.md
+++ b/engineering-team/stories/8-community-reference-nostr-relay-stub.test-plan.md
@@ -4,6 +4,8 @@
 **ADR:** `engineering-team/decisions/0005-community-reference-nostr-relay-stub.md` (depends on ADR 0004)
 **Date:** 2026-05-17
 
+> **Revision (2026-05-18, ADR 0005 Rev 1):** `communityReference.relayHints` is now `["wss://dcosl.brainstorm.world"]` (matches the revised export target). TI1 unchanged and still valid (non-empty `ws(s)://` array). Smoke M1/M3 publish/seek the community Header on the dcosl DList relay.
+
 ## Approach
 
 Precedent: stories #5 / #6. The behavioral core — a real community kind-39998 Header fetched off a relay, imported as a **distinct foreign node**, the Neo4j `IMPORT` placeholder edge created, graceful skip when no relay carries it, `knownGoodEventId` mismatch handling, and re-install idempotency — needs a live firmware install + relays + Neo4j and is **not reproducible in the hand-rolled Node runner**. The in-runner suite pins the **stable contract** (the manifest data shape + the install wiring/ordering/graceful contract ADR 0005 fixed); the behavioral proof is the **authoritative local/staging smoke** below.

--- a/engineering-team/stories/9-publish-export-a-concept.md
+++ b/engineering-team/stories/9-publish-export-a-concept.md
@@ -39,4 +39,4 @@ None blocking. Note: full Concept-Graph-rooted *retrieval* on the import side de
 ## Linked artifacts
 - ADR: `engineering-team/decisions/0004-publish-export-a-concept.md` (Accepted)
 - Test plan: `engineering-team/stories/9-publish-export-a-concept.test-plan.md` (3 sentinels; behavioral AC-1…AC-6 deferred to local/staging smoke — authoritative, Reviewer-required)
-- Review: `engineering-team/reviews/8-community-reference-and-export.md` (covers #8 & #9) — **CHANGES_REQUESTED**
+- Review: `engineering-team/reviews/8-community-reference-and-export.md` (covers #8 & #9) — re-review **PASS (code/ADR/scope)** after ADR 0004 Rev 1; behavioral gate = stepwise deploy smoke

--- a/engineering-team/stories/9-publish-export-a-concept.md
+++ b/engineering-team/stories/9-publish-export-a-concept.md
@@ -1,0 +1,42 @@
+# Story 9: Publish/export a concept to the community
+
+**Status:** Approved
+**Created:** 2026-05-17
+**Type:** Feature
+
+## Background
+The community-reference import (Story 8) consumes whatever a curator publishes. That import contract cannot be soundly specified until the **export** contract is fixed — export is the producer. Today there is no concept-level publish, only per-event browser-side `publishEverywhere` ([ui/src/utils/nostrPublish.js:95](../../ui/src/utils/nostrPublish.js)). This story defines the owner action that exports a locally-curated concept so other instances can discover and (per Story 8) import it.
+
+Decided in the Architecture step-back:
+- **Default = Full, Concept-Graph-rooted:** the 39998 Header + the 39999 Concept Graph node + its transitive closure (superset, sets, elements, schema, primary property, properties-set, property-tree-graph, core-nodes-graph).
+- **The 39998 Header is always included as the graceful-degradation floor** — consistent with Story 8's "Header is the minimum an importer needs."
+- **Scope = own-authored TA-signed events only.** Imported foreign nodes are NOT re-exported (provenance principle: you never rebroadcast someone else's concept under your identity). This also keeps Story 8's Neo4j-only IMPORT edges from leaking on export — both sides stay consistent for free.
+- **Owner-only** action (like Settings).
+
+## User-facing description
+As the owner/operator, I want a "Publish concept" action that broadcasts my locally-curated concept to community relays, so other instances can discover and reference my definition.
+
+## Acceptance criteria
+- [ ] Given the owner triggers "Publish concept" for `nostr-relay`, when it runs, then every own-authored (TA-signed) constituent event — Header + Concept Graph node + its transitive closure (superset/sets/elements/schema/properties/3 graphs) — is published to the community relays.
+- [ ] Given the concept includes nodes imported from other authors, when export runs, then those foreign-authored nodes are NOT published (only TA-authored events).
+- [ ] Given `graphContext` is local-only, when an event is exported, then `graphContext` is stripped (portable word-wrapper only).
+- [ ] Given export is re-run, when it runs again, then it is idempotent (replaceable events; no divergence).
+- [ ] Given some relays fail, when export runs, then per-event/per-relay successes and failures are reported; partial failure does not abort the whole export.
+- [ ] Given a non-owner, when they attempt the action, then it is denied (owner-only).
+
+## Concepts touched
+- `39998:<TA-pubkey>:nostr-relay` (Header) and its 8 core nodes incl. `39999:<TA-pubkey>:nostr-relay-concept-graph`, plus sets/elements — all TA-authored.
+
+## Out of scope
+- Privacy-tiered selective export (deferred — three-tier privacy model).
+- The Header → Concept-Graph nostr-event-tag protocol change (plan item (1) / ADR). Without it, an importer can't auto-discover the Concept Graph from a single fetched Header — but **export itself is unaffected**; importers degrade to the Header floor until that lands.
+- Export progress/UX polish.
+- Any concept beyond `nostr-relay` for end-to-end verification.
+
+## Open questions
+None blocking. Note: full Concept-Graph-rooted *retrieval* on the import side depends on the deferred Header→ConceptGraph tag; until then importers degrade to Header-only — acceptable and already the agreed floor.
+
+## Linked artifacts
+- ADR: `engineering-team/decisions/0004-publish-export-a-concept.md` (Accepted)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/9-publish-export-a-concept.md
+++ b/engineering-team/stories/9-publish-export-a-concept.md
@@ -38,5 +38,5 @@ None blocking. Note: full Concept-Graph-rooted *retrieval* on the import side de
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/0004-publish-export-a-concept.md` (Accepted)
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/9-publish-export-a-concept.test-plan.md` (3 sentinels; behavioral AC-1…AC-6 deferred to local/staging smoke — authoritative, Reviewer-required)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/9-publish-export-a-concept.md
+++ b/engineering-team/stories/9-publish-export-a-concept.md
@@ -39,4 +39,4 @@ None blocking. Note: full Concept-Graph-rooted *retrieval* on the import side de
 ## Linked artifacts
 - ADR: `engineering-team/decisions/0004-publish-export-a-concept.md` (Accepted)
 - Test plan: `engineering-team/stories/9-publish-export-a-concept.test-plan.md` (3 sentinels; behavioral AC-1…AC-6 deferred to local/staging smoke — authoritative, Reviewer-required)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/8-community-reference-and-export.md` (covers #8 & #9) — **CHANGES_REQUESTED**

--- a/engineering-team/stories/9-publish-export-a-concept.test-plan.md
+++ b/engineering-team/stories/9-publish-export-a-concept.test-plan.md
@@ -4,6 +4,8 @@
 **ADR:** `engineering-team/decisions/0004-publish-export-a-concept.md`
 **Date:** 2026-05-17
 
+> **Revision (2026-05-18, ADR 0004 Rev 1):** concept export publishes ONLY to `wss://dcosl.brainstorm.world` (relay-parameterized `publishEverywhere`). Sentinels unchanged and still valid (TE1 still pins `publishEverywhere` usage; RE1 still pins the primitive + `PUBLISH_RELAYS` present). Smoke relay target below is now the dcosl DList relay.
+
 ## Approach
 
 Precedent: stories #5 / #6 / strfry-router-first-boot. Export is a relay round-trip — its real behavior (events landing on community relays, Concept-Graph-rooted closure, foreign nodes excluded, idempotency, partial-failure reporting, owner-only enforcement) is **not reproducible in the hand-rolled Node runner** without infra this project has no ADR for, and ADR 0004 deliberately left the route name/path open ("`src/api/concept/` OR extend `src/api/concept-graph/`"). So the in-runner suite pins only the **stable contract ADR 0004 did fix**, and the behavioral proof is the **authoritative local/staging smoke** below.
@@ -34,7 +36,7 @@ TE1, TE2 = FAIL pre-implementation, PASS post. RE1 = PASS pre AND post (scope gu
 
 Run on the local docker stack (`cycle-local`, `http://localhost:8080`) or `staging.brainstorm.world`.
 
-**N1 — AC-1/AC-3 (full Concept-Graph-rooted export, graphContext stripped):** as owner, trigger "Publish concept" for `nostr-relay`. Query a `PUBLISH_RELAYS` member via `/api/relay/external` for `{kinds:[39998,39999],authors:["<local TA pubkey>"]}` scoped to the concept. Expect the 39998 Header **and** the 39999 Concept Graph node **and** its closure (superset, sets, elements, schema, primary-property, properties-set, property-tree-graph, core-nodes-graph). Expect **no `graphContext`** in any published event.
+**N1 — AC-1/AC-3 (full Concept-Graph-rooted export, graphContext stripped):** as owner, trigger "Publish concept" for `nostr-relay`. Query `wss://dcosl.brainstorm.world` via `/api/relay/external` for `{kinds:[39998,39999],authors:["<local TA pubkey>"]}` scoped to the concept. Expect the 39998 Header **and** the 39999 Concept Graph node **and** its closure (superset, sets, elements, schema, primary-property, properties-set, property-tree-graph, core-nodes-graph). Expect **no `graphContext`** in any published event.
 
 **N2 — AC-2 (provenance: foreign nodes excluded):** plant a foreign-authored node inside the `nostr-relay` concept (an element/superset signed by a non-TA pubkey — e.g. via the Story #8 import, or hand-published). Run export. Expect that foreign-authored event is **absent** from the published set (only `authors:["<TA>"]` events emitted).
 

--- a/engineering-team/stories/9-publish-export-a-concept.test-plan.md
+++ b/engineering-team/stories/9-publish-export-a-concept.test-plan.md
@@ -1,0 +1,81 @@
+# Test Plan: Story 9 — Publish/export a concept to the community
+
+**Story:** `engineering-team/stories/9-publish-export-a-concept.md`
+**ADR:** `engineering-team/decisions/0004-publish-export-a-concept.md`
+**Date:** 2026-05-17
+
+## Approach
+
+Precedent: stories #5 / #6 / strfry-router-first-boot. Export is a relay round-trip — its real behavior (events landing on community relays, Concept-Graph-rooted closure, foreign nodes excluded, idempotency, partial-failure reporting, owner-only enforcement) is **not reproducible in the hand-rolled Node runner** without infra this project has no ADR for, and ADR 0004 deliberately left the route name/path open ("`src/api/concept/` OR extend `src/api/concept-graph/`"). So the in-runner suite pins only the **stable contract ADR 0004 did fix**, and the behavioral proof is the **authoritative local/staging smoke** below.
+
+**Deliberate limitation (read this).** Source sentinels cannot prove that export actually emits the right event set or that it excludes foreign-authored nodes — a structurally-present but semantically-wrong implementation could pass TE1/TE2. The authoritative behavioral gate for AC-1…AC-6 is the §"Not covered" smoke. **The Reviewer must treat that smoke evidence as required, not optional.**
+
+## Coverage map
+
+| Criterion | Test / mechanism | File | Level |
+|---|---|---|---|
+| AC-1 (own concept fully published) | **TE1** pins that a concept-scoped export is wired through the existing `publishEverywhere`; the actual Header + Concept-Graph closure reaching relays is **smoke N1** | test/publish-export-a-concept.test.js | source + smoke |
+| AC-2 (foreign nodes NOT published) | **TE2** pins a server export path filtered to this instance's own/TA pubkey (provenance); concrete exclusion of a planted foreign node is **smoke N2** | test/publish-export-a-concept.test.js | source + smoke |
+| AC-3 (graphContext stripped) | Invariant of reusing the existing share path (ADR 0004); verified by **smoke N1** (published events carry no `graphContext`) | — | smoke |
+| AC-4 (idempotent re-run) | Replaceable-event property; **smoke N3** | — | smoke |
+| AC-5 (partial relay failure reported, no abort) | **smoke N4** | — | smoke |
+| AC-6 (owner-only) | **TE2** pins provenance in the server path; owner-guard enforcement is **smoke N5** | test/publish-export-a-concept.test.js | source + smoke |
+
+TE1, TE2 = FAIL pre-implementation, PASS post. RE1 = PASS pre AND post (scope guard; flip to FAIL ⇒ Implementer changed the out-of-scope publish primitive or drifted to ADR Option B).
+
+## Edge cases
+
+- [x] **Existing per-profile `publishEverywhere` not false-matched.** TE1 requires `publishEverywhere` **and** a concept-export token in the same file; `ui/src/hooks/useProfileActions.js` (profile publish) has no such token → correctly still FAIL pre-impl (confirmed in the run below).
+- [x] **Option-B drift caught.** RE1 fails if any `src/api` file gains `SimplePool` + `.publish(` (server-side external publisher). Pre-impl `fetchEvents.js` uses `SimplePool.querySync` for FETCH only — guard holds.
+- [x] **Publish primitive freeze.** RE1 fails if `publishEverywhere`/`PUBLISH_RELAYS` is removed/renamed (ADR 0004 "No change to nostrPublish.js").
+- [ ] **Semantically-wrong export (wrong event set / foreign node leak).** Not catchable in source — this is exactly what smoke N1/N2 exist to catch.
+
+## Not covered (deferred to local/staging smoke — authoritative behavioral gate)
+
+Run on the local docker stack (`cycle-local`, `http://localhost:8080`) or `staging.brainstorm.world`.
+
+**N1 — AC-1/AC-3 (full Concept-Graph-rooted export, graphContext stripped):** as owner, trigger "Publish concept" for `nostr-relay`. Query a `PUBLISH_RELAYS` member via `/api/relay/external` for `{kinds:[39998,39999],authors:["<local TA pubkey>"]}` scoped to the concept. Expect the 39998 Header **and** the 39999 Concept Graph node **and** its closure (superset, sets, elements, schema, primary-property, properties-set, property-tree-graph, core-nodes-graph). Expect **no `graphContext`** in any published event.
+
+**N2 — AC-2 (provenance: foreign nodes excluded):** plant a foreign-authored node inside the `nostr-relay` concept (an element/superset signed by a non-TA pubkey — e.g. via the Story #8 import, or hand-published). Run export. Expect that foreign-authored event is **absent** from the published set (only `authors:["<TA>"]` events emitted).
+
+**N3 — AC-4 (idempotent):** run export twice. Expect identical a-tags, no divergence (replaceable events).
+
+**N4 — AC-5 (partial failure):** make one relay hint unreachable. Expect the action reports per-event/per-relay successes+failures and completes (no abort).
+
+**N5 — AC-6 (owner-only):** attempt the action without an owner session. Expect denied.
+
+**Strongest end-to-end:** instance B runs N1; instance A imports it via Story #8 — the two stories' smoke compose into one cross-instance proof.
+
+## Test infrastructure
+
+- **Framework:** existing hand-rolled Node runner (`npm test` → `test/test.js`). No new deps/framework (house rule). Registered: `publishExportConcept` in `test/test.js`.
+- **No Playwright spec.** Externally-dependent relay round-trips are not deterministically reproducible in-runner without mocking infra this project has no ADR for; pinning a fetch/publish URL would prescribe the ADR-open mechanism. Behavioral proof is the smoke above (story #5/#6 precedent).
+- **Fixtures:** none in-runner (source scans). Smoke fixtures: local docker stack or staging; a planted foreign-authored node for N2.
+
+## How to run
+
+```
+npm test
+```
+
+Targeted:
+```
+node -e "require('./test/publish-export-a-concept.test.js').run()"
+```
+
+## Verification
+
+New tests fail on the pre-implementation tree (working tree atop story/ADR commit `b416c938`):
+
+```
+publish-export-a-concept suite:
+  ✗ TE1: a "publish concept" action is wired through the existing publishEverywhere primitive (AC-1, ADR 0004 Option A)
+  ✗ TE2: a server endpoint enumerates a concept's OWN-authored events (provenance filter to this TA pubkey) (AC-2/AC-6, ADR 0004)
+  ✓ RE1: publish primitive reused unchanged; no ADR-Option-B server-side external publisher introduced
+publish-export-a-concept suite:                  FAIL (1 passed, 2 failed)
+Overall:                                         FAIL
+```
+
+- TE1, TE2 fail citing AC + ADR, describing what must change without prescribing the ADR-open route — not a typo/import error (suite loaded and ran).
+- RE1 passes (intentional scope guard; a flip to FAIL during Implementation = Option-B drift or publish-primitive change).
+- All 6 pre-existing suites stay green — no collateral regression from registering the new suite.

--- a/firmware/versions/v1.0.0/manifest.json
+++ b/firmware/versions/v1.0.0/manifest.json
@@ -225,11 +225,7 @@
             "communityReference": {
                 "headerATag": "39998:919ba08af7786892093b8264332d817379662a0ba0ba1f5c791ed7b62a7ee2ff:nostr-relay",
                 "relayHints": [
-                    "wss://purplepag.es",
-                    "wss://wot.grapevine.network",
-                    "wss://relay.primal.net",
-                    "wss://nos.lol",
-                    "wss://relay.damus.io"
+                    "wss://dcosl.brainstorm.world"
                 ]
             }
         },

--- a/firmware/versions/v1.0.0/manifest.json
+++ b/firmware/versions/v1.0.0/manifest.json
@@ -221,7 +221,17 @@
             "jsonSchema": "json-schema.json",
             "categories": [
                 "nostr"
-            ]
+            ],
+            "communityReference": {
+                "headerATag": "39998:919ba08af7786892093b8264332d817379662a0ba0ba1f5c791ed7b62a7ee2ff:nostr-relay",
+                "relayHints": [
+                    "wss://purplepag.es",
+                    "wss://wot.grapevine.network",
+                    "wss://relay.primal.net",
+                    "wss://nos.lol",
+                    "wss://relay.damus.io"
+                ]
+            }
         },
         {
             "slug": "dog-breed",

--- a/src/api/concept/exportSet.js
+++ b/src/api/concept/exportSet.js
@@ -1,0 +1,81 @@
+/**
+ * Story #9 / ADR 0004 — Publish/export a concept (Concept-Graph-rooted).
+ *
+ * GET /api/concept/:handle/export-set   (owner-only)
+ *
+ * Enumerates a concept's OWN-authored constituent events so the owner UI can
+ * re-publish them via the existing browser `publishEverywhere` primitive
+ * (ADR 0004 Option A — no server-side external publisher).
+ *
+ * Concept-Graph-rooted: from the ConceptHeader we gather the class thread
+ * (Superset → IS_A_SUPERSET_OF* → Sets → elements) plus the core nodes
+ * (schema, primary property, properties set, the 3 graph nodes incl. the
+ * Concept Graph node). Provenance principle (AC-2): only events whose
+ * `pubkey` is THIS instance's TA are returned — you never re-export someone
+ * else's concept under your identity. The events come straight from strfry,
+ * which is the portable signed form (no `graphContext` — that lives only in
+ * the Neo4j/JSON layer, never in the signed event).
+ */
+
+const { exec } = require('child_process');
+const { runCypher } = require('../../lib/neo4j-driver');
+const { getOwnerAssistantPubkey } = require('../../utils/assistantKeys');
+
+function strfryScan(filter) {
+  return new Promise((resolve, reject) => {
+    const safeFilter = JSON.stringify(filter).replace(/'/g, "'\\''");
+    exec(`strfry scan '${safeFilter}'`, { maxBuffer: 16 * 1024 * 1024 }, (error, stdout) => {
+      if (error) return reject(error);
+      const events = [];
+      for (const line of String(stdout).trim().split('\n')) {
+        if (!line) continue;
+        try { events.push(JSON.parse(line)); } catch {}
+      }
+      resolve(events);
+    });
+  });
+}
+
+async function handleConceptExportSet(req, res) {
+  try {
+    const handle = decodeURIComponent(req.params.handle || '');
+    if (!handle) {
+      return res.status(400).json({ success: false, error: 'handle is required' });
+    }
+
+    const taPubkey = getOwnerAssistantPubkey();
+    if (!taPubkey) {
+      return res.status(500).json({ success: false, error: 'TA pubkey unavailable' });
+    }
+
+    // Concept-Graph-rooted traversal: header + class thread + core nodes.
+    const rows = await runCypher(
+      `
+      MATCH (h:ListHeader {uuid: $handle})
+      OPTIONAL MATCH (h)-[:IS_THE_CONCEPT_FOR]->(s:Superset)
+      OPTIONAL MATCH (h)-[:IS_THE_CONCEPT_FOR]->(:Superset)-[:IS_A_SUPERSET_OF*0..6]->(ss)
+      OPTIONAL MATCH (ss)-[:HAS_ELEMENT]->(elem)
+      OPTIONAL MATCH (core)-[:IS_THE_JSON_SCHEMA_FOR|IS_THE_PRIMARY_PROPERTY_FOR|IS_THE_PROPERTIES_SET_FOR|IS_THE_PROPERTY_TREE_GRAPH_FOR|IS_THE_CORE_GRAPH_FOR|IS_THE_CONCEPT_GRAPH_FOR]->(h)
+      WITH collect(DISTINCT h) + collect(DISTINCT s) + collect(DISTINCT ss) + collect(DISTINCT elem) + collect(DISTINCT core) AS ns
+      UNWIND ns AS n
+      WITH DISTINCT n
+      WHERE n IS NOT NULL AND n.pubkey = $taPubkey AND n.id IS NOT NULL
+      RETURN n.id AS id, n.uuid AS uuid
+      `,
+      { handle, taPubkey }
+    );
+
+    const ids = [...new Set(rows.map((r) => r.id).filter(Boolean))];
+    if (ids.length === 0) {
+      return res.json({ success: true, count: 0, events: [], note: 'no own-authored events for this concept' });
+    }
+
+    const events = await strfryScan({ ids });
+    res.json({ success: true, count: events.length, events });
+  } catch (err) {
+    console.error('[concept/export-set]', err);
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+module.exports = { handleConceptExportSet };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -486,6 +486,10 @@ async function register(app) {
     const { registerConceptGraphRoutes } = require('./concept-graph');
     registerConceptGraphRoutes(app);
 
+    // ── Concept export (Story #9 / ADR 0004) — owner-only ──
+    const { handleConceptExportSet } = require('./concept/exportSet.js');
+    app.get('/api/concept/:handle/export-set', requireOwner, handleConceptExportSet);
+
     // ── Tapestry Key / LMDB Store API ──
     const { registerTapestryKeyRoutes } = require('./tapestry-key');
     registerTapestryKeyRoutes(app);

--- a/src/firmware/install.js
+++ b/src/firmware/install.js
@@ -974,6 +974,85 @@ async function pass2_enrich(opts = {}) {
   return { updated, skipped, errors };
 }
 
+// ── Community references (Story #8 / ADR 0005) ───────────────
+//
+// For each firmware concept carrying a `communityReference`, fetch the
+// community-curated kind-39998 Concept Header from the relay hints and
+// publish it to local strfry WITHOUT re-signing (it is the curator's
+// already-signed event). The Neo4j IMPORT placeholder edge is wired
+// AFTER Pass-3 derive (returned as pending), since the community node
+// does not exist until derive turns the published event into a node.
+//
+// Graceful by contract: a relay miss, id mismatch, or any error logs and
+// continues — it never throws out of install (AC-3). The local firmware
+// concept is created exactly as before.
+
+async function pass_communityReferences(opts = {}) {
+  const { dryRun = false } = opts;
+  const manifest = firmware.getManifest();
+  const taPubkey = firmware.getTAPubkey();
+  const pending = [];
+
+  console.log('\n── Community references ──\n');
+
+  for (const entry of manifest.concepts) {
+    const cr = entry.communityReference;
+    if (!cr || !cr.headerATag) continue;
+    const slug = entry.slug;
+
+    try {
+      const parts = String(cr.headerATag).split(':'); // 39998:<curatorPk>:<dTag>
+      if (parts.length < 3 || parts[0] !== '39998') {
+        console.log(`  ⚠️  ${slug}: malformed communityReference.headerATag "${cr.headerATag}" — skipped`);
+        continue;
+      }
+      const curatorPk = parts[1];
+      const dTag = parts.slice(2).join(':');
+
+      const filter = cr.knownGoodEventId
+        ? { ids: [cr.knownGoodEventId] }
+        : { kinds: [39998], authors: [curatorPk], '#d': [dTag] };
+      const relays = (cr.relayHints || []).join(',');
+
+      if (dryRun) {
+        console.log(`  (dry-run) ${slug} → ${cr.headerATag} via ${relays}`);
+        continue;
+      }
+
+      const fetched = await apiGet('/api/relay/external', {
+        filter: JSON.stringify(filter),
+        relays,
+      });
+      const ev = fetched && Array.isArray(fetched.events) ? fetched.events[0] : null;
+
+      if (!ev) {
+        console.log(`  ⚠️  ${slug}: community Header not found on relay hints — skipped (graceful)`);
+        continue;
+      }
+      if (cr.knownGoodEventId && ev.id !== cr.knownGoodEventId) {
+        console.log(`  ⚠️  ${slug}: fetched id ${ev.id} ≠ knownGoodEventId — skipped (graceful)`);
+        continue;
+      }
+
+      // Pass the already-signed foreign event through unchanged (no re-sign —
+      // you cannot sign someone else's event). Pass-3 derive will turn it
+      // into a distinct foreign node (uuid = its own a-tag).
+      await apiPost('/api/strfry/publish', { event: ev });
+
+      pending.push({
+        slug,
+        from: `39998:${taPubkey}:${slug}`,
+        to: cr.headerATag,
+      });
+      console.log(`  ✅ ${slug}: community Header published locally → IMPORT pending`);
+    } catch (err) {
+      console.log(`  ❌ ${slug}: ${err.message} (graceful — continuing)`);
+    }
+  }
+
+  return { pending };
+}
+
 // ── Full install ─────────────────────────────────────────────
 
 async function install(opts = {}) {
@@ -1002,6 +1081,10 @@ async function install(opts = {}) {
   if (pass2) {
     p2Result = await pass2_enrich({ dryRun });
   }
+
+  // Community references: fetch + publish before Pass-3 derive so the
+  // community Header becomes a node; the IMPORT edge is wired post-derive.
+  const crResult = await pass_communityReferences({ dryRun });
 
   // ── Pass 3: Derive + Apply Enumerations + Wire Implicit Elements ──
   let p3Result = null;
@@ -1047,6 +1130,28 @@ async function install(opts = {}) {
     }
 
     console.log('');
+  }
+
+  // ── Community-reference IMPORT edges (post-derive) ──────────
+  // The community Header is now a node (Pass-3 derived it). MERGE the
+  // Neo4j-only placeholder: local Concept Header -[:IMPORT]-> community
+  // Header. MERGE ⇒ idempotent across re-installs (AC-5). Graceful: a
+  // missing community node (derive lagged / fetch was skipped) just
+  // wires no edge — never throws.
+  if (!dryRun && crResult && crResult.pending && crResult.pending.length) {
+    console.log('\n── Community-reference IMPORT edges ──\n');
+    for (const link of crResult.pending) {
+      try {
+        await runCypherApi(
+          `MATCH (a:NostrEvent {uuid:$from}), (b:NostrEvent {uuid:$to})
+           MERGE (a)-[:IMPORT]->(b)`,
+          { from: link.from, to: link.to }
+        );
+        console.log(`  ✅ ${link.slug}: IMPORT → ${link.to}`);
+      } catch (err) {
+        console.log(`  ⚠️  ${link.slug}: IMPORT wiring skipped — ${err.message} (graceful)`);
+      }
+    }
   }
 
   console.log('\n╔══════════════════════════════════════════════════════════╗');
@@ -1176,4 +1281,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { install, pass1_bootstrap, pass2_enrich, handleFirmwareInstall };
+module.exports = { install, pass1_bootstrap, pass2_enrich, pass_communityReferences, handleFirmwareInstall };

--- a/src/firmware/install.js
+++ b/src/firmware/install.js
@@ -1142,6 +1142,19 @@ async function install(opts = {}) {
     console.log('\n── Community-reference IMPORT edges ──\n');
     for (const link of crResult.pending) {
       try {
+        // The edge is real only if the community node exists. MATCH...MERGE
+        // silently no-ops (no error, no edge) when it is absent, so check
+        // presence first and log accurately — the Reviewer-required smoke
+        // reads this line as M1 evidence (review finding #2).
+        const found = await runCypherApi(
+          `MATCH (b:NostrEvent {uuid:$to}) RETURN count(b) AS cnt`,
+          { to: link.to }
+        );
+        const present = ((found && found.data) || [])[0]?.cnt || 0;
+        if (!present) {
+          console.log(`  ⏭️  ${link.slug}: community node ${link.to} not present yet — IMPORT deferred (graceful)`);
+          continue;
+        }
         await runCypherApi(
           `MATCH (a:NostrEvent {uuid:$from}), (b:NostrEvent {uuid:$to})
            MERGE (a)-[:IMPORT]->(b)`,

--- a/test/community-reference-nostr-relay-stub.test.js
+++ b/test/community-reference-nostr-relay-stub.test.js
@@ -1,0 +1,181 @@
+/**
+ * Story #8: Community-reference pointer — Nostr Relay stub.
+ * ADR 0005 (Accepted; depends on ADR 0004) — Option A: a firmware
+ * `communityReference` manifest field + an idempotent firmware-install
+ * sub-pass that fetches the community kind-39998 Header via the existing
+ * /api/relay/external, publishes it to local strfry WITHOUT re-signing, and
+ * MERGEs a Neo4j-only `IMPORT` placeholder edge (local Header → community
+ * Header), failing gracefully (never throws out of install).
+ *
+ * Precedent: stories #5 / #6. The behavioral round-trip — a real community
+ * Header fetched off a relay, imported as a distinct foreign node, the IMPORT
+ * edge present, graceful skip when no relay carries it, knownGoodEventId
+ * mismatch handling, and re-install idempotency — needs a live firmware
+ * install + relays + Neo4j and is NOT reproducible in this hand-rolled
+ * runner. It is the **authoritative behavioral gate via local docker smoke
+ * (cycle-local) + staging**, documented in the test plan §"Not covered".
+ * The Reviewer must treat that smoke as required, not optional.
+ *
+ * TI1, TI2 : FAIL pre-implementation, PASS post.
+ * RI1, RI2 : PASS pre AND post — scope guards. RI1 flips to FAIL if the
+ *            Implementer drifts to ADR Option B (a first-class IMPORT
+ *            firmware relationship-type). RI2 flips if the Implementer edits
+ *            files ADR 0005 declared "No source change".
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const MANIFEST = path.join(ROOT, 'firmware/active/manifest.json');
+const INSTALL = path.join(ROOT, 'src/firmware/install.js');
+const NO_TOUCH = [
+  'src/api/relay/fetchEvents.js',
+  'src/api/strfry/commands/publishEvent.js',
+  'src/api/tapestry-key/index.js',
+];
+
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'Assertion failed');
+}
+
+// ---------------------------------------------------------------------------
+// Failing tests — FAIL now, PASS once Story #8 is implemented per ADR 0005.
+// ---------------------------------------------------------------------------
+
+test('TI1: firmware manifest carries a well-formed `communityReference` on the nostr-relay concept (AC-1, ADR 0005)', () => {
+  const m = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+  const entry = (m.concepts || []).find((c) => c.slug === 'nostr-relay');
+  assert(entry, 'nostr-relay concept entry not found in firmware/active/manifest.json (firmware shape changed?).');
+  const cr = entry.communityReference;
+  assert(
+    cr && typeof cr === 'object',
+    'nostr-relay concept entry has no `communityReference` (AC-1). ADR 0005 Implementation ' +
+      'notes: add `communityReference: { headerATag, relayHints[], knownGoodEventId? }` to ' +
+      'the nostr-relay entry in the versioned firmware manifest.'
+  );
+  assert(
+    typeof cr.headerATag === 'string' && /^39998:[0-9a-f]{64}:nostr-relay$/.test(cr.headerATag),
+    '`communityReference.headerATag` must be a kind-39998 a-tag `39998:<64-hex curator pubkey>:nostr-relay` ' +
+      `(AC-1). Got: ${JSON.stringify(cr.headerATag)}.`
+  );
+  assert(
+    Array.isArray(cr.relayHints) &&
+      cr.relayHints.length > 0 &&
+      cr.relayHints.every((r) => typeof r === 'string' && /^wss?:\/\//.test(r)),
+    '`communityReference.relayHints` must be a non-empty array of ws(s):// URLs (ADR 0005: ' +
+      'defaults to the PUBLISH_RELAYS set per ADR 0004 so it matches what export emits). Got: ' +
+      `${JSON.stringify(cr.relayHints)}.`
+  );
+  assert(
+    cr.knownGoodEventId === undefined ||
+      (typeof cr.knownGoodEventId === 'string' && /^[0-9a-f]{64}$/.test(cr.knownGoodEventId)),
+    '`communityReference.knownGoodEventId`, when present, must be a 64-hex event id (AC-4 ' +
+      `integrity pin). Got: ${JSON.stringify(cr.knownGoodEventId)}.`
+  );
+});
+
+test('TI2: install.js has a graceful community-reference sub-pass, wired before Pass-3 derive (AC-1/AC-3/AC-5, ADR 0005)', () => {
+  const src = fs.readFileSync(INSTALL, 'utf8');
+
+  const iRelay = src.indexOf('/api/relay/external');
+  const iStrfry = src.indexOf('/api/strfry/publish');
+  const iImport = src.search(/:\s*IMPORT\s*\]/);
+  const iDerive = src.indexOf('/api/tapestry-key/derive-all/');
+
+  assert(
+    iRelay !== -1,
+    'install.js does not fetch the community Header via `/api/relay/external` (AC-1). ' +
+      'ADR 0005: the sub-pass builds a {kinds:[39998],authors:[curatorPk],"#d":[slug]} (or ' +
+      'ids:[knownGoodEventId]) filter and calls the existing /api/relay/external.'
+  );
+  assert(
+    iStrfry !== -1,
+    'install.js does not publish the fetched community Header via `/api/strfry/publish` ' +
+      '(AC-1). ADR 0005: pass the already-signed foreign event through WITHOUT re-signing, ' +
+      'so the existing derive turns it into a distinct foreign node.'
+  );
+  assert(
+    iImport !== -1,
+    'install.js never MERGEs an `[:IMPORT]` edge (AC-2 placeholder). ADR 0005: ' +
+      'MERGE (localHeader)-[:IMPORT]->(communityHeader), Neo4j-only, idempotent.'
+  );
+  assert(
+    iDerive !== -1,
+    'install.js Pass-3 derive marker `/api/tapestry-key/derive-all/` not found ' +
+      '(install flow changed? — re-baseline this ordering sentinel).'
+  );
+  assert(
+    iRelay !== -1 && iDerive !== -1 && iRelay < iDerive,
+    'The community-reference sub-pass must be wired BEFORE the Pass-3 derive block (ADR 0005: ' +
+      '"after pass1_bootstrap, before the Pass-3 derive block" — the published community Header ' +
+      'must exist in strfry before derive runs so it becomes a node). Found /api/relay/external ' +
+      `at ${iRelay}, derive-all at ${iDerive}.`
+  );
+  // Graceful: a per-concept try/catch must exist in the community-ref region
+  // (ADR 0005 / AC-3 / AC-5: a miss or error must never throw out of install).
+  const region = src.slice(iRelay === -1 ? 0 : iRelay, iDerive === -1 ? src.length : iDerive);
+  assert(
+    /\btry\s*\{/.test(region) && /\bcatch\s*\(/.test(region),
+    'The community-reference sub-pass must wrap each concept in try/catch and never throw out ' +
+      'of install (AC-3 graceful degradation: relay miss / id-mismatch / error ⇒ log + continue; ' +
+      'the local firmware concept is created exactly as before).'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Regression sentinels — PASS now AND post-implementation.
+// ---------------------------------------------------------------------------
+
+test('RI1: no first-class IMPORT firmware relationship-type added (ADR 0005 chose Option A, rejected Option B)', () => {
+  const m = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+  assert(
+    Array.isArray(m.relationshipTypes) && m.relationshipTypes.length === 11,
+    `manifest.relationshipTypes must stay at the known 11 (Option A: the IMPORT edge is ` +
+      `Neo4j-only, NOT a firmware relationship-type). Found ${m.relationshipTypes && m.relationshipTypes.length}. ` +
+      'A change here means the Implementer drifted into ADR 0005 Option B (out of scope; ' +
+      'belongs to plan item (1)).'
+  );
+  const importRel = m.relationshipTypes.filter((r) => /import/i.test(JSON.stringify(r)));
+  assert(
+    importRel.length === 0,
+    'A relationship-type referencing IMPORT was registered in the firmware manifest — that is ' +
+      'ADR 0005 Option B (protocol-correct signed IMPORT), explicitly deferred. The stub keeps ' +
+      'IMPORT as a Neo4j-only edge.'
+  );
+});
+
+test('RI2: ADR-0005 "No source change" files stay free of community-reference logic', () => {
+  for (const rel of NO_TOUCH) {
+    const s = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+    assert(
+      !/community[-\s]?[Rr]eference|communityReference/.test(s),
+      `${rel} gained community-reference logic. ADR 0005 Implementation notes: "No source ` +
+        `change to fetchEvents.js / publishEvent.js / tapestry-key/index.js — reuse as-is." ` +
+        `The new behavior belongs only in src/firmware/install.js + the firmware manifest.`
+    );
+  }
+});
+
+async function run() {
+  let pass = 0;
+  let fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/publish-export-a-concept.test.js
+++ b/test/publish-export-a-concept.test.js
@@ -1,0 +1,152 @@
+/**
+ * Story #9: Publish/export a concept to the community.
+ * ADR 0004 (Accepted) — Concept-Graph-rooted export; own-authored TA-signed
+ * events only; Header as the graceful floor; reuse the existing browser
+ * publish primitive (`publishEverywhere`); owner-only.
+ *
+ * Precedent: stories #5 / #6 / strfry-router-first-boot — the deterministic
+ * part of a relay/Neo4j feature is pinned with source/structural sentinels;
+ * the actual round-trip (events landing on relays, foreign nodes excluded,
+ * idempotency, partial-failure reporting, owner-only enforcement) is NOT
+ * reproducible in this hand-rolled Node runner and is the **authoritative
+ * behavioral gate via local docker smoke (cycle-local) + staging**, documented
+ * in the test plan §"Not covered". The Reviewer must treat that smoke as
+ * required, not optional.
+ *
+ * Deliberate limitation (read this): ADR 0004 left the exact route name/path
+ * open ("new handler under src/api/concept/ OR extend src/api/concept-graph/").
+ * These sentinels therefore pin the **stable contract** the ADR did fix —
+ * (a) the feature is wired through the existing publish primitive, (b) export
+ * is provenance-filtered to this instance's own pubkey — WITHOUT prescribing
+ * the open mechanism. A semantically-correct implementation that renames
+ * things keeps these green by updating the anchor; a missing or
+ * provenance-unsafe implementation fails.
+ *
+ * TE1, TE2 : FAIL pre-implementation, PASS post.
+ * RE1      : PASS pre AND post — scope guard; a flip to FAIL means the
+ *            Implementer drifted to ADR Option B (new server-side external
+ *            publisher) or changed the out-of-scope publish primitive.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const NOSTR_PUBLISH = path.join(ROOT, 'ui/src/utils/nostrPublish.js');
+
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'Assertion failed');
+}
+
+/** Recursively collect .js/.jsx files under a dir (no node_modules under these trees). */
+function collect(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...collect(p));
+    else if (/\.(js|jsx)$/.test(e.name)) out.push(p);
+  }
+  return out;
+}
+
+const UI_FILES = collect(path.join(ROOT, 'ui/src'));
+const API_FILES = collect(path.join(ROOT, 'src/api'));
+
+// A concept-scoped export/publish token (distinct from the existing
+// per-PROFILE publishEverywhere usage in ui/src/hooks/useProfileActions.js).
+const CONCEPT_EXPORT = /export-set|publish[-\s.]{0,3}concept|concept[\s\S]{0,40}export/i;
+
+// ---------------------------------------------------------------------------
+// Failing tests — FAIL now, PASS once Story #9 is implemented per ADR 0004.
+// ---------------------------------------------------------------------------
+
+test('TE1: a "publish concept" action is wired through the existing publishEverywhere primitive (AC-1, ADR 0004 Option A)', () => {
+  const wired = UI_FILES.some((f) => {
+    const s = fs.readFileSync(f, 'utf8');
+    return s.includes('publishEverywhere') && CONCEPT_EXPORT.test(s);
+  });
+  assert(
+    wired,
+    'No UI surface pairs a concept event-set export with `publishEverywhere` (AC-1; ADR 0004 ' +
+      'Option A: the owner "Publish concept" action loops the existing browser publish primitive ' +
+      'over the concept\'s constituent events). The existing per-profile use of publishEverywhere ' +
+      'in useProfileActions.js does NOT satisfy this — a concept-scoped export/publish path must ' +
+      'exist. STRUCTURAL sentinel only; the authoritative proof (events actually reach the ' +
+      'community relays, Concept-Graph-rooted) is the local/staging smoke in the test plan.'
+  );
+});
+
+test('TE2: a server endpoint enumerates a concept\'s OWN-authored events (provenance filter to this TA pubkey) (AC-2/AC-6, ADR 0004)', () => {
+  const ok = API_FILES.some((f) => {
+    const s = fs.readFileSync(f, 'utf8');
+    const isExport = CONCEPT_EXPORT.test(s);
+    const provenance =
+      /getTAPubkey|getOwnerAssistantPubkey/.test(s) &&
+      /\bpubkey\b\s*[:=]|n\.pubkey|\.pubkey\s*=|pubkey\s*===|WHERE[\s\S]{0,80}pubkey/i.test(s);
+    return isExport && provenance;
+  });
+  assert(
+    ok,
+    'No server export path enumerates a concept\'s constituent events filtered to THIS ' +
+      'instance\'s own/TA pubkey (AC-2 provenance principle: you never re-export someone ' +
+      'else\'s concept under your identity; ADR 0004 Implementation notes: `WHERE node.pubkey ' +
+      '= <TA pubkey>`). Owner-only enforcement (AC-6) and the actual exclusion of foreign ' +
+      'nodes are the authoritative local/staging smoke gate — this sentinel only pins that ' +
+      'the provenance filter is present in source.'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Regression sentinel — PASS now AND post-implementation.
+// ---------------------------------------------------------------------------
+
+test('RE1: publish primitive reused unchanged; no ADR-Option-B server-side external publisher introduced', () => {
+  const np = fs.readFileSync(NOSTR_PUBLISH, 'utf8');
+  assert(
+    /export\s+(async\s+)?function\s+publishEverywhere/.test(np) && /PUBLISH_RELAYS\s*=/.test(np),
+    'ui/src/utils/nostrPublish.js must keep exporting `publishEverywhere` and defining ' +
+      '`PUBLISH_RELAYS` (ADR 0004 Option A: reuse as-is, "No change to nostrPublish.js"). ' +
+      'Sentinel failing ⇒ the out-of-scope publish primitive was altered.'
+  );
+  const optionB = API_FILES.find((f) => {
+    const s = fs.readFileSync(f, 'utf8');
+    return /SimplePool/.test(s) && /\.publish\s*\(/.test(s);
+  });
+  assert(
+    !optionB,
+    'A server-side external-relay publisher (SimplePool + .publish()) was introduced' +
+      (optionB ? ` in ${path.relative(ROOT, optionB)}` : '') +
+      ' — that is ADR 0004 Option B, explicitly REJECTED for this stub. Export must reuse the ' +
+      'browser-side publish path (Option A). (Pre-impl: fetchEvents.js uses SimplePool.querySync ' +
+      'for FETCH only, never .publish — this guard holds.)'
+  );
+});
+
+async function run() {
+  let pass = 0;
+  let fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -28,6 +28,8 @@ const scheduledRefresh = require('./scheduled-search-and-house-scores-refresh.te
 const strfryRouterFirstBoot = require('./strfry-router-first-boot-config.test.js');
 const perQueryNeo4jTimeout = require('./per-query-neo4j-timeout-safety-net.test.js');
 const nip05CheckmarkVerification = require('./nip05-checkmark-verification.test.js');
+const publishExportConcept = require('./publish-export-a-concept.test.js');
+const communityReferenceStub = require('./community-reference-nostr-relay-stub.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -50,6 +52,12 @@ async function main() {
   console.log('\nnip05-checkmark-verification suite:');
   const nip05CheckmarkVerificationResult = await nip05CheckmarkVerification.run();
 
+  console.log('\npublish-export-a-concept suite:');
+  const publishExportConceptResult = await publishExportConcept.run();
+
+  console.log('\ncommunity-reference-nostr-relay-stub suite:');
+  const communityReferenceStubResult = await communityReferenceStub.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -68,6 +76,12 @@ async function main() {
   console.log(
     `nip05-checkmark-verification suite:              ${nip05CheckmarkVerificationResult.fail === 0 ? 'PASS' : 'FAIL'} (${nip05CheckmarkVerificationResult.pass} passed, ${nip05CheckmarkVerificationResult.fail} failed)`
   );
+  console.log(
+    `publish-export-a-concept suite:                  ${publishExportConceptResult.fail === 0 ? 'PASS' : 'FAIL'} (${publishExportConceptResult.pass} passed, ${publishExportConceptResult.fail} failed)`
+  );
+  console.log(
+    `community-reference-nostr-relay-stub suite:      ${communityReferenceStubResult.fail === 0 ? 'PASS' : 'FAIL'} (${communityReferenceStubResult.pass} passed, ${communityReferenceStubResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -75,7 +89,9 @@ async function main() {
     scheduledRefreshResult.fail === 0 &&
     strfryRouterFirstBootResult.fail === 0 &&
     perQueryNeo4jTimeoutResult.fail === 0 &&
-    nip05CheckmarkVerificationResult.fail === 0;
+    nip05CheckmarkVerificationResult.fail === 0 &&
+    publishExportConceptResult.fail === 0 &&
+    communityReferenceStubResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/ui/src/pages/concepts/ConceptDetail.jsx
+++ b/ui/src/pages/concepts/ConceptDetail.jsx
@@ -1,9 +1,10 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useParams, NavLink, Outlet } from 'react-router-dom';
 import { useCypher } from '../../hooks/useCypher';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import useProfiles from '../../hooks/useProfiles';
 import AuthorCell from '../../components/AuthorCell';
+import { publishEverywhere } from '../../utils/nostrPublish';
 
 export default function ConceptDetail() {
   const { uuid } = useParams();
@@ -26,6 +27,48 @@ export default function ConceptDetail() {
     [concept?.author]
   );
   const profiles = useProfiles(authorPubkeys);
+
+  // Story #9 / ADR 0004 — owner publishes this concept to the community.
+  // Server enumerates the own-authored (TA) event set (Concept-Graph-rooted,
+  // owner-only); we re-publish each via the existing publishEverywhere
+  // primitive. Non-owners get a server error surfaced in the status line.
+  const [publishStatus, setPublishStatus] = useState(null);
+  const [publishing, setPublishing] = useState(false);
+
+  const publishConcept = async () => {
+    setPublishing(true);
+    setPublishStatus('Collecting concept events…');
+    try {
+      const resp = await fetch(`/api/concept/${encodeURIComponent(decodedUuid)}/export-set`);
+      const data = await resp.json();
+      if (!resp.ok || !data.success) {
+        setPublishStatus(`Error: ${data.error || `HTTP ${resp.status}`}`);
+        return;
+      }
+      const events = data.events || [];
+      if (events.length === 0) {
+        setPublishStatus('Nothing to publish — no own-authored events for this concept.');
+        return;
+      }
+      let ok = 0;
+      let fail = 0;
+      for (const ev of events) {
+        setPublishStatus(`Publishing ${ok + fail + 1}/${events.length}…`);
+        try {
+          const r = await publishEverywhere(ev);
+          if (r?.local?.success || (r?.external?.successes?.length > 0)) ok++;
+          else fail++;
+        } catch {
+          fail++;
+        }
+      }
+      setPublishStatus(`Published ${ok}/${events.length} concept events to the community${fail ? ` (${fail} failed)` : ''}.`);
+    } catch (err) {
+      setPublishStatus(`Error: ${err.message}`);
+    } finally {
+      setPublishing(false);
+    }
+  };
 
   const tabs = [
     { to: '', label: 'Overview', end: true },
@@ -52,6 +95,19 @@ export default function ConceptDetail() {
             <span className="meta-item">UUID: <code>{concept.uuid}</code></span>
             <span className="meta-item">Elements: <strong>{concept.elementCount}</strong></span>
             <span className="meta-item">Author: <AuthorCell pubkey={concept.author} profiles={profiles} /></span>
+          </div>
+
+          <div className="concept-actions">
+            <button
+              type="button"
+              className="btn"
+              onClick={publishConcept}
+              disabled={publishing}
+              title="Publish this concept's own-authored events to the community relays"
+            >
+              {publishing ? 'Publishing…' : 'Publish concept to community'}
+            </button>
+            {publishStatus && <span className="meta-item" style={{ marginLeft: '0.75rem' }}>{publishStatus}</span>}
           </div>
 
           <nav className="tab-nav">

--- a/ui/src/pages/concepts/ConceptDetail.jsx
+++ b/ui/src/pages/concepts/ConceptDetail.jsx
@@ -28,10 +28,13 @@ export default function ConceptDetail() {
   );
   const profiles = useProfiles(authorPubkeys);
 
-  // Story #9 / ADR 0004 — owner publishes this concept to the community.
-  // Server enumerates the own-authored (TA) event set (Concept-Graph-rooted,
-  // owner-only); we re-publish each via the existing publishEverywhere
-  // primitive. Non-owners get a server error surfaced in the status line.
+  // Story #9 / ADR 0004 (Rev 1) — owner publishes this concept to the
+  // community. Server enumerates the own-authored (TA) event set
+  // (Concept-Graph-rooted, owner-only); we re-publish each via the existing
+  // publishEverywhere primitive, targeting ONLY the DList relay
+  // wss://dcosl.brainstorm.world (not the general-purpose PUBLISH_RELAYS) so
+  // we don't pollute popular relays. Non-owners get a server error surfaced.
+  const CONCEPT_PUBLISH_RELAYS = ['wss://dcosl.brainstorm.world'];
   const [publishStatus, setPublishStatus] = useState(null);
   const [publishing, setPublishing] = useState(false);
 
@@ -55,7 +58,7 @@ export default function ConceptDetail() {
       for (const ev of events) {
         setPublishStatus(`Publishing ${ok + fail + 1}/${events.length}…`);
         try {
-          const r = await publishEverywhere(ev);
+          const r = await publishEverywhere(ev, CONCEPT_PUBLISH_RELAYS);
           if (r?.local?.success || (r?.external?.successes?.length > 0)) ok++;
           else fail++;
         } catch {

--- a/ui/src/utils/nostrPublish.js
+++ b/ui/src/utils/nostrPublish.js
@@ -88,14 +88,17 @@ export async function publishToRelays(signedEvent, relays = PUBLISH_RELAYS) {
 }
 
 /**
- * Publish a signed event to both local strfry and all external relays.
+ * Publish a signed event to local strfry and a set of external relays.
  * @param {object} signedEvent - A fully signed nostr event
+ * @param {string[]} [relays=PUBLISH_RELAYS] - External relay targets. Defaults
+ *   to PUBLISH_RELAYS so every existing caller is unchanged; the concept-export
+ *   path passes a restricted DList relay set (ADR 0004 Rev 1).
  * @returns {Promise<{local: object, external: {successes: string[], failures: string[]}}>}
  */
-export async function publishEverywhere(signedEvent) {
+export async function publishEverywhere(signedEvent, relays = PUBLISH_RELAYS) {
   const [local, external] = await Promise.all([
     publishToLocalStrfry(signedEvent),
-    publishToRelays(signedEvent),
+    publishToRelays(signedEvent, relays),
   ]);
   return { local, external };
 }


### PR DESCRIPTION
## Summary

Promotes staging to main after green verification on `staging.brainstorm.world` (deploy run 26039742908).

## Bundled

- **#156** — Community-reference stub (Story #8) + concept export (Story #9). Firmware `communityReference` pointer + `pass_communityReferences` (graceful fetch/publish, post-derive idempotent Neo4j-only `IMPORT` MERGE); owner-only `GET /api/concept/:handle/export-set` (Concept-Graph-rooted, own-authored provenance); relay-parameterized `publishEverywhere`; concept export publishes to `wss://dcosl.brainstorm.world` only (ADR 0004/0005 Rev 1). Full engineering-team chain in history (ADR→test→impl→review→ADR rev→re-impl→re-review PASS).

## Net production impact

New owner-only endpoint and a "Publish concept to community" action on the concept detail page. No behavior change for unauthenticated users or existing `publishEverywhere` callers (default arg unchanged). The firmware `communityReference` only takes effect on a manual `POST /api/firmware/install`; until brainstorm.world's owner runs the concept export, import graceful-degrades (no-op, concept intact). No forced sign-out, no data migration.

## Verification trail

- Staging deploy run 26039742908 — success, 1m29s.
- Staging smoke PASS: Tier 1 stability, Tier 2 sanity, Tier 3a export-set → 401 unauthenticated, Tier 3b nostr-relay concept intact + no spurious IMPORT edge, Tier 5 regression.
- `npm test` green (4 spec sentinels + 3 scope guards + 6 pre-existing suites); cycle-local verified import graceful-degradation end-to-end.

## Test plan

- [ ] After merge: deploy-brainstorm.yml runs to completion.
- [ ] Smoke on brainstorm.world: stability, sanity.
- [ ] `GET /api/concept/<39998 handle>/export-set` → 401 Not authenticated.
- [ ] prod nostr-relay concept intact; IMPORT edge absent until the owner runs the M1-closing export (expected).
- [ ] Tier 5 regression: no collateral breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)