### PR TITLE
docs: ADR 0006 + BIBLE §22 community-reference theory

### DIFF
--- a/BIBLE.md
+++ b/BIBLE.md
@@ -290,6 +290,7 @@ strfry replaces existing events (kind 39999 is replaceable), and Neo4j MERGEs on
 | `IMPORT` | "I agree with your concept definition" — implies IS_A_SUPERSET_OF between supersets |
 | `SUPERCEDES` | "I've evaluated your definition and replaced it with mine" — non-destructive |
 | `PROVIDED_THE_TEMPLATE_FOR` | Provenance link from original to forked node |
+| `REFERENCES` (concept-level) | Deferred non-committal pointer: local Concept Header → an external curator's Concept Header. Neo4j-only, carries `source`. NOT an explicit event, NOT agreement, NOT `IS_A_SUPERSET_OF`. Disambiguate from the tag-level `REFERENCES` (`NostrEventTag → NostrEvent`, every `e`/`a` tag) by endpoint labels + `source`. See §22. |
 
 #### Infrastructure
 | Relationship | Meaning |
@@ -1528,7 +1529,10 @@ docker compose exec tapestry strfry sync wss://dcosl.brainstorm.world \
 | **GrapeRank** | "PageRank for people" — iterative, personalized-per-observer trust scoring. Weighted average of raters' influence × rating × rating confidence, with an attenuation factor on non-observer raters. Converges to a fixed point determined purely by the observer pubkey and the rating graph. |
 | **Grapevine** | The Web of Trust system that determines which curations achieve community consensus. |
 | **IMPORT** | Editorial relationship: "I agree with your concept and want to benefit from your curated elements." |
+| **communityReference** | A firmware-concept pointer `{ headerATag, relayHints[], knownGoodEventId? }` to an external curator's published concept. Resolved at install into a `REFERENCES` placeholder. See §22. |
+| **grapevine → firmware → none** | The community-reference resolution precedence: the user's Grapevine is the correct selector of "the community's definition"; the firmware-baked pointer is only a cold-start default; else nothing. Mirrors Warm Start's `self → owner → cold`. See §22. |
 | **Loose Consensus** | When two users' WoTs overlap enough to converge on the same definition without central coordination. |
+| **REFERENCES (concept-level)** | Neo4j-only deferred stub edge: local Concept Header → an external curator's Concept Header (`source` set). NOT agreement/import. Overloaded with the tag-level `REFERENCES`; disambiguate by endpoint labels + `source`. See §22. |
 | **Meilisearch** | Full-text search engine used for profile search. Runs as a separate Docker container (`nostr-search-meili`). Indexes 2M+ kind 0 profiles with sub-10ms query times. |
 | **NIP-05** | Nostr verification standard. A NIP-05 identifier (e.g., `bob@example.com`) is verified by fetching `https://domain/.well-known/nostr.json?name=bob` and checking the pubkey mapping. |
 | **NIP-07** | Nostr browser extension signing standard. Used for authentication. |
@@ -1546,6 +1550,28 @@ docker compose exec tapestry strfry sync wss://dcosl.brainstorm.world \
 | **Warm Start** | An opt-in GrapeRank initialization mode that seeds scorecards from previously-computed scores instead of `[0,0,0,0]`. Three sources in tiered fallback: `self` (customer's own prior scores), `owner` (owner's `NostrUser` scores when the owner is within 3 directed FOLLOWS hops downstream of the customer), and `cold` (no seed available; legacy behavior). Typically cuts customer GrapeRank runtime from ~20 min to ~5 min. |
 | **Word-wrapper** | The canonical JSON format where every node's data includes a `word` section plus type-specific sections. |
 | **z-tag** | The `z` tag on a ListItem that points to its parent concept's a-tag. Fundamental parent pointer. |
+
+---
+
+## 22. Community-Reference Model
+
+A firmware concept may carry a `communityReference` — `{ headerATag, relayHints[], knownGoodEventId? }` — a **deferred, non-committal pointer** to an external curator's published concept (a kind-39998 Header). At firmware install, `pass_communityReferences` fetches that Header from `relayHints`, republishes it to local strfry **without re-signing**, **explicitly materializes it as a Neo4j node** (`buildImportCypher`/`executeCypher`), then MERGEs `(localHeader)-[:REFERENCES {source:'firmware-community'}]->(communityHeader)`. Idempotent; fully graceful (any miss → log + continue, never throws; the local concept is unaffected).
+
+**The `REFERENCES` edge is a stub, not an assertion.** It means "this external curator's concept is a recognized reference for my local concept; I *may* later pull from it" — not agreement, not "imported," not `IS_A_SUPERSET_OF`. It is distinct from the (deferred) editorial `IMPORT`. One local concept may `REFERENCES` **many** external concepts (e.g. Miles's *Jazz Musicians* and Dizzy's) — many-to-one via distinct target nodes; provenance per-edge via `source`.
+
+**Collision contract (binding).** `REFERENCES` is overloaded: event ingest builds high-volume `(:NostrEventTag)-[:REFERENCES]->(:NostrEvent)` for every `e`/`a` tag. Concept-level `REFERENCES` is disambiguated by **endpoint labels** (`ListHeader→ListHeader`) **and** `r.source` (tag-level never sets it). Any consumer traversal MUST filter on both; a bare `MATCH ()-[:REFERENCES]->()` is a defect.
+
+**Resolution model.** The *correct* long-term selector of "the community's definition" is the user's Grapevine (WoT loose consensus over published curations). The firmware-baked pointer is a **cold-start default**, not the truth. Precedence: **`grapevine-resolved → firmware-blessed → none`** — mirroring the Warm Start tiered fallback (`self → owner → cold`).
+
+**Accepted compromise (Flaw A) and its exit.** A firmware-baked pointer is a *centralized* editorial choice (the dev team picks the blessed curator pubkey — currently the reference deployment's TA). Accepted **temporarily**; the exit is the **registry-as-DList**: the per-concept pointer itself becomes a community-curated, Grapevine-ranked DList, retiring the hardcoded choice.
+
+**Invariants & principles.**
+1. *Relay invariant:* concept export and `communityReference.relayHints` must target the same relay set (the purpose-built DList relay, not general-purpose relays) or the round-trip cannot close.
+2. *Export is own-authored:* you never re-export another curator's concept under your identity.
+3. *Materialization ≠ derive:* publishing to strfry does not create a Neo4j node — Pass-3 derive only computes `tapestryJSON` for nodes already present; ingesting a foreign event requires the explicit eventSync import path.
+4. *Verification:* structural sentinels cannot prove relay + Neo4j + install round-trips — the local/staging/prod smoke is the authoritative behavioral gate (it caught the materialization defect that all structural tests missed).
+
+**Deferred (see ADR 0006):** Header→ConceptGraph single-event tag; privacy tiers; signed/first-class editorial relationship-type; registry-as-DList; element/superset materialization.
 
 ---
 

--- a/engineering-team/decisions/0006-community-reference-theory.md
+++ b/engineering-team/decisions/0006-community-reference-theory.md
@@ -1,0 +1,34 @@
+# ADR 0006: Community-reference protocol model & deferred roadmap
+
+**Status:** Accepted
+**Date:** 2026-05-19
+**Relates to:** ADR 0004 (+Rev 1), ADR 0005 (+Rev 1, Rev 2) — the implementing decisions; 0006 is their theory umbrella.
+
+## Context
+The community-reference + concept-export feature shipped through a long arc (stories #8/#9; ADRs 0004/0005 and three revisions; PRs #156/#157/#158/#159). The *implementation* decisions are recorded, but the *theory* — why it's shaped this way, the resolution model, the accepted compromise and its exit, and the explicitly-deferred protocol/feature streams — lived only in the originating session's transcript. Tapestry Theory belongs in BIBLE.md; ratified decisions belong in an ADR.
+
+## Options considered
+- **Option A — Umbrella theory ADR (0006) + canonical BIBLE §22 + §6/glossary updates (chosen).** One ratifiable theory record; the artifact future cycles get ratified against; the collision contract documented where consumers look.
+- **Option B — Leave theory inside 0004/0005 + revisions.** Rejected: not discoverable as a whole; no single ratifiable model; the deferred roadmap stays tribal memory.
+- **Option C — BIBLE only, no ADR.** Rejected: BIBLE is descriptive, not decision-historied; loses the options/why and the ratification record.
+
+## Decision
+**Option A.** Record the model as ratified theory; defer the rest explicitly with blast radii so each future stream is designed against a written model.
+
+## Consequences
+- Theory is durable + ratifiable; Header→ConceptGraph, privacy tiers, registry-as-DList, materialization, and the signed editorial relationship-type each get designed against BIBLE §22.
+- The `REFERENCES` collision contract is documented where consumers will hit it (BIBLE §6 + glossary).
+- Flaw A and its exit (registry-as-DList) are on the record, not tribal.
+- **Firmware reinstall required?** No. **Blast radius:** docs only.
+
+## Implementation notes
+- New `engineering-team/decisions/0006-community-reference-theory.md` (this file).
+- BIBLE.md: new `## 22. Community-Reference Model` before the maintainer footer; add a concept-level `REFERENCES` row to §6 with the collision contract; glossary entries for `REFERENCES` (concept-level), `communityReference`, and the `grapevine → firmware → none` resolution fallback.
+
+## Out of scope
+Implementing any deferred stream. This ADR only records the model and defers, with blast radius:
+- **Header→ConceptGraph tag** — single-event full retrieval; every header `create-concept` emits + re-derivation of all existing headers + BIBLE §5/§8. Own ADR.
+- **Privacy tiers** (private/encrypted, local/unencrypted, published) — consensus computable only over the published tier by construction; tier-promotion leaks prior versions unless a fresh event is minted. Own ADR.
+- **Signed/first-class editorial relationship-type** (the protocol-correct IMPORT-as-signed-event, ADR 0005 Option B) — firmware relationship-types change → reinstall + cross-instance. Own ADR.
+- **Registry-as-DList** — retires flaw A; the per-concept pointer becomes a community-curated, Grapevine-ranked DList. Own stories/ADR.
+- **Element/superset materialization** — walk the `REFERENCES` edge to pull the community concept's elements/subsets/schema; wants this theory + possibly Header→ConceptGraph first.


### PR DESCRIPTION
## Summary

Docs-only. Records the community-reference + concept-export theory (from the #156–#159 arc) as ratifiable Tapestry Theory: ADR 0006 (umbrella decision + deferred roadmap with blast radii) and a canonical BIBLE §22 the future streams get ratified against. No code, tests, firmware, or behavior change.

## Changes

- `engineering-team/decisions/0006-community-reference-theory.md` (new) — umbrella theory ADR; defers Header→ConceptGraph tag, privacy tiers, signed editorial relationship-type, registry-as-DList, element/superset materialization, each with blast radius.
- `BIBLE.md` — new `§22 Community-Reference Model`; concept-level `REFERENCES` row in §6 (with the collision contract vs the tag-level REFERENCES); 3 glossary entries.

## Test plan

- [ ] After merge: deploy-staging.yml runs green.
- [ ] **Docs-only — nothing to runtime-smoke** (verify by reading; per the cycle skills, doc changes need no rebuild/behavioral check). Confirm: staging.brainstorm.world still serves (stability + sanity), and the diff is a clean 2-file docs delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)