### PR TITLE
Promote staging → main: Superset link Phase A (story #11)

### DIFF
--- a/BIBLE.md
+++ b/BIBLE.md
@@ -1580,9 +1580,11 @@ A firmware concept may carry a `communityReference` — `{ headerATag, relayHint
 3. *Materialization ≠ derive:* publishing to strfry does not create a Neo4j node — Pass-3 derive only computes `tapestryJSON` for nodes already present; ingesting a foreign event requires the explicit eventSync import path.
 4. *Verification:* structural sentinels cannot prove relay + Neo4j + install round-trips — the local/staging/prod smoke is the authoritative behavioral gate (it caught the materialization defect that all structural tests missed).
 
-**Header→ConceptGraph (implemented — ADR 0007, §5):** the `concept-graph` header tag + tag-else-compute resolution makes a single fetched Header self-resolve its full concept off-relay. This is the keystone the still-deferred element/superset materialization will consume.
+**Header→ConceptGraph (implemented — ADR 0007, §5):** the `concept-graph` header tag + tag-else-compute resolution makes a single fetched Header self-resolve its full concept off-relay.
 
-**Deferred (see ADR 0006):** privacy tiers; signed/first-class editorial relationship-type; registry-as-DList; element/superset materialization.
+**Superset link, Phase A (implemented — ADR 0008):** at firmware install, `pass_communityReferences` also materializes the community Superset (deterministic `39999:<curatorPk>:<dtag>-superset`), explicitly labels it `:Superset` (`buildImportCypher` gives only `:ListItem` for 39999), and MERGEs the **canonical** `(localSup:Superset)-[:IS_A_SUPERSET_OF]->(communitySup:Superset)` edge — a structural bookmark that participates in class-thread traversals. Community element/set *data* are still NOT pulled local (the link is a placeholder; bulk import remains deferred).
+
+**Deferred (see ADR 0006):** privacy tiers; signed/first-class editorial relationship-type; registry-as-DList; element/set bulk import (the deferred Phase-B of materialization that walks `IS_A_SUPERSET_OF` to actually pull community elements/subsets/schema into the local concept).
 
 ---
 

--- a/engineering-team/decisions/0008-community-reference-superset-link.md
+++ b/engineering-team/decisions/0008-community-reference-superset-link.md
@@ -1,0 +1,57 @@
+# ADR 0008: Community-reference Superset link (materialization placeholder)
+
+**Status:** Accepted
+**Date:** 2026-05-19
+**Story:** `engineering-team/stories/11-community-reference-superset-link.md`
+**Relates to:** ADR 0005 (+Rev 1, Rev 2), ADR 0006, ADR 0007
+
+## Context
+The `REFERENCES` edge from ADR 0005 is inert; #10 unblocked Phase A by giving deterministic concept-graph resolution. Story #11's intent (verbatim from the originating discussion): establish the **structural placeholder** — `localSuperset-[:IS_A_SUPERSET_OF]->communitySuperset` — so the community's structure is reachable by class-thread traversal **without bulk-copying** the curator's elements/sets (explicitly deferred).
+
+Grounded facts:
+- Community Superset a-tag is **deterministically derivable**: `39999:<curator-pubkey>:<slug>-superset` (firmware `${slug}-superset` convention, `src/api/normalize/index.js:338`). Same pragmatism as #10.
+- `pass_communityReferences` already materializes the foreign Header via `buildImportCypher`/`executeCypher` and MERGEs `REFERENCES` post-derive — the symmetrical pattern applies.
+- `IS_A_SUPERSET_OF` is the **canonical class-thread propagation relationship** (firmware rel-type, derived consumers exist), unlike the Neo4j-only stub `REFERENCES`. Reachability "just works" if the materialized community Superset carries the `:Superset` label.
+- `buildImportCypher` labels by kind: 39999 → `:ListItem` (`src/api/neo4j/eventSync.js` `kindToLabel`). So the foreign community Superset arrives `:NostrEvent:ListItem` — the `:Superset` label must be **explicitly SET** for class-thread queries (`(:Superset)-[:IS_A_SUPERSET_OF]->…`) to include it.
+
+## Options considered
+
+### Option A — Deterministic compute + SET :Superset + post-derive MERGE (chosen)
+In `pass_communityReferences`, after the existing Header materialization, compute `communitySupersetUuid = 39999:${curatorPk}:${dTag}-superset`; fetch via `/api/relay/external`; `apiPost('/api/strfry/publish', { event })`; `executeCypher(buildImportCypher(ev))`; **then `SET n:Superset` on that node** (one-line Cypher). Extend the `pending` link record so the existing post-derive block also MERGEs `(localSup:NostrEvent {uuid:$from})-[:IS_A_SUPERSET_OF]->(communitySup:NostrEvent {uuid:$to})` with the same presence-check + graceful-log pattern Rev 2 established. **No `source` property** on this edge — it's the canonical relationship, not the Neo4j-only stub. Provenance is implicit in the target node's a-tag.
+**Pros:** smallest change, mirrors the proven Rev-2 materialize-pre-derive / MERGE-post-derive shape; deterministic + idempotent; graceful (missing community Superset → log + skip; the existing REFERENCES edge is unaffected); reuses the same primitives.
+**Cons:** non-conforming curators (Superset published under a different d-tag than `<slug>-superset`) graceful-skip — acceptable for Phase A.
+
+### Option B — Concept-graph-mediated resolution (deferred enhancement)
+Use #10's `concept-graph` tag-else-compute to fetch the foreign Concept Graph node, parse its members, identify the superset. Heavier (extra fetch + parse + tolerance for foreign Concept-Graph formats); covers non-conforming curators. Rejected for Phase A; recorded as its own future enhancement if non-conforming curators materially appear.
+
+### Option C — MERGE the edge without materializing the foreign Superset node
+Skip fetch/materialize; just `MERGE (b:NostrEvent {uuid:$to})` (creates a stub node by uuid). Defeats the reachability purpose — a stub without the `:Superset` label and without the foreign event's tags is not a useful target for class-thread queries. Rejected.
+
+## Decision
+**Option A.** Deterministic compute; fetch + publish + materialize via the proven primitives; **explicitly SET `:Superset` on the materialized foreign node**; MERGE the canonical `IS_A_SUPERSET_OF` edge post-derive; graceful + idempotent.
+
+## Consequences
+- Reachability is real: `(localSup:Superset)-[:IS_A_SUPERSET_OF]->(communitySup:Superset)` participates in class-thread traversals (concept-graph summaries' `IS_A_SUPERSET_OF*` patterns will include it).
+- **Honest invariant preserved:** community element/set nodes still aren't local; traversal reaches `communitySup` but its `HAS_ELEMENT` children don't exist locally until the deferred bulk/on-demand pull. The `IS_A_SUPERSET_OF` edge is the bookmark.
+- **Normalization interactions (the Story-#11 open questions, settled here):**
+  1. *Prune-superset-edges pass* (`install.js` Pass-1e, Pass 2) — looks for *alternate paths* between local Superset and the same target; our new cross-curator edge has no alternate path (the community Superset is freshly imported with only our edge incoming) → **non-firing, safe by construction**. Documented; cycle-local smoke confirms.
+  2. *Rule 5* ("Superset nodes MUST reference the canonical superset concept") — the foreign Superset's z-tag references the curator's superset concept (`39998:<curatorPk>:superset`), not ours. **Resolution: let the cycle-local smoke surface whatever the audit does**; if it flags, the in-line fix is a Rule-5 exemption keyed on the incoming-edge source / pubkey-not-equal-to-local-TA. Do **not** preemptively engineer it.
+- **Firmware reinstall required?** Yes — `pass_communityReferences` extended; the `IS_A_SUPERSET_OF` edge materializes only on install.
+- **BIBLE update:** §22 "Community-Reference Model" — note the Superset link is now wired (Phase A); update "Deferred" line to "element/set *bulk* import" (the Superset link itself is no longer deferred).
+- **Blast radius:** `src/firmware/install.js` `pass_communityReferences` (+ post-derive block) + BIBLE §22. No new files; no manifest change; no UI change; no scope creep.
+
+## Implementation notes
+- **`src/firmware/install.js` `pass_communityReferences`** — after the existing `await executeCypher(buildImportCypher(ev))` for the Header, add:
+  - compute `communitySupersetUuid = \`39999:${curatorPk}:${dTag}-superset\``;
+  - build `/api/relay/external` filter `{kinds:[39999],authors:[curatorPk],"#d":[\`${dTag}-superset\`]}`; `apiGet`; missing event ⇒ log + continue (no edge);
+  - `apiPost('/api/strfry/publish', { event })`;
+  - `await executeCypher(buildImportCypher(ev))`;
+  - **`runCypherApi('MATCH (n:NostrEvent {uuid:$uuid}) SET n:Superset', { uuid: communitySupersetUuid })`** — the critical labeling step.
+  - extend `pending` with `{ slug, supersetFrom: \`39999:${taPubkey}:${dTag}-superset\`, supersetTo: communitySupersetUuid }`.
+- **Post-derive block (`install.js` ~`:1141`)**: alongside the existing REFERENCES MERGE, add (with presence-check + graceful try/catch identical to Rev 2's pattern):
+  `MATCH (a:NostrEvent {uuid:$from}),(b:NostrEvent {uuid:$to}) MERGE (a)-[:IS_A_SUPERSET_OF]->(b)` — no `source` property; this is the canonical class-thread propagation relationship.
+- **`BIBLE.md` §22** — one line under the model: "Phase A of element/superset materialization (story #11): the community Superset is materialized and linked via the canonical `(localSup)-[:IS_A_SUPERSET_OF]->(communitySup)`; community element/set *data* pull remains deferred." Update the "Deferred" list to replace "element/superset materialization" with "element/set bulk import".
+- **Tester:** structural sentinel that `pass_communityReferences` (a) fetches the `-superset` variant via `/api/relay/external`, (b) emits the `SET n:Superset` Cypher, (c) post-derive MERGEs `[:IS_A_SUPERSET_OF]` between the deterministic local and community Superset a-tags. Behavioral proof — cycle-local smoke: after firmware install, query confirms the foreign Superset exists as `:NostrEvent:ListItem:Superset` and the edge `(:Superset)-[:IS_A_SUPERSET_OF]->(:Superset)` matches between `39999:<localTA>:nostr-relay-superset` and `39999:<curator>:nostr-relay-superset`; idempotency on reinstall; graceful skip when the foreign Superset isn't on dcosl; check whether Rule-5 audit flags the foreign Superset (and decide inline if it does).
+
+## Out of scope
+Bulk element/set import (Option B / "full importation" — future stream, own ADR with trust/provenance/dedup designed); on-demand expansion API; any consumer/query that surfaces community elements; changes to #10 / REFERENCES / `communityReference` field / export. Non-conforming-curator Concept-Graph-mediated resolution (deferred Option-B-resolution-path).

--- a/engineering-team/reviews/11-community-reference-superset-link.md
+++ b/engineering-team/reviews/11-community-reference-superset-link.md
@@ -39,5 +39,28 @@ None.
 2. **Sharpen smoke S1's edge check.** Cypher `MATCH (a:Superset {uuid:'39999:<localTA>:nostr-relay-superset'})-[:IS_A_SUPERSET_OF]->(b:Superset {uuid:'39999:<curatorPk>:nostr-relay-superset'}) RETURN count(*)` must = 1. Matching on `:Superset` on both endpoints exercises both T2 (label SET) and T3 (MERGE) end-to-end.
 3. **S5 (Rule-5 audit interaction) is binding.** Per ADR 0008, the smoke MUST explicitly run whatever audit enforces Rule 5 and decide inline (benign / exemption needed). Don't ship past staging without this verified.
 
-## Verdict
+## Verdict (initial — PASS, code/ADR/scope, pre-smoke)
 **PASS (code/ADR/scope).** No blocking issues; minimal, ADR-conformant, no regression; the Rev-2 graceful/idempotent pattern is preserved per-edge. Behavioral acceptance gate = the **Reviewer-required cycle-local smoke S1–S5** (sharpened per findings #1–#3 above), which is the explicitly-authorized immediate next step. AC-1/AC-2 not "proven" until that smoke is observed. Same posture as #10's pre-smoke verdict (which #10's smoke promptly caught a real defect under — the structural sentinel + archaeology was insufficient there; the discipline holds here).
+
+---
+
+## Re-review (cycle-local smoke, 2026-05-19) — PASS confirmed end-to-end
+
+**Pre-check:** curator Superset `39999:919ba08a…:nostr-relay-superset` (event `e54d96c7be02…`) confirmed live on `wss://dcosl.brainstorm.world` — the Story-#9 export from prod did publish the full Concept-Graph-rooted set including the Superset.
+
+**Sharpened evidence (every Reviewer-required check confirmed):**
+
+| Smoke | Cypher / action | Result | Verdict |
+|---|---|---|---|
+| **S1a** | `MATCH (n:NostrEvent {uuid:'39999:919ba08a…:nostr-relay-superset'}) RETURN labels(n)` | `['NostrEvent','ListItem','Superset']` | **PASS** — explicit `SET n:Superset` landed (label is in the set alongside kindToLabel's `:ListItem`) |
+| **S1b** | `MATCH (a:Superset {uuid:'…<localTA>…'})-[r:IS_A_SUPERSET_OF]->(b:Superset {uuid:'…<curator>…'}) RETURN count(r)` | `1` | **PASS** — canonical edge with both endpoints matched as `:Superset` by uuid; T2 + T3 end-to-end |
+| **S1c** | local Header → `IS_THE_CONCEPT_FOR` → `:Superset` → `IS_A_SUPERSET_OF` → `comm` | community Superset uuid appears (plus the local concept's own internal sets — expected) | **PASS** — class-thread reachability promise |
+| **S2** | graceful Superset miss path | sentinels + independent-graceful refactor (R1, post-derive try/catch) structurally prove it; natural inline test absent (curator IS on dcosl) — documented out of scope | **PASS (structural)** |
+| **S3** | reinstall → re-query S1b + node count | edge=1, node=1 (no dup) | **PASS** |
+| **S4** | community Superset `HAS_ELEMENT` count | `0` | **PASS** — honest invariant: no bulk element import; structural bookmark only |
+| **S5** | Rule-5 audit interaction | **No programmatic Rule-5 audit exists on the server** (BIBLE §10 documents it; the actual enforcement lives in `tapestry-cli` per BIBLE §3 — separate repo). Cross-curator `IS_A_SUPERSET_OF` is therefore **benign on the server side**. If `tapestry-cli`'s `tapestry normalize check-supersets`-style commands are later run against a Neo4j containing foreign Supersets, that's where the interaction would matter — out of scope for this server-side smoke. **Surfaced + documented; no exemption needed for the server.** | **PASS (surfaced + benign)** |
+
+**`npm test` re-run:** Overall PASS (community-reference-superset-link 4/4 + all 9 prior suites + config green).
+
+### Final verdict
+**PASS — code/ADR/scope AND behavioral.** Story #11 / ADR 0008 Phase A is verified end-to-end on a real consumer instance (local TA `e00ed090…` ≠ curator `919ba08a…`). The cross-curator `(:Superset)-[:IS_A_SUPERSET_OF]->(:Superset)` edge is real, labelled correctly on both endpoints, idempotent on reinstall, the honest invariant (no element pull) holds, and Rule-5 is candidly benign on the server. Ready for the deploy chain (cycle-staging → cycle-prod, each gated).

--- a/engineering-team/reviews/11-community-reference-superset-link.md
+++ b/engineering-team/reviews/11-community-reference-superset-link.md
@@ -1,0 +1,43 @@
+# Review: Story #11 — Community-reference Superset link (Phase A)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-19
+**Diff:** impl commit `5edc270d` (vs Test-Design boundary `e7a6c502`)
+**Story/ADR/Plan:** `stories/11-community-reference-superset-link.md` · `decisions/0008-community-reference-superset-link.md` · `stories/11-community-reference-superset-link.test-plan.md`
+
+## Quality gate (run by reviewer, not trusted)
+- [x] `npm test` — **Overall PASS**. community-reference-superset-link 4/4 (T1, T2, T3 now PASS; R1 PASS); all 9 prior suites + config green. Re-run by reviewer.
+- [x] Lint/typecheck/build — not configured; skipped.
+
+## Spec adherence
+- **AC-1** ✓ — `pass_communityReferences` fetches `${dTag}-superset` via `/api/relay/external` (inline-template literal, T1 anchor); publishes via `/api/strfry/publish` (no re-sign); materializes via `executeCypher(buildImportCypher(supEv))`; **explicitly `SET n:Superset` on the materialized foreign node by uuid** (T2 anchor; ordering verified at `install.js:1080→1082`). Post-derive MERGEs `(localSup)-[:IS_A_SUPERSET_OF]->(communitySup)` (T3 anchor; carries **no `source` property** — canonical relationship). Behavioral proof = smoke S1.
+- **AC-2** ✓ — graceful by construction: missing Superset event → log + continue (REFERENCES still wired); Superset materialization error → log + continue (REFERENCES still wired); post-derive presence-check + try/catch on both edges independently; **no `continue` between Header and Superset blocks** (verified at `:1230` log-only catch fall-through, `:1234` `if (!link.supersetTo) continue` only when nothing to wire). Behavioral proof = smoke S2.
+- **AC-3** ✓ — deterministic a-tags + MERGE + idempotent. Behavioral proof = smoke S3.
+- **AC-4** ✓ (the honest invariant) — no bulk element/set import code added. The IS_A_SUPERSET_OF edge is a structural bookmark; community elements remain unmaterialized. Verified by smoke S4.
+- **AC-5** ✓ — R1 regression guard green; the Rev-2 contract (Header materialization + REFERENCES MERGE + `source` property) is byte-preserved.
+
+## ADR 0008 adherence
+- Option A — deterministic compute `39999:${curatorPk}:${supersetDTag}` (no graph lookup) ✓.
+- Explicit `SET n:Superset` label on the foreign node (kindToLabel gives `:ListItem` only for 39999) ✓.
+- Post-derive MERGE of the canonical `[:IS_A_SUPERSET_OF]` edge with no `source` property ✓.
+- Independent-graceful between Header and Superset edges ✓.
+- BIBLE §22 updated: "Phase A implemented" paragraph + Deferred list now "element/set bulk import" ✓.
+- Blast radius = `install.js` `pass_communityReferences` + post-derive block + BIBLE §22 (2 files, +94/−23) ✓. No new files, no manifest change, no UI change.
+
+## Things tests can't catch (reviewer audit)
+- **`:Superset` label SET correctness depends on `buildImportCypher` having created the node first.** Ordering verified at `:1080→1082`: materialize → MATCH-by-uuid → SET. If the underlying MERGE were silently broken, the SET would be a no-op (no error, but no label). The structural sentinel cannot prove the label is actually present on the foreign event. **Smoke S1's Cypher (`MATCH (n {uuid:'39999:<curator>:nostr-relay-superset'}) RETURN labels(n)`) is the authoritative check** — must include `:Superset`. Echoes the #10 `pubkey` archaeology lesson: trust the smoke.
+- **Cross-curator `IS_A_SUPERSET_OF` interaction with normalization.** ADR 0008's analysis (prune-superset-edges non-firing by construction; Rule 5 audit deliberately *surfaces* in smoke, not preempt) stands. Smoke must explicitly run Rule-5 audit and either record benign or apply the documented in-line `source`/non-local-TA exemption.
+- **Inline-template tweak** (`'#d': [\`${dTag}-superset\`]` instead of `[supersetDTag]`) — candidly documented in the commit as a Tester-anchor accommodation. Reviewer assessment: not a spec deviation (the value computed is identical to `supersetDTag` defined a line above); makes the deterministic resolution self-evident at the filter site, which is arguably an improvement. Accepted.
+- No secrets, no debug cruft, no commented-out code, no concurrency surface.
+
+## Findings
+### Blocking
+None.
+
+### Non-blocking (binding-on-smoke)
+1. **Sharpen smoke S1's label check.** Cypher `MATCH (n:NostrEvent {uuid:'39999:<curatorPk>:nostr-relay-superset'}) RETURN labels(n)` must include `:Superset` (alongside `:NostrEvent:ListItem`). Without it, `(:Superset)-[:IS_A_SUPERSET_OF]->(:Superset)` traversals don't include the foreign node and the reachability promise of #11 is broken.
+2. **Sharpen smoke S1's edge check.** Cypher `MATCH (a:Superset {uuid:'39999:<localTA>:nostr-relay-superset'})-[:IS_A_SUPERSET_OF]->(b:Superset {uuid:'39999:<curatorPk>:nostr-relay-superset'}) RETURN count(*)` must = 1. Matching on `:Superset` on both endpoints exercises both T2 (label SET) and T3 (MERGE) end-to-end.
+3. **S5 (Rule-5 audit interaction) is binding.** Per ADR 0008, the smoke MUST explicitly run whatever audit enforces Rule 5 and decide inline (benign / exemption needed). Don't ship past staging without this verified.
+
+## Verdict
+**PASS (code/ADR/scope).** No blocking issues; minimal, ADR-conformant, no regression; the Rev-2 graceful/idempotent pattern is preserved per-edge. Behavioral acceptance gate = the **Reviewer-required cycle-local smoke S1–S5** (sharpened per findings #1–#3 above), which is the explicitly-authorized immediate next step. AC-1/AC-2 not "proven" until that smoke is observed. Same posture as #10's pre-smoke verdict (which #10's smoke promptly caught a real defect under — the structural sentinel + archaeology was insufficient there; the discipline holds here).

--- a/engineering-team/stories/11-community-reference-superset-link.md
+++ b/engineering-team/stories/11-community-reference-superset-link.md
@@ -39,4 +39,4 @@ As an installer/operator, after firmware install completes, my local concept's S
 ## Linked artifacts
 - ADR: `engineering-team/decisions/0008-community-reference-superset-link.md` (Accepted; Option A — deterministic compute + SET :Superset + post-derive IS_A_SUPERSET_OF MERGE)
 - Test plan: `engineering-team/stories/11-community-reference-superset-link.test-plan.md` (T1/T2/T3 sentinels + R1 regression guard; behavioral ACs deferred to cycle-local smoke — authoritative, Reviewer-required, incl. Rule-5 audit interaction)
-- Review: `engineering-team/reviews/11-community-reference-superset-link.md` — **PASS (code/ADR/scope)**; behavioral acceptance gated on Reviewer-required cycle-local smoke S1–S5 (incl. Rule-5 audit interaction)
+- Review: `engineering-team/reviews/11-community-reference-superset-link.md` — **PASS (code/ADR/scope + behavioral)**; cycle-local smoke S1–S5 confirmed end-to-end (`:Superset` label SET ✓, canonical edge by uuid ✓, idempotent ✓, honest invariant ✓; Rule-5 surfaced as benign on server — audit lives in tapestry-cli)

--- a/engineering-team/stories/11-community-reference-superset-link.md
+++ b/engineering-team/stories/11-community-reference-superset-link.md
@@ -1,0 +1,42 @@
+# Story 11: Community-reference Superset link (materialization placeholder)
+
+**Status:** Approved
+**Created:** 2026-05-19
+**Type:** Feature
+
+## Background
+Stream #5 of the ADR 0006 deferred roadmap, now unblocked by #10 (deterministic Header→ConceptGraph resolution). Today the `REFERENCES` edge (`localHeader → communityHeader`) is **inert** — `pass_communityReferences` materializes only the community Header. This story wires the **structural placeholder** the owner described at the very start of this whole arc:
+
+> *"I will not necessarily go through the motions of the importation … but by establishing the `is a superset of` relationship, this acts as a placeholder for some time in the future when I may wish to query the community for data and input it into my local Tapestry."*
+
+Grounding finding: the community Superset a-tag is **deterministically derivable** exactly like #10's concept-graph — `39999:<curator-pubkey>:<slug>-superset` (firmware `${slug}-superset` convention, `index.js:338`).
+
+## User-facing description
+As an installer/operator, after firmware install completes, my local concept's Superset has a real `IS_A_SUPERSET_OF` edge to the materialized community curator's Superset. The community's structure is *reachable* by class-thread traversal — without bulk-copying the curator's element/set nodes (which is explicitly deferred).
+
+## Acceptance criteria
+- [ ] Given a `communityReference` whose curator Superset is published on `relayHints`, when firmware install runs, then `39999:<curator-pubkey>:<slug>-superset` is fetched, materialized as a distinct Neo4j node (uuid = its a-tag), and `(localSuperset)-[:IS_A_SUPERSET_OF]->(communitySuperset)` exists.
+- [ ] Given the community Superset is unreachable (relay miss / not published), install **logs + continues**; no edge wired; local concept + the existing `REFERENCES` edge unaffected (graceful).
+- [ ] Re-install is **idempotent** — no duplicate node, no duplicate edge (deterministic a-tags + MERGE).
+- [ ] **Honest invariant (this story does NOT pull element/set data):** community element/set *nodes are NOT* materialized; the edge is a structural bookmark only. Class-thread traversal reaches the community Superset; surfacing concrete community elements is the explicitly-deferred next stream.
+- [ ] Zero behavior change for anything not traversing the new edge.
+
+## Concepts touched
+- `localSuperset` (`39999:<localTA>:nostr-relay-superset`) — gains one outgoing `IS_A_SUPERSET_OF`.
+- New foreign node `39999:<curator-pubkey>:nostr-relay-superset` (materialized community Superset).
+- Existing `(localHeader)-[:REFERENCES]->(communityHeader)` — unchanged.
+
+## Out of scope (named, deferred under ADR 0006)
+- **Bulk element/set import (Option B / "full importation")** — the curator's elements + sets as local nodes; its own future stream with its own ADR (trust/provenance/dedup designed deliberately).
+- Any consumer/query that surfaces community elements via the new link (the link is structural; surfacing/expansion is a separate on-demand stream).
+- Changes to #10 (`concept-graph` tag), the `REFERENCES` edge, the `communityReference` manifest field, export, or any of the editorial-relationship deferred items.
+
+## Open questions (resolved in Architecture / ADR 0008)
+- **Canonical Superset-resolution path** — deterministic compute (`39999:<curator>:<slug>-superset`) vs via the #10 `concept-graph` tag → Concept Graph member resolution. Recommend deterministic-compute-only for this phase (Phase-A simplicity; matches #10's pragmatism); the concept-graph-mediated fallback is its own future enhancement.
+- **`IS_A_SUPERSET_OF` interaction with existing normalization** — unlike the Neo4j-only `REFERENCES`, this is the **canonical class-thread propagation relationship**, so normalization already understands it (reachability "just works") *but*: (a) the install's "prune redundant Superset edges" pass — analyzed as non-firing for the new cross-curator edge (no alternate path to the foreign node), confirm in ADR; (b) Rule 5 ("Superset nodes MUST reference the canonical superset concept") — the foreign curator's Superset event z-tags reference *their* superset concept-header pubkey, not ours; ADR must state whether that audit interaction is benign/documented or needs a `source`-property exemption; cycle-local smoke will surface either way.
+- **`:Superset` label on the materialized foreign node** — `buildImportCypher` labels by kind (`ListItem` for 39999); to satisfy the class-thread reachability promise, the community Superset needs the `:Superset` label SET as a follow-up (existing local pattern). One-line addition; ADR confirms.
+
+## Linked artifacts
+- ADR: `engineering-team/decisions/0008-community-reference-superset-link.md` (Accepted; Option A — deterministic compute + SET :Superset + post-derive IS_A_SUPERSET_OF MERGE)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/11-community-reference-superset-link.md
+++ b/engineering-team/stories/11-community-reference-superset-link.md
@@ -38,5 +38,5 @@ As an installer/operator, after firmware install completes, my local concept's S
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/0008-community-reference-superset-link.md` (Accepted; Option A — deterministic compute + SET :Superset + post-derive IS_A_SUPERSET_OF MERGE)
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/11-community-reference-superset-link.test-plan.md` (T1/T2/T3 sentinels + R1 regression guard; behavioral ACs deferred to cycle-local smoke — authoritative, Reviewer-required, incl. Rule-5 audit interaction)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/11-community-reference-superset-link.md
+++ b/engineering-team/stories/11-community-reference-superset-link.md
@@ -39,4 +39,4 @@ As an installer/operator, after firmware install completes, my local concept's S
 ## Linked artifacts
 - ADR: `engineering-team/decisions/0008-community-reference-superset-link.md` (Accepted; Option A — deterministic compute + SET :Superset + post-derive IS_A_SUPERSET_OF MERGE)
 - Test plan: `engineering-team/stories/11-community-reference-superset-link.test-plan.md` (T1/T2/T3 sentinels + R1 regression guard; behavioral ACs deferred to cycle-local smoke — authoritative, Reviewer-required, incl. Rule-5 audit interaction)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/11-community-reference-superset-link.md` — **PASS (code/ADR/scope)**; behavioral acceptance gated on Reviewer-required cycle-local smoke S1–S5 (incl. Rule-5 audit interaction)

--- a/engineering-team/stories/11-community-reference-superset-link.test-plan.md
+++ b/engineering-team/stories/11-community-reference-superset-link.test-plan.md
@@ -1,0 +1,67 @@
+# Test Plan: Story 11 — Community-reference Superset link (Phase A)
+
+**Story:** `engineering-team/stories/11-community-reference-superset-link.md`
+**ADR:** `engineering-team/decisions/0008-community-reference-superset-link.md`
+**Date:** 2026-05-19
+
+## Approach
+Same precedent as #5/#6/#8/#10. Source/structural sentinels pin the spec-required code shape ADR 0008 specified. The behavioral round-trip — real install actually fetches the `-superset` event, materializes a foreign `:NostrEvent:ListItem:Superset`, MERGEs the canonical cross-curator `IS_A_SUPERSET_OF` between two `(:Superset)` nodes, behaves idempotently, graceful-skips when missing, and the **Rule-5 audit interaction** (z-tag references the curator's superset concept, not ours) — is **not** reproducible in the hand-rolled Node runner and is the **authoritative cycle-local smoke** (Reviewer-required). Story #10's cycle-local definitively vindicated this discipline (it caught the pubkey double-encode); same expectation here.
+
+## Coverage map
+
+| AC | Test / mechanism | File | Level |
+|---|---|---|---|
+| AC-1 (fetch+materialize community Superset; canonical IS_A_SUPERSET_OF edge) | **T1** (fetch via `-superset` `#d` filter), **T2** (SET :Superset on the materialized foreign node), **T3** (post-derive [:IS_A_SUPERSET_OF] MERGE) — together pin the spec. Behavioral S1 = cycle-local | test/community-reference-superset-link.test.js | source + smoke |
+| AC-2 (graceful: community Superset unreachable ⇒ install continues, no edge) | Symmetrical to the Rev-2 Header graceful pattern (T3 requires presence-check; R1 preserves the pattern). Behavioral S2 = cycle-local | test/community-reference-superset-link.test.js | source + smoke |
+| AC-3 (idempotent re-install) | Deterministic a-tags + MERGE ⇒ idempotent by construction. Behavioral S3 = cycle-local | — | smoke |
+| AC-4 (honest invariant — community element/set nodes NOT pulled local) | Out of scope by design; nothing in the sentinel exercises bulk element import. The smoke explicitly verifies element nodes do NOT appear local. | — | smoke |
+| AC-5 (zero behavior change for non-traversers) | **R1** preserves the Rev-2 Header+REFERENCES contract; T1/T2/T3 are additions only | test/community-reference-superset-link.test.js | source (sentinel) |
+
+T1/T2/T3 = FAIL pre-impl, PASS post. R1 = PASS pre AND post (regression guard on the Rev-2 Header materialization + REFERENCES MERGE).
+
+## Edge cases
+- [x] **No false-positive on existing upstream `IS_A_SUPERSET_OF` MERGEs.** T3 uses `lastIndexOf(':IS_A_SUPERSET_OF]')` and requires it to be AFTER `lastIndexOf(':REFERENCES]')` (the existing Rev-2 post-derive REFERENCES MERGE near the end of install.js). Pre-impl, all existing IS_A_SUPERSET_OF MERGEs are upstream (~`:470`, `:563`) — earlier than the REFERENCES MERGE (~`:1177`) — so T3 correctly FAILs pre-impl.
+- [x] **No false-positive on local `:Superset` label SETs in other files.** T2 reads only `install.js`; local Supersets get the label via `src/api/normalize/index.js`, not install.js. install.js pre-impl has no `SET … :Superset`.
+- [x] **No false-positive from existing `-superset` slug strings.** T1 anchors on the tag-filter literal shape (`"#d": […-superset…]`), not bare `-superset`. The existing slug literals like `superset-for-the-concept-of-…` and d-tag `${slug}-superset` strings are not inside `#d` filter arrays.
+- [ ] **Cross-curator `IS_A_SUPERSET_OF` interaction with normalization (prune + Rule 5).** Not catchable in source — the **cycle-local smoke is the authoritative check** (per ADR 0008's stated stance: surface, don't preemptively engineer).
+
+## Not covered (deferred to cycle-local smoke — authoritative, Reviewer-required)
+Run on the local Docker stack (`:7778`):
+
+**S1 — AC-1 (real materialization + canonical edge):** `POST /api/firmware/install`. Then:
+- `docker exec tapestry strfry scan '{"kinds":[39999],"authors":["<curatorPk>"],"#d":["nostr-relay-superset"]}'` → assert exactly one event found (the curator's Superset on dcosl, post-#10).
+- Cypher `MATCH (n:NostrEvent {uuid:'39999:<curatorPk>:nostr-relay-superset'}) RETURN labels(n)` → assert `:Superset` is in the labels (alongside `:NostrEvent:ListItem`).
+- Cypher `MATCH (a:Superset {uuid:'39999:<localTA>:nostr-relay-superset'})-[r:IS_A_SUPERSET_OF]->(b:Superset {uuid:'39999:<curatorPk>:nostr-relay-superset'}) RETURN count(r)` → **= 1** (the canonical edge between two `(:Superset)` nodes — proves the label-SET is correct AND the MERGE landed).
+- Cypher `MATCH (h:ListHeader {uuid:'39998:<localTA>:nostr-relay'})-[:IS_THE_CONCEPT_FOR]->(s:Superset)-[:IS_A_SUPERSET_OF]->(comm) RETURN comm.uuid` → confirms the class-thread traversal reaches the community Superset from the local concept Header (the reachability promise).
+
+**S2 — AC-2 (graceful):** temporarily mismatch `communityReference.headerATag`'s `<dtag>` so the `-superset` fetch returns nothing (or point relayHints at an empty relay). Run install. Expect: log "community Superset … not found … skipped (graceful)"; no `IS_A_SUPERSET_OF` edge; local concept + existing REFERENCES edge unaffected; install completes.
+
+**S3 — AC-3 (idempotent):** re-run firmware install. Expect: exactly one foreign Superset node, exactly one `IS_A_SUPERSET_OF` edge (no duplicates).
+
+**S4 — AC-4 (honest invariant):** `MATCH (s:Superset {uuid:'39999:<curatorPk>:nostr-relay-superset'})-[:HAS_ELEMENT]->(e) RETURN count(e)` → expect 0 (community elements/sets are NOT materialized locally — the link is structural only; element pull is the deferred next stream).
+
+**S5 — Rule-5 audit interaction (ADR 0008 stated to surface, not preempt):** run whatever audit/normalize check enforces Rule 5; record whether it flags the foreign Superset (z-tag references `39998:<curatorPk>:superset`, not the local TA's). If it flags, the in-line resolution (small audit exemption keyed on source / non-local-TA pubkey) is the Reviewer-authorized follow-up; if benign, document.
+
+## Test infrastructure
+- Existing hand-rolled Node runner (`npm test` → `test/test.js`); no new deps. Registered: `communityReferenceSupersetLink`.
+- Asserts only against `src/firmware/install.js`. No Playwright (relay+firmware-install+Neo4j is smoke territory).
+
+## How to run
+```
+npm test
+```
+Targeted: `node -e "require('./test/community-reference-superset-link.test.js').run()"`
+
+## Verification
+New tests fail on the pre-implementation tree (atop ADR commit `4dd08428`):
+
+```
+community-reference-superset-link suite:
+  ✗ T1: pass_communityReferences fetches the -superset variant via /api/relay/external (AC-1, ADR 0008)
+  ✗ T2: install.js explicitly SETs :Superset on the materialized community Superset node (AC-1, ADR 0008)
+  ✗ T3: post-derive block MERGEs a canonical [:IS_A_SUPERSET_OF] edge after the existing :REFERENCES MERGE (AC-1, ADR 0008)
+  ✓ R1: existing pass_communityReferences Header materialization + post-derive :REFERENCES MERGE preserved (regression guard)
+community-reference-superset-link suite:         FAIL (1 passed, 3 failed)
+Overall:                                         FAIL
+```
+(Filled from the actual run below.)

--- a/src/firmware/install.js
+++ b/src/firmware/install.js
@@ -1051,10 +1051,50 @@ async function pass_communityReferences(opts = {}) {
       await apiPost('/api/strfry/publish', { event: ev });
       await executeCypher(buildImportCypher(ev));
 
+      // ── Phase A (story #11 / ADR 0008): community Superset link ─────
+      // Also fetch + materialize the community Superset (deterministic
+      // 39999:<curatorPk>:<dTag>-superset), and explicitly SET :Superset
+      // on the foreign node (buildImportCypher gives :ListItem only for
+      // kind 39999; class-thread queries match `(:Superset)`). The
+      // canonical IS_A_SUPERSET_OF edge is wired post-derive.
+      // Independent inner graceful: a Superset miss does NOT block the
+      // already-succeeded Header → REFERENCES wiring above. Element/set
+      // *data* pull remains deferred (Option B; the link is a bookmark).
+      let supersetTo = null;
+      try {
+        const supersetDTag = `${dTag}-superset`;
+        const supersetUuid = `39999:${curatorPk}:${supersetDTag}`;
+        // Inline `${dTag}-superset` here (also assigned to `supersetDTag`
+        // above) so the deterministic `-superset` resolution is self-evident
+        // in the filter literal (also: TI sentinel anchors on this pattern).
+        const supFilter = { kinds: [39999], authors: [curatorPk], '#d': [`${dTag}-superset`] };
+        const supFetched = await apiGet('/api/relay/external', {
+          filter: JSON.stringify(supFilter),
+          relays,
+        });
+        const supEv = supFetched && Array.isArray(supFetched.events) ? supFetched.events[0] : null;
+        if (!supEv) {
+          console.log(`  ⚠️  ${slug}: community Superset (${supersetDTag}) not found on relay hints — skipped (graceful; REFERENCES still wired)`);
+        } else {
+          await apiPost('/api/strfry/publish', { event: supEv });
+          await executeCypher(buildImportCypher(supEv));
+          await runCypherApi(
+            'MATCH (n:NostrEvent {uuid:$uuid}) SET n:Superset',
+            { uuid: supersetUuid }
+          );
+          supersetTo = supersetUuid;
+          console.log(`  ✅ ${slug}: community Superset published + materialized + labelled :Superset`);
+        }
+      } catch (supErr) {
+        console.log(`  ⚠️  ${slug}: community Superset step failed — ${supErr.message} (graceful; REFERENCES still wired)`);
+      }
+
       pending.push({
         slug,
         from: `39998:${taPubkey}:${slug}`,
         to: cr.headerATag,
+        supersetFrom: `39999:${taPubkey}:${slug}-superset`,
+        supersetTo, // null if Superset materialization skipped/failed (graceful)
       });
       console.log(`  ✅ ${slug}: community Header published + materialized → REFERENCES pending`);
     } catch (err) {
@@ -1145,42 +1185,71 @@ async function install(opts = {}) {
     console.log('');
   }
 
-  // ── Community-reference REFERENCES edges (post-derive) ──────
-  // The community Header was materialized as a node in
-  // pass_communityReferences. MERGE the Neo4j-only placeholder edge:
-  // (local Concept Header)-[:REFERENCES {source:'firmware-community'}]->
-  // (community Header). The `source` property is the disambiguator from
-  // the unrelated, high-volume eventSync (:NostrEventTag)-[:REFERENCES]->
-  // (:NostrEvent) edges (ADR 0005 Rev 2 accepted-collision mitigation):
-  // concept-level REFERENCES is ListHeader→ListHeader AND carries
-  // source; tag-level never sets source. MERGE ⇒ idempotent (AC-5).
-  // Graceful: a missing community node just wires no edge — never throws.
+  // ── Community-reference edges (post-derive) ────────────────
+  //
+  // Two edges per concept, each independently wired:
+  //
+  //   (1) (localHeader)-[:REFERENCES {source:'firmware-community'}]->(communityHeader)
+  //       Neo4j-only placeholder (ADR 0005 Rev 2). `source` disambiguates from
+  //       the high-volume eventSync (:NostrEventTag)-[:REFERENCES]->(:NostrEvent)
+  //       edges (accepted-collision mitigation): concept-level REFERENCES is
+  //       ListHeader→ListHeader AND carries source; tag-level never sets it.
+  //
+  //   (2) (localSuperset:Superset)-[:IS_A_SUPERSET_OF]->(communitySuperset:Superset)
+  //       Canonical class-thread propagation relationship (story #11 / ADR 0008
+  //       Phase A) — wired only if pass_communityReferences successfully
+  //       materialized the foreign Superset (link.supersetTo set) and SET the
+  //       :Superset label on it. No `source` property — this is the canonical
+  //       relationship class-thread queries already understand.
+  //
+  // Both use the same presence-check + graceful try/catch pattern (a missing
+  // node just wires no edge — never throws). Independent: a Header miss
+  // does NOT skip the Superset wiring, and vice versa. MERGEs are idempotent.
   if (!dryRun && crResult && crResult.pending && crResult.pending.length) {
-    console.log('\n── Community-reference REFERENCES edges ──\n');
+    console.log('\n── Community-reference edges (REFERENCES + IS_A_SUPERSET_OF) ──\n');
     for (const link of crResult.pending) {
+      // (1) Header → REFERENCES
       try {
-        // The edge is real only if the community node exists. MATCH...MERGE
-        // silently no-ops (no error, no edge) when it is absent, so check
-        // presence first and log accurately — the Reviewer-required smoke
-        // reads this line as M1 evidence (review finding #2).
         const found = await runCypherApi(
           `MATCH (b:NostrEvent {uuid:$to}) RETURN count(b) AS cnt`,
           { to: link.to }
         );
         const present = ((found && found.data) || [])[0]?.cnt || 0;
         if (!present) {
-          console.log(`  ⏭️  ${link.slug}: community node ${link.to} not present yet — REFERENCES deferred (graceful)`);
+          console.log(`  ⏭️  ${link.slug}: community Header ${link.to} not present yet — REFERENCES deferred (graceful)`);
+        } else {
+          await runCypherApi(
+            `MATCH (a:NostrEvent {uuid:$from}), (b:NostrEvent {uuid:$to})
+             MERGE (a)-[r:REFERENCES]->(b)
+             SET r.source = 'firmware-community'`,
+            { from: link.from, to: link.to }
+          );
+          console.log(`  ✅ ${link.slug}: REFERENCES {source:firmware-community} → ${link.to}`);
+        }
+      } catch (err) {
+        console.log(`  ⚠️  ${link.slug}: REFERENCES wiring skipped — ${err.message} (graceful)`);
+      }
+
+      // (2) Superset → IS_A_SUPERSET_OF (story #11 / ADR 0008)
+      if (!link.supersetTo) continue;
+      try {
+        const foundS = await runCypherApi(
+          `MATCH (b:NostrEvent {uuid:$to}) RETURN count(b) AS cnt`,
+          { to: link.supersetTo }
+        );
+        const presentS = ((foundS && foundS.data) || [])[0]?.cnt || 0;
+        if (!presentS) {
+          console.log(`  ⏭️  ${link.slug}: community Superset ${link.supersetTo} not present yet — IS_A_SUPERSET_OF deferred (graceful)`);
           continue;
         }
         await runCypherApi(
           `MATCH (a:NostrEvent {uuid:$from}), (b:NostrEvent {uuid:$to})
-           MERGE (a)-[r:REFERENCES]->(b)
-           SET r.source = 'firmware-community'`,
-          { from: link.from, to: link.to }
+           MERGE (a)-[:IS_A_SUPERSET_OF]->(b)`,
+          { from: link.supersetFrom, to: link.supersetTo }
         );
-        console.log(`  ✅ ${link.slug}: REFERENCES {source:firmware-community} → ${link.to}`);
+        console.log(`  ✅ ${link.slug}: IS_A_SUPERSET_OF → ${link.supersetTo}`);
       } catch (err) {
-        console.log(`  ⚠️  ${link.slug}: REFERENCES wiring skipped — ${err.message} (graceful)`);
+        console.log(`  ⚠️  ${link.slug}: IS_A_SUPERSET_OF wiring skipped — ${err.message} (graceful)`);
       }
     }
   }

--- a/test/community-reference-superset-link.test.js
+++ b/test/community-reference-superset-link.test.js
@@ -1,0 +1,120 @@
+/**
+ * Story #11 / ADR 0008 — Community-reference Superset link (Phase A).
+ *
+ * Extends pass_communityReferences (after the existing Header materialization)
+ * to also: (1) fetch the community Superset 39999:<curatorPk>:<dtag>-superset
+ * via the existing /api/relay/external (a `#d` filter containing the
+ * `-superset` value), (2) publish + materialize via the proven primitives,
+ * (3) explicitly SET :Superset on the materialized foreign node (kindToLabel
+ * gives only :ListItem for 39999), (4) in the post-derive block, MERGE the
+ * canonical (localSup)-[:IS_A_SUPERSET_OF]->(communitySup) edge after the
+ * existing REFERENCES MERGE.
+ *
+ * Precedent: #5/#6/#8/#10. Source/structural sentinels pin the spec-required
+ * code shape without prescribing implementer naming; the behavioral proof
+ * (real install actually emits the -superset fetch, materializes :Superset,
+ * forms the canonical edge between deterministic a-tags; idempotent; graceful
+ * miss; Rule-5 audit interaction) is the **authoritative cycle-local smoke**
+ * (Reviewer-required) — only the smoke can prove the foreign node ends up
+ * `:NostrEvent:ListItem:Superset` and the cross-curator `IS_A_SUPERSET_OF`
+ * matches between `(:Superset)…(:Superset)` class-thread traversal.
+ *
+ * T1/T2/T3 : FAIL pre-implementation, PASS post.
+ * R1       : PASS pre AND post — regression guard on the existing
+ *            pass_communityReferences Header materialization + post-derive
+ *            REFERENCES MERGE. Flip ⇒ implementer broke prior behavior.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const INSTALL = path.resolve(__dirname, '../src/firmware/install.js');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+
+// ---------------------------------------------------------------------------
+// Failing tests — FAIL now, PASS once Story #11 is implemented per ADR 0008.
+// ---------------------------------------------------------------------------
+
+test('T1: pass_communityReferences fetches the -superset variant via /api/relay/external (AC-1, ADR 0008)', () => {
+  const src = fs.readFileSync(INSTALL, 'utf8');
+  // Match any tag-filter "#d" whose value contains "-superset" — the new
+  // /api/relay/external filter the Implementer adds for the Superset fetch.
+  // Pre-impl install.js's only #d filter is the bare slug (Header fetch);
+  // post-impl gains a second filter referencing the `-superset` d-tag.
+  const re = /['"`]#d['"`]\s*:\s*\[[^\]]*-superset/;
+  assert(
+    re.test(src),
+    'install.js does not fetch the community Superset event by its -superset d-tag (AC-1; ADR 0008). ' +
+      'Add a second /api/relay/external call in pass_communityReferences with a filter whose `#d` ' +
+      'value contains `${dTag}-superset` (deterministic Phase-A resolution).'
+  );
+});
+
+test('T2: install.js explicitly SETs :Superset on the materialized community Superset node (AC-1, ADR 0008)', () => {
+  const src = fs.readFileSync(INSTALL, 'utf8');
+  // buildImportCypher labels kind-39999 as :ListItem — the Superset label is
+  // derived locally but NOT added to imported foreign events. Without an
+  // explicit SET, class-thread queries that match `(:Superset)` won't include
+  // the materialized community Superset, breaking the reachability claim.
+  const re = /SET\s+\w+:Superset\b/;
+  assert(
+    re.test(src),
+    'install.js does not explicitly SET :Superset on the materialized community Superset node ' +
+      '(AC-1; ADR 0008). buildImportCypher gives :ListItem only for kind 39999; without ' +
+      'SET n:Superset, class-thread queries `(:Superset)-[:IS_A_SUPERSET_OF]->…` will not ' +
+      'traverse it and the reachability promise of Story #11 is broken.'
+  );
+});
+
+test('T3: post-derive block MERGEs a canonical [:IS_A_SUPERSET_OF] edge after the existing :REFERENCES MERGE (AC-1, ADR 0008)', () => {
+  const src = fs.readFileSync(INSTALL, 'utf8');
+  // install.js already contains IS_A_SUPERSET_OF MERGEs upstream (existing-sets
+  // wiring + concept manifest wiring in pass1). To pin the NEW post-derive
+  // MERGE specifically, require the last :IS_A_SUPERSET_OF appearance to be
+  // AFTER the existing post-derive :REFERENCES] MERGE.
+  const iRef = src.lastIndexOf(':REFERENCES]');
+  const iSuper = src.lastIndexOf(':IS_A_SUPERSET_OF]');
+  assert(
+    iRef !== -1,
+    'Existing post-derive [:REFERENCES] MERGE not found in install.js — re-baseline this sentinel (the existing community-reference wiring may have moved).'
+  );
+  assert(
+    iSuper !== -1 && iSuper > iRef,
+    'install.js does not MERGE a canonical [:IS_A_SUPERSET_OF] edge in the post-derive block AFTER ' +
+      'the existing :REFERENCES MERGE (AC-1; ADR 0008). Add the cross-curator class-thread edge ' +
+      '`MATCH (a {uuid:$from}),(b {uuid:$to}) MERGE (a)-[:IS_A_SUPERSET_OF]->(b)` (no `source` ' +
+      'property — this is the canonical relationship, not a Neo4j-only stub).'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Regression sentinel — PASS now AND post-implementation.
+// ---------------------------------------------------------------------------
+
+test('R1: existing pass_communityReferences Header materialization + post-derive :REFERENCES MERGE preserved (regression guard)', () => {
+  const src = fs.readFileSync(INSTALL, 'utf8');
+  // Pin the Rev-2 contract: pass_communityReferences must still
+  // (a) fetch via /api/relay/external,
+  // (b) publish via /api/strfry/publish (no re-sign),
+  // (c) materialize the Header via buildImportCypher/executeCypher, and
+  // (d) post-derive MERGE the [:REFERENCES] edge.
+  // Story #11 extends this — it must not break it.
+  assert(src.includes('/api/relay/external'), 'R1: install.js no longer fetches via /api/relay/external — Header materialization broken.');
+  assert(src.includes('/api/strfry/publish'), 'R1: install.js no longer publishes via /api/strfry/publish.');
+  assert(/buildImportCypher|executeCypher/.test(src), 'R1: install.js no longer materializes via buildImportCypher/executeCypher (Rev 2 contract).');
+  assert(/:\s*REFERENCES\s*\]/.test(src), 'R1: install.js no longer MERGEs the [:REFERENCES] placeholder edge (ADR 0005 contract).');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try { await t.fn(); console.log(`  ✓ ${t.name}`); pass++; }
+    catch (err) { console.log(`  ✗ ${t.name}`); console.log(`      ${err.message}`); fail++; }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,7 @@ const nip05CheckmarkVerification = require('./nip05-checkmark-verification.test.
 const publishExportConcept = require('./publish-export-a-concept.test.js');
 const communityReferenceStub = require('./community-reference-nostr-relay-stub.test.js');
 const headerConceptGraphTag = require('./header-conceptgraph-tag.test.js');
+const communityReferenceSupersetLink = require('./community-reference-superset-link.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -62,6 +63,9 @@ async function main() {
   console.log('\nheader-conceptgraph-tag suite:');
   const headerConceptGraphTagResult = await headerConceptGraphTag.run();
 
+  console.log('\ncommunity-reference-superset-link suite:');
+  const communityReferenceSupersetLinkResult = await communityReferenceSupersetLink.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -89,6 +93,9 @@ async function main() {
   console.log(
     `header-conceptgraph-tag suite:                   ${headerConceptGraphTagResult.fail === 0 ? 'PASS' : 'FAIL'} (${headerConceptGraphTagResult.pass} passed, ${headerConceptGraphTagResult.fail} failed)`
   );
+  console.log(
+    `community-reference-superset-link suite:         ${communityReferenceSupersetLinkResult.fail === 0 ? 'PASS' : 'FAIL'} (${communityReferenceSupersetLinkResult.pass} passed, ${communityReferenceSupersetLinkResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -99,7 +106,8 @@ async function main() {
     nip05CheckmarkVerificationResult.fail === 0 &&
     publishExportConceptResult.fail === 0 &&
     communityReferenceStubResult.fail === 0 &&
-    headerConceptGraphTagResult.fail === 0;
+    headerConceptGraphTagResult.fail === 0 &&
+    communityReferenceSupersetLinkResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }


### PR DESCRIPTION
## Summary

Promotes staging to main after green verification on `staging.brainstorm.world` (deploy 26137107696). Stream #5 Phase A of the ADR 0006 deferred roadmap — the structural materialization placeholder originally described at the start of the community-reference arc.

## Bundled

- **#164** — Story #11 / ADR 0008. `pass_communityReferences` now also fetches the community Superset (deterministic `39999:<curatorPk>:<dtag>-superset`), materializes it via the proven `buildImportCypher`/`executeCypher` primitives, explicitly **`SET n:Superset`** on the foreign node (kindToLabel gives only `:ListItem` for 39999), and post-derive MERGEs the **canonical** `(localSup:Superset)-[:IS_A_SUPERSET_OF]->(communitySup:Superset)` edge — no `source` property; this is the real class-thread propagation relationship. Independent-graceful per edge. Element/set bulk import explicitly deferred.

## Net production impact

Firmware install gains a Superset materialization + canonical `IS_A_SUPERSET_OF` edge for each concept with a `communityReference` (currently `nostr-relay` only). **Existing prod nodes are unchanged until an owner-gated firmware reinstall** (hybrid C — no mass re-emit). Class-thread traversals will *now* reach the community Superset via the canonical edge after a reinstall; community elements still aren't pulled (Phase B deferred). No behavior change for unauthenticated users, no migration, no forced sign-out. **Prod corner case (candid):** prod TA IS the curator (`919ba08a…`), so on prod itself the link is a degenerate self-reference; the real cross-instance value is on consumer instances (local + staging).

## Verification trail

- cycle-local smoke verified end-to-end on a real consumer instance (local TA `e00ed090…` ≠ curator `919ba08a…`): S1a foreign Superset labels include `:Superset` ✓ · S1b canonical edge `(:Superset)-[:IS_A_SUPERSET_OF]->(:Superset)` count=1 ✓ · S1c class-thread reachability from local Header ✓ · S3 idempotent reinstall (edge=1, node=1) ✓ · S4 community Superset HAS_ELEMENT=0 (honest invariant) ✓ · S5 Rule-5 audit: no programmatic enforcement on server (lives in tapestry-cli) → benign. npm test all suites + config green.
- Staging deploy 26137107696 success (1m29s); smoke PASS (stability, sanity w/ documented warmup-500 retry, Tier-3 read-only header-intact/edges-absent-EXPECTED-pre-reinstall, regression clean).

## Test plan

- [ ] After merge: deploy-brainstorm.yml green.
- [ ] Stability + Tier 2 sanity (expect transient warmup-500 — retry per OPERATIONS §8).
- [ ] prod nostr-relay 39998 header present with its normal 8 core relationships; foreign-curator edges (REFERENCES + IS_A_SUPERSET_OF) ABSENT until an owner-gated firmware reinstall (EXPECTED — same headless limit as #8/#10 had on staging/prod). No regression of concept-graph/normalize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)