### PR TITLE
Promote staging → main: task-queue Neo4j-heavy serialization (story #15)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -460,3 +460,81 @@ A faster alternative for full deployments: flip `TASK_QUEUE_ENABLED=false`, `sup
 ### 10.5 Redis persistence
 
 `docker-compose.yml` runs Redis with `--appendonly yes --appendfsync everysec`. Queued jobs survive `docker restart tapestry-redis` and container updates. No adverse interaction with the strfry-stream-consumer (which uses `blpop` on `strfry:events`) — AOF only adds an on-disk append per list operation.
+
+### 10.6 Cross-task resource-class concurrency caps
+
+**Story #15 / ADR 0013.** Story #13 introduced per-task queues with per-task concurrency caps — sufficient to serialize against same-task contention but not across different task names. Triggering `calculateOwnerGrapeRank` and `calculateOwnerPageRank` back-to-back will still run them concurrently because they live in different per-task queues. This subsection covers the additional cross-task layer.
+
+Requires `TASK_QUEUE_ENABLED=true` (§10.1). When the flag is off, the legacy direct-spawn path runs and resource-class tags have no effect.
+
+#### The `resourceClass` registry tag
+
+Tasks in `src/manage/taskQueue/taskRegistry.json` opt into cross-task serialization by adding a top-level `resourceClass` string, e.g.:
+
+```json
+{
+  "name": "Calculate Owner GrapeRank",
+  "resourceClass": "neo4j-heavy",
+  "categories": ["algorithms", "owner"],
+  ...
+}
+```
+
+Tasks without the tag are unaffected — they continue to use story #13's per-task concurrency only.
+
+The **initial tag set** shipped with this story is the owner trio:
+- `calculateOwnerHops`
+- `calculateOwnerPageRank`
+- `calculateOwnerGrapeRank`
+
+These are the three Neo4j-heavy tasks the operator demonstrated the cross-task pain with on `brainstorm.world`. Extend the set operationally by editing the registry and restarting the control panel.
+
+#### The `resourceClassCaps` config key
+
+Per-class concurrency caps live in `/etc/brainstorm-task-queue.json` as a sibling key to story #13's `concurrencyByTask`:
+
+```json
+{
+  "defaultConcurrency": 1,
+  "concurrencyByTask": {},
+  "resourceClassCaps": {
+    "neo4j-heavy": 1
+  }
+}
+```
+
+Cap default for `neo4j-heavy` is **1** — one Neo4j-heavy task at a time, the strictest interpretation matching the demonstrated pain. Raise to `2` (or higher) per environment if Neo4j proves it can handle concurrent heavy ops; lower to `0` (after a future enhancement) is not currently supported — a missing cap entry treats the class as cap=1 with a warning.
+
+#### Tagging a new task
+
+1. Edit `src/manage/taskQueue/taskRegistry.json`. Add `"resourceClass": "<class-name>"` to the entry.
+2. If `<class-name>` is new, edit `/etc/brainstorm-task-queue.json` and add an entry to `resourceClassCaps` with a numeric cap. (Untagged class = warning + cap=1 fallback.)
+3. `supervisorctl restart brainstorm`.
+4. Trigger the task. Inspect `/var/log/brainstorm/taskQueue/events.jsonl` for `phase=resource_class_*` events to confirm the wrap is active.
+
+#### Observability — `events.jsonl` phase tokens
+
+Resource-class lifecycle events are written to the same `events.jsonl` that bash `emit_task_event` uses (Node-side equivalent at `src/utils/structuredEvents.js`). Three phase tokens to grep for:
+
+- `resource_class_wait_begin` — task waiting for a slot. Metadata: `resourceClass`, `cap`, `jobId`.
+- `resource_class_wait_end` — wait resolved. Metadata: `resourceClass`, `wait_seconds`, `outcome` (`"acquired"` or `"timeout"`), `jobId`.
+- `resource_class_released` — task done, slot returned. Metadata: `resourceClass`, `held_seconds`, `jobId`.
+
+Quick operator check: "why hasn't my task started?" →
+```bash
+tail -f /var/log/brainstorm/taskQueue/events.jsonl | grep resource_class
+```
+
+#### The `RESOURCE_CLASS_WAIT_TIMEOUT` failure mode
+
+If a task waits longer than the configured `acquireTimeoutMs` (default **4 hours** — longer than any single heavy-task expected duration), the wait rejects with an Error whose `.code === 'RESOURCE_CLASS_WAIT_TIMEOUT'`. BullMQ marks the job failed; the job appears in BullBoard's `failed` tab with the error message containing `RESOURCE_CLASS_WAIT_TIMEOUT`. The corresponding `events.jsonl` entry is a `TASK_ERROR` event with `metadata.outcome: "timeout"`.
+
+This should be rare. If it fires, something upstream is stuck (e.g., a single heavy task running for >4 hours). Operator action: investigate the holder, manually clear the Redis hash if needed: `docker exec tapestry-redis redis-cli DEL taskQueue:resource-class:neo4j-heavy:holders`.
+
+#### Composes additively with story #13
+
+- Per-`(taskName, pubkey)` jobId dedup → unchanged.
+- Per-task concurrency from `concurrencyByTask` → unchanged.
+- Resource-class semaphore wraps the Worker callback BEFORE `processor.processJob` runs.
+
+For a tagged task with `concurrencyByTask: 2` and `resourceClassCaps.neo4j-heavy: 1`: the **effective** concurrency is the more restrictive of the two (here, 1 — one per class regardless of per-task budget).

--- a/engineering-team/decisions/0013-task-queue-neo4j-resource-class.md
+++ b/engineering-team/decisions/0013-task-queue-neo4j-resource-class.md
@@ -1,0 +1,247 @@
+# ADR 0013: Cross-task Neo4j-heavy serialization via Redis-backed counted semaphore
+
+**Status:** Proposed
+**Date:** 2026-05-21
+**Story:** `engineering-team/stories/15-task-queue-neo4j-resource-class.md`
+**Builds on:** ADR 0012 (story #13 — task-queue phase 1 BullMQ)
+
+## Context
+
+Story #13 / ADR 0012 shipped per-task BullMQ Queue+Worker pairs with per-task concurrency caps (default 1) and per-`(taskName, pubkey)` jobId dedup. Confirmed in production cycle-staging + cycle-prod: each task name correctly serializes against itself. But **two different task names** (e.g., `calculateOwnerGrapeRank` and `calculateOwnerPageRank`) live in different per-task queues with independent concurrency budgets and run concurrently — directly reproduced on `brainstorm.world` after #13's promote, matching the operational pain the operator originally articulated when story #13 was being planned.
+
+ADR 0012's "Forward-compat hook" pinned the architectural shape for this story:
+
+> Per-task queues are the natural injection point for the future "Neo4j-heavy class" cross-task coordination story. That sibling story will: (1) Add an optional `resourceClass` field to task registry entries (e.g., `"resourceClass": "neo4j-heavy"`). (2) Add a Redis-backed counted semaphore module (e.g., `neo4j-heavy: max 1`). (3) Wrap each Worker's processor with `acquire(resourceClass) → run → release(resourceClass)`.
+
+This ADR ratifies that design and resolves the four Architect-deferred questions from story #15: semaphore primitive, wait-timeout behavior, config-file location, and single-string vs. list `resourceClass`.
+
+### Grounded facts after re-reading the shipped source
+
+- **Worker construction** ([src/manage/taskQueue/queue/index.js:103](src/manage/taskQueue/queue/index.js:103)): `new Worker(taskName, async (job) => processor.processJob(job, taskDef), { connection: redis, concurrency })`. The Worker callback closure already has `taskDef` in scope — the natural place to wrap `processJob` with semaphore acquire/release. Keeps [processor.js](src/manage/taskQueue/queue/processor.js) resource-class-agnostic.
+- **Processor signature** ([processor.js:73](src/manage/taskQueue/queue/processor.js:73)): `processJob(job, taskDef) → Promise<result>`. No internal changes needed; the wrap is around the call.
+- **Shared ioredis connection** is already provided by `_state.redis` from ADR 0012. The semaphore reuses it (BullMQ duplicates internally for blocking ops; the semaphore's Lua scripts are not blocking, so the shared connection works directly).
+- **Owner trio in registry** confirmed present at the top level of `taskRegistry.json`: `calculateOwnerHops`, `calculateOwnerPageRank`, `calculateOwnerGrapeRank`. Each has a standard top-level shape (name, script, arguments, scope) — adding a sibling `resourceClass` field is non-invasive.
+- **Story #13's config file** at `/etc/brainstorm-task-queue.json` already established the shape `{defaultConcurrency, concurrencyByTask}`. Extending it with a sibling `resourceClassCaps` key is the obvious single-file operator surface.
+- **No `emit_task_event` Node-side equivalent exists yet** — story #13's processor uses plain `console.log` for queue-side logging. This ADR adds the Node-side equivalent (`src/utils/structuredEvents.js`) so queue events land in `events.jsonl` alongside bash-emitted events — making the existing structured-event UI / `events.jsonl` grep workflow uniform across bash- and Node-emitted events. (PO-resolved: invest now rather than defer.)
+
+### Concept-graph impact
+
+None. `/api/concept-graph/summaries` returns zero concepts matching `task|queue|redis|concurrency|semaphore|dispatch|worker|scheduler|bull` — operational/infrastructure layer only. **Firmware reinstall: no.**
+
+## Options considered
+
+### Option A — Custom Lua-scripted counted semaphore with TTL leases + poll-and-retry acquire (chosen)
+
+A small new module `src/manage/taskQueue/queue/resourceSemaphore.js`. Per-class state lives in a Redis hash `taskQueue:resource-class:<className>:holders`, mapping `leaseId → expiresAtMs`. Operations:
+
+- **Acquire** (atomic via a Lua script):
+  1. Sweep entries with `expiresAtMs < now` (crash-recovery — if a Worker died without releasing, its lease ages out and the next acquirer reclaims the slot).
+  2. If `HLEN(holders) < cap`, `HSET leaseId = now + leaseTtlMs`, return `1` (acquired).
+  3. Otherwise return `0` (denied).
+- **Release**: `HDEL holders leaseId`.
+- **Wait loop** (JS-side): on denial, sleep 500 ms, retry. Hard timeout at `acquireTimeoutMs` (default 4 h) → reject with `RESOURCE_CLASS_WAIT_TIMEOUT`.
+
+Wrap at Worker construction in `queue/index.js` (NOT inside `processor.js`):
+```js
+const sem = resourceSemaphore.createSemaphore(redis, queueConfig.resourceClassCaps || {});
+// ...
+const worker = new Worker(taskName, async (job) => {
+  const rc = taskDef.resourceClass;
+  if (rc) {
+    const release = await sem.acquire(rc);
+    try { return await processor.processJob(job, taskDef); }
+    finally { await release(); }
+  }
+  return processor.processJob(job, taskDef);
+}, { connection: redis, concurrency });
+```
+
+**Pros**
+- No new external dependency. Lua script is ~25 lines; JS wrapper ~80 lines.
+- TTL leases give crash-safety automatically — a Worker that dies mid-task doesn't permanently consume a slot. Next acquirer sweeps the stale lease.
+- Composes cleanly with story #13's per-task concurrency: a task with both per-task cap and resourceClass cap waits on whichever binds first.
+- Reuses the existing shared `ioredis` connection — no extra Redis client.
+- Processor stays resource-class-agnostic. Future stories that add new wrap behavior (rate-limiting, priority, etc.) follow the same pattern: edit the Worker callback in queue/index.js.
+- Operator failure mode is recognizable: `RESOURCE_CLASS_WAIT_TIMEOUT` is a literal error code; BullMQ marks the job failed with the error message visible in BullBoard's "failed" tab.
+
+**Cons**
+- 500 ms polling adds ~2 Redis ops/sec per waiter. At a cap of 1 and the operator's manual-trigger cadence, this is irrelevant load (Redis handles 10k+ ops/sec trivially).
+- TTL sweep is best-effort: if the entire process dies and no other acquire fires, the lease can technically outlive its TTL until the next acquire sweeps it. Acceptable because Worker restart implies a new acquire immediately.
+- BullMQ's BullBoard shows the waiting task as `active` (the Worker is in its processor callback, just sleeping in the acquire loop). This matches story #15's accepted observability minimum (structured events on wait) — the BullBoard misleading-active-state is documented and operator-detectable via the wait events.
+
+### Option B — Redlock or @sesamecare-oss/redlock library (counted-semaphore variant)
+
+Add a battle-tested distributed-lock library that ships counted-semaphore primitives.
+
+**Pros:** library handles fencing tokens, retry/backoff, crash-recovery internally; less code to maintain.
+**Cons:** new dependency for a single tiny use-case (~80 lines of our own code); redlock's algorithm is designed for multi-Redis-node clusters we don't have; brings opinionated retry behavior that may interact unpredictably with BullMQ's retry behavior. Rejected on minimal-deps + YAGNI grounds.
+
+### Option C — Defer marking the job `active` until the semaphore acquires (use BullMQ's `waiting` state to model the wait)
+
+Custom Worker that polls Redis for jobs in `waiting`, checks semaphore availability, and only `moveToActive`s when both are satisfied.
+
+**Pros:** BullBoard shows the wait state honestly (jobs appear in `waiting` while semaphore is full).
+**Cons:** rewrites the Worker dispatch loop that BullMQ provides. Significant complexity for a UI nicety. Story #15 explicitly marks this an "Architect upgrade if cheap" — it isn't cheap. Rejected; deferred as a potential follow-up if operator observability proves inadequate in practice.
+
+### Option D — BullMQ's per-Worker `limiter` option
+
+BullMQ Workers accept `{ limiter: { max: N, duration: Y } }`. But this is per-Worker, not cross-Worker. With 51 Workers (one per task), there's no way to share a limiter across `calculateOwnerGrapeRank` and `calculateOwnerPageRank` Workers using this API.
+
+Rejected — doesn't address the cross-task case at all.
+
+## Decision
+
+**We chose Option A** — custom Lua-scripted counted semaphore with TTL leases, polling acquire loop, wrap at Worker callback site.
+
+Reasons:
+- Smallest mechanical bridge from ADR 0012's per-task queue topology to cross-task serialization.
+- Uses the existing Redis dependency without adding a third concurrent library.
+- TTL leases close the crash-leak hole that any blocking-pop-on-a-token-pool design would have.
+- The Lua-script + 500ms-poll pair is well within the operator's mental model (read the script, understand the semantics in 5 minutes).
+- Composes additively with story #13's per-task concurrency — no breakage, just an additional gate.
+
+What we are trading away: visual fidelity in BullBoard (jobs appear `active` during wait, not `waiting`). Mitigated by the structured-event vocabulary that tells the operator what's happening; upgrade to honest `waiting` state is a future story if needed.
+
+## Consequences
+
+**Enabled**
+- Operator can trigger `calculateOwnerGrapeRank` + `calculateOwnerPageRank` back-to-back from Task Explorer and have them automatically serialize through Neo4j, eliminating the manual "wait for one to finish before starting the next" discipline.
+- Future resource classes (e.g., `io-bound`, `cpu-heavy`) are a one-config-line addition with no code change — the semaphore module is class-agnostic.
+- A future "honest `waiting` state in BullBoard" upgrade is mechanically possible without touching the registry or the cap configuration.
+
+**Constrained / made harder**
+- Adds a new module (`resourceSemaphore.js`) and a wrap point in the Worker callback. Anyone modifying queue/index.js needs to remember the wrap exists.
+- The 500 ms poll cadence is a tunable, but adds a small heartbeat of Redis traffic when many tasks are waiting on the same class. Bounded; not concerning at expected scale.
+- Operator who tags a task with a non-existent `resourceClass` (typo) gets `cap = 0` semantics in this design (no entry in `resourceClassCaps` → undefined → treated as 0 → tasks never acquire). Mitigation: log a warning at init for tagged-but-unconfigured classes; treat missing-cap as cap=1 with a console warning (operator-friendly default).
+
+**Follow-up debt (out of scope here)**
+- **BullBoard honest `waiting` state** (Option C above).
+- **Per-customer or per-tenant resource budgets.** This story does global per-class caps.
+- **Adopt `structuredEvents.emitTaskEvent` in story #13's processor.js** so queue-lifecycle events (currently `console.log`-only) also land in `events.jsonl`. Trivial follow-up commit once the helper exists.
+
+**Firmware reinstall required?** No.
+
+## Implementation notes
+
+The Implementer reads this section verbatim.
+
+### New files
+
+- **`src/utils/structuredEvents.js`** — Node-side equivalent of bash `emit_task_event` (from `src/utils/structuredLogging.sh`). Exports:
+  - `emitTaskEvent(eventType, taskName, target, metadata)` — writes a single JSONL line to `${BRAINSTORM_LOG_DIR}/taskQueue/events.jsonl` matching the bash version's shape exactly:
+    ```json
+    {"timestamp":"<ISO-8601>","eventType":"<...>","taskName":"<...>","target":"<...>","metadata":{...},"scriptName":"<source.js>","pid":<process.pid>}
+    ```
+  - Reads `BRAINSTORM_LOG_DIR` from `brainstormConfig.get('BRAINSTORM_LOG_DIR')` (defaults to `/var/log/brainstorm`).
+  - Implementation: `fs.appendFileSync(path, line + '\n')`. Atomic at the syscall level for line sizes under `PIPE_BUF` (4 KB on Linux); resource-class metadata payloads are <500 bytes, well within bounds. Sync write is acceptable because emissions are infrequent (a handful per minute under expected load).
+  - Captures `scriptName` from `require.main` or the call stack (best-effort; fallback to `'node'`). `pid` is `process.pid` of the control-panel process — that's correct attribution since all Worker emissions originate there (in contrast to bash where each spawned script has its own `$$`).
+  - Honors `BRAINSTORM_STRUCTURED_LOGGING=false` env var to short-circuit (matches the bash version's gate).
+  - Does NOT implement the bash version's rotation (`BRAINSTORM_EVENTS_MAX_SIZE`) — the bash side already rotates this file; Node-side just appends. Architect's call to keep ownership of rotation in one place.
+  - Future stories (Cypher dedup, story #13's processor, etc.) can adopt this helper as an incremental cleanup; not required by this story.
+
+- **`src/manage/taskQueue/queue/resourceSemaphore.js`** — exports:
+  - `createSemaphore(redis, caps, options?)` — factory. `caps` is the `resourceClassCaps` object (`{ "neo4j-heavy": 1, ... }`). `options` is optional with `{ leaseTtlMs, pollIntervalMs, acquireTimeoutMs }` defaults below.
+  - The returned semaphore has `.acquire(resourceClass) → Promise<release>` where `release` is an `async () => Promise<void>` to release the lease. On timeout, the Promise rejects with an `Error` whose `code === 'RESOURCE_CLASS_WAIT_TIMEOUT'`.
+  - On startup, validate that every task in the registry whose `resourceClass` is set has a corresponding entry in `caps`. For mismatches: log a warning `[task-queue] Task X has resourceClass Y but caps has no entry — treating as cap=1 with warning`; proceed with effective cap = 1.
+  - Defaults: `leaseTtlMs = 4 * 60 * 60 * 1000` (4 hours), `pollIntervalMs = 500`, `acquireTimeoutMs = 4 * 60 * 60 * 1000` (4 hours).
+  - Internal Lua script (loaded once at construction via `redis.defineCommand`):
+    ```lua
+    -- KEYS[1] = holders key (Redis hash)
+    -- ARGV: leaseId, cap, leaseTtlMs, nowMs
+    local fields = redis.call('HGETALL', KEYS[1])
+    for i = 1, #fields, 2 do
+      if tonumber(fields[i+1]) < tonumber(ARGV[4]) then
+        redis.call('HDEL', KEYS[1], fields[i])
+      end
+    end
+    local current = redis.call('HLEN', KEYS[1])
+    if current < tonumber(ARGV[2]) then
+      redis.call('HSET', KEYS[1], ARGV[1], tonumber(ARGV[4]) + tonumber(ARGV[3]))
+      return 1
+    end
+    return 0
+    ```
+  - Acquire emits **structured events via `structuredEvents.emitTaskEvent`** (new — see below) — same JSONL shape as bash-side `emit_task_event`, landing in the same `events.jsonl`:
+    - On wait-begin: `eventType="PROGRESS"`, `taskName=<taskName-being-waited-for>`, `metadata={phase:"resource_class_wait_begin", resourceClass, cap, jobId}`.
+    - On wait-end (acquired): `eventType="PROGRESS"`, `metadata={phase:"resource_class_wait_end", resourceClass, wait_seconds, outcome:"acquired", jobId}`.
+    - On wait-end (timeout): `eventType="TASK_ERROR"`, `metadata={phase:"resource_class_wait_end", resourceClass, wait_seconds, outcome:"timeout", jobId}` and reject the Promise.
+  - On release: `emitTaskEvent("PROGRESS", taskName, "", {phase:"resource_class_released", resourceClass, held_seconds, jobId})` (best-effort; ignore release errors).
+
+### Edited files
+
+- **`src/manage/taskQueue/queue/index.js`** — three changes inside `initTaskQueue`:
+  1. After loading `queueConfig`, construct the semaphore: `const semaphore = resourceSemaphore.createSemaphore(redis, queueConfig.resourceClassCaps || {});`
+  2. Inside the Worker construction loop, wrap the processor callback:
+     ```js
+     const rc = taskDef && taskDef.resourceClass;
+     const workerFn = rc
+       ? async (job) => {
+           const release = await semaphore.acquire(rc, { jobId: job.id });
+           try { return await processor.processJob(job, taskDef); }
+           finally { await release(); }
+         }
+       : async (job) => processor.processJob(job, taskDef);
+     const worker = new Worker(taskName, workerFn, { connection: redis, concurrency });
+     ```
+  3. Add `semaphore` to the `_state` object; close it in `closeTaskQueue` (no-op call for the Lua-scripted variant; the JS module just clears its in-memory map).
+- Optionally export `getSemaphore()` for cycle-local smoke / future tooling.
+
+- **`src/manage/taskQueue/taskRegistry.json`** — add `"resourceClass": "neo4j-heavy"` to each of the three owner-trio entries (top-level, alongside `name`, `script`, etc.):
+  - `calculateOwnerHops`
+  - `calculateOwnerPageRank`
+  - `calculateOwnerGrapeRank`
+
+### Config
+
+- **`/etc/brainstorm-task-queue.json`** — extend the JSON shape with a sibling `resourceClassCaps` key. Deploy default:
+  ```json
+  {
+    "defaultConcurrency": 1,
+    "concurrencyByTask": {},
+    "resourceClassCaps": {
+      "neo4j-heavy": 1
+    }
+  }
+  ```
+  The Implementer ships the deploy-time default in whichever file generation step produces `/etc/brainstorm-task-queue.json` on the droplet. If no such generation step exists yet (story #13 may have left it as "operator-creates-on-demand"), the queue module already handles the missing-file case (empty `resourceClassCaps` → no class enforcement, all tagged tasks log a warning + proceed at cap=1).
+
+### Documentation (`OPERATIONS.md` §10)
+
+Add a new subsection **§10.6 Resource-class concurrency caps**:
+- Explains the `resourceClass` registry field and the `resourceClassCaps` config key.
+- Documents the initial `neo4j-heavy: 1` cap and the three tagged tasks.
+- Documents the structured-event vocabulary written to `events.jsonl` via the new `src/utils/structuredEvents.js`:
+  - `metadata.phase: "resource_class_wait_begin"` — waiter starts polling for a slot.
+  - `metadata.phase: "resource_class_wait_end"` with `metadata.outcome: "acquired" | "timeout"` — wait resolved.
+  - `metadata.phase: "resource_class_released"` — task done, slot returned.
+  Each event's `taskName` is the task being waited on; `metadata.resourceClass` identifies the class.
+- Documents how to add a new tagged task: add `"resourceClass": "<class>"` to the registry entry, ensure `<class>` is in `resourceClassCaps`, restart control-panel.
+- Documents how to raise/lower a cap: edit `resourceClassCaps` in `/etc/brainstorm-task-queue.json`, restart control-panel.
+- Documents the rare `RESOURCE_CLASS_WAIT_TIMEOUT` failure mode and what it means.
+
+### Tests
+
+The Tester writes source-sentinel tests pinning:
+- `resourceSemaphore.js` exists, exports `createSemaphore`, uses Redis Lua scripting, has the `RESOURCE_CLASS_WAIT_TIMEOUT` error code literal.
+- `queue/index.js` constructs a semaphore and wraps the Worker callback conditionally on `taskDef.resourceClass`.
+- `taskRegistry.json` has `"resourceClass": "neo4j-heavy"` on the three owner-trio entries.
+- `src/utils/structuredEvents.js` exists and exports `emitTaskEvent` with the bash-matching JSONL shape (writes to `${BRAINSTORM_LOG_DIR}/taskQueue/events.jsonl`).
+- `resourceSemaphore.js` calls `structuredEvents.emitTaskEvent` (not `console.log`) for `resource_class_wait_begin` / `resource_class_wait_end` / `resource_class_released` phase tokens.
+- `OPERATIONS.md` §10.6 documents the new vocabulary.
+- Regression: story #13's per-task concurrency (`concurrencyByTask`), `jobId` dedup, BullBoard mount, feature-flag rollback, and 503 path remain intact.
+
+Cycle-local smoke (Reviewer-driven) validates the behavioral round-trip: trigger `calculateOwnerHops + calculateOwnerPageRank` with flag on + tags applied, observe the second waits via console-log `phase=wait_begin` then `phase=wait_end outcome=acquired` once the first releases.
+
+### Concept handle
+
+None. No new concepts.
+
+## Out of scope
+
+- **Honest `waiting` state in BullBoard** (Option C). Deferred unless operator observability proves inadequate in practice.
+- **Multi-class `resourceClass`** (e.g., `["neo4j-heavy", "io-bound"]`). Single string in this story; can be extended later without breaking the registry.
+- **Per-customer or per-tenant resource budgets.** Global per-class caps only.
+- **Auto-tagging additional tasks** as `neo4j-heavy`. Operator extends operationally.
+- **Retrofitting the legacy direct-spawn path** (`TASK_QUEUE_ENABLED=false`). Same scope boundary as ADR 0012.
+- **Cross-host distributed coordination.** Single droplet, single Redis.
+- **Pub/Sub wake-up instead of polling.** Polling at 500 ms is plenty for the expected cap/cadence.

--- a/engineering-team/reviews/15-task-queue-neo4j-resource-class.md
+++ b/engineering-team/reviews/15-task-queue-neo4j-resource-class.md
@@ -1,0 +1,155 @@
+# Review: Story 15 — Cross-task Neo4j-heavy serialization
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-21
+**Diff:** `git diff origin/staging...HEAD` (commit `70556d88`, 4 commits: `fe22905f` story, `25d9f345` ADR, `126c7b30` tests, `70556d88` impl)
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **PASS**. `task-queue-neo4j-resource-class suite: PASS (14 passed, 0 failed)` (10 ADR sentinels + 4 regression guards green). All 12 prior suites still PASS, unchanged. Overall: **PASS**.
+- [x] `node -c` parse — all 3 modified/new JS modules parse clean.
+- [x] _Playwright not applicable — no UI surface changed._
+- [x] _Lint / typecheck / build not configured — skipped per house rules._
+- [x] **Cycle-local smoke** — **PASS end-to-end** (see §"Cycle-local smoke verification" below). The behavioral round-trip the source-sentinels can't reach.
+
+## Spec adherence (AC walk)
+
+| AC | Status | Notes |
+|---|---|---|
+| AC-1 taggable + untagged unaffected | ✓ | T3+T7 source + smoke. Boot log: `resourceClasses=neo4j-heavy`. Untagged tasks hit the non-wrapped branch at [queue/index.js:128-129](src/manage/taskQueue/queue/index.js:128). |
+| AC-2 same-class concurrent → second waits | ✓ | T3+T4+T5 source + **smoke S2 end-to-end PROVED.** Two heavy tasks triggered ~0.5s apart: events.jsonl shows first acquired immediately (wait_seconds=0), second `wait_begin cap=1` → wait → `wait_end outcome=acquired wait_seconds=27` matching first's `held_seconds=27` exactly. |
+| AC-3 operator-configurable cap | ✓ source | T8 + smoke partial: `/etc/brainstorm-task-queue.json` with `resourceClassCaps.neo4j-heavy: 1` was loaded and respected. Did not re-test cap=2 (would require an additional config-edit smoke pass; ADR spec is straightforward). |
+| AC-4 untagged untouched | ✓ | T7 + R1. Conditional wrap at [queue/index.js:117](src/manage/taskQueue/queue/index.js:117): `resourceClass ? wrappedFn : directFn`. |
+| AC-5 story #13 contracts unchanged | ✓ | R1–R4 + 13 task-queue-bullmq sentinels remain green. |
+| AC-6 owner trio tagged | ✓ | T9 + visual audit: all three entries in `taskRegistry.json` have `"resourceClass": "neo4j-heavy"`. Clean 3-line diff (no whitespace noise after surgical re-Edit). |
+| AC-7 observability | ✓ | T1+T2+T6+T10 source + smoke. Five events.jsonl entries observed during the smoke — all three phase tokens (`wait_begin`, `wait_end`, `released`) present with the exact metadata the ADR specified. |
+| AC-8 orchestrator unaffected | smoke-deferred | bash-level orchestrator behavior unchanged by Node-side semaphore. Not separately re-tested; would just observe extra semaphore acquire/release per bash-orchestrator child. |
+| AC-9 flag-off → no effect | ✓ | Smoke S6: flipped `TASK_QUEUE_ENABLED=false`, restart, boot log: `Task queue disabled — legacy direct-spawn path active`. `/admin/queues → 200` (SPA shell, no BullBoard mount). |
+| AC-10 flag-on no tags → no effect | ✓ source | T7's conditional wrap is the proof. Not separately smoked but trivially follows from the branch. |
+| AC-11 no regression | ✓ | All 12 prior suites + 14 sentinels green. |
+
+## ADR adherence
+
+- [x] Files changed match ADR §Implementation notes exactly:
+  - New `src/utils/structuredEvents.js` ✓
+  - New `src/manage/taskQueue/queue/resourceSemaphore.js` ✓
+  - Edited `src/manage/taskQueue/queue/index.js` (semaphore construction + conditional Worker-callback wrap) ✓
+  - `src/manage/taskQueue/taskRegistry.json` (owner trio tagged) ✓
+  - `OPERATIONS.md` §10.6 ✓
+- [x] Lua script semantics match ADR pseudocode line-for-line: HGETALL → sweep expired → HLEN → HSET only if `current < cap`. Single round-trip. Atomic.
+- [x] Wait-and-retry loop semantics match: 500 ms poll, 4 h hard timeout, `RESOURCE_CLASS_WAIT_TIMEOUT` literal error code.
+- [x] Worker callback wrap follows the ADR's exact `try { processJob } finally { release }` shape — release guaranteed even if processor throws.
+- [x] structuredEvents writes JSONL to `${BRAINSTORM_LOG_DIR}/taskQueue/events.jsonl` matching bash `emit_task_event` shape exactly. Confirmed by smoke: events parse cleanly, fields match.
+
+## Concept-graph integrity
+
+- [x] No concept-graph schema changes (ADR §Consequences). Verified — no `firmware/concepts/` edits in the diff.
+- [x] No handles touched.
+
+## Things tests can't catch — pre-smoke audit findings
+
+Audited the implementation for hazards source-sentinels by design cannot reach:
+
+| Hazard | Status |
+|---|---|
+| Lua atomicity (two concurrent acquires both passing the HLEN<cap check) | **Closed** by Redis single-threaded Lua execution + script doing sweep+check+set atomically |
+| Release function not idempotent (double-release on processor retry) | **Closed** by `released` flag guard at [resourceSemaphore.js:125-128](src/manage/taskQueue/queue/resourceSemaphore.js:125) |
+| Processor throws → release never called → lease leaked | **Closed** by `try { processJob } finally { release }` in queue/index.js |
+| Worker crash mid-processing → lease leaked | **Closed** by TTL leases — next acquirer's Lua script sweeps expired entries |
+| `process` global shadowed (story #13's blocker) | **Closed** — function is named `emitTaskEvent`/`createSemaphore`/`acquire`, not `process` |
+| `BRAINSTORM_STRUCTURED_LOGGING=false` short-circuit | **Closed** — match bash semantics; gates events at the writer |
+| effectiveCap fallback on misconfigured class | **Acceptable** — warns to stderr + defaults to cap=1 (operator-friendly; non-blocking for ship) |
+| Sync `appendFileSync` blocking event loop | **Acceptable** — events emit 3 times per task; sub-millisecond writes; negligible at operator-trigger cadence |
+| Polling cadence Redis load | **Acceptable** — 2 ops/sec per waiter; bounded by waiter count (rarely >2 at cap=1) |
+
+## Cycle-local smoke verification
+
+Drove the validation that source-sentinels by design couldn't do. Container: `tapestry` Docker. Deployed delta (4 files: structuredEvents.js NEW, resourceSemaphore.js NEW, queue/index.js, taskRegistry.json). Wrote `/etc/brainstorm-task-queue.json` with `resourceClassCaps: { "neo4j-heavy": 1 }`. Flipped `TASK_QUEUE_ENABLED=true`. `supervisorctl restart brainstorm`.
+
+### Boot
+```
+Found TASK_QUEUE_ENABLED=true
+[task-queue] Initialized 51 queues + workers (defaultConcurrency=1, resourceClasses=neo4j-heavy)
+Task queue initialized (TASK_QUEUE_ENABLED=true)
+[bull-board] Mounted at /admin/queues (owner-only)
+```
+✓ The `resourceClasses=neo4j-heavy` segment is the new log line introduced by this story — direct evidence the config is being read and the semaphore is being constructed at the correct location in the init sequence.
+
+### S2 — Cross-task serialization PROVED end-to-end
+
+Triggered `calculateOwnerHops`, waited 0.5s, triggered `calculateOwnerPageRank`. Both tasks tagged `neo4j-heavy`. Observed events.jsonl phase tokens:
+
+```
+[PROGRESS  ] task=calculateOwnerHops      phase=resource_class_wait_end    resourceClass=neo4j-heavy wait_seconds=0  outcome=acquired
+[PROGRESS  ] task=calculateOwnerPageRank  phase=resource_class_wait_begin  resourceClass=neo4j-heavy cap=1
+[PROGRESS  ] task=calculateOwnerHops      phase=resource_class_released    resourceClass=neo4j-heavy held_seconds=27
+[PROGRESS  ] task=calculateOwnerPageRank  phase=resource_class_wait_end    resourceClass=neo4j-heavy wait_seconds=27 outcome=acquired
+[PROGRESS  ] task=calculateOwnerPageRank  phase=resource_class_released    resourceClass=neo4j-heavy held_seconds=6
+```
+
+**Read this carefully:**
+- Hops acquired in 0 seconds (instant — slot was free).
+- PageRank's wait started immediately on its second-place arrival.
+- Hops held for 27 seconds, then released.
+- PageRank's `wait_seconds=27` matches Hops's `held_seconds=27` **exactly** — PageRank acquired within one 500 ms poll window of Hops releasing.
+
+This is the **exact behavior the operator has been asking for since story #13 staging promotion**: two different Neo4j-heavy tasks triggered back-to-back run sequentially, not concurrently.
+
+### Redis state evidence
+
+During the wait window, Redis showed:
+```
+KEYS taskQueue:resource-class:*
+  → 1) "taskQueue:resource-class:neo4j-heavy:holders"
+HGETALL taskQueue:resource-class:neo4j-heavy:holders
+  → 8714ac1a-844d-4b66-9d49-3d5ce8cfb0ea  (leaseId)
+    1779356511743                          (expiresAtMs — 4 h from now)
+```
+Exactly ONE lease held (cap=1 respected). Lease-ID is a UUID per `crypto.randomUUID()`. Expiry epoch is `now + 4h` matching the ADR's `leaseTtlMs` default.
+
+After both tasks completed: `HLEN taskQueue:resource-class:neo4j-heavy:holders` → `0`. Slot returned cleanly.
+
+### S6 — Rollback round-trip
+
+`TASK_QUEUE_ENABLED=false`, restart. Boot log: `Task queue disabled (TASK_QUEUE_ENABLED=false) — legacy direct-spawn path active`. No `[task-queue] Initialized` line, no `[bull-board] Mounted` line. `/admin/queues → 200` (SPA shell). Story #15 has **zero effect** when the flag is off — semaphore module is never required.
+
+### Smoke scenarios NOT performed (acceptable gaps)
+
+- **S3** (operator tunes cap=2, verify two run concurrently) — not re-tested. The cap value is read from JSON via `loadQueueConfig`; trivially verifiable. ADR spec is straightforward.
+- **S5** (orchestrator scripts unaffected) — not separately smoked. The bash-level `updateAllScoresForOwner.sh` orchestrator calls children sequentially anyway; each child's acquire/release would just observe a freshly-empty slot.
+- **S7** (flag-on, no tags) — implicit from the conditional branch in queue/index.js; not separately smoked.
+- **S8** (RESOURCE_CLASS_WAIT_TIMEOUT) — not smoked. Would require either configuring a 10-second timeout + 3+ heavy tasks, or holding the semaphore in a side process for 4 hours. Acceptable risk: the timeout path is well-isolated (single `if` at [resourceSemaphore.js:156-171](src/manage/taskQueue/queue/resourceSemaphore.js:156)) and matches the source-sentinel-asserted error-code literal.
+
+## House rules check
+
+- [x] Concept Graph API authority respected (no concept change).
+- [x] No new lint/typecheck/build tooling.
+- [x] No firmware reinstall needed.
+- [x] Per-phase commits in order: story → adr → test → impl. Clean stack on top of `origin/staging` (which already includes story #13 merged + promoted to main).
+- [x] No source files modified outside the ADR's scope.
+
+## Findings
+
+### Blocking
+
+_None._
+
+### Non-blocking (recorded, do not gate)
+
+1. **AOF write amplification at very high event-emission rates (theoretical).** `appendFileSync` per emission combined with Redis AOF persistence (story #13) means each task generates ~3 sync disk writes to events.jsonl + ~2 Redis appends per resource-class lifecycle. At the operator's manual-trigger cadence this is negligible (sub-millisecond, sub-1KB writes). If story #16+ ever moves to high-throughput automated scheduling, batched async writes with periodic fsync would be worth considering. Not in scope here.
+
+2. **No node-side rotation of events.jsonl.** The bash `structuredLogging.sh` side rotates the file at 10k lines; Node-side does not (single-owner-of-rotation per ADR). If the Node-side ever becomes the dominant writer (e.g., when story #13's processor.js adopts emitTaskEvent), the rotation cadence may need to be re-thought. Out of scope here.
+
+3. **Smoke smoke-pass missed S3 + S8.** I covered the high-value scenarios (S2 cross-task serialization, S6 rollback). Cap-tuning (S3) and timeout-failure (S8) would be a useful follow-up but are well-isolated single-conditional paths; risk of bug-in-untested-path is low.
+
+4. **`getCallerScriptName` returns `'[eval]'` for emissions from `node -e` invocations** (observed during the Implementer's functional sanity test). Cosmetic; matches the actual filename Node would report.
+
+5. **First-time acquire emits `resource_class_wait_end outcome=acquired` even when wait_seconds=0** (no preceding `wait_begin`). Possibly slightly confusing in events.jsonl: a `wait_end` without a `wait_begin`. The operator can mentally infer "zero-wait grants emit only the end token." Could be addressed by suppressing wait_end when waitEmitted is false, but the current behavior is more informative (every acquire produces an end event for correlation) and is exactly what was specified. Non-issue.
+
+## Verdict
+
+**PASS end-to-end.**
+
+Both source-side (14/14 sentinels) and behavioral-side (cycle-local smoke S2 + S6) confirm the implementation matches ADR 0013 and resolves the operator's cross-task pain. The five non-blocking observations are cosmetic or out-of-scope; none gate ship.
+
+The story is ready for the deploy chain (`cycle-staging`, then on explicit confirmation `cycle-prod`). Recommend keeping `TASK_QUEUE_ENABLED=false` as the deploy default; operator flips on per environment after their own validation. Once flag is on, the operator can also extend the registry tag set operationally (e.g., add `syncWoT`, `reconciliation`, etc.) without re-deploying.

--- a/engineering-team/stories/15-task-queue-neo4j-resource-class.md
+++ b/engineering-team/stories/15-task-queue-neo4j-resource-class.md
@@ -1,0 +1,71 @@
+# Story 15: Serialize cross-task Neo4j-heavy operations through a shared concurrency cap
+
+**Status:** Approved
+**Created:** 2026-05-21
+**Type:** Feature (sibling to story #13)
+
+## Background
+
+Story #13's BullMQ task queue shipped **per-task** concurrency caps (default 1) plus per-`(taskName, pubkey)` dedup. This serializes within a single task name — two `calculateOwnerGrapeRank` triggers can't coexist. But two *different* task names live in different per-task queues with independent concurrency budgets and **run concurrently**. Observed on prod immediately after story #13 promoted (`brainstorm.world`, 2026-05-21): the operator triggered `calculateOwnerGrapeRank + calculateOwnerPageRank` back-to-back and both ran concurrently, exactly as before story #13 shipped.
+
+This is the operational pain that originally motivated story #13 (per its Background §"2026-05-20 update"). Story #13 deliberately deferred the fix to a sibling story so it could ship the durable-queue foundation first. This is that sibling.
+
+The operator's day-to-day pattern is **manual triggers from Task Explorer** (cron is disabled because reconciliation is broken; the only scheduled task is the Meilisearch refresh). Without cross-task serialization for Neo4j-heavy operations, every manual recalc requires the operator to remember to wait for prior heavy work to finish before triggering the next — and forgetting risks Neo4j crashes.
+
+ADR 0012 §Forward-compat hook pinned the design space: a resource-class tag on registry entries + a shared counted semaphore around the Worker's processor. This story ratifies that design and adds the operator-facing knobs.
+
+## User-facing description
+
+**As an operator** manually triggering Neo4j-heavy tasks via Task Explorer (or any future trigger surface), **I want** tasks tagged as "Neo4j-heavy" to share a concurrency cap (one at a time by default), **so that** I can trigger a sequence of heavy recalcs without remembering to wait for each to finish — and Neo4j is protected from concurrent expensive operations regardless of how many tasks I queue.
+
+## Acceptance criteria
+
+- [ ] Task registry entries can be tagged with a resource-class name (e.g., `"resourceClass": "neo4j-heavy"`). Tasks without a tag are unaffected by this story.
+- [ ] When two tasks tagged with the same resource class are submitted to the queue concurrently, only one runs at a time; the second waits until the first completes. Per-class cap is configurable; **default cap = 1** for `neo4j-heavy`.
+- [ ] The cap is operator-configurable per class (raise to 2 if Neo4j proves it can handle two concurrent heavies).
+- [ ] Tasks **without** a resource class continue to run per their own per-task concurrency cap — semaphore is **additive**, not replacing.
+- [ ] Story #13's per-task concurrency caps + per-`(taskName, pubkey)` dedup continue to work unchanged. The semaphore composes cleanly with them.
+- [ ] **Initial registry tag set:** the owner trio `calculateOwnerHops`, `calculateOwnerPageRank`, `calculateOwnerGrapeRank` are tagged `neo4j-heavy` in this story (resolves the prod-observed pain directly). Operator can extend the set in `taskRegistry.json` operationally without changing this story.
+- [ ] **Observability:** when a task is waiting on the resource-class semaphore (queued but not running due to the cap), this is visible — at minimum via structured events on `events.jsonl` with phase tokens like `resource_class_wait_begin` / `resource_class_wait_end`. Operator can answer "why hasn't my task started?" without reading source. Architect may additionally surface the wait state in BullBoard (deferring marking the job `active` until the semaphore acquires) if cheap; that's an Architect upgrade, not pinned by this story.
+- [ ] **Orchestrator scripts unaffected:** `updateAllScoresForOwner.sh` and similar pipelines that invoke multiple heavy tasks sequentially at the bash level already serialize at the script level — adding the semaphore does not break or duplicate that serialization (each child's enqueue + wait still works correctly).
+- [ ] **Behavior when `TASK_QUEUE_ENABLED=false`:** this story has no effect (the legacy direct-spawn path is unaware of the semaphore). That's intentional — the path to relief is to flip the queue flag on per environment, then this story serializes manual triggers.
+- [ ] **Behavior when `TASK_QUEUE_ENABLED=true` but no tasks are tagged:** no effect. Story #13's behavior unchanged.
+- [ ] No regression in story #13's 18-test source-sentinel suite or any of the other 11 suites.
+
+## Concepts touched
+
+- BullMQ task queue (introduced by story #13 / ADR 0012)
+- Task Registry (`taskRegistry.json`)
+- Redis (semaphore storage; shared with BullMQ + sessions + strfry-stream-consumer; all three coexist on different keyspaces)
+- Operator triggers via Task Explorer / `/api/run-task` (existing — contract unchanged)
+
+## Out of scope
+
+- **Auto-detection of "which tasks are Neo4j-heavy."** Operator tags them; the Architect may suggest extensions to the initial set.
+- **Per-customer or per-tenant resource budgets.** Single global semaphore per class. Per-customer caps are a future story.
+- **Multiple resource classes with cross-class interactions** (priority, deadlock detection, fair scheduling). This story introduces one class (`neo4j-heavy`); the mechanism may support multiple, but inter-class dynamics are not in scope.
+- **Retrofitting the legacy direct-spawn path** (`TASK_QUEUE_ENABLED=false`). If the operator wants protection without the queue, that's a separate, simpler story (bash-level lock or per-class `pgrep`).
+- **UI for tagging tasks or tuning caps.** Server-side config + registry edits in this phase, matching story #13's posture.
+- **Cross-host distributed coordination.** Single droplet, single Redis. Same scope as story #13.
+- **Expanding the initial tag set to customer-equivalent tasks** (`calculateCustomerHops/PageRank/GrapeRank`, etc.) or other orchestrator-aware heavies (`syncWoT`, `reconciliation`, `processOwnerFollowsMutesReports`, `calculateReportScores`). Operator will extend operationally as load patterns emerge; not in initial scope to avoid front-loading tags before observation.
+
+## Open questions
+
+**Resolved with operator at Planning (2026-05-21):**
+
+- **Default cap for `neo4j-heavy`** → **1** (one heavy task at a time; matches the demonstrated pain directly).
+- **Initial registry tag set** → **owner trio only** (`calculateOwnerHops`, `calculateOwnerPageRank`, `calculateOwnerGrapeRank`). Narrow start; operator extends operationally as load patterns emerge.
+- **Observability surface** → **structured events minimum** (`resource_class_wait_begin` / `resource_class_wait_end` phase tokens on `events.jsonl`). Architect may upgrade to BullBoard-visible `waiting` state if the change is cheap; not required.
+
+**Deferred to Architect (PO reviews at architecture gate):**
+
+- Exact config-file location for per-class caps (extend `/etc/brainstorm-task-queue.json` or sibling file).
+- Wait-timeout behavior (what happens if a task can't acquire the semaphore within N seconds — fail, requeue, infinite wait).
+- Whether to extend `resourceClass` to support multiple classes per task (`["neo4j-heavy", "io-bound"]`) or keep single-string for now.
+- Semaphore implementation primitive (Redis SET with TTL, Lua-script atomicity, BullMQ's built-in rate-limiter, etc.) — ADR 0012 mentioned "Redis-backed counted semaphore" as the forward-compat hook; Architect picks the concrete primitive.
+
+## Linked artifacts
+
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/15-task-queue-neo4j-resource-class.md
+++ b/engineering-team/stories/15-task-queue-neo4j-resource-class.md
@@ -68,4 +68,4 @@ ADR 0012 §Forward-compat hook pinned the design space: a resource-class tag on 
 
 - ADR: [0013-task-queue-neo4j-resource-class.md](../decisions/0013-task-queue-neo4j-resource-class.md)
 - Test plan: [15-task-queue-neo4j-resource-class.test-plan.md](15-task-queue-neo4j-resource-class.test-plan.md)
-- Review: (filled in after Review phase)
+- Review: [../reviews/15-task-queue-neo4j-resource-class.md](../reviews/15-task-queue-neo4j-resource-class.md) — **PASS** end-to-end (14/14 sentinels + cycle-local smoke S2 cross-task serialization PROVED on the live container).

--- a/engineering-team/stories/15-task-queue-neo4j-resource-class.md
+++ b/engineering-team/stories/15-task-queue-neo4j-resource-class.md
@@ -66,6 +66,6 @@ ADR 0012 §Forward-compat hook pinned the design space: a resource-class tag on 
 
 ## Linked artifacts
 
-- ADR: (filled in after Architecture phase)
+- ADR: [0013-task-queue-neo4j-resource-class.md](../decisions/0013-task-queue-neo4j-resource-class.md)
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/15-task-queue-neo4j-resource-class.md
+++ b/engineering-team/stories/15-task-queue-neo4j-resource-class.md
@@ -67,5 +67,5 @@ ADR 0012 §Forward-compat hook pinned the design space: a resource-class tag on 
 ## Linked artifacts
 
 - ADR: [0013-task-queue-neo4j-resource-class.md](../decisions/0013-task-queue-neo4j-resource-class.md)
-- Test plan: (filled in after Test Design phase)
+- Test plan: [15-task-queue-neo4j-resource-class.test-plan.md](15-task-queue-neo4j-resource-class.test-plan.md)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/15-task-queue-neo4j-resource-class.test-plan.md
+++ b/engineering-team/stories/15-task-queue-neo4j-resource-class.test-plan.md
@@ -1,0 +1,115 @@
+# Test Plan: Story 15 — Cross-task Neo4j-heavy serialization
+
+**Story:** `engineering-team/stories/15-task-queue-neo4j-resource-class.md`
+**ADR:** `engineering-team/decisions/0013-task-queue-neo4j-resource-class.md`
+**Date:** 2026-05-21
+
+## Approach
+
+Same precedent as #5/#6/#8/#10/#11/#12/#13. Source/structural sentinels in the hand-rolled Node runner pin the ADR-required code shape — new modules (`src/utils/structuredEvents.js`, `src/manage/taskQueue/queue/resourceSemaphore.js`), Lua-scripted Redis primitives, `RESOURCE_CLASS_WAIT_TIMEOUT` error code literal, conditional Worker-callback wrap on `taskDef.resourceClass`, `resourceClassCaps` config extension, owner-trio registry tags, and the structured-event phase vocabulary.
+
+The **behavioral round-trip** — actually triggering two `neo4j-heavy`-tagged tasks back-to-back with the queue flag on and observing the second wait via `events.jsonl` phase tokens; confirming the 4-hour timeout; verifying cap-tuning via config — is reproducible only against the live Docker stack with BullMQ deps installed and is the **authoritative cycle-local smoke** (Reviewer-required, per project precedent #5/#6/#8/#10/#11/#12/#13).
+
+## Coverage map
+
+| AC | Test / mechanism | File | Level |
+|---|---|---|---|
+| AC-1 (tasks taggable with resourceClass; untagged unaffected) | **T3** (semaphore module exists), **T7** (queue/index.js wraps only when `resourceClass` is truthy). Behavioral S1 = cycle-local | test/task-queue-neo4j-resource-class.test.js | source + smoke |
+| AC-2 (same-class concurrent → second waits; default cap 1) | **T3** + **T4** (Lua atomicity) + **T5** (timeout code). Behavioral S2 = cycle-local | test/task-queue-neo4j-resource-class.test.js | source + smoke |
+| AC-3 (cap operator-configurable) | **T8** (`resourceClassCaps` consumed from queueConfig). Behavioral S3 = cycle-local (operator raises cap to 2; verify two run) | test/task-queue-neo4j-resource-class.test.js | source + smoke |
+| AC-4 (untagged tasks per per-task concurrency; semaphore additive) | **T7** (conditional wrap) + **R1** (per-task topology preserved) | test/task-queue-neo4j-resource-class.test.js | source |
+| AC-5 (story #13 per-task concurrency + jobId dedup unchanged) | **R1** + **R2** + **R3** + **R4** + the 18-test task-queue-bullmq suite remaining green | test/task-queue-neo4j-resource-class.test.js + test/task-queue-bullmq.test.js | source (regression) |
+| AC-6 (initial registry tags: owner trio = neo4j-heavy) | **T9** (taskRegistry.json owner-trio entries have the tag) | test/task-queue-neo4j-resource-class.test.js | source |
+| AC-7 (observability via structured events; phase tokens) | **T1** + **T2** (structuredEvents.js exists, writes JSONL) + **T6** (semaphore calls emitTaskEvent with the three phase tokens) + **T10** (OPERATIONS.md §10.6 documents the vocabulary). Behavioral S4 = cycle-local (grep events.jsonl) | test/task-queue-neo4j-resource-class.test.js | source + smoke |
+| AC-8 (orchestrator scripts unaffected — bash-level serialization unchanged) | Behavioral only — bash orchestrator behavior not changed by Node-side semaphore. S5 = cycle-local | — | smoke |
+| AC-9 (TASK_QUEUE_ENABLED=false → no effect) | Inherits from story #13's #T13: when flag is off, queue module is never required → semaphore module never loaded → tag fields have no effect. **R3** preserves the flag branch | test/task-queue-neo4j-resource-class.test.js | source (via R3) + smoke S6 |
+| AC-10 (TASK_QUEUE_ENABLED=true but no tags → no effect) | Same as AC-1 conditional-wrap behavior (**T7**). Behavioral S7 = cycle-local | test/task-queue-neo4j-resource-class.test.js | source + smoke |
+| AC-11 (no regression in story #13's 18 sentinels + other 11 suites) | **R1**–**R4** + full `npm test` re-run pre/post-impl | full test gate | source (regression) |
+
+**Totals:** T1..T10 = **10 failing sentinels** pre-impl (flip to PASS post-impl). R1..R4 = **4 regression guards** that PASS pre AND post (catch regressions on per-task topology, the `process`→`processJob` rename, the feature-flag/503 contract, and the BullBoard mount).
+
+## Edge cases
+
+- [x] **Defensive file reads.** T2/T4/T5/T6 first check the parent file exists and short-circuit to "module missing — Tn must pass first" — avoids confusing "regex undefined" cascades when the implementer hasn't created the file yet.
+- [x] **T4 Lua-pattern tolerance.** Accepts any of `defineCommand`, `eval`, or `evalsha` — ioredis's three idiomatic ways to put Lua on the wire. Implementer can pick.
+- [x] **T4 hash-op tolerance.** Case-insensitive grep for `HSET`/`HDEL`/`HLEN` covers both Redis command-name casing conventions.
+- [x] **T6 multi-token assertion.** All three phase tokens (`resource_class_wait_begin`, `_wait_end`, `_released`) must appear; partial coverage fails with a specific message naming which token is missing.
+- [x] **T7 token-set assertion.** Pins three independent signals (`resourceSemaphore`/`createSemaphore` reference, `resourceClass` reference, `acquire`/`release` reference) so a partial wrap that imports the module but doesn't use it correctly still fails.
+- [x] **T9 JSON parse.** `readJsonSafe` returns null on malformed JSON so a registry corruption surfaces as a clear error rather than a parse exception. Each task tested independently with task-specific failure messages.
+- [x] **R2 anti-shadow guard.** Asserts both the positive (`processJob` referenced) AND the negative (no `function process(` re-introduction). Prevents the story-#13 review's blocking bug from sneaking back in via a refactor.
+- [ ] **Real Redis Lua atomicity, actual wait-and-release under contention, real timeout behavior, real config-tuned cap changes, real events.jsonl content shape under load** — not catchable in source; **cycle-local smoke is the authoritative check**.
+
+## Not covered (deferred to cycle-local smoke — authoritative, Reviewer-required)
+
+Run on the live Docker stack with `TASK_QUEUE_ENABLED=true` + BullMQ deps installed:
+
+**S1 — AC-1 (taggable + untagged unaffected):** Trigger `calculateOwnerGrapeRank` (tagged) — observe `resource_class_wait_begin` + `resource_class_wait_end outcome=acquired` events in `/var/log/brainstorm/taskQueue/events.jsonl`. Trigger an untagged task (e.g., `exportWhitelist`) — observe NO `resource_class_*` events for it.
+
+**S2 — AC-2 (concurrent → second waits):** Trigger `calculateOwnerGrapeRank` (long-running). While it runs, trigger `calculateOwnerPageRank`. Observe in events.jsonl:
+- First task: `wait_begin` → immediate `wait_end outcome=acquired`.
+- Second task: `wait_begin` → blocks → `wait_end outcome=acquired` only after first task's `released`.
+- Both tasks complete successfully; no concurrent execution overlap.
+
+**S3 — AC-3 (operator tunes cap):** Edit `/etc/brainstorm-task-queue.json` to set `"neo4j-heavy": 2`; `supervisorctl restart brainstorm`. Trigger the same two tasks back-to-back: assert both run concurrently. Restore cap to 1; restart; assert serial behavior returns.
+
+**S4 — AC-7 (observability surface):** Inspect `events.jsonl` after S2 — confirm JSONL well-formed; each event has the bash-matching shape (`timestamp`, `eventType`, `taskName`, `target`, `metadata`, `scriptName`, `pid`); `metadata.resourceClass` field present; `metadata.phase` field carries the three phase tokens; `metadata.wait_seconds` reasonable.
+
+**S5 — AC-8 (orchestrator scripts unaffected):** Trigger `updateAllScoresForOwner` (which in bash invokes Hops → PageRank → GrapeRank → ... sequentially). The orchestrator's sequential bash-level invocation continues to work; each child task enqueues through the queue path; the semaphore observes them one at a time (which they already are, by bash-level serialization). No deadlock, no duplicate serialization.
+
+**S6 — AC-9 (flag-off → no effect):** Set `TASK_QUEUE_ENABLED=false`; restart. Trigger the two heavy tasks back-to-back — both run concurrently (legacy direct-spawn path; semaphore module never loaded). No `resource_class_*` events emitted.
+
+**S7 — AC-10 (flag-on but no tags → no effect):** Flag on; temporarily revert the three owner-trio `resourceClass` tags in the runtime taskRegistry (or trigger a never-tagged task). Confirm: no semaphore wrap, no events emitted, behavior identical to story #13.
+
+**S8 — RESOURCE_CLASS_WAIT_TIMEOUT failure mode:** Configure a very short `acquireTimeoutMs` (e.g., 10 s) via the config or set the cap to 1 and trigger 3 heavy tasks back-to-back. The third should fail with `RESOURCE_CLASS_WAIT_TIMEOUT` after the timeout. BullBoard's failed tab surfaces the job; events.jsonl has `wait_end outcome=timeout` + a `TASK_ERROR` event.
+
+## Test infrastructure
+
+- Existing hand-rolled Node runner (`npm test` → `test/test.js`); no new deps.
+- Registered: `taskQueueNeo4jResourceClass` (at the end of `test/test.js`'s suite list, after `taskQueueBullmq`).
+- Asserts only against in-repo files: `src/utils/structuredEvents.js` (new), `src/manage/taskQueue/queue/{resourceSemaphore,index,processor,bullBoardMount}.js`, `src/manage/taskQueue/taskRegistry.json`, `src/api/manage/commands/runTask.js`, `OPERATIONS.md`.
+- No Playwright (the behavioral layer is filesystem + Redis + BullMQ + Lua — smoke territory; nothing pure-frontend).
+
+## How to run
+
+```
+npm test
+```
+
+Targeted: `node -e "require('./test/task-queue-neo4j-resource-class.test.js').run()"`
+
+## Verification
+
+New tests fail on the pre-implementation tree (atop ADR commit `25d9f345`):
+
+```
+task-queue-neo4j-resource-class suite:
+  ✗ T1: src/utils/structuredEvents.js exists and exports emitTaskEvent (ADR 0013 §New files; PO refinement)
+      Node-side structured-events helper does not exist at src/utils/structuredEvents.js (ADR 0013 §New files). Create the Node equivalent of bash emit_task_event (from src/utils/structuredLogging.sh) so queue-side events land in events.jsonl alongside bash-emitted events — PO-resolved to invest now rather than defer to console.log + a future cleanup.
+  ✗ T2: structuredEvents.js writes JSONL to taskQueue/events.jsonl using sync atomic append (ADR 0013 §New files)
+      structuredEvents.js missing — T1 must pass first.
+  ✗ T3: resourceSemaphore.js exists at the ADR-specified path and exports createSemaphore (AC-1, AC-2; ADR 0013 §New files)
+      Resource-semaphore module does not exist at src/manage/taskQueue/queue/resourceSemaphore.js (AC-1, AC-2; ADR 0013 §New files). Create the module that owns cross-task serialization via a Redis-backed counted semaphore with TTL leases.
+  ✗ T4: resourceSemaphore.js uses Redis-side Lua atomicity for check+set+sweep (AC-2; ADR 0013 §Option A)
+      resourceSemaphore.js missing — T3 must pass first.
+  ✗ T5: resourceSemaphore.js carries the RESOURCE_CLASS_WAIT_TIMEOUT error code literal (AC-2; ADR 0013 §Decision)
+      resourceSemaphore.js missing — T3 must pass first.
+  ✗ T6: resourceSemaphore.js emits structured events via emitTaskEvent (not console.log) (AC-7; ADR 0013 §Observability)
+      resourceSemaphore.js missing — T3 must pass first.
+  ✗ T7: queue/index.js constructs the semaphore and wraps the Worker callback conditionally on taskDef.resourceClass (AC-1, AC-4; ADR 0013 §Edited files)
+      queue/index.js does not reference the semaphore module (AC-1, AC-4; ADR 0013 §Edited files). The Worker construction loop must import and call createSemaphore so per-class caps are enforced before processor.processJob runs.
+  ✗ T8: queue/index.js consumes queueConfig.resourceClassCaps from the existing brainstorm-task-queue.json (AC-3; ADR 0013 §Config)
+      queue/index.js does not consume queueConfig.resourceClassCaps (AC-3; ADR 0013 §Config). The per-class cap configuration extends story #13's /etc/brainstorm-task-queue.json — same file, sibling key. Pass queueConfig.resourceClassCaps to createSemaphore so operators tune caps in one config surface.
+  ✗ T9: taskRegistry.json owner trio is tagged "resourceClass": "neo4j-heavy" (AC-6; ADR 0013 §Implementation notes)
+      taskRegistry.json entry for `calculateOwnerHops` is not tagged with "resourceClass": "neo4j-heavy" (AC-6; ADR 0013 §Implementation notes). This is the initial tag set the operator demonstrated the pain with on brainstorm.world (calculateOwnerGrapeRank + calculateOwnerPageRank running concurrently post-story-#13). Add the tag at the top level of the entry, alongside `name`, `script`, etc.
+  ✗ T10: OPERATIONS.md §10.6 documents the resource-class config + phase tokens (AC-7; ADR 0013 §Documentation)
+      OPERATIONS.md does not document: the `resourceClass` registry field, the `resourceClassCaps` config key, the `neo4j-heavy` class name, the resource_class_wait_begin/wait_end/released phase tokens (AC-7; ADR 0013 §Documentation). Add §10.6 covering: …
+  ✓ R1: queue/index.js still constructs per-task Queue + Worker per registry task (story #13 topology preserved, AC-5)
+  ✓ R2: processor.js still exports processJob (NOT process, story #13 blocker-fix preserved)
+  ✓ R3: runTask.js feature-flag branch + 503 QUEUE_UNAVAILABLE preserved (story #13 / ADR 0012 contract)
+  ✓ R4: BullBoard mount module still exists and references /admin/queues + requireOwnerOnly (story #13 / ADR 0012 contract)
+
+task-queue-neo4j-resource-class suite:           FAIL (4 passed, 10 failed)
+Overall:                                         FAIL
+```
+
+All 12 prior suites continue to PASS (no regressions introduced by the new sentinel registration).

--- a/src/manage/taskQueue/queue/index.js
+++ b/src/manage/taskQueue/queue/index.js
@@ -25,6 +25,7 @@ const { Queue, Worker, QueueEvents } = require('bullmq');
 const Redis = require('ioredis');
 const brainstormConfig = require('../../../utils/brainstormConfig');
 const processor = require('./processor');
+const resourceSemaphore = require('./resourceSemaphore');
 
 const QUEUE_CONFIG_PATH = '/etc/brainstorm-task-queue.json';
 const DEFAULT_QUEUE_CONFIG = { defaultConcurrency: 1, concurrencyByTask: {} };
@@ -87,6 +88,15 @@ async function initTaskQueue({ registry } = {}) {
   const queueConfig = loadQueueConfig();
   const redis = createRedisConnection();
 
+  // Construct the cross-task resource-class semaphore (story #15 / ADR 0013).
+  // When resourceClassCaps is empty/missing, only tagged tasks (those with
+  // taskDef.resourceClass set) hit the wrap below — untagged tasks call the
+  // processor directly with no overhead, no behavior change vs story #13.
+  const semaphore = resourceSemaphore.createSemaphore(
+    redis,
+    queueConfig.resourceClassCaps || {}
+  );
+
   const queues = new Map();
   const workers = new Map();
   const queueEvents = new Map();
@@ -100,11 +110,27 @@ async function initTaskQueue({ registry } = {}) {
       queueConfig.defaultConcurrency;
 
     const taskDef = registry.tasks[taskName];
-    const worker = new Worker(
-      taskName,
-      async (job) => processor.processJob(job, taskDef),
-      { connection: redis, concurrency }
-    );
+    const resourceClass = taskDef && taskDef.resourceClass;
+
+    // Conditional Worker-callback wrap. Tagged tasks acquire the resource-
+    // class semaphore before processor.processJob runs; untagged tasks call
+    // the processor directly (story #13 behavior unchanged).
+    const workerFn = resourceClass
+      ? async (job) => {
+          const release = await semaphore.acquire(resourceClass, {
+            taskName,
+            target: (job && job.data && job.data.customerArgs && job.data.customerArgs.pubkey) || '',
+            jobId: job && job.id
+          });
+          try {
+            return await processor.processJob(job, taskDef);
+          } finally {
+            await release();
+          }
+        }
+      : async (job) => processor.processJob(job, taskDef);
+
+    const worker = new Worker(taskName, workerFn, { connection: redis, concurrency });
     worker.on('failed', (job, err) => {
       console.error(`[task-queue] Worker for ${taskName} failed job ${job && job.id}: ${err && err.message}`);
     });
@@ -113,8 +139,12 @@ async function initTaskQueue({ registry } = {}) {
     queueEvents.set(taskName, new QueueEvents(taskName, { connection: redis }));
   }
 
-  _state = { redis, queues, workers, queueEvents, registry, queueConfig };
-  console.log(`[task-queue] Initialized ${queues.size} queues + workers (defaultConcurrency=${queueConfig.defaultConcurrency})`);
+  _state = { redis, queues, workers, queueEvents, registry, queueConfig, semaphore };
+  console.log(
+    `[task-queue] Initialized ${queues.size} queues + workers ` +
+    `(defaultConcurrency=${queueConfig.defaultConcurrency}, ` +
+    `resourceClasses=${Object.keys(queueConfig.resourceClassCaps || {}).join(',') || 'none'})`
+  );
   return _state;
 }
 

--- a/src/manage/taskQueue/queue/resourceSemaphore.js
+++ b/src/manage/taskQueue/queue/resourceSemaphore.js
@@ -1,0 +1,180 @@
+/**
+ * Resource Semaphore — cross-task concurrency control for the BullMQ task queue.
+ * Story #15 / ADR 0013.
+ *
+ * Per-class state lives in a Redis hash keyed by leaseId → expiresAtMs at
+ *   `taskQueue:resource-class:<className>:holders`
+ *
+ * Acquire is atomic via a Lua script that (1) sweeps expired leases, (2)
+ * checks HLEN < cap, (3) HSETs a fresh lease on success. Single Redis
+ * round-trip per attempt.
+ *
+ * Wait loop: poll at pollIntervalMs (default 500 ms) until acquire returns 1
+ * OR the hard timeout (default 4 hours) elapses → reject with an Error whose
+ * `.code === 'RESOURCE_CLASS_WAIT_TIMEOUT'`.
+ *
+ * Crash safety: TTL leases. If a Worker dies without releasing, its lease
+ * ages out at `leaseTtlMs` (default 4 hours) and the next acquirer sweeps it
+ * automatically.
+ *
+ * Observability: emits structured events to events.jsonl via the Node-side
+ * emit_task_event helper at src/utils/structuredEvents.js, with phase tokens:
+ *   - resource_class_wait_begin    (waiter starts polling)
+ *   - resource_class_wait_end      (wait resolved — outcome: "acquired" | "timeout")
+ *   - resource_class_released      (lease released — held_seconds)
+ */
+
+const crypto = require('crypto');
+const { emitTaskEvent } = require('../../../utils/structuredEvents');
+
+const DEFAULT_LEASE_TTL_MS = 4 * 60 * 60 * 1000;        // 4 hours
+const DEFAULT_POLL_INTERVAL_MS = 500;                    // 0.5 s
+const DEFAULT_ACQUIRE_TIMEOUT_MS = 4 * 60 * 60 * 1000;   // 4 hours
+
+// Atomic Lua script: sweep expired leases, then check HLEN < cap, then HSET.
+// Returns 1 if a slot was acquired, 0 if denied.
+const ACQUIRE_LUA = `
+local fields = redis.call('HGETALL', KEYS[1])
+for i = 1, #fields, 2 do
+  if tonumber(fields[i+1]) < tonumber(ARGV[4]) then
+    redis.call('HDEL', KEYS[1], fields[i])
+  end
+end
+local current = redis.call('HLEN', KEYS[1])
+if current < tonumber(ARGV[2]) then
+  redis.call('HSET', KEYS[1], ARGV[1], tonumber(ARGV[4]) + tonumber(ARGV[3]))
+  return 1
+end
+return 0
+`;
+
+function holdersKey(resourceClass) {
+  return `taskQueue:resource-class:${resourceClass}:holders`;
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Factory. Returns a semaphore instance bound to the given ioredis client and
+ * per-class caps map.
+ *
+ * @param {import('ioredis').Redis} redis    shared ioredis connection
+ * @param {Object<string, number>} caps      per-class concurrency caps; e.g., { "neo4j-heavy": 1 }
+ * @param {Object} [options]                 { leaseTtlMs, pollIntervalMs, acquireTimeoutMs }
+ */
+function createSemaphore(redis, caps, options) {
+  const opts = options || {};
+  const leaseTtlMs       = opts.leaseTtlMs       || DEFAULT_LEASE_TTL_MS;
+  const pollIntervalMs   = opts.pollIntervalMs   || DEFAULT_POLL_INTERVAL_MS;
+  const acquireTimeoutMs = opts.acquireTimeoutMs || DEFAULT_ACQUIRE_TIMEOUT_MS;
+
+  // Register the Lua script as a custom ioredis command. Single registration
+  // up front; each call invokes via the EVALSHA fast path.
+  redis.defineCommand('semaphoreAcquire', {
+    numberOfKeys: 1,
+    lua: ACQUIRE_LUA
+  });
+
+  function effectiveCap(resourceClass) {
+    if (caps && typeof caps[resourceClass] === 'number') {
+      return caps[resourceClass];
+    }
+    // Tagged-but-unconfigured: warn and treat as cap=1 (operator-friendly).
+    console.warn(
+      `[task-queue][resource-class] No cap configured for class "${resourceClass}" ` +
+      `in resourceClassCaps — treating as cap=1.`
+    );
+    return 1;
+  }
+
+  /**
+   * Attempt to acquire a slot in the named resource class. Returns a
+   * `release` function (async; idempotent) on success. Rejects with an Error
+   * whose `.code === 'RESOURCE_CLASS_WAIT_TIMEOUT'` if acquireTimeoutMs
+   * elapses without acquiring.
+   *
+   * @param {string} resourceClass
+   * @param {Object} [context]  { taskName, target, jobId } — included in
+   *                            structured events for operator visibility.
+   */
+  async function acquire(resourceClass, context) {
+    const ctx = context || {};
+    const cap = effectiveCap(resourceClass);
+    const key = holdersKey(resourceClass);
+    const leaseId = crypto.randomUUID();
+    const start = Date.now();
+    let waitEmitted = false;
+
+    while (true) {
+      const now = Date.now();
+      const result = await redis.semaphoreAcquire(key, leaseId, cap, leaseTtlMs, now);
+
+      if (result === 1) {
+        const waitSeconds = Math.round((Date.now() - start) / 1000);
+        emitTaskEvent('PROGRESS', ctx.taskName || resourceClass, ctx.target || '', {
+          phase: 'resource_class_wait_end',
+          resourceClass,
+          wait_seconds: waitSeconds,
+          outcome: 'acquired',
+          jobId: ctx.jobId || null
+        });
+
+        const acquiredAt = Date.now();
+        let released = false;
+        return async function release() {
+          if (released) return;
+          released = true;
+          try {
+            await redis.hdel(key, leaseId);
+            const heldSeconds = Math.round((Date.now() - acquiredAt) / 1000);
+            emitTaskEvent('PROGRESS', ctx.taskName || resourceClass, ctx.target || '', {
+              phase: 'resource_class_released',
+              resourceClass,
+              held_seconds: heldSeconds,
+              jobId: ctx.jobId || null
+            });
+          } catch (_e) {
+            // Best-effort; ignore release errors so a Redis blip mid-task
+            // doesn't propagate as a job failure.
+          }
+        };
+      }
+
+      // Denied — emit wait_begin (only on first denial), then sleep.
+      if (!waitEmitted) {
+        emitTaskEvent('PROGRESS', ctx.taskName || resourceClass, ctx.target || '', {
+          phase: 'resource_class_wait_begin',
+          resourceClass,
+          cap,
+          jobId: ctx.jobId || null
+        });
+        waitEmitted = true;
+      }
+
+      if (Date.now() - start >= acquireTimeoutMs) {
+        const waitSeconds = Math.round((Date.now() - start) / 1000);
+        emitTaskEvent('TASK_ERROR', ctx.taskName || resourceClass, ctx.target || '', {
+          phase: 'resource_class_wait_end',
+          resourceClass,
+          wait_seconds: waitSeconds,
+          outcome: 'timeout',
+          jobId: ctx.jobId || null
+        });
+        const err = new Error(
+          `Could not acquire resource class "${resourceClass}" within ${acquireTimeoutMs}ms ` +
+          `(cap=${cap}). RESOURCE_CLASS_WAIT_TIMEOUT.`
+        );
+        err.code = 'RESOURCE_CLASS_WAIT_TIMEOUT';
+        throw err;
+      }
+
+      await sleep(pollIntervalMs);
+    }
+  }
+
+  return { acquire };
+}
+
+module.exports = { createSemaphore };

--- a/src/manage/taskQueue/taskRegistry.json
+++ b/src/manage/taskQueue/taskRegistry.json
@@ -539,6 +539,7 @@
 
     "calculateOwnerGrapeRank": {
       "name": "Calculate Owner GrapeRank",
+      "resourceClass": "neo4j-heavy",
       "categories": ["algorithms", "owner"],
       "description": "Calculates personalized GrapeRank scores for the instance owner",
       "scripts": [
@@ -592,6 +593,7 @@
 
     "calculateOwnerPageRank": {
       "name": "Calculate Owner PageRank",
+      "resourceClass": "neo4j-heavy",
       "categories": ["algorithms", "owner"],
       "description": "Calculates personalized PageRank scores for the instance owner",
       "scripts": [
@@ -635,6 +637,7 @@
 
     "calculateOwnerHops": {
       "name": "Calculate Owner Hops (Frontier)",
+      "resourceClass": "neo4j-heavy",
       "categories": ["algorithms", "owner"],
       "description": "Calculates hop distances from the instance owner using frontier-based BFS — only scans each hop level's edges, not the entire graph",
       "scripts": [

--- a/src/utils/structuredEvents.js
+++ b/src/utils/structuredEvents.js
@@ -1,0 +1,106 @@
+/**
+ * Node-side structured-events emitter.
+ * Story #15 / ADR 0013.
+ *
+ * Node equivalent of bash `emit_task_event` (from src/utils/structuredLogging.sh).
+ * Writes single JSONL lines to ${BRAINSTORM_LOG_DIR}/taskQueue/events.jsonl
+ * matching the bash version's shape exactly, so the existing structured-event
+ * UI / grep workflow doesn't have to learn a second format.
+ *
+ * Bash-matching JSONL shape per line:
+ *   {
+ *     "timestamp":   "<ISO-8601>",
+ *     "eventType":   "<TASK_START | PROGRESS | TASK_END | TASK_ERROR | ...>",
+ *     "taskName":    "<...>",
+ *     "target":      "<...>",
+ *     "metadata":    { ...arbitrary... },
+ *     "scriptName":  "<filename derived from caller stack>",
+ *     "pid":         <process.pid of the Node process>
+ *   }
+ *
+ * Design notes (per ADR 0013 §New files):
+ * - `fs.appendFileSync` for line-atomic writes under PIPE_BUF (4 KB on Linux).
+ *   Async appendFile interleaves under concurrent writes and corrupts JSONL.
+ * - Honors `BRAINSTORM_STRUCTURED_LOGGING=false` env var to short-circuit
+ *   (matches bash version's gate).
+ * - Does NOT implement rotation; the bash structuredLogging.sh side already
+ *   rotates the events.jsonl file. Single owner of rotation = simpler.
+ * - `scriptName` is derived from the call stack (best-effort) so events
+ *   originated from different Node modules are distinguishable in `events.jsonl`.
+ * - `pid` is always `process.pid` of the Node process. For Worker emissions
+ *   this is the control-panel process PID (all Workers share it). Bash-side
+ *   emitters capture each spawned script's `$$`, which differs.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const brainstormConfig = require('./brainstormConfig');
+
+function getEventsPath() {
+  const logDir = brainstormConfig.get('BRAINSTORM_LOG_DIR') || '/var/log/brainstorm';
+  return path.join(logDir, 'taskQueue', 'events.jsonl');
+}
+
+function ensureDir(filePath) {
+  try { fs.mkdirSync(path.dirname(filePath), { recursive: true }); }
+  catch (_e) { /* best-effort */ }
+}
+
+/**
+ * Derive a useful `scriptName` for the event payload by walking the V8 stack
+ * back to the first frame outside this module. Falls back to require.main or
+ * the literal string 'node' if we can't find one.
+ */
+function getCallerScriptName() {
+  try {
+    const stack = new Error().stack || '';
+    const lines = stack.split('\n');
+    for (let i = 2; i < lines.length; i++) {
+      // Match either "at fn (path:line:col)" or "at path:line:col".
+      const m = lines[i].match(/\(([^)]+):\d+:\d+\)/) || lines[i].match(/at ([^\s]+):\d+:\d+/);
+      if (m && m[1] && !m[1].endsWith('structuredEvents.js')) {
+        return path.basename(m[1]);
+      }
+    }
+  } catch (_e) { /* fall through */ }
+  if (require.main && require.main.filename) return path.basename(require.main.filename);
+  return 'node';
+}
+
+/**
+ * Emit a single structured event to events.jsonl.
+ *
+ * Signature mirrors bash emit_task_event:
+ *   emit_task_event "EVENT_TYPE" "task-name" "target" '{"k":"v"}'
+ *
+ * @param {string} eventType    e.g., "TASK_START", "PROGRESS", "TASK_ERROR"
+ * @param {string} taskName     e.g., "calculateOwnerGrapeRank"
+ * @param {string} target       e.g., a pubkey, customer id, or ""
+ * @param {object} metadata     arbitrary structured metadata
+ */
+function emitTaskEvent(eventType, taskName, target, metadata) {
+  if (process.env.BRAINSTORM_STRUCTURED_LOGGING === 'false') return;
+
+  const eventsPath = getEventsPath();
+  ensureDir(eventsPath);
+
+  const event = {
+    timestamp: new Date().toISOString(),
+    eventType: eventType || 'UNKNOWN',
+    taskName: taskName || '',
+    target: target || '',
+    metadata: metadata || {},
+    scriptName: getCallerScriptName(),
+    pid: process.pid
+  };
+
+  try {
+    fs.appendFileSync(eventsPath, JSON.stringify(event) + '\n');
+  } catch (e) {
+    // Best-effort: don't crash the caller if event logging fails.
+    // (e.g., disk full, permission denied) — log to stderr and proceed.
+    console.warn(`[structured-events] Failed to write event: ${e.message}`);
+  }
+}
+
+module.exports = { emitTaskEvent };

--- a/test/task-queue-neo4j-resource-class.test.js
+++ b/test/task-queue-neo4j-resource-class.test.js
@@ -1,0 +1,341 @@
+/**
+ * Story #15 / ADR 0013 — Cross-task Neo4j-heavy serialization via Redis-backed
+ * counted semaphore.
+ *
+ * Source/structural sentinels pin the ADR-required code shape. The behavioral
+ * round-trip — actually triggering two `neo4j-heavy`-tagged tasks back-to-back
+ * with the queue flag on, observing the second wait via `events.jsonl`
+ * `resource_class_wait_*` phase tokens, and confirming the timeout-failure
+ * mode — is reproducible only against the live Docker stack with deps
+ * installed and is the **authoritative cycle-local smoke** (Reviewer-required,
+ * per project precedent #5/#6/#8/#10/#11/#12/#13).
+ *
+ * T1..T10 : FAIL pre-implementation, PASS post.
+ * R1..R4  : PASS pre AND post — regression guards on story #13's per-task
+ *           queue topology, the processor.processJob entry point, the
+ *           feature-flag branch + 503 path, and the BullBoard mount.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const STRUCTURED_EVENTS  = path.join(ROOT, 'src/utils/structuredEvents.js');
+const RESOURCE_SEMAPHORE = path.join(ROOT, 'src/manage/taskQueue/queue/resourceSemaphore.js');
+const QUEUE_INDEX        = path.join(ROOT, 'src/manage/taskQueue/queue/index.js');
+const QUEUE_PROCESSOR    = path.join(ROOT, 'src/manage/taskQueue/queue/processor.js');
+const BULLBOARD_MOUNT    = path.join(ROOT, 'src/manage/taskQueue/queue/bullBoardMount.js');
+const RUN_TASK_JS        = path.join(ROOT, 'src/api/manage/commands/runTask.js');
+const TASK_REGISTRY      = path.join(ROOT, 'src/manage/taskQueue/taskRegistry.json');
+const OPERATIONS_MD      = path.join(ROOT, 'OPERATIONS.md');
+
+function readSafe(p) {
+  try { return fs.readFileSync(p, 'utf8'); }
+  catch (_e) { return null; }
+}
+
+function readJsonSafe(p) {
+  const s = readSafe(p);
+  if (s === null) return null;
+  try { return JSON.parse(s); }
+  catch (_e) { return null; }
+}
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+
+// ---------------------------------------------------------------------------
+// Failing tests — FAIL now, PASS once Story #15 is implemented per ADR 0013.
+// ---------------------------------------------------------------------------
+
+test('T1: src/utils/structuredEvents.js exists and exports emitTaskEvent (ADR 0013 §New files; PO refinement)', () => {
+  const src = readSafe(STRUCTURED_EVENTS);
+  assert(
+    src !== null,
+    'Node-side structured-events helper does not exist at src/utils/structuredEvents.js (ADR 0013 §New ' +
+      'files). Create the Node equivalent of bash emit_task_event (from src/utils/structuredLogging.sh) so ' +
+      'queue-side events land in events.jsonl alongside bash-emitted events — PO-resolved to invest now ' +
+      'rather than defer to console.log + a future cleanup.'
+  );
+  assert(
+    /\bemitTaskEvent\b/.test(src),
+    'src/utils/structuredEvents.js does not export emitTaskEvent (ADR 0013 §New files). The function ' +
+      'signature must match bash emit_task_event: (eventType, taskName, target, metadata).'
+  );
+  assert(
+    /module\.exports/.test(src),
+    'src/utils/structuredEvents.js is missing module.exports (ADR 0013 §New files). The module is a ' +
+      'CommonJS-style helper — must export emitTaskEvent for require() callers.'
+  );
+});
+
+test('T2: structuredEvents.js writes JSONL to taskQueue/events.jsonl using sync atomic append (ADR 0013 §New files)', () => {
+  const src = readSafe(STRUCTURED_EVENTS);
+  assert(src !== null, 'structuredEvents.js missing — T1 must pass first.');
+  // ADR pins: write to `${BRAINSTORM_LOG_DIR}/taskQueue/events.jsonl` matching
+  // the bash version's path; use appendFileSync for line-atomic writes (under
+  // PIPE_BUF on Linux).
+  assert(
+    /events\.jsonl/.test(src),
+    'structuredEvents.js does not target events.jsonl (ADR 0013 §New files). Writes must land in the ' +
+      'same path bash emit_task_event uses: ${BRAINSTORM_LOG_DIR}/taskQueue/events.jsonl. Anything else ' +
+      'forks the structured-event stream — which is the exact thing this helper exists to avoid.'
+  );
+  assert(
+    /appendFileSync/.test(src),
+    'structuredEvents.js does not use fs.appendFileSync (ADR 0013 §New files). Sync append is required for ' +
+      'line-atomic concurrent writes under PIPE_BUF (4 KB on Linux). Async appendFile interleaves under ' +
+      'concurrent writes and corrupts JSONL lines.'
+  );
+  assert(
+    /BRAINSTORM_LOG_DIR/.test(src),
+    'structuredEvents.js does not consult BRAINSTORM_LOG_DIR (ADR 0013 §New files). The base path must ' +
+      'come from brainstormConfig.get(\'BRAINSTORM_LOG_DIR\'), matching the bash version\'s configurable ' +
+      'log root.'
+  );
+});
+
+test('T3: resourceSemaphore.js exists at the ADR-specified path and exports createSemaphore (AC-1, AC-2; ADR 0013 §New files)', () => {
+  const src = readSafe(RESOURCE_SEMAPHORE);
+  assert(
+    src !== null,
+    'Resource-semaphore module does not exist at src/manage/taskQueue/queue/resourceSemaphore.js (AC-1, ' +
+      'AC-2; ADR 0013 §New files). Create the module that owns cross-task serialization via a Redis-backed ' +
+      'counted semaphore with TTL leases.'
+  );
+  assert(
+    /\bcreateSemaphore\b/.test(src),
+    'resourceSemaphore.js does not export createSemaphore factory (AC-1, AC-2; ADR 0013 §New files). The ' +
+      'ADR pins the public surface: createSemaphore(redis, caps, options?) returns an instance with ' +
+      '.acquire(resourceClass) → Promise<release>.'
+  );
+});
+
+test('T4: resourceSemaphore.js uses Redis-side Lua atomicity for check+set+sweep (AC-2; ADR 0013 §Option A)', () => {
+  const src = readSafe(RESOURCE_SEMAPHORE);
+  assert(src !== null, 'resourceSemaphore.js missing — T3 must pass first.');
+  // ADR pins: atomic check+set via Lua script (one Redis round-trip). Either
+  // ioredis defineCommand OR raw eval/evalsha is acceptable; both put Lua on
+  // the wire. Without Lua atomicity, the check-then-set race re-introduces
+  // the very contention the story aims to eliminate.
+  assert(
+    /defineCommand|\beval\b|evalsha/.test(src),
+    'resourceSemaphore.js does not use Redis Lua scripting (AC-2; ADR 0013 §Option A). Atomic check+set ' +
+      '(sweep-expired-leases, check HLEN < cap, HSET on success) must happen in a single Redis round-trip ' +
+      'via Lua — otherwise two concurrent acquires can both observe HLEN < cap and both HSET, exceeding the ' +
+      'cap. Use ioredis defineCommand or raw eval to register/invoke the Lua script.'
+  );
+  // ADR pins the data model: Redis hash mapping leaseId → expiresAtMs.
+  assert(
+    /HSET|HDEL|HLEN/i.test(src),
+    'resourceSemaphore.js does not use Redis HASH operations (HSET / HDEL / HLEN) (AC-2; ADR 0013 §Option ' +
+      'A). The per-class state model is a hash mapping leaseId → expiresAtMs — HSET on acquire, HDEL on ' +
+      'release, HLEN for the cap check.'
+  );
+});
+
+test('T5: resourceSemaphore.js carries the RESOURCE_CLASS_WAIT_TIMEOUT error code literal (AC-2; ADR 0013 §Decision)', () => {
+  const src = readSafe(RESOURCE_SEMAPHORE);
+  assert(src !== null, 'resourceSemaphore.js missing — T3 must pass first.');
+  // ADR pins the exact error-code string so operators and automated probes
+  // can identify the timeout-failure mode without string-parsing arbitrary
+  // error messages.
+  assert(
+    /RESOURCE_CLASS_WAIT_TIMEOUT/.test(src),
+    'resourceSemaphore.js does not carry the literal RESOURCE_CLASS_WAIT_TIMEOUT error code (AC-2; ADR ' +
+      '0013 §Decision). When acquire() exceeds acquireTimeoutMs, reject with an Error whose .code === ' +
+      '\'RESOURCE_CLASS_WAIT_TIMEOUT\'. Operators rely on this literal for monitoring and BullBoard ' +
+      'failure-tab triage.'
+  );
+});
+
+test('T6: resourceSemaphore.js emits structured events via emitTaskEvent (not console.log) (AC-7; ADR 0013 §Observability)', () => {
+  const src = readSafe(RESOURCE_SEMAPHORE);
+  assert(src !== null, 'resourceSemaphore.js missing — T3 must pass first.');
+  // PO refined the ADR at draft review: invest now in the Node-side
+  // emit_task_event equivalent rather than console.log. resourceSemaphore.js
+  // is the first consumer.
+  assert(
+    /emitTaskEvent|structuredEvents/.test(src),
+    'resourceSemaphore.js does not call emitTaskEvent (AC-7; ADR 0013 §Observability). The wait-begin / ' +
+      'wait-end / released phase events must land in events.jsonl alongside bash-emitted events, not in ' +
+      'plain console.log. Import { emitTaskEvent } from \'../../../utils/structuredEvents\' and emit ' +
+      'PROGRESS / TASK_ERROR events as the ADR specifies.'
+  );
+  // ADR pins the three phase tokens.
+  for (const phase of ['resource_class_wait_begin', 'resource_class_wait_end', 'resource_class_released']) {
+    assert(
+      src.includes(phase),
+      'resourceSemaphore.js does not emit the `' + phase + '` phase token (AC-7; ADR 0013 §Observability). ' +
+        'Operators answer "why hasn\'t my task started?" by greping events.jsonl for these literals; ' +
+        'they must appear in the source.'
+    );
+  }
+});
+
+test('T7: queue/index.js constructs the semaphore and wraps the Worker callback conditionally on taskDef.resourceClass (AC-1, AC-4; ADR 0013 §Edited files)', () => {
+  const src = readSafe(QUEUE_INDEX);
+  assert(src !== null, 'queue/index.js missing — story #13 should have shipped it; re-baseline this sentinel.');
+  // ADR pins: createSemaphore is called inside initTaskQueue, and the Worker
+  // callback wraps processor.processJob in an acquire/release pair when
+  // taskDef.resourceClass is truthy. Both tokens must appear.
+  assert(
+    /resourceSemaphore|createSemaphore/.test(src),
+    'queue/index.js does not reference the semaphore module (AC-1, AC-4; ADR 0013 §Edited files). The ' +
+      'Worker construction loop must import and call createSemaphore so per-class caps are enforced ' +
+      'before processor.processJob runs.'
+  );
+  assert(
+    /resourceClass/.test(src),
+    'queue/index.js does not branch on taskDef.resourceClass (AC-1, AC-4; ADR 0013 §Edited files). Tagged ' +
+      'tasks must be wrapped with semaphore.acquire / release; untagged tasks must call processor.processJob ' +
+      'directly (no wrapping overhead, no behavior change vs story #13).'
+  );
+  assert(
+    /\bacquire\b/.test(src) && /\brelease\b/.test(src),
+    'queue/index.js does not invoke semaphore acquire/release in the Worker callback (AC-1, AC-4; ADR ' +
+      '0013 §Edited files). The ADR pins the wrap shape: `const release = await semaphore.acquire(rc); ' +
+      'try { return await processor.processJob(job, taskDef); } finally { await release(); }`.'
+  );
+});
+
+test('T8: queue/index.js consumes queueConfig.resourceClassCaps from the existing brainstorm-task-queue.json (AC-3; ADR 0013 §Config)', () => {
+  const src = readSafe(QUEUE_INDEX);
+  assert(src !== null, 'queue/index.js missing — re-baseline this sentinel.');
+  // ADR pins: extend story #13's /etc/brainstorm-task-queue.json with a
+  // sibling `resourceClassCaps` key. queue/index.js (which already loads
+  // queueConfig in story #13) must pass this map to createSemaphore.
+  assert(
+    /resourceClassCaps/.test(src),
+    'queue/index.js does not consume queueConfig.resourceClassCaps (AC-3; ADR 0013 §Config). The per-class ' +
+      'cap configuration extends story #13\'s /etc/brainstorm-task-queue.json — same file, sibling key. ' +
+      'Pass queueConfig.resourceClassCaps to createSemaphore so operators tune caps in one config surface.'
+  );
+});
+
+test('T9: taskRegistry.json owner trio is tagged "resourceClass": "neo4j-heavy" (AC-6; ADR 0013 §Implementation notes)', () => {
+  const r = readJsonSafe(TASK_REGISTRY);
+  assert(r !== null && r.tasks, 'taskRegistry.json missing or malformed — re-baseline this sentinel.');
+  for (const taskName of ['calculateOwnerHops', 'calculateOwnerPageRank', 'calculateOwnerGrapeRank']) {
+    const entry = r.tasks[taskName];
+    assert(
+      entry,
+      'taskRegistry.json has no entry for `' + taskName + '` — re-baseline this sentinel (the registry may ' +
+        'have changed since ADR 0013 was drafted).'
+    );
+    assert(
+      entry.resourceClass === 'neo4j-heavy',
+      'taskRegistry.json entry for `' + taskName + '` is not tagged with "resourceClass": "neo4j-heavy" (AC-6; ' +
+        'ADR 0013 §Implementation notes). This is the initial tag set the operator demonstrated the pain ' +
+        'with on brainstorm.world (calculateOwnerGrapeRank + calculateOwnerPageRank running concurrently ' +
+        'post-story-#13). Add the tag at the top level of the entry, alongside `name`, `script`, etc.'
+    );
+  }
+});
+
+test('T10: OPERATIONS.md §10.6 documents the resource-class config + phase tokens (AC-7; ADR 0013 §Documentation)', () => {
+  const src = readSafe(OPERATIONS_MD);
+  assert(src !== null, 'OPERATIONS.md missing — re-baseline this sentinel.');
+  const missing = [];
+  if (!/resourceClass/.test(src)) missing.push('the `resourceClass` registry field');
+  if (!/resourceClassCaps/.test(src)) missing.push('the `resourceClassCaps` config key');
+  if (!/neo4j-heavy/.test(src)) missing.push('the `neo4j-heavy` class name');
+  if (!/resource_class_wait_begin|resource_class_wait_end|resource_class_released/.test(src)) {
+    missing.push('the resource_class_wait_begin/wait_end/released phase tokens');
+  }
+  assert(
+    missing.length === 0,
+    'OPERATIONS.md does not document: ' + missing.join(', ') + ' (AC-7; ADR 0013 §Documentation). ' +
+      'Add §10.6 covering: (1) the `resourceClass` registry field + how to tag a new task; (2) the ' +
+      '`resourceClassCaps` config key in /etc/brainstorm-task-queue.json; (3) the initial neo4j-heavy:1 cap ' +
+      'and the owner-trio tag set; (4) the three structured-event phase tokens operators grep ' +
+      'events.jsonl for; (5) the RESOURCE_CLASS_WAIT_TIMEOUT failure mode.'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Regression sentinels — PASS now AND post-implementation.
+// ---------------------------------------------------------------------------
+
+test('R1: queue/index.js still constructs per-task Queue + Worker per registry task (story #13 topology preserved, AC-5)', () => {
+  const src = readSafe(QUEUE_INDEX);
+  assert(src !== null, 'queue/index.js missing — re-baseline this sentinel.');
+  // Story #13's per-task queue topology must survive. R1 trips if the
+  // Implementer refactors the per-task loop into something else while
+  // wiring in the semaphore.
+  assert(
+    /new Queue\(/.test(src) && /new Worker\(/.test(src),
+    'R1: queue/index.js no longer instantiates per-task BullMQ Queue + Worker (AC-5; story #13 / ADR 0012 ' +
+      'topology regression). The semaphore wrapper is ADDITIVE — it composes with the existing per-task ' +
+      'concurrency, it does not replace it.'
+  );
+  assert(
+    /for\s*\(/.test(src) || /Object\.keys/.test(src),
+    'R1: queue/index.js no longer iterates the task registry to create per-task queues (story #13 ' +
+      'topology regression). The 51-task enumeration must remain — the semaphore is an additional wrap, ' +
+      'not a topology change.'
+  );
+});
+
+test('R2: processor.js still exports processJob (NOT process, story #13 blocker-fix preserved)', () => {
+  const src = readSafe(QUEUE_PROCESSOR);
+  assert(src !== null, 'processor.js missing — re-baseline this sentinel.');
+  // Story #13 review found that `function process(...)` shadows the Node
+  // global; fix renamed it to `processJob`. R2 trips if the Implementer ever
+  // reverts that rename. The shadow bug would silently break the spawn\'s
+  // env inheritance — same risk reappears.
+  assert(
+    /\bprocessJob\b/.test(src),
+    'R2: processor.js no longer references processJob (story #13 blocker-fix regression). The function ' +
+      'rename from `process` → `processJob` resolved the Node global-shadow bug that broke every queued ' +
+      'job\'s spawn env. Do NOT revert this rename — see the explanatory comment above the function.'
+  );
+  // Also pin that the dangerous original name is NOT a function declaration.
+  assert(
+    !/^function\s+process\s*\(/m.test(src) && !/\bfunction\s+process\s*\(/.test(src),
+    'R2: processor.js declares `function process(...)` again (story #13 blocker-fix regression). This ' +
+      'shadows Node\'s global `process`, breaking the spawn\'s env inheritance. Rename to processJob (or ' +
+      'similar non-shadowing name) per ADR 0012.'
+  );
+});
+
+test('R3: runTask.js feature-flag branch + 503 QUEUE_UNAVAILABLE preserved (story #13 / ADR 0012 contract)', () => {
+  const src = readSafe(RUN_TASK_JS);
+  assert(src !== null, 'runTask.js missing — re-baseline this sentinel.');
+  assert(
+    /TASK_QUEUE_ENABLED/.test(src) && /QUEUE_UNAVAILABLE/.test(src),
+    'R3: runTask.js no longer carries the TASK_QUEUE_ENABLED branch or QUEUE_UNAVAILABLE 503 code (story ' +
+      '#13 / ADR 0012 regression). Story #15 is purely additive over story #13; the feature-flag rollback ' +
+      'path and the Redis-down failure mode must remain intact.'
+  );
+});
+
+test('R4: BullBoard mount module still exists and references /admin/queues + requireOwnerOnly (story #13 / ADR 0012 contract)', () => {
+  const mount = readSafe(BULLBOARD_MOUNT);
+  assert(mount !== null, 'bullBoardMount.js missing — re-baseline this sentinel.');
+  assert(
+    /['"`]\/admin\/queues['"`]/.test(mount),
+    'R4: bullBoardMount.js no longer references the canonical /admin/queues path (story #13 / ADR 0012 ' +
+      'regression). The mount path is part of the operator-facing contract; do not change it as a side ' +
+      'effect of story #15.'
+  );
+  assert(
+    /requireOwnerOnly|requireOwner/.test(mount),
+    'R4: bullBoardMount.js no longer references the owner-only auth gate (story #13 / ADR 0012 ' +
+      'regression). retry / remove / pause controls remain capable of affecting in-flight calculations; the ' +
+      'gate stays.'
+  );
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try { await t.fn(); console.log(`  ✓ ${t.name}`); pass++; }
+    catch (err) { console.log(`  ✗ ${t.name}`); console.log(`      ${err.message}`); fail++; }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -35,6 +35,7 @@ const communityReferenceSupersetLink = require('./community-reference-superset-l
 const graperankSharedCsvRace = require('./graperank-shared-csv-race.test.js');
 const communityClassThreadPull = require('./community-class-thread-pull.test.js');
 const taskQueueBullmq = require('./task-queue-bullmq.test.js');
+const taskQueueNeo4jResourceClass = require('./task-queue-neo4j-resource-class.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -78,6 +79,9 @@ async function main() {
   console.log('\ntask-queue-bullmq suite:');
   const taskQueueBullmqResult = await taskQueueBullmq.run();
 
+  console.log('\ntask-queue-neo4j-resource-class suite:');
+  const taskQueueNeo4jResourceClassResult = await taskQueueNeo4jResourceClass.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -117,6 +121,9 @@ async function main() {
   console.log(
     `task-queue-bullmq suite:                         ${taskQueueBullmqResult.fail === 0 ? 'PASS' : 'FAIL'} (${taskQueueBullmqResult.pass} passed, ${taskQueueBullmqResult.fail} failed)`
   );
+  console.log(
+    `task-queue-neo4j-resource-class suite:           ${taskQueueNeo4jResourceClassResult.fail === 0 ? 'PASS' : 'FAIL'} (${taskQueueNeo4jResourceClassResult.pass} passed, ${taskQueueNeo4jResourceClassResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -131,7 +138,8 @@ async function main() {
     communityReferenceSupersetLinkResult.fail === 0 &&
     graperankSharedCsvRaceResult.fail === 0 &&
     communityClassThreadPullResult.fail === 0 &&
-    taskQueueBullmqResult.fail === 0;
+    taskQueueBullmqResult.fail === 0 &&
+    taskQueueNeo4jResourceClassResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`. Bundle is **story #15 only** — the cross-task Neo4j-heavy serialization built on top of story #13's BullMQ foundation. Closes the gap the operator demonstrated on `brainstorm.world` immediately after #13 promoted: triggering `calculateOwnerGrapeRank` + `calculateOwnerPageRank` back-to-back still ran them concurrently because per-task queues don't compose across task names.

## Bundled

- **#171** — feat: cross-task Neo4j-heavy serialization (story #15, ADR 0013). Redis-backed counted semaphore (Lua-scripted, TTL leases, 500ms poll, 4h timeout) wrapped around each Worker callback in the BullMQ task queue. Tasks tagged with `"resourceClass": "neo4j-heavy"` share a single concurrency budget (cap=1 default). Initial tags: the owner trio (`calculateOwnerHops`, `calculateOwnerPageRank`, `calculateOwnerGrapeRank`). Also lands Node-side `emit_task_event` equivalent so queue events join the existing `events.jsonl` stream.

## Net production impact

**Zero user-visible change in the default deploy state.** `TASK_QUEUE_ENABLED=false` remains the deploy default (from story #13). The new code (`structuredEvents.js`, `resourceSemaphore.js`, queue/index.js wrap, registry tags) all ship but stay dormant until the operator flips the flag on per environment. When flipped on, the resource-class semaphore automatically gates the owner trio at cap=1.

To enable in production: ssh to droplet, edit `/etc/brainstorm.conf` (`TASK_QUEUE_ENABLED=true`), create `/etc/brainstorm-task-queue.json` with `{"defaultConcurrency":1,"concurrencyByTask":{},"resourceClassCaps":{"neo4j-heavy":1}}`, `supervisorctl restart brainstorm`. **No new npm deps this PR** — story #13 already brought in bullmq + bullboard.

## Verification trail

- Staging deploy [run 26208096902](https://github.com/nous-clawds4/tapestry/actions/runs/26208096902) — 1m17s (warm Docker cache; no new npm deps).
- Staging smoke `https://staging.brainstorm.world`:
  - Tier 1 stability: 6 attempts → 3-in-a-row 200s + 5s settle.
  - Tier 2 sanity: all 200; concept-graph count=36.
  - Tier 3 PR-specific (flag default off): `/admin/queues` correctly serves SPA shell (not BullBoard); no `resourceClasses=` boot log; semaphore dormant.
  - Tier 5 regression: `/api/get-user-counts`, `/api/search/profiles/meili` both 200.
- Cycle-local smoke (pre-staging) validated the cross-task serialization behavior end-to-end. The `events.jsonl` trace from triggering two tagged tasks 0.5s apart:
  ```
  Hops:     wait_end acquired wait_seconds=0
  PageRank: wait_begin cap=1
  Hops:     released held_seconds=27
  PageRank: wait_end acquired wait_seconds=27   ← within one 500ms poll of Hops releasing
  PageRank: released held_seconds=6
  ```
  `wait_seconds=27` matching `held_seconds=27` exactly is the smoking gun — handoff was clean on the next poll tick. Redis state confirmed: exactly 1 lease in `taskQueue:resource-class:neo4j-heavy:holders` during the wait window.

## Test plan

- [ ] After merge: `deploy-brainstorm.yml` runs to completion. Expect ~80s (same warm-cache range as staging).
- [ ] Stability poll `https://brainstorm.world` → 3-in-a-row 200s.
- [ ] Tier 2 sanity: `/api/concept-graph/summaries`, `/api/assistant/pubkey`, `/` all 200.
- [ ] Tier 3 (story-specific, flag-off default): boot log says `Task queue disabled — legacy direct-spawn path active`. No `[task-queue] Initialized` line. `/admin/queues` serves SPA shell.
- [ ] Tier 5 regression: other unauthenticated endpoints unchanged.
- [ ] (Operator decision) Whether to flip `TASK_QUEUE_ENABLED=true` on production: operator-controlled per environment. Recommend running the staging flag-on validation first (ssh + flip + trigger owner trio + tail events.jsonl) before flipping prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)