### PR TITLE
Promote staging → main: Header→ConceptGraph tag (story #10)

### DIFF
--- a/BIBLE.md
+++ b/BIBLE.md
@@ -208,6 +208,14 @@ Every ListItem has a `z` tag pointing to its parent concept's a-tag:
 ```
 This is the fundamental link between items and concepts.
 
+### Header→ConceptGraph Pointer (`concept-graph` tag)
+
+Every kind-39998 ConceptHeader emitted by `create-concept` carries a self-describing pointer to its Concept Graph core node:
+```json
+["concept-graph", "39999:<pubkey>:<d-tag>-concept-graph"]
+```
+The value is **computed** from the header's own (signing) pubkey + d-tag — not Neo4j-looked-up — so it is correct even before the Concept Graph node exists. **Resolution contract:** to locate a concept's Concept Graph from only its Header, use the `concept-graph` tag **if present, else compute** `39999:<pubkey>:<d-tag>-concept-graph`. The deterministic fallback covers legacy/firmware headers minted before this tag (no mass re-emit needed) and headers from curators who don't carry it. This lets a single fetched Header self-resolve its full concept off-relay, without the (invisible-off-relay) `IS_THE_CONCEPT_GRAPH_FOR` Neo4j edge. ADR 0007, hybrid design C; the consumer is the deferred element/superset materialization stream.
+
 ### Implicit vs. Explicit Relationships
 
 **Most relationships are implicit** — derived by the graph engine from event structure (z-tags, kind numbers, naming conventions). Only editorial/provenance relationships (IMPORT, SUPERCEDES, PROVIDED_THE_TEMPLATE_FOR, ENUMERATES) are explicit nostr events.
@@ -1529,6 +1537,7 @@ docker compose exec tapestry strfry sync wss://dcosl.brainstorm.world \
 | **GrapeRank** | "PageRank for people" — iterative, personalized-per-observer trust scoring. Weighted average of raters' influence × rating × rating confidence, with an attenuation factor on non-observer raters. Converges to a fixed point determined purely by the observer pubkey and the rating graph. |
 | **Grapevine** | The Web of Trust system that determines which curations achieve community consensus. |
 | **IMPORT** | Editorial relationship: "I agree with your concept and want to benefit from your curated elements." |
+| **concept-graph (header tag)** | Self-describing tag on a kind-39998 ConceptHeader: `["concept-graph","39999:<pubkey>:<d-tag>-concept-graph"]` (computed). Resolution = tag-if-present else compute the same a-tag. Lets a single fetched Header resolve its full concept off-relay. ADR 0007. See §5. |
 | **communityReference** | A firmware-concept pointer `{ headerATag, relayHints[], knownGoodEventId? }` to an external curator's published concept. Resolved at install into a `REFERENCES` placeholder. See §22. |
 | **grapevine → firmware → none** | The community-reference resolution precedence: the user's Grapevine is the correct selector of "the community's definition"; the firmware-baked pointer is only a cold-start default; else nothing. Mirrors Warm Start's `self → owner → cold`. See §22. |
 | **Loose Consensus** | When two users' WoTs overlap enough to converge on the same definition without central coordination. |
@@ -1571,7 +1580,9 @@ A firmware concept may carry a `communityReference` — `{ headerATag, relayHint
 3. *Materialization ≠ derive:* publishing to strfry does not create a Neo4j node — Pass-3 derive only computes `tapestryJSON` for nodes already present; ingesting a foreign event requires the explicit eventSync import path.
 4. *Verification:* structural sentinels cannot prove relay + Neo4j + install round-trips — the local/staging/prod smoke is the authoritative behavioral gate (it caught the materialization defect that all structural tests missed).
 
-**Deferred (see ADR 0006):** Header→ConceptGraph single-event tag; privacy tiers; signed/first-class editorial relationship-type; registry-as-DList; element/superset materialization.
+**Header→ConceptGraph (implemented — ADR 0007, §5):** the `concept-graph` header tag + tag-else-compute resolution makes a single fetched Header self-resolve its full concept off-relay. This is the keystone the still-deferred element/superset materialization will consume.
+
+**Deferred (see ADR 0006):** privacy tiers; signed/first-class editorial relationship-type; registry-as-DList; element/superset materialization.
 
 ---
 

--- a/engineering-team/decisions/0007-header-conceptgraph-tag.md
+++ b/engineering-team/decisions/0007-header-conceptgraph-tag.md
@@ -1,0 +1,35 @@
+# ADR 0007: Header→ConceptGraph self-describing tag (hybrid)
+
+**Status:** Accepted
+**Date:** 2026-05-19
+**Story:** `engineering-team/stories/10-header-conceptgraph-tag.md`
+**Relates to:** ADR 0006 (deferred this stream), BIBLE §22
+
+## Context
+Off-relay, a single kind-39998 Header can't resolve its concept (the `IS_THE_CONCEPT_GRAPH_FOR` Neo4j edge is invisible without the graph). The Concept Graph a-tag is deterministically `39999:<pubkey>:<slug>-concept-graph` (`src/api/normalize/index.js:643`). Ratified design **C (hybrid)**: emit an explicit tag on new headers; resolution = **tag-if-present else compute**. Tapestry's tag idiom (BIBLE §5) is custom semantic tags — `["z","39998:<pubkey>:<dtag>"]`, `["json",…]`, `["d",slug]`; it deliberately does NOT use NIP-01 `a` tags for its pointers. Header build site: `handleCreateConcept` (`src/api/normalize/index.js:1183`).
+
+## Options considered — the tag shape
+- **Option A (chosen) — descriptive custom tag** `["concept-graph", "39999:<pubkey>:<slug>-concept-graph"]`. Mirrors the existing `z`/`json`/`d` custom-semantic idiom; value reuses the exact `kind:pubkey:dtag` form `z` uses; self-describing in `strfry scan`; the role name `concept-graph` already exists in code vocabulary (NODE_ROLES, slugs). Trivial emit/consume.
+- **Option B — NIP-01** `["a","39999:…-concept-graph","<relay-hint>","concept-graph"]`. NIP-01-standard + relay-hint slot, but inconsistent with Tapestry's non-NIP-01 pointer idiom; relay-hint slot unneeded (importer already has `communityReference.relayHints`; per BIBLE §22 relay invariant the curator's concept-graph rides the same relay as their header); multi-`a`+marker parsing heavier. Rejected.
+- **Option C — no tag (convention-only).** = Discovery option B, rejected by the owner (folds into #5, not self-describing). Noted for completeness.
+
+## Decision
+**Option A.** Descriptive custom `concept-graph` tag, value `39999:<header-pubkey>:<header-dtag>-concept-graph`, **computed** (not Neo4j-looked-up — correct even before the concept-graph node exists). Resolution contract: **tag-if-present else compute**. New headers only — hybrid C, no mass re-emit.
+
+## Consequences
+- Unblocks stream #5 (resolve a fetched Header → its Concept Graph: explicit tag, or computed fallback for legacy/firmware headers).
+- `create-concept` emits one extra tag; firmware reinstall regenerates firmware headers with it (deterministic ⇒ idempotent, strfry-replaceable; no special migration).
+- BIBLE §5/§8 + glossary document the tag and the tag-else-compute contract. **BIBLE update required.**
+- No consumer yet; zero behavior change for anything not reading the tag.
+- **Firmware reinstall required?** Recommended (so prod firmware headers become self-describing) but NOT required for correctness — the compute-fallback resolves un-reinstalled/legacy headers.
+- **Blast radius:** `handleCreateConcept` (one tag) + BIBLE docs. Explicitly NOT an every-prod-header re-emit.
+
+## Implementation notes
+- `src/api/normalize/index.js` `handleCreateConcept` (~:1183): when assembling the kind-39998 header tags, add `['concept-graph', \`39999:${pubkey}:${dTag}-concept-graph\`]` (pubkey = header/TA pubkey; dTag = header d-tag/slug). Pure compute — no graph lookup.
+- Idempotent: same inputs → identical tag → strfry-replaceable; Neo4j MERGE-on-uuid unaffected.
+- BIBLE.md: §5 tag vocabulary + the tag-else-compute resolution contract; §8 note; glossary entry; state hybrid (legacy resolves by compute).
+- Tester: structural sentinel that `handleCreateConcept` emits the deterministic tag; behavioral proof = cycle-local (firmware reinstall, `strfry scan`, assert the 39998 header carries `["concept-graph","39999:<TA>:<slug>-concept-graph"]`).
+- No change to materialization / REFERENCES / `communityReference` / export.
+
+## Out of scope
+Consumption/traversal of the pointer (that **is** stream #5); mass re-emit/backfill of existing prod headers; policing foreign-curator tagging (compute-fallback + explicit tag both resolve).

--- a/engineering-team/reviews/10-header-conceptgraph-tag.md
+++ b/engineering-team/reviews/10-header-conceptgraph-tag.md
@@ -29,5 +29,26 @@ None.
 ### Non-blocking
 1. **Sharpen smoke S1 (Reviewer-required).** The structural sentinel only checks the literal pattern. S1 must assert the emitted 39998 header's `concept-graph` tag value **exactly equals** `39999:<instance TA pubkey from /api/assistant/pubkey>:<dtag>-concept-graph` (not just a 64-hex regex) — this is the authoritative end-to-end confirmation that the `pubkey` var is the real signing pubkey. Plus S2 idempotency on reinstall.
 
-## Verdict
-**PASS (code/ADR/scope).** No blocking issues; minimal, ADR-conformant, no regression. Behavioral acceptance gate = the **Reviewer-required cycle-local smoke S1/S2** (sharpened per finding #1), which is the explicitly-authorized immediate next step. #10 AC-1/AC-2 are not "proven" until that smoke is observed. No further code changes required to proceed.
+## Verdict (initial — SUPERSEDED, see Re-review)
+~~**PASS (code/ADR/scope).**~~ Premature — see Re-review below.
+
+---
+
+## Re-review (cycle-local S1 — 2026-05-19) — verdict corrected to CHANGES_REQUESTED
+
+**S1 FAILED.** The emitted `nostr-relay` 39998 header carried `["concept-graph","39999:653030656430...6166653964663336:nostr-relay-concept-graph"]`. The pubkey segment is the **hex of the ASCII** of `e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36` — i.e. **double-encoded**. Root cause: `index.js:1198` `const pubkey = Buffer.from(nt().getPublicKey(privBytes)).toString('hex')` — in this nostr-tools build `getPublicKey` already returns hex, so the `Buffer.from(...).toString('hex')` wrapper re-encodes. The tag's pubkey ≠ the header's real pubkey ⇒ AC-1 broken.
+
+**Reviewer self-correction (candid):** the initial PASS dismissed exactly this risk via code-archaeology ("same idiom as shipped trustedList + load-bearing in dup-check ⇒ must be correct"). That was unsound — under double-encoding the dup-check would *silently never match*, so "it works" was never provable by inspection. The structural sentinel (T1) is pattern-only and stayed green throughout. Only the Reviewer-required behavioral smoke caught it. This is the canonical justification for treating that smoke as **mandatory, not optional** — it did its job.
+
+**Scoped fix applied (Implementer kickback):** `handleCreateConcept` now builds the tag with `nt().getPublicKey(privBytes)` directly (un-wrapped). The shared `pubkey` var at :1198 is **deliberately not touched** — that double-encode is a **pre-existing latent bug** affecting the concept dup-check (`:1206`) and `src/api/trustedList/index.js:44` (and possibly other sites), out of scope for #10 and **spun off as a separate flagged task**.
+
+**Verdict: CHANGES_REQUESTED → re-verifying.** Fix applied; cycle-local S1 (exact tag pubkey == real TA) + S2 (idempotent) re-running. Final PASS only on observed-green S1/S2 + npm test. No scope change; the fix is minimal and within ADR 0007.
+
+### Re-review result (cycle-local, post-fix) — PASS
+
+- **S1 (nostr-relay, authoritative):** real firmware-install-emitted 39998 header carries **exactly** `["concept-graph","39999:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-relay-concept-graph"]`; tag pubkey == `event.pubkey` == real TA. Double-encode resolved. **PASS.**
+- **S2 (idempotent):** second firmware reinstall → byte-identical tag value. **PASS.**
+- **npm test:** header-conceptgraph-tag 2/2 (T1, R1), all prior suites + config green, Overall PASS. Clean container startup.
+- **Ad-hoc direct `POST /api/normalize/create-concept`:** not headlessly testable — owner-auth-gated (`{"error":"Authentication required"}`), same class as export-set/firmware-install. Firmware install exercises the identical `handleCreateConcept` path internally, already proven by S1. Documented caveat, **not** a feature signal.
+
+**Final verdict: PASS.** The CHANGES_REQUESTED defect (pubkey double-encode) is fixed and behaviorally verified on the authoritative cycle-local smoke; scope unchanged; the pre-existing shared-`pubkey` double-encode (`:1198`, `trustedList:44`) is spun off as a separate flagged task. Ready for the deploy chain (cycle-staging → cycle-prod, gated).

--- a/engineering-team/reviews/10-header-conceptgraph-tag.md
+++ b/engineering-team/reviews/10-header-conceptgraph-tag.md
@@ -1,0 +1,33 @@
+# Review: Story #10 — Header→ConceptGraph self-describing tag
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-19
+**Diff:** impl commit `51fcdf33` (vs test-design boundary `2accc87a`)
+**Story/ADR/Plan:** `stories/10-header-conceptgraph-tag.md` · `decisions/0007-header-conceptgraph-tag.md` · `stories/10-header-conceptgraph-tag.test-plan.md`
+
+## Quality gate (run by reviewer, not trusted)
+- [x] `npm test` — **Overall PASS**. header-conceptgraph-tag 2/2 (T1 PASS, R1 PASS); all 8 prior suites + config green. Re-run by reviewer.
+- [x] Lint/typecheck/build — not configured; skipped.
+
+## Spec adherence
+- **AC-1** ✓ — `['concept-graph', \`39999:${pubkey}:${headerDTag}-concept-graph\`]` added to `headerTags` in `handleCreateConcept`. Value computed from `pubkey` (the signing pubkey, see correctness note) + `headerDTag`; no Neo4j lookup → correct even before the concept-graph node exists, per ADR 0007. Behavioral proof = smoke S1.
+- **AC-2** ✓ — deterministic value + kind-39998 replaceable ⇒ idempotent by construction. Behavioral proof = smoke S2.
+- **AC-3** ✓ — tag-else-compute resolution contract documented (BIBLE §5). Consumer is stream #5 (out of scope).
+- **AC-4** ✓ — nothing reads the tag; existing header tag shape preserved (R1 green).
+- **AC-5** ✓ — BIBLE §5 subsection + glossary + §22 deferred-list update. **Placement deviation from ADR's literal "§8 note":** Implementer placed it in §5 (protocol/tags — correct home for an event tag) + glossary + §22 xref, candidly flagged in the commit. Reviewer assessment: this is *more correct* than the ADR note (§8 is word-wrapper JSON, not event tags) — an improvement, not a defect.
+
+## ADR 0007 adherence
+- Option A descriptive `concept-graph` tag ✓; computed not graph-looked-up ✓; new headers only, **no mass re-emit / no migration code** ✓ (hybrid C); resolution contract documented ✓. Blast radius = `handleCreateConcept` (one tag) + BIBLE — diff is exactly 2 files, +18/−1. No new deps. No scope creep.
+
+## Things tests can't catch (reviewer audit)
+- **`pubkey`-var correctness (resolved):** `src/api/normalize/index.js:1198` `Buffer.from(nt().getPublicKey(privBytes)).toString('hex')` is the established working idiom (identical to `src/api/trustedList/index.js:44`, a shipped feature) and is already load-bearing in handleCreateConcept's duplicate-check Cypher (`:1206`, matched against the finalized `event.pubkey`). If it were double-encoded/malformed, concept creation + dup-detection would already be broken — they are not (used throughout this session). Therefore `pubkey` === the header's signing pubkey and the tag value is correct. No defect.
+- No secrets, no debug cruft, no commented-out code, no concurrency surface (pure synchronous tag construction).
+
+## Findings
+### Blocking
+None.
+### Non-blocking
+1. **Sharpen smoke S1 (Reviewer-required).** The structural sentinel only checks the literal pattern. S1 must assert the emitted 39998 header's `concept-graph` tag value **exactly equals** `39999:<instance TA pubkey from /api/assistant/pubkey>:<dtag>-concept-graph` (not just a 64-hex regex) — this is the authoritative end-to-end confirmation that the `pubkey` var is the real signing pubkey. Plus S2 idempotency on reinstall.
+
+## Verdict
+**PASS (code/ADR/scope).** No blocking issues; minimal, ADR-conformant, no regression. Behavioral acceptance gate = the **Reviewer-required cycle-local smoke S1/S2** (sharpened per finding #1), which is the explicitly-authorized immediate next step. #10 AC-1/AC-2 are not "proven" until that smoke is observed. No further code changes required to proceed.

--- a/engineering-team/stories/10-header-conceptgraph-tag.md
+++ b/engineering-team/stories/10-header-conceptgraph-tag.md
@@ -30,5 +30,5 @@ As a consumer of a community-published concept, given only the curator's 39998 H
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/0007-header-conceptgraph-tag.md` (Accepted; Option A — descriptive `concept-graph` tag, hybrid tag-else-compute)
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/10-header-conceptgraph-tag.test-plan.md` (T1 sentinel; behavioral AC-1/AC-2 deferred to cycle-local smoke — authoritative, Reviewer-required)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/10-header-conceptgraph-tag.md
+++ b/engineering-team/stories/10-header-conceptgraph-tag.md
@@ -1,0 +1,34 @@
+# Story 10: Header→ConceptGraph self-describing tag (hybrid)
+
+**Status:** Approved
+**Created:** 2026-05-19
+**Type:** Feature
+
+## Background
+A single fetched kind-39998 Header cannot self-resolve its concept off-relay — the `IS_THE_CONCEPT_GRAPH_FOR` Neo4j edge is invisible without the graph. Discovery established that the Concept Graph node's a-tag is **deterministically computable** from the Header (`39999:<pubkey>:<slug>-concept-graph`, per `src/api/normalize/index.js:643`). Ratified design **C (hybrid)**: new headers carry an explicit pointer tag; resolution is **tag-if-present, else compute** the deterministic a-tag. This is the keystone primitive that later unblocks stream #5 (element/superset materialization). Tracked under ADR 0006 §"Out of scope"; ADR 0007 designs it.
+
+## User-facing description
+As a consumer of a community-published concept, given only the curator's 39998 Header, I can locate its Concept Graph (and thence the full concept) — because the Header is self-describing (or deterministically computable), with no reliance on a Neo4j edge I can't see off-relay.
+
+## Acceptance criteria
+- [ ] A new Header from `POST /api/normalize/create-concept` carries a concept-graph pointer tag whose value is exactly `39999:<header-pubkey>:<header-dtag>-concept-graph`.
+- [ ] Firmware reinstall produces firmware headers carrying the tag; deterministic ⇒ re-runs identical (idempotent), strfry-replaceable.
+- [ ] Headers **without** the tag remain resolvable via the documented compute rule (rule documented in BIBLE; the *consumer* is stream #5, not this story).
+- [ ] Zero behavior change for anything not reading the tag (nothing reads it yet).
+- [ ] BIBLE documents the tag **and** the `tag-else-compute` resolution contract (§5/§8 + glossary).
+
+## Concepts touched
+- Every kind-39998 ConceptHeader emitted by `create-concept` / firmware install (gains one tag). No existing prod header is re-emitted (compute-fallback covers them — the point of hybrid C).
+
+## Out of scope
+- Consumption/traversal of the pointer — that **is** stream #5 (element/superset materialization).
+- Any mass re-emit/backfill/re-derivation of existing prod headers (hybrid C deliberately avoids this; legacy/firmware headers resolve via the compute fallback).
+- Changes to materialization, REFERENCES, the firmware `communityReference`, or export.
+
+## Open questions (resolved in Architecture / ADR 0007)
+- Exact tag key/shape — descriptive custom `["concept-graph","39999:…"]` vs NIP-01 `["a","39999:…","","concept-graph"]`. BIBLE §5 protocol surface; ratified by the user at ADR time.
+
+## Linked artifacts
+- ADR: `engineering-team/decisions/0007-header-conceptgraph-tag.md` (Accepted; Option A — descriptive `concept-graph` tag, hybrid tag-else-compute)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/10-header-conceptgraph-tag.md
+++ b/engineering-team/stories/10-header-conceptgraph-tag.md
@@ -31,4 +31,4 @@ As a consumer of a community-published concept, given only the curator's 39998 H
 ## Linked artifacts
 - ADR: `engineering-team/decisions/0007-header-conceptgraph-tag.md` (Accepted; Option A — descriptive `concept-graph` tag, hybrid tag-else-compute)
 - Test plan: `engineering-team/stories/10-header-conceptgraph-tag.test-plan.md` (T1 sentinel; behavioral AC-1/AC-2 deferred to cycle-local smoke — authoritative, Reviewer-required)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/10-header-conceptgraph-tag.md` — **PASS (code/ADR/scope)**; behavioral acceptance gated on the Reviewer-required cycle-local smoke S1/S2

--- a/engineering-team/stories/10-header-conceptgraph-tag.test-plan.md
+++ b/engineering-team/stories/10-header-conceptgraph-tag.test-plan.md
@@ -1,0 +1,56 @@
+# Test Plan: Story 10 — Header→ConceptGraph self-describing tag (hybrid)
+
+**Story:** `engineering-team/stories/10-header-conceptgraph-tag.md`
+**ADR:** `engineering-team/decisions/0007-header-conceptgraph-tag.md`
+**Date:** 2026-05-19
+
+## Approach
+Precedent: stories #5/#6/#8. The spec-required change is a single deterministic tag emission in `handleCreateConcept`. A source/structural sentinel pins the contract without prescribing pre- vs post-sign computation. Whether the emitted 39998 event actually carries the tag with the right value after a real firmware reinstall is **not** reproducible in the hand-rolled Node runner — that is the **authoritative cycle-local smoke** (Reviewer-required).
+
+## Coverage map
+
+| AC | Test / mechanism | File | Level |
+|---|---|---|---|
+| AC-1 (new header carries deterministic tag) | **T1** pins the `["concept-graph","39999:…-concept-graph"]` emission in `handleCreateConcept`; the *actual emitted event value* is **smoke S1** | test/header-conceptgraph-tag.test.js | source + smoke |
+| AC-2 (firmware reinstall → headers carry it; idempotent) | Deterministic value ⇒ idempotent by construction; **smoke S2** (reinstall twice, identical) | — | smoke |
+| AC-3 (tag-absent headers resolvable by compute rule) | Documented contract (BIBLE); the *consumer* is stream #5 — pinned here only as documentation, exercised by #5 | — | doc / #5 |
+| AC-4 (zero behavior change for non-readers) | **R1** guards the existing header builder; nothing reads the tag (no consumer this story) | test/header-conceptgraph-tag.test.js | source (sentinel) |
+| AC-5 (BIBLE documents tag + contract) | Verified by reading the BIBLE diff at Review | BIBLE.md | doc |
+
+T1 = FAIL pre-impl, PASS post. R1 = PASS pre AND post (out-of-scope guard on the existing 39998 header tag shape).
+
+## Edge cases
+- [x] **No false-match on existing `concept-graph` strings.** The T1 regex is anchored on a tag-literal start (`['concept-graph',` then a `39999:…-concept-graph` value). It does NOT match NODE_ROLES' `'concept-graph'` role string, the `concept-header-for-the-concept-of-…` slugs, or `['z', firmware.conceptUuid('concept-graph')]` — confirmed: T1 FAILs pre-impl.
+- [x] **Pre/post-sign agnostic.** T1 matches whether the value is a template literal, string concat, or built from the signing pubkey post-sign — only the `['concept-graph', …39999:…-concept-graph…]` shape is required, not a specific code path.
+- [ ] **Actual emitted event value / idempotency / firmware-header backfill** — not catchable in source; that's smoke S1/S2.
+
+## Not covered (deferred to cycle-local smoke — authoritative, Reviewer-required)
+Run on the local docker stack (`:7778` per this env; `cycle-local`):
+
+**S1 — AC-1 (real emission):** `POST /api/firmware/install`, then `strfry scan '{"kinds":[39998]}'`; assert the `nostr-relay` header event carries a tag `["concept-graph","39999:<local TA pubkey>:nostr-relay-concept-graph"]`. Also create an ad-hoc concept via `POST /api/normalize/create-concept` and assert the same shape on its header.
+
+**S2 — AC-2 (idempotent):** re-run firmware install; the header's `concept-graph` tag value is identical (deterministic; kind-39998 replaceable — no divergence).
+
+**S3 — AC-3 (compute fallback, documentation check):** confirm BIBLE §5 states the `tag-if-present else compute 39999:<pubkey>:<slug>-concept-graph` resolution contract (the consumer is stream #5; nothing resolves it here).
+
+## Test infrastructure
+- Existing hand-rolled Node runner (`npm test` → `test/test.js`); no new deps/framework. Registered: `headerConceptGraphTag`.
+- Asserts against `src/api/normalize/index.js`. No Playwright (externally-dependent firmware-install + strfry round-trip → smoke, per precedent).
+
+## How to run
+```
+npm test
+```
+Targeted: `node -e "require('./test/header-conceptgraph-tag.test.js').run()"`
+
+## Verification
+New test fails on the pre-implementation tree (working tree atop ADR commit `f052984e`):
+
+```
+header-conceptgraph-tag suite:
+  ✗ T1: handleCreateConcept emits the deterministic concept-graph tag on the 39998 header (AC-1, ADR 0007)
+  ✓ R1: the existing 39998 header tag builder is preserved (regression guard)
+header-conceptgraph-tag suite:                   FAIL (1 passed, 1 failed)
+Overall:                                         FAIL
+```
+(Filled from the actual run below.)

--- a/src/api/normalize/index.js
+++ b/src/api/normalize/index.js
@@ -1250,7 +1250,12 @@ async function handleCreateConcept(req, res) {
       // not Neo4j-looked-up, so it is correct even before the concept-graph
       // node exists. Resolution contract (consumed by stream #5, not here):
       // tag-if-present else compute the same deterministic a-tag.
-      ['concept-graph', `39999:${pubkey}:${headerDTag}-concept-graph`],
+      // NOTE: use nt().getPublicKey directly — it already returns 64-char
+      // hex in this nostr-tools build. The `pubkey` var (:1198) wraps it in
+      // Buffer.from(...).toString('hex'), which DOUBLE-ENCODES (story #10
+      // cycle-local smoke caught this). Scoped to this tag; the shared
+      // `pubkey` var double-encode is a separate pre-existing finding.
+      ['concept-graph', `39999:${nt().getPublicKey(privBytes)}:${headerDTag}-concept-graph`],
       ['json', JSON.stringify(headerWord)],
     ];
     if (description) headerTags.push(['description', description.trim()]);

--- a/src/api/normalize/index.js
+++ b/src/api/normalize/index.js
@@ -1245,6 +1245,12 @@ async function handleCreateConcept(req, res) {
       ['d', headerDTag],
       ['names', names.oNames.singular, names.oNames.plural],
       ['slug', slug],
+      // ADR 0007 — self-describing pointer to this concept's Concept Graph
+      // node. Value COMPUTED from the header's own (signing) pubkey + d-tag,
+      // not Neo4j-looked-up, so it is correct even before the concept-graph
+      // node exists. Resolution contract (consumed by stream #5, not here):
+      // tag-if-present else compute the same deterministic a-tag.
+      ['concept-graph', `39999:${pubkey}:${headerDTag}-concept-graph`],
       ['json', JSON.stringify(headerWord)],
     ];
     if (description) headerTags.push(['description', description.trim()]);

--- a/test/header-conceptgraph-tag.test.js
+++ b/test/header-conceptgraph-tag.test.js
@@ -1,0 +1,76 @@
+/**
+ * Story #10 / ADR 0007 — Header→ConceptGraph self-describing tag (hybrid C).
+ *
+ * `handleCreateConcept` must emit, on the kind-39998 ConceptHeader, a
+ * descriptive custom tag `["concept-graph", "39999:<pubkey>:<dtag>-concept-graph"]`
+ * — the value COMPUTED from the header's own pubkey + d-tag (no Neo4j lookup),
+ * so it is correct even before the concept-graph node exists. Resolution
+ * contract (consumed by the deferred stream #5, NOT here): tag-if-present
+ * else compute the same deterministic a-tag.
+ *
+ * Precedent: stories #5/#6/#8 — a source/structural sentinel pins the
+ * spec-required emission without prescribing whether the Implementer
+ * computes the value pre- or post-sign. The behavioral proof (the emitted
+ * 39998 event actually carries the tag with the right value after a real
+ * firmware reinstall) is NOT reproducible in this hand-rolled runner and is
+ * the **authoritative cycle-local smoke** documented in the test plan
+ * §"Not covered" — the Reviewer must treat that smoke as required.
+ *
+ * T1 : FAIL pre-implementation, PASS post.
+ * R1 : PASS pre AND post — regression guard on the existing header builder;
+ *      flips to FAIL only if the existing 39998 header tag shape is broken.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const NORMALIZE = path.resolve(__dirname, '../src/api/normalize/index.js');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+
+// The spec-required emission: a tag literal whose FIRST element is exactly
+// `concept-graph` and whose value position contains a deterministic
+// `39999:…-concept-graph` a-tag. Anchored on the tag-literal start so it does
+// NOT false-match NODE_ROLES' 'concept-graph' role string, the
+// `concept-header-for-the-concept-of-…` slugs, or `['z', conceptUuid('concept-graph')]`.
+const CONCEPT_GRAPH_TAG = /\[\s*['"]concept-graph['"]\s*,\s*[`'"][^\n]*39999:[^\n]*-concept-graph/;
+
+test('T1: handleCreateConcept emits the deterministic concept-graph tag on the 39998 header (AC-1, ADR 0007)', () => {
+  const src = fs.readFileSync(NORMALIZE, 'utf8');
+  assert(
+    CONCEPT_GRAPH_TAG.test(src),
+    'src/api/normalize/index.js does not emit a `["concept-graph", "39999:<pubkey>:<dtag>-concept-graph"]` ' +
+      'tag on the kind-39998 ConceptHeader (AC-1; ADR 0007 Option A). Add it to the `headerTags` ' +
+      'array in handleCreateConcept (~:1244), value COMPUTED from the header pubkey + d-tag — ' +
+      'no Neo4j lookup. STRUCTURAL sentinel only; the authoritative proof (a real reinstalled ' +
+      '39998 event actually carries the tag with the right value) is the cycle-local smoke in the plan.'
+  );
+});
+
+test('R1: the existing 39998 header tag builder is preserved (regression guard)', () => {
+  const src = fs.readFileSync(NORMALIZE, 'utf8');
+  // ADR 0007: blast radius is one added tag — the existing header tag shape
+  // (`['d', headerDTag]` + `['json', JSON.stringify(headerWord)]` in
+  // handleCreateConcept) must remain intact. Flip to FAIL ⇒ the Implementer
+  // disturbed the out-of-scope existing header construction.
+  assert(
+    /\[\s*['"]d['"]\s*,\s*headerDTag\s*\]/.test(src) &&
+      /\[\s*['"]json['"]\s*,\s*JSON\.stringify\(headerWord\)\s*\]/.test(src),
+    'The existing kind-39998 header tag construction in handleCreateConcept ' +
+      "(`['d', headerDTag]` and `['json', JSON.stringify(headerWord)]`) must be preserved — " +
+      'ADR 0007 adds ONE tag and changes nothing else. Sentinel failing ⇒ out-of-scope change to the header builder.'
+  );
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try { await t.fn(); console.log(`  ✓ ${t.name}`); pass++; }
+    catch (err) { console.log(`  ✗ ${t.name}`); console.log(`      ${err.message}`); fail++; }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -30,6 +30,7 @@ const perQueryNeo4jTimeout = require('./per-query-neo4j-timeout-safety-net.test.
 const nip05CheckmarkVerification = require('./nip05-checkmark-verification.test.js');
 const publishExportConcept = require('./publish-export-a-concept.test.js');
 const communityReferenceStub = require('./community-reference-nostr-relay-stub.test.js');
+const headerConceptGraphTag = require('./header-conceptgraph-tag.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -58,6 +59,9 @@ async function main() {
   console.log('\ncommunity-reference-nostr-relay-stub suite:');
   const communityReferenceStubResult = await communityReferenceStub.run();
 
+  console.log('\nheader-conceptgraph-tag suite:');
+  const headerConceptGraphTagResult = await headerConceptGraphTag.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -82,6 +86,9 @@ async function main() {
   console.log(
     `community-reference-nostr-relay-stub suite:      ${communityReferenceStubResult.fail === 0 ? 'PASS' : 'FAIL'} (${communityReferenceStubResult.pass} passed, ${communityReferenceStubResult.fail} failed)`
   );
+  console.log(
+    `header-conceptgraph-tag suite:                   ${headerConceptGraphTagResult.fail === 0 ? 'PASS' : 'FAIL'} (${headerConceptGraphTagResult.pass} passed, ${headerConceptGraphTagResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -91,7 +98,8 @@ async function main() {
     perQueryNeo4jTimeoutResult.fail === 0 &&
     nip05CheckmarkVerificationResult.fail === 0 &&
     publishExportConceptResult.fail === 0 &&
-    communityReferenceStubResult.fail === 0;
+    communityReferenceStubResult.fail === 0 &&
+    headerConceptGraphTagResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }


### PR DESCRIPTION
## Summary

Promotes staging to main after green verification on `staging.brainstorm.world` (deploy 26117727513). Stream #1 of the ADR 0006 deferred roadmap.

## Bundled

- **#162** — Story #10 / ADR 0007: every kind-39998 ConceptHeader emitted by `handleCreateConcept` now carries a self-describing `["concept-graph","39999:<pubkey>:<dtag>-concept-graph"]` tag (computed; double-encode bug caught by cycle-local & fixed). Resolution = tag-if-present else compute (hybrid C, no mass re-emit). No consumer yet (stream #5). BIBLE §5/glossary/§22. Full chain: ADR→test→impl→review→fix.

## Net production impact

New ConceptHeaders gain one deterministic `concept-graph` tag going forward. **Nothing reads it yet** (consumer is the deferred materialization stream). Existing prod headers are unchanged until a firmware reinstall — the documented compute-fallback resolves them meanwhile. No behavior change for unauthenticated users, no migration, no forced sign-out.

## Verification trail

- cycle-local: S1 nostr-relay header exact-match `39999:<real TA>:nostr-relay-concept-graph` (tag pubkey == event.pubkey == TA); S2 reinstall byte-identical; npm test all suites green.
- Staging deploy 26117727513 success (1m24s); smoke PASS (stability, sanity w/ documented warmup-500 retry, Tier-3 read-only header-present/tag-absent-EXPECTED, regression clean).
- Pre-existing shared-`pubkey` double-encode (`:1198`/`trustedList:44`) spun off as a separate task — out of scope here.

## Test plan

- [ ] After merge: deploy-brainstorm.yml green.
- [ ] Stability + Tier 2 sanity (expect transient warmup-500; retry per OPERATIONS §8).
- [ ] prod nostr-relay 39998 header present; `concept-graph` tag ABSENT until an owner-gated firmware reinstall (EXPECTED — hybrid-C compute-fallback covers it). No regression of concept-graph/normalize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)