### PR TITLE
Promote story #16 to prod: conf templates as source of truth

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -18,6 +18,8 @@
 7. [Active team and branch ownership](#7-active-team-and-branch-ownership)
 8. [Active tracking issues](#8-active-tracking-issues)
 9. [Operational gotchas we've hit](#9-operational-gotchas-weve-hit)
+10. [Task queue (BullMQ behind /api/run-task)](#10-task-queue-bullmq-behind-apirun-task)
+11. [Conf templates are the source of truth for fresh containers](#11-conf-templates-are-the-source-of-truth-for-fresh-containers)
 
 ---
 
@@ -538,3 +540,47 @@ This should be rare. If it fires, something upstream is stuck (e.g., a single he
 - Resource-class semaphore wraps the Worker callback BEFORE `processor.processJob` runs.
 
 For a tagged task with `concurrencyByTask: 2` and `resourceClassCaps.neo4j-heavy: 1`: the **effective** concurrency is the more restrictive of the two (here, 1 — one per class regardless of per-task budget).
+
+## 11. Conf templates are the source of truth for fresh containers
+
+Story #16 / ADR 0014. Until 2026-05-21 the Docker entrypoint regenerated `/etc/brainstorm.conf` from an 80-line heredoc embedded in `docker/entrypoint.sh`. `config/brainstorm.conf.template` was consulted only by the bare-metal install path and had silently drifted to be missing ~25 of the variables the heredoc carried — including story #13's `TASK_QUEUE_ENABLED=false`, which never reached any fresh Docker container until an operator manually added the line.
+
+After story #16, the contract for fresh containers is:
+
+> **`config/brainstorm.conf.template` is the single source of truth for `/etc/brainstorm.conf`.** The entrypoint renders the template via `tools/render-conf-template.js` at every container start; the heredoc is gone.
+
+### What this means for the operator
+
+- **Adding a new feature flag or env var.** Edit `config/brainstorm.conf.template`, commit, rebuild the image. The next container that starts gets the new line in `/etc/brainstorm.conf` automatically — no entrypoint.sh edit needed.
+- **The renderer fails the boot loudly on a missing env var.** If the template references `${SOME_NEW_VAR}` and the entrypoint never exports it, the container's boot fails with `RenderError: missing env vars in brainstorm.conf.template: SOME_NEW_VAR`. This is by design — better than silently emitting `SOME_NEW_VAR=""` and discovering it at runtime. When adding a template variable, also add the corresponding `export` to `docker/entrypoint.sh` (currently exports `OWNER_PUBKEY`, `ADMIN_PUBKEYS`, `NEO4J_PASSWORD`, `DOMAIN_NAME`, `RELAY_URL`, `BRAINSTORM_MODULE_BASE_DIR`, `BRAINSTORM_NODE_BIN`, `SESSION_SECRET`, `OWNER_NPUB`).
+- **`brainstorm-task-queue.json` follows the conditional-copy pattern.** Its template at `config/brainstorm-task-queue.json.template` is copied to `/etc/brainstorm-task-queue.json` only if the destination does not already exist. Operator edits to the live JSON survive container restarts (unlike `/etc/brainstorm.conf`, which is regenerated unconditionally on every boot).
+
+### The trap — edits inside a running container are lost on restart
+
+The entrypoint **unconditionally overwrites** `/etc/brainstorm.conf` on every container start. This matches the prior heredoc behavior; story #16 did not change it.
+
+If you `docker exec tapestry sed -i ... /etc/brainstorm.conf` to flip a flag (the pattern used during story #15's `TASK_QUEUE_ENABLED` rollout — see §10.1), your edit lasts **until the next container restart**. To make an edit persist:
+
+1. **Repo-level (recommended).** Edit `config/brainstorm.conf.template`, commit, rebuild the image. Fresh containers and restarts both pick it up.
+2. **Operator-level (long-running containers).** Use the `if grep -q ...; else docker exec ... >> ...` recipe below for an in-container append, then **also** update the template so the next deploy doesn't reintroduce the old value.
+
+```bash
+# Append-if-absent recipe (use inside a running container):
+docker exec tapestry bash -c '
+  if grep -q "^export FOO=" /etc/brainstorm.conf; then
+    echo "FOO already set"
+  else
+    echo "export FOO=value" >> /etc/brainstorm.conf
+    echo "appended FOO"
+  fi
+'
+# This wins only until the next restart, when the template re-renders.
+```
+
+### Drift sentinels
+
+`test/entrypoint-template-rendering.test.js` carries two drift sentinels that fail npm test if:
+- A `<<CONFEOF` heredoc reappears in `docker/entrypoint.sh` (T7 — re-introducing a second source of truth).
+- The `render-conf-template.js` invocation count moves off exactly one (T8 — second write-path, or lost integration).
+
+A future reviewer who sees these tests fail should stop and ask whether the change is reintroducing the very drift class story #16 closed.

--- a/config/brainstorm-task-queue.json.template
+++ b/config/brainstorm-task-queue.json.template
@@ -1,0 +1,7 @@
+{
+  "defaultConcurrency": 1,
+  "concurrencyByTask": {},
+  "resourceClassCaps": {
+    "neo4j-heavy": 1
+  }
+}

--- a/config/brainstorm.conf.template
+++ b/config/brainstorm.conf.template
@@ -1,28 +1,59 @@
-#!/bin/bash
-# Brainstorm Configuration File
-# This file should be installed at /etc/brainstorm.conf
-# with proper permissions: chmod 640 /etc/brainstorm.conf
-# and ownership: chown root:brainstorm /etc/brainstorm.conf
+# Brainstorm Configuration (Docker)
+#
+# This template is rendered by tools/render-conf-template.js into
+# /etc/brainstorm.conf at container start. Curly-brace env-var references are
+# substituted against the entrypoint's process env (see docker/entrypoint.sh).
+# Literal values are emitted as-is. Edits to this template propagate to fresh
+# containers on the next image build — operator-level edits to a running
+# container's /etc/brainstorm.conf are LOST on restart.
+#
+# Story #16 / ADR 0014. The previous "bare-metal install" copy of this file
+# was selectively maintained and dropped most of the variables the Docker
+# heredoc carried; story #16 backfills it to be the single source of truth.
 
-# ==========================================
-# SENSITIVE CONFIGURATION - KEEP SECURE
-# ==========================================
+BRAINSTORM_NODE_BIN="${BRAINSTORM_NODE_BIN}"
+export BRAINSTORM_NODE_BIN
 
-export STRFRY_DOMAIN="your.relay.com"
+# File paths
+BRAINSTORM_MODULE_BASE_DIR="${BRAINSTORM_MODULE_BASE_DIR}"
+BRAINSTORM_MODULE_SRC_DIR="${BRAINSTORM_MODULE_BASE_DIR}src/"
+BRAINSTORM_MODULE_ALGOS_DIR="${BRAINSTORM_MODULE_BASE_DIR}src/algos"
+BRAINSTORM_EXPORT_DIR="${BRAINSTORM_MODULE_BASE_DIR}src/export"
+BRAINSTORM_MODULE_MANAGE_DIR="${BRAINSTORM_MODULE_BASE_DIR}src/manage"
+BRAINSTORM_NIP85_DIR="${BRAINSTORM_MODULE_BASE_DIR}src/algos/nip85"
+BRAINSTORM_MODULE_PIPELINE_DIR="${BRAINSTORM_MODULE_BASE_DIR}src/pipeline"
+STRFRY_PLUGINS_BASE="/usr/local/lib/strfry/plugins/"
+STRFRY_PLUGINS_DATA="/usr/local/lib/strfry/plugins/data/"
+BRAINSTORM_LOG_DIR="/var/log/brainstorm"
+BRAINSTORM_BASE_DIR="/var/lib/brainstorm"
 
-# Relay configuration
-export BRAINSTORM_RELAY_URL="wss://your.relay.com"
-export BRAINSTORM_RELAY_PUBKEY="your-relay-pubkey"
-export BRAINSTORM_RELAY_PRIVKEY="your-relay-private-key"
+export BRAINSTORM_MODULE_BASE_DIR
+export BRAINSTORM_MODULE_SRC_DIR
+export BRAINSTORM_MODULE_ALGOS_DIR
+export BRAINSTORM_EXPORT_DIR
+export BRAINSTORM_MODULE_MANAGE_DIR
+export BRAINSTORM_NIP85_DIR
+export STRFRY_PLUGINS_BASE
+export STRFRY_PLUGINS_DATA
+export BRAINSTORM_LOG_DIR
+export BRAINSTORM_BASE_DIR
 
-# Neo4j configuration
-export NEO4J_URI="bolt://localhost:7687"
-export NEO4J_USER="neo4j"
-export NEO4J_PASSWORD="neo4j"
+# WoT relays
+export BRAINSTORM_DEFAULT_WOT_RELAYS='wss://wot.grapevine.network,wss://wot.brainstorm.social,wss://profiles.nostr1.com,wss://relay.hasenpfeffr.com'
+export BRAINSTORM_WOT_RELAYS='wss://wot.grapevine.network,wss://wot.brainstorm.social,wss://profiles.nostr1.com,wss://relay.hasenpfeffr.com'
 
-# ==========================================
-# GENERAL CONFIGURATION
-# ==========================================
+# NIP-85 relays
+export BRAINSTORM_DEFAULT_NIP85_RELAYS='wss://nip85.brainstorm.world,wss://nip85.nostr1.com'
+export BRAINSTORM_NIP85_RELAYS='wss://nip85.brainstorm.world,wss://nip85.nostr1.com'
+export BRAINSTORM_DEFAULT_NIP85_HOME_RELAY='wss://nip85.brainstorm.world'
+export BRAINSTORM_NIP85_HOME_RELAY='wss://nip85.brainstorm.world'
+
+# Popular general purpose relays
+export BRAINSTORM_DEFAULT_POPULAR_GENERAL_PURPOSE_RELAYS='wss://relay.nostr.band,wss://relay.damus.io,wss://relay.primal.net'
+export BRAINSTORM_POPULAR_GENERAL_PURPOSE_RELAYS='wss://relay.nostr.band,wss://relay.damus.io,wss://relay.primal.net'
+
+# NIP-85 configuration
+export BRAINSTORM_30382_LIMIT="250000"
 
 # Performance tuning
 export BRAINSTORM_BATCH_SIZE="100"
@@ -31,14 +62,36 @@ export BRAINSTORM_DELAY_BETWEEN_EVENTS="50"
 export BRAINSTORM_MAX_RETRIES="3"
 export BRAINSTORM_MAX_CONCURRENT_CONNECTIONS="5"
 
-# File paths
-export BRAINSTORM_INPUT_FILE="/usr/local/lib/node_modules/brainstorm/src/algos/nip85.json"
-export BRAINSTORM_KEYS_FILE="/usr/local/lib/node_modules/brainstorm/src/nostr/keys/brainstorm_relay_keys"
+# Relay configuration
+export BRAINSTORM_RELAY_URL="${RELAY_URL}"
 
-# Control panel configuration
-export CONTROL_PANEL_PORT="7778"
+# Neo4j configuration
+export BRAINSTORM_NEO4J_BROWSER_URL="http://${DOMAIN_NAME}:7474"
+export NEO4J_URI="bolt://localhost:7687"
+export NEO4J_USER="neo4j"
+export NEO4J_PASSWORD="${NEO4J_PASSWORD}"
 
-# Task queue (story #13 / ADR 0010). When true, /api/run-task enqueues jobs
+# Strfry configuration
+export STRFRY_DOMAIN="${DOMAIN_NAME}"
+
+# Owner
+export BRAINSTORM_OWNER_PUBKEY="${OWNER_PUBKEY}"
+export BRAINSTORM_OWNER_NPUB="${OWNER_NPUB}"
+export BRAINSTORM_MANAGER_PUBKEYS=""
+export BRAINSTORM_ADMIN_PUBKEYS="${ADMIN_PUBKEYS}"
+
+# Security
+export SESSION_SECRET="${SESSION_SECRET}"
+
+# Process all tasks interval
+export BRAINSTORM_PROCESS_ALL_TASKS_INTERVAL="12hours"
+
+# Actions
+export BRAINSTORM_SEND_EMAIL_UPDATES=0
+export BRAINSTORM_ACCESS=0
+export BRAINSTORM_CREATED_CONSTRAINTS_AND_INDEXES=0
+
+# Task queue (story #13 / ADR 0012). When true, /api/run-task enqueues jobs
 # through BullMQ instead of directly spawning launchChildTask.sh. When false
 # (default in phase 1), the legacy direct-spawn path runs unchanged — this is
 # the rollback path. Requires Redis (already a runtime dependency for sessions

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,6 +10,7 @@ RELAY_URL="${RELAY_URL:-ws://localhost:7777}"
 
 BRAINSTORM_MODULE_BASE_DIR="/usr/local/lib/node_modules/brainstorm/"
 BRAINSTORM_NODE_BIN="$(which node)"
+CONFIG_DIR="${BRAINSTORM_MODULE_BASE_DIR}config"
 
 # Persist SESSION_SECRET across container rebuilds. Stored on the tapestry-data
 # volume so that user session cookies remain valid through deploys. To force-rotate
@@ -36,97 +37,28 @@ if [ "$OWNER_PUBKEY" != "unassigned" ] && [ ${#OWNER_PUBKEY} -eq 64 ]; then
   " 2>/dev/null || echo "unassigned")
 fi
 
-# Generate /etc/brainstorm.conf
-cat > /etc/brainstorm.conf << CONFEOF
-# Brainstorm Configuration (Docker)
+# Render /etc/brainstorm.conf from the template (story #16 / ADR 0014).
+# Replaces the prior 80-line heredoc. The renderer reads ${VAR_NAME} references
+# from process.env, so we export the variables the template references before
+# invoking it — they are local shell vars at this point. The renderer rejects
+# unknown ${VAR} references with nonzero exit, so a missing env var fails the
+# boot loudly rather than producing a silently-incomplete conf file.
+export OWNER_PUBKEY ADMIN_PUBKEYS NEO4J_PASSWORD DOMAIN_NAME RELAY_URL
+export BRAINSTORM_MODULE_BASE_DIR BRAINSTORM_NODE_BIN SESSION_SECRET OWNER_NPUB
 
-BRAINSTORM_NODE_BIN="${BRAINSTORM_NODE_BIN}"
-export BRAINSTORM_NODE_BIN
-
-# File paths
-BRAINSTORM_MODULE_BASE_DIR="${BRAINSTORM_MODULE_BASE_DIR}"
-BRAINSTORM_MODULE_SRC_DIR="${BRAINSTORM_MODULE_BASE_DIR}src/"
-BRAINSTORM_MODULE_ALGOS_DIR="${BRAINSTORM_MODULE_BASE_DIR}src/algos"
-BRAINSTORM_EXPORT_DIR="${BRAINSTORM_MODULE_BASE_DIR}src/export"
-BRAINSTORM_MODULE_MANAGE_DIR="${BRAINSTORM_MODULE_BASE_DIR}src/manage"
-BRAINSTORM_NIP85_DIR="${BRAINSTORM_MODULE_BASE_DIR}src/algos/nip85"
-BRAINSTORM_MODULE_PIPELINE_DIR="${BRAINSTORM_MODULE_BASE_DIR}src/pipeline"
-STRFRY_PLUGINS_BASE="/usr/local/lib/strfry/plugins/"
-STRFRY_PLUGINS_DATA="/usr/local/lib/strfry/plugins/data/"
-BRAINSTORM_LOG_DIR="/var/log/brainstorm"
-BRAINSTORM_BASE_DIR="/var/lib/brainstorm"
-
-export BRAINSTORM_MODULE_BASE_DIR
-export BRAINSTORM_MODULE_SRC_DIR
-export BRAINSTORM_MODULE_ALGOS_DIR
-export BRAINSTORM_EXPORT_DIR
-export BRAINSTORM_MODULE_MANAGE_DIR
-export BRAINSTORM_NIP85_DIR
-export STRFRY_PLUGINS_BASE
-export STRFRY_PLUGINS_DATA
-export BRAINSTORM_LOG_DIR
-export BRAINSTORM_BASE_DIR
-
-# WoT relays
-export BRAINSTORM_DEFAULT_WOT_RELAYS='wss://wot.grapevine.network,wss://wot.brainstorm.social,wss://profiles.nostr1.com,wss://relay.hasenpfeffr.com'
-export BRAINSTORM_WOT_RELAYS='wss://wot.grapevine.network,wss://wot.brainstorm.social,wss://profiles.nostr1.com,wss://relay.hasenpfeffr.com'
-
-# NIP-85 relays
-export BRAINSTORM_DEFAULT_NIP85_RELAYS='wss://nip85.brainstorm.world,wss://nip85.nostr1.com'
-export BRAINSTORM_NIP85_RELAYS='wss://nip85.brainstorm.world,wss://nip85.nostr1.com'
-export BRAINSTORM_DEFAULT_NIP85_HOME_RELAY='wss://nip85.brainstorm.world'
-export BRAINSTORM_NIP85_HOME_RELAY='wss://nip85.brainstorm.world'
-
-# Popular general purpose relays
-export BRAINSTORM_DEFAULT_POPULAR_GENERAL_PURPOSE_RELAYS='wss://relay.nostr.band,wss://relay.damus.io,wss://relay.primal.net'
-export BRAINSTORM_POPULAR_GENERAL_PURPOSE_RELAYS='wss://relay.nostr.band,wss://relay.damus.io,wss://relay.primal.net'
-
-# NIP-85 configuration
-export BRAINSTORM_30382_LIMIT="250000"
-
-# Performance tuning
-export BRAINSTORM_BATCH_SIZE="100"
-export BRAINSTORM_DELAY_BETWEEN_BATCHES="1000"
-export BRAINSTORM_DELAY_BETWEEN_EVENTS="50"
-export BRAINSTORM_MAX_RETRIES="3"
-export BRAINSTORM_MAX_CONCURRENT_CONNECTIONS="5"
-
-# Relay configuration
-export BRAINSTORM_RELAY_URL="${RELAY_URL}"
-
-# Neo4j configuration
-export BRAINSTORM_NEO4J_BROWSER_URL="http://${DOMAIN_NAME}:7474"
-export NEO4J_URI="bolt://localhost:7687"
-export NEO4J_USER="neo4j"
-export NEO4J_PASSWORD="${NEO4J_PASSWORD}"
-
-# Strfry configuration
-export STRFRY_DOMAIN="${DOMAIN_NAME}"
-
-# Owner
-export BRAINSTORM_OWNER_PUBKEY="${OWNER_PUBKEY}"
-export BRAINSTORM_OWNER_NPUB="${OWNER_NPUB}"
-export BRAINSTORM_MANAGER_PUBKEYS=""
-export BRAINSTORM_ADMIN_PUBKEYS="${ADMIN_PUBKEYS}"
-
-# Security
-export SESSION_SECRET="${SESSION_SECRET}"
-
-# Process all tasks interval
-export BRAINSTORM_PROCESS_ALL_TASKS_INTERVAL="12hours"
-
-# Actions
-export BRAINSTORM_SEND_EMAIL_UPDATES=0
-export BRAINSTORM_ACCESS=0
-export BRAINSTORM_CREATED_CONSTRAINTS_AND_INDEXES=0
-CONFEOF
-
+if ! node "${BRAINSTORM_MODULE_BASE_DIR}tools/render-conf-template.js" \
+        "${CONFIG_DIR}/brainstorm.conf.template" > /etc/brainstorm.conf; then
+  echo "[entrypoint] FATAL: render of /etc/brainstorm.conf failed" >&2
+  exit 1
+fi
 chmod 664 /etc/brainstorm.conf
+echo "[entrypoint] /etc/brainstorm.conf generated from config/brainstorm.conf.template"
 
 # ── Install algorithm config files from templates (if not already present) ──
 # These are created by setup/install-control-panel.sh on bare-metal installs.
 # In Docker, we create them here from the shipped templates.
-CONFIG_DIR="${BRAINSTORM_MODULE_BASE_DIR}config"
+# CONFIG_DIR was defined near the top of this script so the brainstorm.conf
+# renderer invocation could use it too.
 for conffile in graperank whitelist blacklist nip56; do
   if [ ! -f "/etc/${conffile}.conf" ] && [ -f "${CONFIG_DIR}/${conffile}.conf.template" ]; then
     cp "${CONFIG_DIR}/${conffile}.conf.template" "/etc/${conffile}.conf"
@@ -134,6 +66,17 @@ for conffile in graperank whitelist blacklist nip56; do
     echo "Installed /etc/${conffile}.conf from template"
   fi
 done
+
+# Install /etc/brainstorm-task-queue.json on fresh containers (story #16 / ADR 0014).
+# Mirrors the copy-if-absent pattern above. The template ships with deploy-safe
+# defaults (defaultConcurrency=1, resourceClassCaps.neo4j-heavy=1). Operators
+# tune knobs by editing /etc/brainstorm-task-queue.json after first install;
+# operator edits survive container restarts because of the [ ! -f ] guard.
+if [ ! -f /etc/brainstorm-task-queue.json ] && [ -f "${CONFIG_DIR}/brainstorm-task-queue.json.template" ]; then
+  cp "${CONFIG_DIR}/brainstorm-task-queue.json.template" /etc/brainstorm-task-queue.json
+  chmod 644 /etc/brainstorm-task-queue.json
+  echo "[entrypoint] Installed /etc/brainstorm-task-queue.json from template"
+fi
 
 # Generate strfry.conf from the default template
 if [ -f /usr/local/src/strfry/strfry.conf ]; then

--- a/engineering-team/decisions/0014-entrypoint-template-rendering.md
+++ b/engineering-team/decisions/0014-entrypoint-template-rendering.md
@@ -1,0 +1,364 @@
+# ADR 0014: Render `/etc/brainstorm.conf` from the template via a Node-based renderer
+
+**Status:** Proposed
+**Date:** 2026-05-21
+**Story:** `engineering-team/stories/16-entrypoint-conf-templates-source-of-truth.md`
+
+## Context
+
+Story #16 closes a class-of-bug surfaced during story #15's flag-flip: `docker/entrypoint.sh` regenerates `/etc/brainstorm.conf` on every container start from a 40-variable heredoc embedded in the entrypoint itself, while `config/brainstorm.conf.template` is consulted only by the bare-metal install path. The two have drifted dramatically (template has 16 variables; heredoc has 40), so the template is silently incomplete and any feature flag added to it (like story #13's `TASK_QUEUE_ENABLED`) never reaches fresh Docker containers.
+
+The story specifies two ordered steps with a strict byte-equivalence guarantee between the new and old `/etc/brainstorm.conf`. This ADR makes the mechanical choices that determine how Step 1 (template backfill) and Step 2 (entrypoint swap) play out:
+
+1. **Variable-substitution mechanism** for the new rendering step.
+2. **Where to land the new task-queue.json template** + how the entrypoint installs it.
+3. **Byte-equivalence verification mechanism** — how the Tester and Reviewer confirm zero semantic divergence.
+4. **Drift sentinel** to prevent future regression.
+
+### Grounded facts after reading the relevant source
+
+- **`envsubst` is NOT in the `tapestry` image.** Confirmed via `docker exec tapestry which envsubst` returning empty. Repo-wide grep finds zero existing usages of `envsubst`. Adopting it requires a Dockerfile change (`apt install -y gettext-base`).
+- **Node IS available at entrypoint time.** [entrypoint.sh:30-36](docker/entrypoint.sh:30) already invokes `node -e '...'` for owner-pubkey lookup before the `/etc/brainstorm.conf` heredoc runs. So a Node-based template renderer can run from the entrypoint without any new image dependency.
+- **The existing conf-copy loop ([entrypoint.sh:130-134](docker/entrypoint.sh:130))** iterates a hard-coded list `for conffile in graperank whitelist blacklist nip56; do`. It strips the `.conf.template` suffix to produce `/etc/<name>.conf`. The task-queue file ends in `.json`, so it does not fit the existing pattern as-is.
+- **Heredoc structure** ([entrypoint.sh:40-122](docker/entrypoint.sh:40)) has three kinds of values:
+  1. **Literal strings** (e.g., `BRAINSTORM_BATCH_SIZE="100"`) — no substitution needed.
+  2. **Bare env-var substitution** (e.g., `BRAINSTORM_RELAY_URL="${RELAY_URL}"`, `NEO4J_PASSWORD="${NEO4J_PASSWORD}"`) — single-variable substitutions against env state.
+  3. **Composed env-var substitution** (e.g., `BRAINSTORM_MODULE_SRC_DIR="${BRAINSTORM_MODULE_BASE_DIR}src/"`) — one substitution embedded in a longer string.
+
+  No command substitution (`$(...)`), no arithmetic, no conditionals, no `${VAR:-default}` patterns. The substitution surface is **plain `${VAR_NAME}` text replacement** — nothing fancier.
+
+### Concept-graph impact
+
+None. `/api/concept-graph/summaries` returns zero concepts matching template/entrypoint/config/conf/docker/envsubst/heredoc. **Firmware reinstall: no.**
+
+## Options considered
+
+### Option A — Node-based renderer at `tools/render-conf-template.js` (chosen)
+
+Add a small Node script (~30 lines) that:
+
+- Reads a template file from argv.
+- Performs plain `${VAR_NAME}` text substitution against `process.env`.
+- Refuses to interpret anything else (no `$(...)`, no shell, no eval).
+- Throws an explicit error on undefined variables — surfaces config bugs at boot rather than silently emitting empty strings.
+- Writes the rendered output to stdout (caller redirects to the target file).
+
+The entrypoint changes from a heredoc to a one-line invocation:
+```bash
+node "${BRAINSTORM_MODULE_BASE_DIR}/tools/render-conf-template.js" \
+  "${CONFIG_DIR}/brainstorm.conf.template" > /etc/brainstorm.conf
+```
+
+For the task-queue.json case, the entrypoint gets a small new block (mirroring the existing `for conffile in graperank ...` pattern but adapted for the .json extension and conditional-copy semantic):
+```bash
+if [ ! -f /etc/brainstorm-task-queue.json ] && [ -f "${CONFIG_DIR}/brainstorm-task-queue.json.template" ]; then
+  cp "${CONFIG_DIR}/brainstorm-task-queue.json.template" /etc/brainstorm-task-queue.json
+  chmod 644 /etc/brainstorm-task-queue.json
+  echo "Installed /etc/brainstorm-task-queue.json from template"
+fi
+```
+
+The task-queue.json template does NOT need substitution — it's literal JSON with hard-coded defaults `{"defaultConcurrency":1,"concurrencyByTask":{},"resourceClassCaps":{"neo4j-heavy":1}}`. Plain copy.
+
+**Pros**
+- **No new image dependency.** Node is already in the container; the renderer is one .js file in the repo.
+- **Predictable substitution semantics.** Regex-based `${VAR_NAME}` replacement — only env vars get substituted, nothing else. Cannot accidentally execute `$(date)` or backticks if someone adds them to the template later.
+- **Explicit error on undefined.** Operator gets a clear "missing env var" message at boot, not a silently-empty rendered conf file.
+- **Easy to unit-test.** The Tester's existing Node-runner pattern can directly require + invoke the renderer against fixture templates, with full assertion power. No "exec a shell command and inspect output" awkwardness.
+- **Bare-metal install path is also fixable** by having `setup/install-control-panel.sh` call the same renderer (out of scope here but the door is open).
+- **Simple to extend** with `${VAR:-default}` support later if the operator wants soft defaults; pure regex match in the renderer.
+
+**Cons**
+- One new file. ~30 lines of Node.
+- The entrypoint now depends on Node being available at entrypoint time. It already is (line 30-36) so this is a no-op cost — but worth noting as an architectural constraint.
+- The Implementer has to remember to backfill the template (Step 1) before flipping the entrypoint (Step 2). The byte-equivalence verification is the safety net.
+
+### Option B — `envsubst` via Dockerfile addition
+
+Add `apt install -y gettext-base` to the Dockerfile so `envsubst` is available in the image. Entrypoint becomes:
+```bash
+envsubst '$DOMAIN_NAME $OWNER_PUBKEY ...' < template > /etc/brainstorm.conf
+```
+
+**Pros:** standard, well-known UNIX tool. Explicit allowlist of variables (the quoted list).
+
+**Cons:**
+- **New image dependency.** Touches the Dockerfile, expands image size, adds a build-cache-bust risk.
+- **No `${VAR:-default}` support.** If we ever want soft defaults, we'd need a different mechanism anyway.
+- **Variable allowlist must be maintained** in the entrypoint alongside the template — partial drift hazard (adding a `${NEW_VAR}` to template + forgetting to add to envsubst's allowlist = silent failure).
+- Harder to unit-test (have to invoke a shell command).
+
+Rejected.
+
+### Option C — Pure-bash `eval cat <<EOF` shim
+
+```bash
+TEMPLATE_CONTENT="$(cat config/brainstorm.conf.template)"
+eval "cat > /etc/brainstorm.conf <<CONFEOF
+$TEMPLATE_CONTENT
+CONFEOF"
+```
+
+**Pros:** zero new code, zero new dependency. Pure bash.
+
+**Cons:**
+- **Injection class.** `${VAR}` substitution works, but so does `$(...)`, backticks, and arithmetic. If a future contributor adds (or accidentally creates via a typo) `$(rm -rf ...)` or similar in the template, it executes as root. Template is repo-controlled, so the practical risk is low — but the class is wide open.
+- Newline/quote handling in default values is more fragile.
+- Harder to unit-test.
+
+Rejected. The injection class is worth avoiding even for repo-controlled content; the cost of the Node renderer is small enough.
+
+### Option D — Source the template, then re-emit
+
+```bash
+source config/brainstorm.conf.template
+declare -p VAR1 VAR2 ... > /etc/brainstorm.conf
+```
+
+**Pros:** uses bash's existing substitution natively.
+
+**Cons:** requires enumerating every variable name to emit. Same maintenance burden as Option B's allowlist. Plus, `declare -p` output format differs from the heredoc's `export VAR="value"` style; byte-equivalence becomes harder.
+
+Rejected.
+
+## Decision
+
+**We chose Option A — Node-based renderer.**
+
+Reasons:
+- It's the only option that adds **zero new image dependencies** and **zero new injection class**, while staying within the existing tooling (Node is already in the image and used by the entrypoint).
+- The substitution surface in the template is plain `${VAR_NAME}` — exactly what a 5-line regex handles cleanly. We don't need shell-power; we need predictable text replacement.
+- Unit-testability is a real advantage given the byte-equivalence AC. The Tester can drive the renderer directly from a Node test against multiple env fixtures, asserting exact output.
+- It generalizes: future templates beyond brainstorm.conf could use the same renderer trivially.
+
+What we are trading away: a small amount of "this is just a shell script" simplicity. Acceptable given the explicit predictability + testability gains.
+
+### Variable-substitution semantics
+
+The renderer recognizes exactly two forms:
+- `${VAR_NAME}` — replaced with `process.env.VAR_NAME`. Throws `RenderError: missing env var "VAR_NAME"` if undefined.
+- Literal text — left as-is.
+
+NOT recognized (intentional — these stay as literal text):
+- `$(command)` — never executed.
+- `` `command` `` — never executed.
+- `$VAR_NAME` (no braces) — left as literal. Forcing `${VAR_NAME}` braces makes the substitution boundaries unambiguous and matches the existing heredoc's style.
+- `${VAR:-default}` — left as literal text in this story. May be added in a future enhancement if operator need surfaces (e.g., for feature-flag soft defaults).
+
+### Where the new task-queue.json template lives
+
+`config/brainstorm-task-queue.json.template`. Same directory as the other six templates. Content is the deploy-safe default literal JSON (no substitution needed); operators tune `resourceClassCaps` and concurrency knobs by editing the live `/etc/brainstorm-task-queue.json` after first install.
+
+### Byte-equivalence verification
+
+Two complementary mechanisms:
+
+1. **Tester-authored source-sentinel test** at `test/entrypoint-template-rendering.test.js` that:
+   - Reads the OLD heredoc content from the current `docker/entrypoint.sh` (delimited by `<< CONFEOF` and `CONFEOF`).
+   - Reads the NEW template content from `config/brainstorm.conf.template`.
+   - Sets a fixed fixture env (specific values for `BRAINSTORM_MODULE_BASE_DIR`, `DOMAIN_NAME`, `RELAY_URL`, `NEO4J_PASSWORD`, `OWNER_PUBKEY`, `OWNER_NPUB`, `ADMIN_PUBKEYS`, `SESSION_SECRET`, `BRAINSTORM_NODE_BIN`).
+   - Renders the OLD heredoc by writing the heredoc text to a temp file and running `bash -c 'cat <<HEREDOC ... HEREDOC'`.
+   - Renders the NEW template via the Node renderer.
+   - Normalizes both (strip comments lines starting with `#`, strip blank lines, sort `export VAR=VALUE` lines alphabetically).
+   - Asserts the two normalized strings are identical.
+
+   This test passes pre-Step-2 (heredoc and template both produce the same byte-equivalent normalized output, because the template was backfilled to match in Step 1). After Step 2 (heredoc removed), the test can no longer compare — the Tester adapts it to instead snapshot-test against a known-good rendered output (preserves regression protection going forward).
+
+2. **One-time impl-side script** at `tools/diff-brainstorm-conf-render.sh`:
+   - Sets a fixture env.
+   - Runs the OLD heredoc-based path (against a snapshot of pre-Step-2 entrypoint.sh).
+   - Runs the NEW template + renderer path.
+   - Side-by-side diff output for the Implementer + Reviewer to eyeball during impl and review.
+
+   This script is **deliberately temporary** — kept in the impl PR for review use, then deleted as part of Step 2's cleanup (or moved to `tools/legacy/` for posterity if the team wants the artifact preserved).
+
+### Drift sentinel for future
+
+A small source-sentinel test that asserts:
+- `docker/entrypoint.sh` does not contain a heredoc that writes to `/etc/brainstorm.conf` (regex `<<\s*CONFEOF` should match zero times after Step 2).
+- `docker/entrypoint.sh` DOES contain exactly one invocation of `render-conf-template.js` (regex match exactly one).
+
+This catches the most likely future regression: someone re-introduces a heredoc, or adds a second write-path that bypasses the renderer.
+
+## Consequences
+
+**Enabled**
+- Fresh containers automatically get every variable currently declared in `config/brainstorm.conf.template` — including story #13's `TASK_QUEUE_ENABLED` and any future feature flags.
+- Fresh containers automatically get `/etc/brainstorm-task-queue.json` with the deploy-safe defaults.
+- Bare-metal installs (`setup/install-control-panel.sh`) are incidentally fixed by Step 1's backfill — the template they consume becomes complete.
+- The Node renderer can be reused by future stories that introduce other Node-process-rendered config files. Pattern established.
+
+**Constrained / made harder**
+- The template now contains env-var references (`${OWNER_PUBKEY}`, `${SESSION_SECRET}`, etc.) that won't render correctly outside the entrypoint context. If anyone tries to "just `source` the template" for some other purpose, those references won't resolve. Mitigation: template gets a header comment explaining the `${VAR}` syntax and where the variables come from.
+- Step 1 (template backfill) is **substantial textual work** — 24 variables to add to the template in the right order, with the right quoting, with `${VAR}` markers where the heredoc uses bash substitution. The byte-equivalence AC + test is what makes this safe.
+- The entrypoint now depends on `tools/render-conf-template.js` being present at the correct path under `BRAINSTORM_MODULE_BASE_DIR`. If the Dockerfile doesn't currently COPY the `tools/` directory, the Implementer must add that.
+
+**Follow-up debt (out of scope here)**
+- **Other templates' rendering.** This story switches only `brainstorm.conf`. The other five (`graperank`, `whitelist`, `blacklist`, `nip56`, `concept-graph`) continue using the existing "cp if not present" pattern. If they ever need substitution, the renderer is there.
+- **Bare-metal install path verification.** Step 1 fixes the bare-metal path by making the template complete. The Reviewer should confirm during smoke or file a follow-up if a residual gap surfaces.
+- **`${VAR:-default}` soft-default support** — add to the renderer if/when operator need surfaces.
+- **Operator-friendly override mechanism** (env-var-set-in-docker-compose-overlay overrides template default) — separate story.
+
+**Firmware reinstall required?** No.
+
+## Implementation notes
+
+The Implementer reads this section verbatim.
+
+### Step 1 — Template backfill (do this first, separately commit if it helps reviewers)
+
+**Edit `config/brainstorm.conf.template`** to contain every variable the current `docker/entrypoint.sh` heredoc writes, in the same logical order. For each variable in the heredoc at [entrypoint.sh:40-122](docker/entrypoint.sh:40):
+
+- **Literal values** (e.g., `BRAINSTORM_BATCH_SIZE="100"`): copy verbatim.
+- **Env-var references** (e.g., `${NEO4J_PASSWORD}`, `${OWNER_PUBKEY}`, `${ADMIN_PUBKEYS}`, `${SESSION_SECRET}`, `${RELAY_URL}`, `${DOMAIN_NAME}`, `${BRAINSTORM_NODE_BIN}`, `${BRAINSTORM_MODULE_BASE_DIR}`): preserve the `${VAR}` reference in the template — the Node renderer will substitute at boot.
+- Maintain the heredoc's grouping (`# File paths`, `# WoT relays`, `# NIP-85 relays`, `# Popular general purpose relays`, `# NIP-85 configuration`, `# Performance tuning`, `# Relay configuration`, `# Neo4j configuration`, `# Strfry configuration`, `# Owner`, `# Security`, `# Process all tasks interval`, `# Actions`) as section comments in the template. Helps reviewers diff against the heredoc.
+
+The template's existing variables (`STRFRY_DOMAIN`, `NEO4J_USER`, `NEO4J_PASSWORD`, `BRAINSTORM_BATCH_SIZE`, etc.) that have **literal default values** (e.g., `STRFRY_DOMAIN="your.relay.com"`, `NEO4J_PASSWORD="neo4j"`) need to be **replaced with the `${VAR}` form** so they get substituted at boot from the entrypoint's env state — otherwise byte-equivalence fails (the heredoc writes `${DOMAIN_NAME}`'s actual value, not the literal `"your.relay.com"`).
+
+Concretely, lines like:
+```
+export STRFRY_DOMAIN="your.relay.com"
+export BRAINSTORM_RELAY_URL="wss://your.relay.com"
+export NEO4J_PASSWORD="neo4j"
+```
+become:
+```
+export STRFRY_DOMAIN="${DOMAIN_NAME}"
+export BRAINSTORM_RELAY_URL="${RELAY_URL}"
+export NEO4J_PASSWORD="${NEO4J_PASSWORD}"
+```
+
+`BRAINSTORM_INPUT_FILE` and `BRAINSTORM_KEYS_FILE` and `BRAINSTORM_RELAY_PUBKEY` and `BRAINSTORM_RELAY_PRIVKEY` and `CONTROL_PANEL_PORT` are template-only variables (not in the heredoc). The Implementer's call: keep them or drop them? The heredoc does not emit them, so **drop them** to preserve byte-equivalence — these were dead variables that bare-metal installs may have been writing but never functionally needed (verify in smoke if any code actually reads them; if so, they need to be added to the heredoc's set, then the template, so we don't regress bare-metal).
+
+The story #13 addition `export TASK_QUEUE_ENABLED=false` is the ONE variable that goes into the template WITHOUT being in the old heredoc — that's the entire point of story #16. The byte-equivalence test should explicitly allow this addition.
+
+After Step 1, run the Tester's byte-equivalence test. It should pass.
+
+### Step 2 — Entrypoint swap
+
+**Create `tools/render-conf-template.js`** (new file):
+```js
+#!/usr/bin/env node
+// Render a config template to stdout by substituting ${VAR_NAME} against process.env.
+// Story #16 / ADR 0014.
+//
+// Usage:  node tools/render-conf-template.js <template-path>
+// Output: substituted template on stdout. Exit 0 on success.
+// Errors: nonzero exit + stderr message on unknown ${VAR} reference (missing env var)
+//         or file-read failure.
+//
+// Substitution rules: ${VAR_NAME} only. Bare $VAR, $(cmd), backticks, ${VAR:-default}
+// are left as literal text — this renderer is intentionally NOT a shell evaluator.
+
+const fs = require('fs');
+const path = require('path');
+
+const templatePath = process.argv[2];
+if (!templatePath) {
+  console.error('Usage: render-conf-template.js <template-path>');
+  process.exit(1);
+}
+
+let content;
+try { content = fs.readFileSync(templatePath, 'utf8'); }
+catch (e) { console.error(`Failed to read template ${templatePath}: ${e.message}`); process.exit(1); }
+
+const VAR_REF = /\$\{([A-Z_][A-Z0-9_]*)\}/g;
+const missing = [];
+const rendered = content.replace(VAR_REF, (_match, name) => {
+  if (Object.prototype.hasOwnProperty.call(process.env, name)) return process.env[name];
+  missing.push(name);
+  return '';
+});
+if (missing.length) {
+  console.error(`RenderError: missing env vars in ${path.basename(templatePath)}: ${[...new Set(missing)].join(', ')}`);
+  process.exit(2);
+}
+process.stdout.write(rendered);
+```
+
+**Edit `docker/entrypoint.sh`** ([line 39-122](docker/entrypoint.sh:39)):
+- Remove the entire `# Generate /etc/brainstorm.conf` block (the `cat > ... << CONFEOF ... CONFEOF` heredoc).
+- Replace with:
+```bash
+# Render /etc/brainstorm.conf from the template (story #16 / ADR 0014).
+# See config/brainstorm.conf.template. Variable substitution against the env
+# state set above. The renderer rejects unknown ${VAR} references with
+# nonzero exit, so a missing env var fails the boot loudly.
+if ! node "${BRAINSTORM_MODULE_BASE_DIR}/tools/render-conf-template.js" \
+        "${BRAINSTORM_MODULE_BASE_DIR}config/brainstorm.conf.template" > /etc/brainstorm.conf; then
+  echo "[entrypoint] FATAL: render of /etc/brainstorm.conf failed" >&2
+  exit 1
+fi
+chmod 664 /etc/brainstorm.conf
+echo "[entrypoint] /etc/brainstorm.conf generated from config/brainstorm.conf.template"
+```
+
+Keep `chmod 664` (matches existing behavior, line 124).
+
+**Add the task-queue.json install block** after the existing `for conffile in graperank ...` loop (around line 134):
+```bash
+# Install /etc/brainstorm-task-queue.json on fresh containers (story #16 / ADR 0014).
+if [ ! -f /etc/brainstorm-task-queue.json ] && [ -f "${CONFIG_DIR}/brainstorm-task-queue.json.template" ]; then
+  cp "${CONFIG_DIR}/brainstorm-task-queue.json.template" /etc/brainstorm-task-queue.json
+  chmod 644 /etc/brainstorm-task-queue.json
+  echo "[entrypoint] Installed /etc/brainstorm-task-queue.json from template"
+fi
+```
+
+**Create `config/brainstorm-task-queue.json.template`** (new file):
+```json
+{
+  "defaultConcurrency": 1,
+  "concurrencyByTask": {},
+  "resourceClassCaps": {
+    "neo4j-heavy": 1
+  }
+}
+```
+
+### Dockerfile
+
+Verify `tools/` is COPIED into the image. Check `docker/Dockerfile` or whichever Dockerfile builds the `tapestry` image. If `tools/` isn't currently copied, add `COPY tools/ /usr/local/lib/node_modules/brainstorm/tools/` (or whichever destination matches `BRAINSTORM_MODULE_BASE_DIR`).
+
+If it's already copied as part of a wildcard `COPY . .` or similar, no change needed — verify in cycle-local smoke.
+
+### Tests
+
+The Tester writes:
+
+1. **Byte-equivalence test** at `test/entrypoint-template-rendering.test.js`:
+   - T1: `tools/render-conf-template.js` exists and is parseable.
+   - T2: `config/brainstorm.conf.template` contains every variable name that the heredoc currently writes (extracted by regex from `docker/entrypoint.sh`). The list is hardcoded once at this story; the test does not require entrypoint.sh's heredoc to exist after Step 2.
+   - T3: With a fixed env fixture, rendering the new template via the Node renderer + normalizing (strip comments/blanks, sort by variable name) produces output that contains every `VAR=VALUE` pair the old heredoc would produce under the same env. Plus the new line `TASK_QUEUE_ENABLED=false`.
+   - T4: `config/brainstorm-task-queue.json.template` exists and parses as JSON containing `resourceClassCaps.neo4j-heavy = 1`.
+   - T5: `docker/entrypoint.sh` references `tools/render-conf-template.js` and contains a conditional install block for `brainstorm-task-queue.json`.
+
+2. **Drift sentinel** (folded into the same suite):
+   - T6: `docker/entrypoint.sh` does NOT contain a `<<\s*CONFEOF` heredoc writing to `/etc/brainstorm.conf` (catches future heredoc re-introduction).
+   - T7: `docker/entrypoint.sh` contains exactly one invocation of `render-conf-template.js` (catches future multi-render proliferation).
+
+3. **One-time diff helper** at `tools/diff-brainstorm-conf-render.sh` — for the Reviewer to eyeball the actual rendered output during smoke. Deleted as part of the impl PR's final cleanup commit, OR moved to `tools/legacy/` if the team prefers to keep it.
+
+### Smoke
+
+Cycle-local (Reviewer):
+- Boot a fresh container WITHOUT a pre-existing `/etc/brainstorm.conf`. Observe the entrypoint log: `[entrypoint] /etc/brainstorm.conf generated from config/brainstorm.conf.template`. Then `[entrypoint] Installed /etc/brainstorm-task-queue.json from template`.
+- Diff the resulting `/etc/brainstorm.conf` against what the heredoc would produce for the same env. Zero semantic differences (modulo comments + blanks).
+- Verify `TASK_QUEUE_ENABLED=false` is present.
+- Verify `/etc/brainstorm-task-queue.json` exists with the expected content.
+- Restart the container: `/etc/brainstorm.conf` is regenerated (unconditional overwrite, same as today's heredoc behavior); `/etc/brainstorm-task-queue.json` is preserved (conditional copy, matches the other `*.conf` template behavior).
+
+### Concept handle
+
+None. No new concepts.
+
+## Out of scope
+
+- **Reconciling already-deployed long-running containers.** Operators handle via the manual `docker exec ...` recipe from story #15's flag-flip.
+- **Migrating the other five conf files to the renderer.** Their existing conditional-copy works correctly for fresh containers; no need to touch.
+- **`${VAR:-default}` soft-default support.** Future enhancement if operator need surfaces.
+- **Env-var-overlay-based override mechanism** (e.g., docker-compose env_file lets operator force `TASK_QUEUE_ENABLED=true` per environment). Separate story.
+- **Bare-metal install path code changes.** Step 1's template backfill incidentally fixes the bare-metal path. If a residual gap surfaces, separate story.
+- **Comment / whitespace fidelity** between old and new rendered output. Semantic content (variable names + values) is what byte-equivalence pins.
+- **A drift sentinel that walks `brainstormConfig.get()` call sites** across the JS codebase to assert every consumed variable is in the template. Useful but heavier; can be added later.

--- a/engineering-team/reviews/16-entrypoint-conf-templates-source-of-truth.md
+++ b/engineering-team/reviews/16-entrypoint-conf-templates-source-of-truth.md
@@ -1,0 +1,181 @@
+# Review: Story 16 — Conf templates are the source of truth for fresh containers
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-21
+**Diff:** `git diff origin/staging...HEAD` (commit `6c4c3769`, 4 commits: `74423cd3` story, `753e66b2` ADR, `7d9548c2` tests, `6c4c3769` impl)
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` (host) — **PASS**. `entrypoint-template-rendering suite: PASS (11 passed, 0 failed)` (8 ADR sentinels + 3 regression guards green). All 13 prior suites still PASS, unchanged. Overall: **PASS**.
+- [x] `npm test` (live tapestry container, bind-mounted source) — **PASS**. Same 14/14 suites green as host. Confirms the new files reach the container via the bind-mount and don't break the in-container test harness.
+- [x] `bash -n docker/entrypoint.sh` — syntax valid.
+- [x] `node --check tools/render-conf-template.js` — parse valid.
+- [x] _Playwright not applicable — no UI surface changed._
+- [x] _Lint / typecheck / build not configured — skipped per house rules._
+- [x] **Cycle-local smoke** — **PASS end-to-end** (see §"Cycle-local smoke verification" below). The behavioral round-trip the source-sentinels can't reach.
+
+## Spec adherence (AC walk)
+
+| AC (story §) | Status | Notes |
+|---|---|---|
+| Byte-equivalence (strictest) | ✓ | T4 source + cycle-local smoke S1. The new template+renderer render produces semantically identical VAR=VALUE output to what the old heredoc would have produced under the same env. The 3 differences observed against the live `/etc/brainstorm.conf` are all explained by downstream-of-render mutations: one operator manual edit on `BRAINSTORM_30382_LIMIT`, plus `BRAINSTORM_RELAY_PUBKEY/NPUB` appended by `setup/create_nostr_identity.sh` (which runs AFTER both the old heredoc and the new renderer at the same entrypoint:218 hook). The render step itself is byte-equivalent. |
+| Step 1 — template backfill | ✓ | T2 + T3 source. `config/brainstorm.conf.template` now contains all 41 heredoc variables in the same logical groupings, with literal values preserved where the heredoc had literals and `${VAR}` markers where the heredoc had bash substitution. |
+| Step 2 — entrypoint swap (no heredoc) | ✓ | T7 source + diff walk. The 80-line `<<CONFEOF` heredoc is gone; replaced with a 15-line renderer invocation block. Drift sentinel T7 trips on any future re-introduction. |
+| Template line propagates to fresh containers without entrypoint edit | ✓ | T2+T6 source (template = source of truth; entrypoint = single renderer invocation). Adding `export NEW_VAR=value` to the template alone is sufficient for fresh containers to receive it — proved structurally by T6+T8. |
+| Fresh container has `TASK_QUEUE_ENABLED=false` | ✓ | R2 source + smoke (rendered output contains `export TASK_QUEUE_ENABLED=false` on line 100 of the rendered conf). Story #13's flag finally reaches fresh containers without operator ceremony. |
+| Install `/etc/brainstorm-task-queue.json` from template | ✓ | T5 + T6 source + cycle-local smoke S3a/S3b. Conditional install with the `[ ! -f ]` guard tested both branches: present → preserve operator edits; absent → install deploy-safe defaults. |
+| No regression for existing containers | ✓ | Smoke S1 — byte-equivalence holds; the new render step produces the same variable set the heredoc would. Plus npm test 14/14 confirms no JS-level regression. |
+| No regression for the other 5 `*.conf` files | ✓ | R1 source. The `for conffile in graperank whitelist blacklist nip56; do` loop is preserved unchanged (only the duplicate `CONFIG_DIR=` line inside that block was removed because CONFIG_DIR is now defined once at the top — line 13). |
+| Boot log line | ✓ | T6 source — `echo "[entrypoint] /etc/brainstorm.conf generated from config/brainstorm.conf.template"` immediately after the chmod 664. |
+| Documentation in OPERATIONS.md | ✓ | New §11 with TOC entry. Documents: (1) the template-as-source-of-truth contract; (2) the trap (edits inside a running container are lost on restart); (3) the operator path for persistent overrides (repo-level edit + commit, or the docker exec append-if-absent recipe); (4) the drift sentinels T7+T8 as the long-term safety net. |
+
+## ADR adherence
+
+- [x] Files changed match ADR 0014 §Implementation notes exactly:
+  - New `tools/render-conf-template.js` ✓ — ~30 lines per ADR spec, plain regex against `process.env`, no shell-eval class.
+  - Edited `config/brainstorm.conf.template` ✓ — Step 1 backfill; all variables from heredoc preserved, `${VAR}` markers per ADR §Variable-substitution semantics.
+  - New `config/brainstorm-task-queue.json.template` ✓ — deploy-safe defaults `{defaultConcurrency:1, concurrencyByTask:{}, resourceClassCaps:{neo4j-heavy:1}}`.
+  - Edited `docker/entrypoint.sh` ✓ — heredoc removed; renderer invocation + task-queue install block + boot log line added; chmod 664 preserved.
+  - Edited `OPERATIONS.md` ✓ — §11 added per ADR §Consequences.
+- [x] Renderer implementation matches ADR §Implementation notes line-for-line:
+  - Shebang + 'use strict' + `argv[2]` validation ✓
+  - `readFileSync` with try/catch + exit 1 on file failure ✓
+  - Regex `/\$\{([A-Z_][A-Z0-9_]*)\}/g` ✓
+  - Missing vars collected + exit 2 with deduplicated list + template basename ✓
+  - `process.stdout.write` (not `console.log` — would add trailing `\n` and break byte-equivalence) ✓
+  - `Object.prototype.hasOwnProperty.call(process.env, name)` ✓ — defensive against prototype-pollution-style env-var names (`toString`, etc).
+- [x] Entrypoint wrap follows ADR §Implementation Step 2 shape:
+  - Exports the 9 vars the template references BEFORE invoking the renderer ✓
+  - `if !` block with `[entrypoint] FATAL` message + exit 1 on render failure ✓
+  - `chmod 664` preserved ✓
+  - Success log line per ADR ✓
+- [x] Task-queue install block mirrors the existing `for conffile in graperank...` copy-if-absent pattern.
+- [x] **No new dependencies authorized.** Only Node (already in image, already invoked at entrypoint:32 for owner-npub lookup) — confirmed by `docker exec tapestry which envsubst` returning empty (no Dockerfile change needed).
+- [x] **No Dockerfile change needed** — the existing `COPY . /usr/local/lib/node_modules/brainstorm/` at Dockerfile:92 picks up the new `tools/` directory; `.dockerignore` does not exclude it. Verified by `docker exec tapestry ls /usr/local/lib/node_modules/brainstorm/tools/` showing the new file present in the live container (via bind-mount).
+
+## Concept-graph integrity
+
+- [x] No concept-graph schema changes (ADR §Concept-graph impact confirmed "none"). Verified — no `src/concept-graph/` edits in the diff.
+- [x] No concept handles touched.
+- [x] Firmware reinstall not required (ADR §Implementation notes §Concept handle: "None").
+
+## Things tests can't catch — hidden-hazard audit
+
+| Hazard | Status |
+|---|---|
+| `which node` returns empty (Node not in PATH) → `BRAINSTORM_NODE_BIN=""` gets exported empty → renderer substitutes empty → rendered conf has `BRAINSTORM_NODE_BIN=""` | **Acceptable** — matches old heredoc behavior; downstream `start-brainstorm.sh` would fail to spawn either way. No new failure mode. |
+| Renderer accidentally interprets `$(date)` or backticks as shell substitution | **Closed** by regex shape: `/\$\{([A-Z_][A-Z0-9_]*)\}/g` requires brace + uppercase identifier. `$(cmd)`, backticks, bare `$VAR` are left as literal text. No injection class. |
+| Two-phase boot race: renderer writes /etc/brainstorm.conf, then create_nostr_identity.sh appends to it. If create_nostr_identity.sh runs before render finishes, appends are lost | **Closed** by entrypoint sequential ordering (line 49 renderer; line 216 create_nostr_identity.sh). Each step blocks until the previous completes (no `&`). Same sequence as before story #16. |
+| Operator edits `/etc/brainstorm.conf` then container restarts → edit lost | **Documented**, not eliminated. This is **existing behavior** (the old heredoc was also unconditional overwrite) — story #16 §Out of scope explicitly says "operator overrides written to /etc/brainstorm.conf between restarts are NOT preserved." OPERATIONS.md §11 documents the trap and the operator path forward (template + commit, or docker exec append-if-absent). |
+| Operator edits `/etc/brainstorm-task-queue.json` then container restarts → edit lost | **Closed** by the `[ ! -f ]` guard on the install block. Smoke S3a confirmed: operator edits survive restart. Different pattern from brainstorm.conf — intentional, matches the other 4 conf templates' behavior. |
+| Renderer's `Object.prototype.hasOwnProperty.call(process.env, name)` check — what if `name` is `'toString'` or `'__proto__'`? | **Closed** — defensive lookup pattern blocks prototype-walk lookups; only own-properties counted. (Belt-and-suspenders: ENV var names are uppercase per the regex, so `'__proto__'` couldn't match anyway, but the defensive lookup is correct style.) |
+| Empty-string env var (e.g., `BRAINSTORM_MANAGER_PUBKEYS=""`) → renderer substitutes `""` | **Acceptable** — matches old heredoc exact behavior (heredoc emits `export BRAINSTORM_MANAGER_PUBKEYS=""`). Renderer's `hasOwnProperty` check treats present-but-empty as "set". |
+| Dead variables dropped from template (`BRAINSTORM_INPUT_FILE`, `BRAINSTORM_KEYS_FILE`, `BRAINSTORM_RELAY_PUBKEY`, `BRAINSTORM_RELAY_PRIVKEY`, `CONTROL_PANEL_PORT`) — could break a downstream consumer | **Closed by triangulation:** (1) `BRAINSTORM_INPUT_FILE`/`KEYS_FILE` are only referenced by `bin/update-config.sh` (bare-metal interactive utility, not at runtime). (2) `BRAINSTORM_RELAY_PUBKEY`/`PRIVKEY` are appended at boot by `setup/create_nostr_identity.sh:36-38` regardless of template content — the heredoc never wrote them either. (3) `CONTROL_PANEL_PORT` is read by `bin/control-panel.js:109` and `src/algos/refreshSearchIndex.sh:27` both with `:-7778` fallback; the heredoc never wrote it either; in bare-metal where the template DID write `"7778"`, the value matched the fallback exactly. All 5 droppings are functionally inert. |
+| `lib/config.js` (consumed by test/test.js's smoke check) requires any of the dropped variables | **Closed** — `grep -n` confirmed `lib/config.js` does not reference any of the 5 dropped vars. testConfigLoading() passes (already verified by npm test gate). |
+| Boot-time stderr from renderer's missing-env error gets lost | **Closed** by smoke S2 — `RenderError: missing env vars in brainstorm.conf.template: BRAINSTORM_NODE_BIN, BRAINSTORM_MODULE_BASE_DIR, RELAY_URL, DOMAIN_NAME, NEO4J_PASSWORD, OWNER_PUBKEY, OWNER_NPUB, ADMIN_PUBKEYS, SESSION_SECRET` flows to the entrypoint's stderr, which Docker captures to the container log. The operator sees exactly which vars are missing. |
+| Renderer adds a trailing `\n` and breaks byte-equivalence | **Closed** by `process.stdout.write(rendered)` (not `console.log`). Render output ends exactly where the template ends (the template ends with a `\n` already, matching the heredoc's trailing newline). |
+
+## Cycle-local smoke verification
+
+Drove the validation that source-sentinels by design couldn't do. The local `tapestry` Docker container has been up for 7 days with a bind-mount of the repo at `/usr/local/lib/node_modules/brainstorm/`, so my Implementation-phase edits to `config/brainstorm.conf.template`, `tools/render-conf-template.js`, and `config/brainstorm-task-queue.json.template` are live in-container without a rebuild. (`docker/entrypoint.sh` is NOT live in-container — it's COPYed to `/entrypoint.sh` at image build per Dockerfile:109, and only runs at container start; my smoke validates the renderer + template in isolation, which is what the entrypoint would invoke.)
+
+### S1 — byte-equivalence (render-step diff against live heredoc-produced conf)
+
+Strategy: source the live `/etc/brainstorm.conf` (produced by the OLD heredoc 7 days ago + downstream mutations) to capture its env state, map the conf var names back to the docker-env var names the new entrypoint exports (`BRAINSTORM_OWNER_PUBKEY` → `OWNER_PUBKEY`, etc.), invoke the new renderer, then compare the two files modulo comments + blank lines (sorted).
+
+```
+old normalized: 55 lines (heredoc + downstream appends)
+new normalized: 53 lines (template render)
+
+diff:
+< export BRAINSTORM_30382_LIMIT="10"
+> export BRAINSTORM_30382_LIMIT="250000"
+< export BRAINSTORM_RELAY_NPUB='npub1uq8dpyy...'  (only in old)
+< export BRAINSTORM_RELAY_PUBKEY='e00ed09087...'  (only in old)
+```
+
+**All three differences are explained by downstream-of-render effects, NOT by the render step itself:**
+
+1. `BRAINSTORM_30382_LIMIT="10"` in live conf vs `"250000"` in both heredoc + template. The HEREDOC writes `"250000"`. Confirmed via `grep` on the repo's old heredoc and the new template — both say `"250000"`. **The `"10"` is an operator manual edit** to `/etc/brainstorm.conf` after the entrypoint ran. The new entrypoint would produce `"250000"` (same as the old). **No regression.** This is also the exact trap §11 of OPERATIONS.md now warns about — manual edits survive only until restart.
+
+2+3. `BRAINSTORM_RELAY_PUBKEY` + `BRAINSTORM_RELAY_NPUB` present in live conf but not in render output. **Both are appended at boot by `setup/create_nostr_identity.sh:36-38`**, which runs at entrypoint:216-218 — AFTER the brainstorm.conf is generated (whether by old heredoc or new renderer). The OLD heredoc never wrote them either; they were always added downstream. **The post-render sequence is identical before and after story #16. No regression.**
+
+**Verdict: byte-equivalence holds at the render step.** Downstream mutations (operator manual edits + create_nostr_identity.sh appends) are unchanged.
+
+### S2 — missing-env failure mode
+
+```
+$ env -i PATH=$PATH node /usr/local/lib/node_modules/brainstorm/tools/render-conf-template.js \
+        /usr/local/lib/node_modules/brainstorm/config/brainstorm.conf.template
+exit: 2
+stderr: RenderError: missing env vars in brainstorm.conf.template:
+         BRAINSTORM_NODE_BIN, BRAINSTORM_MODULE_BASE_DIR, RELAY_URL, DOMAIN_NAME,
+         NEO4J_PASSWORD, OWNER_PUBKEY, OWNER_NPUB, ADMIN_PUBKEYS, SESSION_SECRET
+```
+
+Exit 2 (matches ADR `process.exit(2)`). All 9 missing vars listed, deduplicated, with template filename. **This is the LOUD-BOOT behavior the ADR §Variable-substitution semantics pins** — a future template addition that references an env var the entrypoint forgot to export fails the container boot with an actionable error message rather than silently emitting `KEY=""` and failing at runtime.
+
+The entrypoint's outer wrap (`if !` + `[entrypoint] FATAL` + `exit 1`) means the operator sees both messages in the container log, and supervisord never starts.
+
+### S3a — task-queue.json conditional install: file present → preserve
+
+```
+SKIPPED (file present, preserved): {"defaultConcurrency":1,"concurrencyByTask":{},"resourceClassCaps":{"neo4j-heavy":1}}
+```
+
+The `[ ! -f /etc/brainstorm-task-queue.json ]` guard correctly skips. **Operator edits survive restart** — exactly the behavior story #15 needed but couldn't get without manual ceremony on every fresh container.
+
+### S3b — task-queue.json conditional install: file absent → install
+
+```
+INSTALLED from template: {
+  "defaultConcurrency": 1,
+  "concurrencyByTask": {},
+  "resourceClassCaps": {
+    "neo4j-heavy": 1
+  }
+}
+```
+
+Fresh containers get the deploy-safe defaults automatically. Matches story #15's `resourceClassCaps.neo4j-heavy: 1` exactly.
+
+### Smoke scenarios NOT performed (acceptable gaps)
+
+- **Cold container boot from scratch.** The live container is the bind-mount dev setup — a true cold boot from a freshly-built image would require `docker compose down && docker compose up --build`, which interrupts the operator's running stack. Substituted: in-container in-isolation invocation of the renderer (S1) + the conditional-install block (S3a/S3b), plus syntactic validation of the modified entrypoint.sh via `bash -n`. The risk of bug-in-cold-boot path is small — the entrypoint edit is mechanical (heredoc swap + new conditional block); the renderer + template are exercised by the in-container smoke.
+- **`docker compose up --build` smoke on a fresh image.** Same reason — would require interrupting the operator's stack. Defer to staging-deploy smoke; the deploy chain's natural cadence is the right place to validate cold-boot behavior across the actual image build.
+
+## House rules check
+
+- [x] Concept Graph API authority respected (no concept change).
+- [x] No new lint/typecheck/build tooling.
+- [x] No firmware reinstall needed.
+- [x] Per-phase commits in order: story → adr → test → impl. Clean stack on top of `origin/staging` (commit `2becc305`, story #15's merge).
+- [x] No source files modified outside the ADR's scope. The 5 files changed are exactly the 5 the ADR §Implementation notes called out.
+
+## Findings
+
+### Blocking
+
+_None._
+
+### Non-blocking (recorded, do not gate)
+
+1. **Live container's `BRAINSTORM_30382_LIMIT="10"` is a manual operator edit that will be lost on next container restart** — the heredoc has always emitted `"250000"`. This is precisely the trap §11 of OPERATIONS.md now documents; the operator should add `BRAINSTORM_30382_LIMIT="10"` to the template (committed) if they want the value to persist. Not blocking for ship — this is **existing trap behavior, not introduced by story #16**.
+
+2. **`BRAINSTORM_RELAY_PUBKEY/NPUB` appended at boot by `create_nostr_identity.sh` are a kind of "second source of truth" for /etc/brainstorm.conf** — story #16 didn't reconcile this, intentionally. The append-flow is unchanged; the template doesn't carry these vars, same as the old heredoc didn't. If the team ever wants `/etc/brainstorm.conf` to be exclusively template-driven, that's a follow-up story (move the relay-key generation into the template-render flow or have it write to a separate file). Out of scope here.
+
+3. **Dropped template-only vars (`BRAINSTORM_INPUT_FILE`, `BRAINSTORM_KEYS_FILE`, `BRAINSTORM_RELAY_PUBKEY`, `BRAINSTORM_RELAY_PRIVKEY`, `CONTROL_PANEL_PORT`) — bare-metal install path's interactive `bin/update-config.sh` still references them.** That utility prompts and writes them to /etc/brainstorm.conf as new exports if the operator chooses — it doesn't read them from the template. So `update-config.sh` still works in the bare-metal path post-story-#16. Confirmed: `grep -n` in lib/config.js (the runtime consumer) shows zero references to any of the 5 dropped vars.
+
+4. **The renderer's parseability sentinel (T1) uses `node --check` which only validates syntax, not behavior.** T4 spawns the renderer with a fixture env and asserts the output — that's the behavioral check. The combination is correct; just noting that the two sentinels have complementary scopes.
+
+5. **No cold-boot smoke against a freshly-built image** (see §Smoke scenarios NOT performed). The staging-deploy step is the natural place for that validation; the deploy chain's automated container restart on every push exercises the cold-boot path naturally.
+
+## Verdict
+
+**PASS end-to-end.**
+
+Source-side (11/11 sentinels green) and behavioral-side (cycle-local smoke S1 + S2 + S3a + S3b) both confirm the implementation matches ADR 0014 and resolves the heredoc-vs-template drift class story #16 was raised to close. Byte-equivalence at the render step is proven against the live container; the three observed differences are all downstream-of-render effects (unchanged before/after the story) and document the very trap §11 now warns operators about.
+
+The 5 non-blocking observations are either pre-existing behavior, scope-bounded (out-of-scope items called out in the story), or cosmetic. None gate ship.
+
+The story is ready for the deploy chain (`cycle-staging`, then on explicit confirmation `cycle-prod`). The cold-boot validation that the local cycle-local smoke deliberately deferred will naturally occur on the first container restart in staging — if any export was missed, the boot fails loudly per S2's verified failure mode. That's exactly the right place for that failure to happen (caught before prod), and exactly the kind of fast-fail the renderer's design choice was made for.

--- a/engineering-team/stories/16-entrypoint-conf-templates-source-of-truth.md
+++ b/engineering-team/stories/16-entrypoint-conf-templates-source-of-truth.md
@@ -1,0 +1,95 @@
+# Story 16: Conf-template-driven entrypoint as the single source of truth for fresh container state
+
+**Status:** Approved
+**Created:** 2026-05-21
+**Type:** Bug (latent class-of-bug: silent template-vs-heredoc drift)
+
+## Background
+
+While reviewing why story #15's flag-flip required a manual `>> /etc/brainstorm.conf` step on long-running containers, we discovered that `docker/entrypoint.sh` regenerates `/etc/brainstorm.conf` on every container restart from a **heredoc embedded in the entrypoint script itself** ([entrypoint.sh:40-122](docker/entrypoint.sh:40)) — not from `config/brainstorm.conf.template`. The template file is consulted only by the bare-metal install path in `setup/install-control-panel.sh`; it has **no effect on Docker deployments at all**.
+
+This means story #13's addition of `export TASK_QUEUE_ENABLED=false` to `config/brainstorm.conf.template` was **inert at Docker runtime**. A brand-new container spun up today does NOT contain `TASK_QUEUE_ENABLED` in its `/etc/brainstorm.conf`; the variable falls back to its code default (`false`) every time, and any operator wanting to flip the flag must manually add the line. The "story #13 shipped the flag" + "operator must manually backfill the line on each container" pattern is a class-of-bug that will repeat on every future feature flag added to a template.
+
+A related gap: `brainstorm-task-queue.json` (the per-class concurrency config introduced by story #15) has **no install logic in the entrypoint at all**. Operators must create the file manually on every fresh instance, in addition to the brainstorm.conf line.
+
+The other five conf files (`graperank`, `whitelist`, `blacklist`, `nip56`, plus `concept-graph`) already use a template-driven copy-if-absent loop ([entrypoint.sh:130-134](docker/entrypoint.sh:130)) — fresh containers get them correctly from their templates. The trap is **specific to brainstorm.conf** (heredoc duplication) and **`brainstorm-task-queue.json`** (no install path).
+
+This story closes the class by making the templates the **single source of truth** for Docker-fresh container state, eliminating the heredoc duplication and adding install logic for the task-queue config.
+
+### Critical prerequisite discovered at planning gate (2026-05-21)
+
+A direct comparison of the heredoc (40 variables) against `config/brainstorm.conf.template` (16 variables) revealed **dramatic divergence**. The template has been getting selective edits (story #13's `TASK_QUEUE_ENABLED`, plus a few legacy lines from `setup/install-control-panel.sh`) but has **never** been maintained as a complete replacement for the heredoc. Switching the entrypoint to read from the template as-is would silently delete ~25 variables from fresh containers' `/etc/brainstorm.conf`, including:
+
+- All `BRAINSTORM_MODULE_*_DIR` env vars (control panel boot would fail).
+- All `BRAINSTORM_*_RELAYS` lists (WoT, NIP-85, popular general — the system's default relay sets).
+- `BRAINSTORM_OWNER_PUBKEY` / `OWNER_NPUB` / `ADMIN_PUBKEYS` (owner auth would break).
+- `SESSION_SECRET` (sessions would break).
+- `STRFRY_PLUGINS_BASE` / `STRFRY_PLUGINS_DATA` (plugin loading would break).
+- `BRAINSTORM_LOG_DIR` / `BRAINSTORM_BASE_DIR` (filesystem roots used everywhere).
+- `BRAINSTORM_30382_LIMIT`, `BRAINSTORM_NEO4J_BROWSER_URL`, `BRAINSTORM_PROCESS_ALL_TASKS_INTERVAL`, and several action flags.
+
+The work therefore breaks into **two ordered steps**, both inside this story:
+
+**Step 1 — Backfill the template to match the heredoc.** Update `config/brainstorm.conf.template` so it contains every variable the heredoc currently writes, with the same values (literals for fixed values; `${VAR}` substitution markers for env-var-dependent values like `${DOMAIN_NAME}`, `${OWNER_PUBKEY}`, `${NEO4J_PASSWORD}`, `${SESSION_SECRET}`). After this step, the template is functionally complete but the entrypoint still uses the heredoc — verification is just diffing rendered template against heredoc output.
+
+**Step 2 — Swap the entrypoint to read from the template.** With the diff clean, remove the heredoc and replace with a template-render call. Cycle-local smoke confirms the resulting `/etc/brainstorm.conf` is byte-equivalent to today's.
+
+Step 1 is the larger and riskier of the two; Step 2 is mechanically simple once Step 1 is clean. The byte-equivalence AC below pins the safety guarantee for the swap.
+
+## User-facing description
+
+**As an operator** spinning up a fresh Tapestry container (new droplet, sandbox, or rebuild), **I want** the container's `/etc/brainstorm.conf` and `/etc/brainstorm-task-queue.json` to automatically contain every variable currently declared in the repo's `config/` templates, **so that** I don't have to remember to manually backfill missing variables introduced by recent stories — and so that every feature flag added to a template "just works" on the next fresh deploy without operator ceremony.
+
+## Acceptance criteria
+
+- [ ] **Byte-equivalence (strictest AC — the safety guarantee).** The `/etc/brainstorm.conf` produced by the new entrypoint on a fresh container start is **semantically equivalent** (every variable set with the same value) to the `/etc/brainstorm.conf` produced by today's entrypoint heredoc, given the same deploy-time env vars (`DOMAIN_NAME`, `RELAY_URL`, `NEO4J_PASSWORD`, `OWNER_PUBKEY`, `OWNER_NPUB`, `ADMIN_PUBKEYS`, `SESSION_SECRET`, plus any others the heredoc consumes). Verification mechanism: render once with the new path, once with the old, diff (modulo whitespace and comments). Zero semantic differences. The Tester / Reviewer is expected to drive this verification end-to-end against a sandbox container.
+- [ ] **Step 1 — template backfill.** `config/brainstorm.conf.template` contains every variable the current heredoc writes, with the same values. Env-var-dependent values use `${VAR}` substitution markers consistent with the mechanism chosen by the Architect.
+- [ ] **Step 2 — entrypoint swap.** `docker/entrypoint.sh` no longer contains a heredoc duplicating `brainstorm.conf` content. Instead, the entrypoint reads `config/brainstorm.conf.template` and writes the result to `/etc/brainstorm.conf` at container start.
+- [ ] Adding a new `export VAR=value` line to `config/brainstorm.conf.template` and rebuilding the container image is sufficient — by itself — for fresh containers to receive that variable in `/etc/brainstorm.conf`. No corresponding change to `entrypoint.sh` is required for the variable to propagate.
+- [ ] Specifically: on a fresh container start, `/etc/brainstorm.conf` contains `export TASK_QUEUE_ENABLED=false` (the line story #13 added to the template but which never reached fresh Docker deployments).
+- [ ] `docker/entrypoint.sh` is extended to install `/etc/brainstorm-task-queue.json` on fresh containers from a new template (`config/brainstorm-task-queue.json.template` or equivalent), using the same conditional copy-if-absent pattern already used for `graperank.conf` et al. The template ships with the deploy-safe defaults: `{"defaultConcurrency":1,"concurrencyByTask":{},"resourceClassCaps":{"neo4j-heavy":1}}`.
+- [ ] No regression for existing containers: when the new entrypoint runs against a container that already has values in `/etc/brainstorm.conf` (from a prior boot or operator edit), the resulting `/etc/brainstorm.conf` contains all the same variables that today's heredoc would produce, with the same values. (Operator overrides written to `/etc/brainstorm.conf` between restarts are NOT preserved — that's already the current behavior since the heredoc unconditionally overwrites; this story doesn't change that posture.)
+- [ ] No regression for the other five `*.conf` files: their existing copy-if-absent loop continues to work unchanged.
+- [ ] The boot log makes the new behavior observable: at minimum, a single line confirming `[entrypoint] /etc/brainstorm.conf generated from config/brainstorm.conf.template`.
+- [ ] Documentation in `OPERATIONS.md` notes the new "template is single source of truth for fresh containers" contract, and explicitly notes the existing trap: edits to `/etc/brainstorm.conf` made manually inside a running container are lost on the next restart. Operators wanting persistent overrides must add them to the template (committed to the repo) or set them via deploy-environment variables.
+
+## Concepts touched
+
+- `docker/entrypoint.sh` (the script that runs at container startup)
+- `config/brainstorm.conf.template` (currently inert at Docker runtime — becomes the source of truth)
+- `config/brainstorm-task-queue.json.template` (new — companion to the json config introduced by story #15)
+- `/etc/brainstorm.conf` and `/etc/brainstorm-task-queue.json` in the container
+- Operator workflow for enabling new feature flags
+
+## Out of scope
+
+- **Reconciling already-deployed long-running containers** (staging, prod, tags). The operator handles those manually via the `docker exec ... if grep -q ... else echo >> ...` recipe used during story #15's flag-flip. This story benefits new containers spun up after the deploy lands.
+- **Migrating operator edits made inside a running container to the template.** If the operator has manually set `TASK_QUEUE_ENABLED=true` inside a container's `/etc/brainstorm.conf` and we want that to persist across restarts, the operator should put it in the template (commit to repo) — or we should add env-var-driven overrides (a separate story).
+- **Env-var-based overrides** (e.g., `${TASK_QUEUE_ENABLED:-false}` in the template, set via docker-compose env_file). Worth considering but adds design choices; defer to a follow-up if operator need surfaces.
+- **Comment / blank-line fidelity** between template and generated conf. The semantic content is what matters; cosmetic differences are acceptable.
+- **Restructuring the bare-metal install path** (`setup/install-control-panel.sh`). It reads the template directly without the heredoc-overlay. **Important corollary (noted at planning):** because the template was missing ~25 variables before Step 1 of this story, the bare-metal install path has very likely been producing incomplete `/etc/brainstorm.conf` files. This story's Step 1 backfill **incidentally fixes** the bare-metal install path as a side effect. No separate code change to `setup/install-control-panel.sh` is required, but the Reviewer should confirm during smoke that a freshly-rendered template would also produce a working bare-metal `/etc/brainstorm.conf` — or call out the gap as a separate follow-up story if it's broken in a way the template alone can't fix.
+- **The five other conf templates**. Their entrypoint logic is already correct for fresh containers; no change.
+
+## Open questions
+
+**Resolved with operator at Planning (2026-05-21):**
+
+- **Source of truth for `/etc/brainstorm.conf` in Docker** → **the template** (`config/brainstorm.conf.template`). Entrypoint heredoc is eliminated; variable substitution for environment-derived values handled by the template-rendering mechanism the Architect picks.
+- **Install path for `/etc/brainstorm-task-queue.json` on fresh containers** → **yes, mirror the existing conditional-copy pattern**. Ship a new `config/brainstorm-task-queue.json.template` with the deploy-safe defaults.
+
+**Deferred to Architect:**
+
+- **Variable-substitution mechanism for the template.** The current heredoc uses bash `${VAR}` expansion against env vars set earlier in the entrypoint (`${DOMAIN_NAME}`, `${OWNER_PUBKEY}`, `${NEO4J_PASSWORD}`, `${SESSION_SECRET}`, `${ADMIN_PUBKEYS}`, etc.). Architect picks the rendering mechanism: `envsubst`, a small `eval cat <<EOF` shim, or a Node-based renderer. The choice has implications for the template's notation — `envsubst` requires bare `${VAR}` references that exist in the env at render time; `eval cat <<EOF` permits `${VAR:-default}` and conditional/arithmetic expressions but has injection risk if the template ever included untrusted content (low risk here — template is repo-controlled).
+- **Where to land the new task-queue.json template.** `config/brainstorm-task-queue.json.template` is the obvious slot; Architect confirms.
+- **Whether to ship a drift-sentinel test** that fails if `config/brainstorm.conf.template` and `docker/entrypoint.sh` ever disagree — even though the heredoc is being eliminated, an analogous drift could re-emerge if a future Architect adds entrypoint-specific overrides. Architect's call.
+- **How to mechanize the byte-equivalence verification.** Possibilities: (a) cycle-local script that boots two sandbox containers (one with old entrypoint, one with new) and diffs the resulting `/etc/brainstorm.conf`; (b) a render-the-template-to-stdout helper that the Reviewer manually diffs against the heredoc-produced file; (c) a sentinel test that grep-asserts every variable name from the old heredoc appears in the new template. Architect picks the verification mechanism that gives highest confidence with lowest ceremony.
+
+**Resolved at planning amendment (2026-05-21):**
+
+- **Bare-metal install path scope** → **fixed incidentally by this story**, not as a separate story. The template backfill (Step 1) is exactly what the bare-metal path needed too. The Reviewer should confirm during smoke; if a residual bare-metal-only issue surfaces, it gets its own story.
+
+## Linked artifacts
+
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/16-entrypoint-conf-templates-source-of-truth.md
+++ b/engineering-team/stories/16-entrypoint-conf-templates-source-of-truth.md
@@ -91,5 +91,5 @@ Step 1 is the larger and riskier of the two; Step 2 is mechanically simple once 
 ## Linked artifacts
 
 - ADR: [0014-entrypoint-template-rendering.md](../decisions/0014-entrypoint-template-rendering.md)
-- Test plan: (filled in after Test Design phase)
+- Test plan: [16-entrypoint-conf-templates-source-of-truth.test-plan.md](16-entrypoint-conf-templates-source-of-truth.test-plan.md)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/16-entrypoint-conf-templates-source-of-truth.md
+++ b/engineering-team/stories/16-entrypoint-conf-templates-source-of-truth.md
@@ -92,4 +92,4 @@ Step 1 is the larger and riskier of the two; Step 2 is mechanically simple once 
 
 - ADR: [0014-entrypoint-template-rendering.md](../decisions/0014-entrypoint-template-rendering.md)
 - Test plan: [16-entrypoint-conf-templates-source-of-truth.test-plan.md](16-entrypoint-conf-templates-source-of-truth.test-plan.md)
-- Review: (filled in after Review phase)
+- Review: [../reviews/16-entrypoint-conf-templates-source-of-truth.md](../reviews/16-entrypoint-conf-templates-source-of-truth.md) — **PASS** end-to-end (11/11 sentinels + cycle-local smoke S1 byte-equivalence + S2 missing-env failure + S3a/S3b task-queue conditional install PROVED on the live container).

--- a/engineering-team/stories/16-entrypoint-conf-templates-source-of-truth.md
+++ b/engineering-team/stories/16-entrypoint-conf-templates-source-of-truth.md
@@ -90,6 +90,6 @@ Step 1 is the larger and riskier of the two; Step 2 is mechanically simple once 
 
 ## Linked artifacts
 
-- ADR: (filled in after Architecture phase)
+- ADR: [0014-entrypoint-template-rendering.md](../decisions/0014-entrypoint-template-rendering.md)
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/16-entrypoint-conf-templates-source-of-truth.test-plan.md
+++ b/engineering-team/stories/16-entrypoint-conf-templates-source-of-truth.test-plan.md
@@ -1,0 +1,133 @@
+# Test Plan: Story 16 — Entrypoint reads `/etc/brainstorm.conf` from `config/brainstorm.conf.template` (templates as source of truth)
+
+**Story:** `engineering-team/stories/16-entrypoint-conf-templates-source-of-truth.md`
+**ADR:** `engineering-team/decisions/0014-entrypoint-template-rendering.md`
+**Date:** 2026-05-21
+
+## Test posture
+
+Source/structural **sentinels** at `test/entrypoint-template-rendering.test.js` pin the ADR-required shape: a Node-based renderer at `tools/render-conf-template.js`, a backfilled `config/brainstorm.conf.template` containing every variable the current heredoc writes, a sibling `config/brainstorm-task-queue.json.template`, an entrypoint that invokes the renderer + installs the task-queue JSON + logs the rendering, and two drift sentinels guarding against future regression. The **behavioral round-trip** — fresh container with no pre-existing `/etc/brainstorm.conf` boots; the entrypoint log carries `[entrypoint] /etc/brainstorm.conf generated from ...template`; the resulting `/etc/brainstorm.conf` is byte-equivalent to today's heredoc output for the same env — is reproducible only against the live Docker stack and is the **authoritative cycle-local smoke** that the Reviewer drives, per project precedent.
+
+This split matches stories #12, #13, #15 — source-sentinels in CI run on every npm test (cheap, fast, regression-proof); behavioral smoke runs against the live stack (proves the end-to-end is wired up).
+
+## Coverage map
+
+One sentinel per acceptance criterion, with the byte-equivalence AC drawing the heaviest concentration (T2/T3/T4 cover the variable-set inclusion, the `${VAR}`-substitution discipline, and the actual rendered VAR=VALUE equivalence respectively). Drift sentinels (T7/T8) cover the future-regression class. Regression sentinels (R1/R2/R3) protect prior wins.
+
+| Criterion | Test name | Test file | Level |
+|---|---|---|---|
+| AC: Step 1 — template backfill / **byte-equivalence (variable inclusion)** | `T2: template contains every variable the heredoc writes` | `test/entrypoint-template-rendering.test.js` | source sentinel |
+| AC: Step 1 — template backfill / **byte-equivalence (${VAR} substitution discipline)** | `T3: template replaces literal placeholder values with ${VAR} references` | `test/entrypoint-template-rendering.test.js` | source sentinel |
+| AC: **Byte-equivalence (rendered VAR=VALUE equivalence)** | `T4: rendering the template via render-conf-template.js with fixture env produces the expected VAR=VALUE pairs` | `test/entrypoint-template-rendering.test.js` | unit/integration (spawns the renderer) |
+| AC: Step 2 — entrypoint swap (no heredoc) | `T7: docker/entrypoint.sh contains NO <<CONFEOF heredoc` | `test/entrypoint-template-rendering.test.js` | source sentinel (drift) |
+| AC: Adding a new `export VAR=value` line to template is sufficient (template = source of truth) | Covered transitively by T2 + T6 (T6 pins entrypoint invokes renderer; T2 pins every var the heredoc had is in the template, so any *future* additional line in the template will likewise render through) | — | — |
+| AC: Fresh containers contain `export TASK_QUEUE_ENABLED=false` | `R2: brainstorm.conf.template still carries TASK_QUEUE_ENABLED=false` (regression guard) + the template AC of T4's fixture render (TASK_QUEUE_ENABLED=false is in the expected pairs map) | `test/entrypoint-template-rendering.test.js` | source sentinel + integration |
+| AC: Install `/etc/brainstorm-task-queue.json` from template | `T5: brainstorm-task-queue.json.template exists, parses, has resourceClassCaps.neo4j-heavy=1` + `T6: entrypoint references brainstorm-task-queue.json.template + writes /etc/brainstorm-task-queue.json` | `test/entrypoint-template-rendering.test.js` | source sentinel |
+| AC: No regression for existing containers (heredoc-equivalent variable set) | T4 (byte-equivalence assertion on rendered pairs) | `test/entrypoint-template-rendering.test.js` | integration |
+| AC: No regression for the other five `*.conf` files | `R1: entrypoint still iterates [graperank, whitelist, blacklist, nip56] templates` | `test/entrypoint-template-rendering.test.js` | source sentinel (regression) |
+| AC: Boot log makes new behavior observable | `T6` asserts `echo "[entrypoint] /etc/brainstorm.conf generated from config/brainstorm.conf.template"` is present | `test/entrypoint-template-rendering.test.js` | source sentinel |
+| Drift sentinel (future regression class) | `T7` (no `<<CONFEOF` heredoc) + `T8` (exactly one `render-conf-template.js` invocation) | `test/entrypoint-template-rendering.test.js` | source sentinel |
+| AC: Renderer existence + structure | `T1: tools/render-conf-template.js exists, is parseable, uses ${VAR_NAME} regex + process.env` | `test/entrypoint-template-rendering.test.js` | source sentinel + `node --check` parse |
+| Story-#13 regression guard: feature-flag default preserved | `R2: brainstorm.conf.template still carries TASK_QUEUE_ENABLED=false` | `test/entrypoint-template-rendering.test.js` | source sentinel (regression) |
+| Story-#15 regression guard: task-queue.json defaults preserved | `T5` pins `resourceClassCaps[neo4j-heavy]=1` + `defaultConcurrency=1` | `test/entrypoint-template-rendering.test.js` | source sentinel |
+| File-permissions regression | `R3: entrypoint still chmods /etc/brainstorm.conf to 664` | `test/entrypoint-template-rendering.test.js` | source sentinel (regression) |
+| AC: `OPERATIONS.md` documents the contract | Deferred to **cycle-local smoke** (Reviewer eyeballs the OPERATIONS.md diff against the AC). A source sentinel for documentation prose is brittle and bloats the test suite; the Reviewer is the verification surface for this AC. | — | smoke |
+
+### Why one suite, not split
+
+All eight failing sentinels target the same `tools/` + `config/` + `docker/entrypoint.sh` triplet. Splitting into multiple test files would duplicate the variable-list constant (41 names) and the fixture-env block (9 values), inviting drift. One suite, 11 tests, clear pre/post split — matches the pattern stories #12, #13, #15 used.
+
+## Edge cases
+
+Things not in the acceptance criteria but worth covering inside the same suite or surfacing as Reviewer-watch items:
+
+- [x] **Variable in fixture env but not in template.** Covered by T4 (the renderer succeeds; absent variables in expected map are detected as mismatches). Reviewer-watch: if the operator's deploy injects a new env var the template doesn't reference, the renderer silently ignores it (intentional — template controls what's emitted).
+- [x] **Variable in template but not in fixture env (missing-env error).** Covered transitively by T4 — if the template references a `${VAR}` the fixture does not provide, the renderer should exit non-zero with a clear stderr message (ADR §Variable-substitution semantics pins this behavior). T4 will fail with the renderer's stderr surfaced.
+- [x] **Composed substitutions like `${BRAINSTORM_MODULE_BASE_DIR}src/`.** Covered by T4's expected pairs (BRAINSTORM_MODULE_SRC_DIR=`/usr/local/lib/node_modules/brainstorm/src/` requires the inner `${}` to substitute and the trailing literal to concatenate correctly).
+- [x] **TASK_QUEUE_ENABLED on fresh containers (the original motivating gap).** Covered by R2 (template carries the line) + T4 (rendered output contains `TASK_QUEUE_ENABLED=false`).
+- [x] **Drift re-introduction.** Covered by T7 (no `<<CONFEOF` heredoc) + T8 (exactly one renderer invocation) — both will trip if a future commit re-introduces a heredoc or a second write-path.
+- [x] **JSON.parse of the task-queue template.** Covered by T5's `readJsonSafe` — if the file is malformed JSON, the test fails meaningfully.
+- [ ] **Stale `/etc/brainstorm.conf` from prior container run** (Reviewer-watch): the entrypoint unconditionally overwrites this file (matches today's heredoc behavior). Reviewer confirms via cycle-local smoke that a container with a pre-existing `/etc/brainstorm.conf` from a prior boot still gets it regenerated identically.
+- [ ] **Dockerfile copies `tools/` directory** (Reviewer-watch / Implementer-checklist): the renderer must be present in the image at `${BRAINSTORM_MODULE_BASE_DIR}/tools/render-conf-template.js`. ADR §Dockerfile flags this; the Implementer verifies in cycle-local.
+- [ ] **`brainstorm-task-queue.json` PRESERVED on container restart** (Reviewer-watch): the conditional install is `if [ ! -f ... ]`, matching the other four conf files. Reviewer confirms an operator-edited `/etc/brainstorm-task-queue.json` survives a container restart.
+- [ ] **Bare-metal install path** (Reviewer-watch, AC §Out of scope but called out for confirmation): the template backfill incidentally fixes `setup/install-control-panel.sh`. Reviewer eyeballs / smokes if the residual gap surfaces; otherwise we close it as fixed.
+
+## Test infrastructure
+
+- **Framework:** Hand-rolled Node runner (`node test/test.js`). Matches the in-repo style; no jest/mocha. Each test is an `async fn` that throws on assertion failure; the runner reports per-test pass/fail; non-zero exit if any suite fails.
+- **No external dependencies beyond Node stdlib.** `fs`, `path`, `child_process.spawnSync`. The renderer is a Node script — T1 uses `node --check` for parse validation; T4 uses `spawnSync` to drive an actual render with a controlled fixture env.
+- **Fixture env (T4):** Nine variables fully control the renderer's behavior under the test:
+  - `BRAINSTORM_MODULE_BASE_DIR` = `/usr/local/lib/node_modules/brainstorm/`
+  - `BRAINSTORM_NODE_BIN` = `/usr/bin/node`
+  - `DOMAIN_NAME` = `test.example.com`
+  - `RELAY_URL` = `wss://test.example.com`
+  - `NEO4J_PASSWORD` = `test-neo4j-pw`
+  - `OWNER_PUBKEY` = 64 × `'a'`
+  - `OWNER_NPUB` = `npub1testnpub`
+  - `ADMIN_PUBKEYS` = `admin1,admin2`
+  - `SESSION_SECRET` = `test-session-secret-32-bytes-xxx`
+  - PATH inherited from the test runner's env so `node` resolves on macOS dev and Linux CI alike.
+- **Concept Graph API:** not required for this story (no concept handles touched).
+- **Firmware reinstall:** no.
+
+## How to run
+
+```
+npm test
+```
+
+The suite registers as `entrypoint-template-rendering suite:` after `task-queue-neo4j-resource-class suite:` in `test/test.js`.
+
+For the Reviewer's cycle-local smoke (behavioral round-trip; runs against the live Docker stack):
+
+```bash
+# Inside the tapestry container, with no pre-existing /etc/brainstorm.conf:
+docker exec tapestry bash -c 'rm -f /etc/brainstorm.conf && /usr/local/lib/node_modules/brainstorm/docker/entrypoint.sh' 2>&1 | grep "\[entrypoint\]"
+# Should see: [entrypoint] /etc/brainstorm.conf generated from config/brainstorm.conf.template
+
+docker exec tapestry cat /etc/brainstorm.conf
+# Diff this against the old heredoc-produced /etc/brainstorm.conf for the same env state.
+# Zero semantic differences (modulo whitespace/comments).
+
+docker exec tapestry cat /etc/brainstorm-task-queue.json
+# Should contain: {"defaultConcurrency":1,"concurrencyByTask":{},"resourceClassCaps":{"neo4j-heavy":1}}
+```
+
+## Verification
+
+The new tests fail with the current code (pre-impl, before Step 1 backfill and Step 2 swap). Confirmed on 2026-05-21 at commit `753e66b2`:
+
+```
+entrypoint-template-rendering suite:
+  ✗ T1: tools/render-conf-template.js exists, is parseable Node, performs ${VAR_NAME} substitution against process.env (ADR 0014 §Implementation Step 2)
+      Renderer does not exist at tools/render-conf-template.js (ADR 0014 §Implementation Step 2). Create the small Node script ...
+  ✗ T2: config/brainstorm.conf.template contains every variable the heredoc writes (Step 1 byte-equivalence; ADR 0014 §Implementation Step 1)
+      brainstorm.conf.template is missing 31 of 41 variables the docker/entrypoint.sh heredoc currently writes:
+        BRAINSTORM_30382_LIMIT, BRAINSTORM_ACCESS, BRAINSTORM_ADMIN_PUBKEYS, BRAINSTORM_BASE_DIR,
+        BRAINSTORM_CREATED_CONSTRAINTS_AND_INDEXES, BRAINSTORM_DEFAULT_NIP85_HOME_RELAY, ... (31 total)
+  ✗ T3: template replaces literal placeholder values with ${VAR} references for env-var-dependent variables ...
+      brainstorm.conf.template is missing required ${VAR} substitutions:
+        STRFRY_DOMAIN="${DOMAIN_NAME}" (currently "your.relay.com"),
+        BRAINSTORM_RELAY_URL="${RELAY_URL}" (currently "wss://your.relay.com"),
+        NEO4J_PASSWORD="${NEO4J_PASSWORD}" (currently "neo4j"), ... (8 total)
+  ✗ T4: rendering the template via render-conf-template.js with a fixture env produces the expected VAR=VALUE pairs ...
+      renderer missing — T1 must pass first.
+  ✗ T5: config/brainstorm-task-queue.json.template exists, parses as JSON, has resourceClassCaps.neo4j-heavy=1 ...
+      config/brainstorm-task-queue.json.template is missing or not valid JSON ...
+  ✗ T6: docker/entrypoint.sh invokes render-conf-template.js, installs brainstorm-task-queue.json from template, logs the rendering ...
+      docker/entrypoint.sh does not reference render-conf-template.js ...
+  ✗ T7: docker/entrypoint.sh contains NO <<CONFEOF heredoc writing to /etc/brainstorm.conf (drift sentinel) ...
+      docker/entrypoint.sh contains 1 <<CONFEOF heredoc(s) — drift sentinel tripped ...
+  ✗ T8: docker/entrypoint.sh contains EXACTLY ONE invocation of render-conf-template.js (drift sentinel) ...
+      docker/entrypoint.sh has 0 invocations of render-conf-template.js — expected exactly 1 ...
+  ✓ R1: docker/entrypoint.sh still installs the other conf templates (graperank/whitelist/blacklist/nip56) ...
+  ✓ R2: config/brainstorm.conf.template still carries TASK_QUEUE_ENABLED=false ...
+  ✓ R3: docker/entrypoint.sh still chmods /etc/brainstorm.conf to 664 after rendering ...
+
+Test Results
+-------------
+entrypoint-template-rendering suite:             FAIL (3 passed, 8 failed)
+Overall:                                         FAIL
+```
+
+The 13 sibling suites continue to PASS — no collateral damage from the new suite. Each of the 8 failures carries a right-reason message that points the Implementer at the exact gap (which file is missing, which variables are absent, which placeholder needs to become a `${VAR}` reference, which entrypoint block needs to be added). R1–R3 pass now and must continue passing post-impl — they guard the regression class.

--- a/test/entrypoint-template-rendering.test.js
+++ b/test/entrypoint-template-rendering.test.js
@@ -1,0 +1,463 @@
+/**
+ * Story #16 / ADR 0014 — Entrypoint reads `/etc/brainstorm.conf` from
+ * `config/brainstorm.conf.template` via a Node-based renderer; the heredoc
+ * is eliminated; a sibling `/etc/brainstorm-task-queue.json` is installed
+ * from a new template using the existing copy-if-absent pattern.
+ *
+ * Source/structural sentinels pin the template-as-source-of-truth contract
+ * and the byte-equivalence guarantee between the new and old rendering of
+ * `/etc/brainstorm.conf`. The behavioral round-trip — booting a fresh
+ * container with no pre-existing /etc/brainstorm.conf, observing the
+ * `[entrypoint] /etc/brainstorm.conf generated from ...template` line, and
+ * confirming the rendered file is byte-equivalent to today's heredoc output
+ * — is reproducible only against the live Docker stack and is the
+ * authoritative cycle-local smoke (Reviewer-required).
+ *
+ * T1..T8 : FAIL pre-implementation, PASS post.
+ * R1..R3 : PASS pre AND post — regression guards on the other-conf-files
+ *          copy-if-absent loop, story #13's TASK_QUEUE_ENABLED contract,
+ *          and the 664-mode chmod on /etc/brainstorm.conf.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const RENDERER            = path.join(ROOT, 'tools/render-conf-template.js');
+const CONF_TEMPLATE       = path.join(ROOT, 'config/brainstorm.conf.template');
+const TASK_QUEUE_TEMPLATE = path.join(ROOT, 'config/brainstorm-task-queue.json.template');
+const ENTRYPOINT_SH       = path.join(ROOT, 'docker/entrypoint.sh');
+const OPERATIONS_MD       = path.join(ROOT, 'OPERATIONS.md');
+
+// 41 variables the current `docker/entrypoint.sh` heredoc writes to
+// `/etc/brainstorm.conf` (extracted authoritatively from lines 40-122 at
+// story #16 / ADR 0014 time). This list is the source of truth for what
+// the backfilled template MUST contain — frozen here so the test survives
+// Step 2's removal of the heredoc from entrypoint.sh.
+const HEREDOC_VARIABLES = [
+  'BRAINSTORM_30382_LIMIT',
+  'BRAINSTORM_ACCESS',
+  'BRAINSTORM_ADMIN_PUBKEYS',
+  'BRAINSTORM_BASE_DIR',
+  'BRAINSTORM_BATCH_SIZE',
+  'BRAINSTORM_CREATED_CONSTRAINTS_AND_INDEXES',
+  'BRAINSTORM_DEFAULT_NIP85_HOME_RELAY',
+  'BRAINSTORM_DEFAULT_NIP85_RELAYS',
+  'BRAINSTORM_DEFAULT_POPULAR_GENERAL_PURPOSE_RELAYS',
+  'BRAINSTORM_DEFAULT_WOT_RELAYS',
+  'BRAINSTORM_DELAY_BETWEEN_BATCHES',
+  'BRAINSTORM_DELAY_BETWEEN_EVENTS',
+  'BRAINSTORM_EXPORT_DIR',
+  'BRAINSTORM_LOG_DIR',
+  'BRAINSTORM_MANAGER_PUBKEYS',
+  'BRAINSTORM_MAX_CONCURRENT_CONNECTIONS',
+  'BRAINSTORM_MAX_RETRIES',
+  'BRAINSTORM_MODULE_ALGOS_DIR',
+  'BRAINSTORM_MODULE_BASE_DIR',
+  'BRAINSTORM_MODULE_MANAGE_DIR',
+  'BRAINSTORM_MODULE_PIPELINE_DIR',
+  'BRAINSTORM_MODULE_SRC_DIR',
+  'BRAINSTORM_NEO4J_BROWSER_URL',
+  'BRAINSTORM_NIP85_DIR',
+  'BRAINSTORM_NIP85_HOME_RELAY',
+  'BRAINSTORM_NIP85_RELAYS',
+  'BRAINSTORM_NODE_BIN',
+  'BRAINSTORM_OWNER_NPUB',
+  'BRAINSTORM_OWNER_PUBKEY',
+  'BRAINSTORM_POPULAR_GENERAL_PURPOSE_RELAYS',
+  'BRAINSTORM_PROCESS_ALL_TASKS_INTERVAL',
+  'BRAINSTORM_RELAY_URL',
+  'BRAINSTORM_SEND_EMAIL_UPDATES',
+  'BRAINSTORM_WOT_RELAYS',
+  'NEO4J_PASSWORD',
+  'NEO4J_URI',
+  'NEO4J_USER',
+  'SESSION_SECRET',
+  'STRFRY_DOMAIN',
+  'STRFRY_PLUGINS_BASE',
+  'STRFRY_PLUGINS_DATA'
+];
+
+function readSafe(p) {
+  try { return fs.readFileSync(p, 'utf8'); }
+  catch (_e) { return null; }
+}
+
+function readJsonSafe(p) {
+  const s = readSafe(p);
+  if (s === null) return null;
+  try { return JSON.parse(s); }
+  catch (_e) { return null; }
+}
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+
+// ---------------------------------------------------------------------------
+// Failing tests — FAIL now, PASS once story #16 is implemented per ADR 0014.
+// ---------------------------------------------------------------------------
+
+test('T1: tools/render-conf-template.js exists, is parseable Node, performs ${VAR_NAME} substitution against process.env (ADR 0014 §Implementation Step 2)', () => {
+  const src = readSafe(RENDERER);
+  assert(
+    src !== null,
+    'Renderer does not exist at tools/render-conf-template.js (ADR 0014 §Implementation Step 2). Create ' +
+      'the small Node script that performs ${VAR_NAME} regex substitution against process.env and writes ' +
+      'the rendered output to stdout. The ADR pins the implementation; copy it verbatim.'
+  );
+  // Pin the substitution mechanism — the ADR chose plain regex against process.env precisely to avoid
+  // shell-eval injection class. A future "let's just shell out" refactor would re-open that class.
+  assert(
+    /process\.env/.test(src),
+    'Renderer does not consult process.env (ADR 0014 §Variable-substitution semantics). Substitution ' +
+      'source must be process.env so the entrypoint passes config in via its already-prepared env state — ' +
+      'not via argv, not via a separate config file, not via a shell-eval.'
+  );
+  assert(
+    /\$\\\{|\$\{|\\\$\\\{/.test(src) || /VAR_REF/.test(src),
+    'Renderer does not appear to match the ${VAR_NAME} pattern (ADR 0014 §Variable-substitution ' +
+      'semantics). The canonical regex from the ADR is /\\$\\{([A-Z_][A-Z0-9_]*)\\}/g — replace via ' +
+      'process.env, error on missing var, leave everything else as literal text.'
+  );
+  // Parseability check — must be syntactically valid JS or it can't run at boot time.
+  try {
+    // node --check parses but does not execute. Faster than spawning a render and safer than require().
+    const probe = spawnSync('node', ['--check', RENDERER], { encoding: 'utf8' });
+    assert(
+      probe.status === 0,
+      'tools/render-conf-template.js fails `node --check` parse (ADR 0014 §Implementation Step 2). ' +
+        'stderr: ' + (probe.stderr || '<empty>') + '. A syntax error here means the entrypoint ' +
+        'crashes at container boot — boot-time failures are the worst kind for an operator to debug.'
+    );
+  } catch (e) {
+    assert(false, 'Could not invoke `node --check` on the renderer: ' + e.message);
+  }
+});
+
+test('T2: config/brainstorm.conf.template contains every variable the heredoc writes (Step 1 byte-equivalence; ADR 0014 §Implementation Step 1)', () => {
+  const src = readSafe(CONF_TEMPLATE);
+  assert(
+    src !== null,
+    'config/brainstorm.conf.template does not exist (ADR 0014 §Implementation Step 1). Cannot be the ' +
+      'source of truth if it isn\'t present.'
+  );
+  const missing = HEREDOC_VARIABLES.filter(v => !new RegExp('\\b' + v + '\\b').test(src));
+  assert(
+    missing.length === 0,
+    'brainstorm.conf.template is missing ' + missing.length + ' of ' + HEREDOC_VARIABLES.length +
+      ' variables the docker/entrypoint.sh heredoc currently writes:\n  ' + missing.join('\n  ') +
+      '\n(ADR 0014 §Implementation Step 1). Step 1 backfills the template so byte-equivalence holds ' +
+      'before Step 2 removes the heredoc. Without this, fresh Docker containers built from the template ' +
+      'lose ~25 variables — control panel boot, owner auth, sessions, plugin loading, and filesystem ' +
+      'paths all break. The byte-equivalence AC is the safety net; this sentinel is the proof.'
+  );
+});
+
+test('T3: template replaces literal placeholder values with ${VAR} references for env-var-dependent variables (Step 1 byte-equivalence; ADR 0014 §Implementation Step 1)', () => {
+  const src = readSafe(CONF_TEMPLATE);
+  assert(src !== null, 'brainstorm.conf.template missing — T2 must pass first.');
+  // The ADR explicitly calls out these substitutions. If the template still carries literal placeholder
+  // values (STRFRY_DOMAIN="your.relay.com", NEO4J_PASSWORD="neo4j"), byte-equivalence fails — the
+  // heredoc writes the env's actual value, not the placeholder string.
+  const expected = [
+    {
+      pattern: /STRFRY_DOMAIN="\$\{DOMAIN_NAME\}"/,
+      label: 'STRFRY_DOMAIN="${DOMAIN_NAME}" (currently the placeholder "your.relay.com")'
+    },
+    {
+      pattern: /BRAINSTORM_RELAY_URL="\$\{RELAY_URL\}"/,
+      label: 'BRAINSTORM_RELAY_URL="${RELAY_URL}" (currently the placeholder "wss://your.relay.com")'
+    },
+    {
+      pattern: /NEO4J_PASSWORD="\$\{NEO4J_PASSWORD\}"/,
+      label: 'NEO4J_PASSWORD="${NEO4J_PASSWORD}" (currently the placeholder "neo4j")'
+    },
+    {
+      pattern: /BRAINSTORM_OWNER_PUBKEY="\$\{OWNER_PUBKEY\}"/,
+      label: 'BRAINSTORM_OWNER_PUBKEY="${OWNER_PUBKEY}" (sourced from entrypoint env)'
+    },
+    {
+      pattern: /BRAINSTORM_OWNER_NPUB="\$\{OWNER_NPUB\}"/,
+      label: 'BRAINSTORM_OWNER_NPUB="${OWNER_NPUB}" (computed in entrypoint before rendering)'
+    },
+    {
+      pattern: /BRAINSTORM_ADMIN_PUBKEYS="\$\{ADMIN_PUBKEYS\}"/,
+      label: 'BRAINSTORM_ADMIN_PUBKEYS="${ADMIN_PUBKEYS}" (sourced from entrypoint env)'
+    },
+    {
+      pattern: /SESSION_SECRET="\$\{SESSION_SECRET\}"/,
+      label: 'SESSION_SECRET="${SESSION_SECRET}" (sourced from persisted file or generated)'
+    },
+    {
+      pattern: /BRAINSTORM_NODE_BIN="\$\{BRAINSTORM_NODE_BIN\}"/,
+      label: 'BRAINSTORM_NODE_BIN="${BRAINSTORM_NODE_BIN}" (sourced from `which node` in entrypoint)'
+    }
+  ];
+  const missingPatterns = expected.filter(e => !e.pattern.test(src)).map(e => e.label);
+  assert(
+    missingPatterns.length === 0,
+    'brainstorm.conf.template is missing required ${VAR} substitutions:\n  ' +
+      missingPatterns.join('\n  ') + '\n(ADR 0014 §Implementation Step 1). The template currently carries ' +
+      'literal placeholder values that need to become ${VAR} references so the Node renderer substitutes ' +
+      'them at boot. Without this, byte-equivalence fails because the heredoc writes the actual env ' +
+      'value, not the placeholder string.'
+  );
+});
+
+test('T4: rendering the template via render-conf-template.js with a fixture env produces the expected VAR=VALUE pairs (Step 1 byte-equivalence; ADR 0014 §Byte-equivalence verification)', () => {
+  assert(readSafe(RENDERER) !== null, 'renderer missing — T1 must pass first.');
+  assert(readSafe(CONF_TEMPLATE) !== null, 'template missing — T2 must pass first.');
+
+  const fixtureEnv = {
+    PATH: process.env.PATH || '/usr/bin:/bin',
+    BRAINSTORM_MODULE_BASE_DIR: '/usr/local/lib/node_modules/brainstorm/',
+    BRAINSTORM_NODE_BIN: '/usr/bin/node',
+    DOMAIN_NAME: 'test.example.com',
+    RELAY_URL: 'wss://test.example.com',
+    NEO4J_PASSWORD: 'test-neo4j-pw',
+    OWNER_PUBKEY: 'a'.repeat(64),
+    OWNER_NPUB: 'npub1testnpub',
+    ADMIN_PUBKEYS: 'admin1,admin2',
+    SESSION_SECRET: 'test-session-secret-32-bytes-xxx'
+  };
+
+  const result = spawnSync('node', [RENDERER, CONF_TEMPLATE], { env: fixtureEnv, encoding: 'utf8' });
+  assert(
+    result.status === 0,
+    'render-conf-template.js exited with status ' + result.status + ' (stderr: ' +
+      (result.stderr || '<empty>') + ') under the fixture env (ADR 0014 §Byte-equivalence verification). ' +
+      'The renderer must successfully render the backfilled template against the 9 fixture variables ' +
+      '(BRAINSTORM_MODULE_BASE_DIR, BRAINSTORM_NODE_BIN, DOMAIN_NAME, RELAY_URL, NEO4J_PASSWORD, ' +
+      'OWNER_PUBKEY, OWNER_NPUB, ADMIN_PUBKEYS, SESSION_SECRET). Common failure modes: (a) template ' +
+      'references a ${VAR} the fixture does not set — fix by listing it above or removing it from the ' +
+      'template; (b) renderer file missing or unparseable — T1 must pass first.'
+  );
+
+  const rendered = result.stdout;
+
+  // Extract VAR=VALUE pairs from rendered output. Lines look like:
+  //   VAR="value"  |  VAR=value  |  export VAR="value"  |  export VAR='value'
+  const pairs = {};
+  const RE = /^[ \t]*(?:export[ \t]+)?([A-Z_][A-Z0-9_]*)[ \t]*=[ \t]*("[^"]*"|'[^']*'|[^\n]*?)[ \t]*$/gm;
+  let m;
+  while ((m = RE.exec(rendered)) !== null) {
+    let val = m[2];
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    pairs[m[1]] = val;
+  }
+
+  // Expected (var, value) pairs the OLD heredoc produces under the same fixtureEnv. The Implementer's
+  // job is to make the template render this same set. Failure here is byte-equivalence violation.
+  const expected = {
+    BRAINSTORM_NODE_BIN: '/usr/bin/node',
+    BRAINSTORM_MODULE_BASE_DIR: '/usr/local/lib/node_modules/brainstorm/',
+    BRAINSTORM_MODULE_SRC_DIR: '/usr/local/lib/node_modules/brainstorm/src/',
+    BRAINSTORM_MODULE_ALGOS_DIR: '/usr/local/lib/node_modules/brainstorm/src/algos',
+    BRAINSTORM_EXPORT_DIR: '/usr/local/lib/node_modules/brainstorm/src/export',
+    BRAINSTORM_MODULE_MANAGE_DIR: '/usr/local/lib/node_modules/brainstorm/src/manage',
+    BRAINSTORM_NIP85_DIR: '/usr/local/lib/node_modules/brainstorm/src/algos/nip85',
+    BRAINSTORM_MODULE_PIPELINE_DIR: '/usr/local/lib/node_modules/brainstorm/src/pipeline',
+    STRFRY_PLUGINS_BASE: '/usr/local/lib/strfry/plugins/',
+    STRFRY_PLUGINS_DATA: '/usr/local/lib/strfry/plugins/data/',
+    BRAINSTORM_LOG_DIR: '/var/log/brainstorm',
+    BRAINSTORM_BASE_DIR: '/var/lib/brainstorm',
+    BRAINSTORM_30382_LIMIT: '250000',
+    BRAINSTORM_BATCH_SIZE: '100',
+    BRAINSTORM_DELAY_BETWEEN_BATCHES: '1000',
+    BRAINSTORM_DELAY_BETWEEN_EVENTS: '50',
+    BRAINSTORM_MAX_RETRIES: '3',
+    BRAINSTORM_MAX_CONCURRENT_CONNECTIONS: '5',
+    BRAINSTORM_RELAY_URL: 'wss://test.example.com',
+    BRAINSTORM_NEO4J_BROWSER_URL: 'http://test.example.com:7474',
+    NEO4J_URI: 'bolt://localhost:7687',
+    NEO4J_USER: 'neo4j',
+    NEO4J_PASSWORD: 'test-neo4j-pw',
+    STRFRY_DOMAIN: 'test.example.com',
+    BRAINSTORM_OWNER_PUBKEY: 'a'.repeat(64),
+    BRAINSTORM_OWNER_NPUB: 'npub1testnpub',
+    BRAINSTORM_MANAGER_PUBKEYS: '',
+    BRAINSTORM_ADMIN_PUBKEYS: 'admin1,admin2',
+    SESSION_SECRET: 'test-session-secret-32-bytes-xxx',
+    BRAINSTORM_PROCESS_ALL_TASKS_INTERVAL: '12hours',
+    BRAINSTORM_SEND_EMAIL_UPDATES: '0',
+    BRAINSTORM_ACCESS: '0',
+    BRAINSTORM_CREATED_CONSTRAINTS_AND_INDEXES: '0',
+    // Story #13 addition — the ONE variable not in the old heredoc but required in the new template.
+    TASK_QUEUE_ENABLED: 'false'
+  };
+
+  const mismatches = [];
+  for (const [k, want] of Object.entries(expected)) {
+    if (!(k in pairs)) {
+      mismatches.push(k + ' is absent from rendered output');
+    } else if (pairs[k] !== want) {
+      mismatches.push(k + ' = ' + JSON.stringify(pairs[k]) + ' (expected ' + JSON.stringify(want) + ')');
+    }
+  }
+  assert(
+    mismatches.length === 0,
+    'Rendered template diverges from heredoc output for ' + mismatches.length + ' variable(s):\n  ' +
+      mismatches.join('\n  ') + '\n(ADR 0014 §Byte-equivalence verification). Each mismatch is a ' +
+      'byte-equivalence break: under identical env state, the old entrypoint heredoc would have produced ' +
+      'the "expected" value, and the new template+renderer path produced something else. Two common ' +
+      'causes: (a) the template carries a literal placeholder value where the heredoc has ${VAR}; ' +
+      '(b) composed substitutions like "${BRAINSTORM_MODULE_BASE_DIR}src/" need the inner ${} to ' +
+      'substitute and then concatenate the trailing literal — make sure the template preserves the ' +
+      'composition shape (e.g., BRAINSTORM_MODULE_SRC_DIR="${BRAINSTORM_MODULE_BASE_DIR}src/").'
+  );
+});
+
+test('T5: config/brainstorm-task-queue.json.template exists, parses as JSON, has resourceClassCaps.neo4j-heavy=1 (AC; ADR 0014 §Implementation Step 2)', () => {
+  const obj = readJsonSafe(TASK_QUEUE_TEMPLATE);
+  assert(
+    obj !== null,
+    'config/brainstorm-task-queue.json.template is missing or not valid JSON (ADR 0014 §Implementation ' +
+      'Step 2; AC "the template ships with deploy-safe defaults"). Create the file with: ' +
+      '{"defaultConcurrency":1,"concurrencyByTask":{},"resourceClassCaps":{"neo4j-heavy":1}}. The ' +
+      'entrypoint installs it to /etc/brainstorm-task-queue.json on fresh containers via the existing ' +
+      'copy-if-absent pattern.'
+  );
+  assert(
+    obj.resourceClassCaps && obj.resourceClassCaps['neo4j-heavy'] === 1,
+    'brainstorm-task-queue.json.template does not pin resourceClassCaps[neo4j-heavy] === 1 (ADR 0014 ' +
+      '§Implementation Step 2; AC quoted default). Story #15 default is 1 (one heavy task at a time) ' +
+      '— the template default must match so fresh containers get story #15\'s protection. Found ' +
+      'resourceClassCaps = ' + JSON.stringify(obj.resourceClassCaps || {}) + '.'
+  );
+  assert(
+    obj.defaultConcurrency === 1,
+    'brainstorm-task-queue.json.template does not pin defaultConcurrency = 1 (ADR 0014 §Implementation ' +
+      'Step 2; AC quoted default). Story #13 default is 1 (phase-1 safe default). Found ' +
+      'defaultConcurrency = ' + JSON.stringify(obj.defaultConcurrency) + '.'
+  );
+  assert(
+    obj.concurrencyByTask && typeof obj.concurrencyByTask === 'object',
+    'brainstorm-task-queue.json.template is missing concurrencyByTask: {} (ADR 0014 §Implementation ' +
+      'Step 2; AC quoted default). Even when empty, the key must be present so queue/index.js\'s ' +
+      'destructuring does not fall back to undefined.'
+  );
+});
+
+test('T6: docker/entrypoint.sh invokes render-conf-template.js, installs brainstorm-task-queue.json from template, logs the rendering (AC; ADR 0014 §Implementation Step 2)', () => {
+  const src = readSafe(ENTRYPOINT_SH);
+  assert(src !== null, 'docker/entrypoint.sh missing — re-baseline this sentinel.');
+  assert(
+    /render-conf-template\.js/.test(src),
+    'docker/entrypoint.sh does not reference render-conf-template.js (ADR 0014 §Implementation Step 2). ' +
+      'The heredoc-to-renderer swap is the entire point of story #16 Step 2. Replace the `cat > ' +
+      '/etc/brainstorm.conf << CONFEOF ... CONFEOF` block with `node ${BRAINSTORM_MODULE_BASE_DIR}' +
+      '/tools/render-conf-template.js ${CONFIG_DIR}/brainstorm.conf.template > /etc/brainstorm.conf` ' +
+      '— see the ADR for the exact replacement block.'
+  );
+  assert(
+    /brainstorm-task-queue\.json\.template/.test(src),
+    'docker/entrypoint.sh does not reference brainstorm-task-queue.json.template (ADR 0014 §Implementation ' +
+      'Step 2; AC "extended to install /etc/brainstorm-task-queue.json"). Add a conditional install ' +
+      'block after the existing for-loop that copies graperank/whitelist/blacklist/nip56 templates. ' +
+      'Pattern: `if [ ! -f /etc/brainstorm-task-queue.json ] && [ -f ' +
+      '"${CONFIG_DIR}/brainstorm-task-queue.json.template" ]; then cp ...; chmod 644 ...; echo ...; fi`.'
+  );
+  assert(
+    /\/etc\/brainstorm-task-queue\.json\b/.test(src),
+    'docker/entrypoint.sh does not write /etc/brainstorm-task-queue.json (ADR 0014 §Implementation Step ' +
+      '2; AC quoted). The conditional install block must produce /etc/brainstorm-task-queue.json on ' +
+      'first boot so the BullMQ queue config (story #13/#15) lands on fresh containers without operator ' +
+      'ceremony.'
+  );
+  // AC: "The boot log makes the new behavior observable: a single line confirming '[entrypoint]
+  // /etc/brainstorm.conf generated from config/brainstorm.conf.template'."
+  assert(
+    /\[entrypoint\][^\n]*brainstorm\.conf[^\n]*template/.test(src),
+    'docker/entrypoint.sh does not emit the "[entrypoint] /etc/brainstorm.conf generated from ' +
+      'config/brainstorm.conf.template" log line (AC §Boot log). Operators rely on this line to confirm ' +
+      'the new code path actually ran (versus a stale image still using the heredoc). Add an `echo ' +
+      '"[entrypoint] /etc/brainstorm.conf generated from config/brainstorm.conf.template"` immediately ' +
+      'after the renderer invocation succeeds.'
+  );
+});
+
+test('T7: docker/entrypoint.sh contains NO <<CONFEOF heredoc writing to /etc/brainstorm.conf (drift sentinel; ADR 0014 §Drift sentinel)', () => {
+  const src = readSafe(ENTRYPOINT_SH);
+  assert(src !== null, 'docker/entrypoint.sh missing — re-baseline this sentinel.');
+  const heredocCount = (src.match(/<<\s*CONFEOF\b/g) || []).length;
+  assert(
+    heredocCount === 0,
+    'docker/entrypoint.sh contains ' + heredocCount + ' <<CONFEOF heredoc(s) — drift sentinel tripped ' +
+      '(ADR 0014 §Drift sentinel; AC "no longer contains a heredoc duplicating brainstorm.conf content"). ' +
+      'Step 2 removes the heredoc; reintroducing one duplicates the source of truth and reopens the very ' +
+      'drift class story #16 closes. Use render-conf-template.js to write /etc/brainstorm.conf, not a ' +
+      'heredoc — even a "temporary one for a quick fix" causes silent regressions for fresh deploys.'
+  );
+});
+
+test('T8: docker/entrypoint.sh contains EXACTLY ONE invocation of render-conf-template.js (drift sentinel; ADR 0014 §Drift sentinel)', () => {
+  const src = readSafe(ENTRYPOINT_SH);
+  assert(src !== null, 'docker/entrypoint.sh missing — re-baseline this sentinel.');
+  const invocationCount = (src.match(/render-conf-template\.js/g) || []).length;
+  assert(
+    invocationCount === 1,
+    'docker/entrypoint.sh has ' + invocationCount + ' invocations of render-conf-template.js — expected ' +
+      'exactly 1 (drift sentinel; ADR 0014 §Drift sentinel). Multiple invocations suggest a second ' +
+      'write-path that competes with the canonical one (or a half-finished refactor); zero invocations ' +
+      'means the template-renderer integration was lost (T6 should also be failing). Keep the renderer ' +
+      'invocation as the single source of truth for /etc/brainstorm.conf.'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Regression sentinels — PASS now AND post-implementation.
+// ---------------------------------------------------------------------------
+
+test('R1: docker/entrypoint.sh still installs the other conf templates (graperank/whitelist/blacklist/nip56) — Step 2 should not collateral-damage them (AC §No regression for the other five *.conf files)', () => {
+  const src = readSafe(ENTRYPOINT_SH);
+  assert(src !== null, 'docker/entrypoint.sh missing — re-baseline this sentinel.');
+  assert(
+    /for\s+conffile\s+in\s+graperank\s+whitelist\s+blacklist\s+nip56/.test(src),
+    'R1: docker/entrypoint.sh no longer iterates [graperank, whitelist, blacklist, nip56] templates ' +
+      '(regression; AC "No regression for the other five *.conf files"). Story #16 only changes the ' +
+      'brainstorm.conf path; it must leave the existing conditional-copy loop for the other four conf ' +
+      'files intact. If you have a strong reason to refactor that loop too — e.g., to share the renderer ' +
+      'pattern — file a separate story; do not collateral-damage it here.'
+  );
+});
+
+test('R2: config/brainstorm.conf.template still carries TASK_QUEUE_ENABLED=false (story #13 contract preserved; AC "fresh containers contain export TASK_QUEUE_ENABLED=false")', () => {
+  const src = readSafe(CONF_TEMPLATE);
+  assert(src !== null, 'brainstorm.conf.template missing — cannot check story #13 contract.');
+  assert(
+    /TASK_QUEUE_ENABLED\s*=\s*false/.test(src),
+    'R2: config/brainstorm.conf.template no longer carries TASK_QUEUE_ENABLED=false (story #13 / ADR ' +
+      '0012 regression; story #16 AC explicitly requires this line to reach fresh containers). The flag ' +
+      'must remain in the template at the deploy-safe default `false`; flipping it to `true` in template ' +
+      'defaults breaks the rollback path for fresh deploys (the entire point of having the flag).'
+  );
+});
+
+test('R3: docker/entrypoint.sh still chmods /etc/brainstorm.conf to 664 after rendering (file-permissions preserved)', () => {
+  const src = readSafe(ENTRYPOINT_SH);
+  assert(src !== null, 'docker/entrypoint.sh missing — re-baseline this sentinel.');
+  assert(
+    /chmod\s+664\s+\/etc\/brainstorm\.conf/.test(src),
+    'R3: docker/entrypoint.sh no longer chmods /etc/brainstorm.conf to 664 (regression). The old heredoc ' +
+      'path explicitly set 664 (line 124); the new renderer path must preserve this permission. ' +
+      '`source /etc/brainstorm.conf` works only when the file is group-readable (664), and ' +
+      'start-brainstorm.sh sources it on every brainstorm process start. Without 664, the brainstorm ' +
+      'system user can\'t read its own config.'
+  );
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try { await t.fn(); console.log(`  ✓ ${t.name}`); pass++; }
+    catch (err) { console.log(`  ✗ ${t.name}`); console.log(`      ${err.message}`); fail++; }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -36,6 +36,7 @@ const graperankSharedCsvRace = require('./graperank-shared-csv-race.test.js');
 const communityClassThreadPull = require('./community-class-thread-pull.test.js');
 const taskQueueBullmq = require('./task-queue-bullmq.test.js');
 const taskQueueNeo4jResourceClass = require('./task-queue-neo4j-resource-class.test.js');
+const entrypointTemplateRendering = require('./entrypoint-template-rendering.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -82,6 +83,9 @@ async function main() {
   console.log('\ntask-queue-neo4j-resource-class suite:');
   const taskQueueNeo4jResourceClassResult = await taskQueueNeo4jResourceClass.run();
 
+  console.log('\nentrypoint-template-rendering suite:');
+  const entrypointTemplateRenderingResult = await entrypointTemplateRendering.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -124,6 +128,9 @@ async function main() {
   console.log(
     `task-queue-neo4j-resource-class suite:           ${taskQueueNeo4jResourceClassResult.fail === 0 ? 'PASS' : 'FAIL'} (${taskQueueNeo4jResourceClassResult.pass} passed, ${taskQueueNeo4jResourceClassResult.fail} failed)`
   );
+  console.log(
+    `entrypoint-template-rendering suite:             ${entrypointTemplateRenderingResult.fail === 0 ? 'PASS' : 'FAIL'} (${entrypointTemplateRenderingResult.pass} passed, ${entrypointTemplateRenderingResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -139,7 +146,8 @@ async function main() {
     graperankSharedCsvRaceResult.fail === 0 &&
     communityClassThreadPullResult.fail === 0 &&
     taskQueueBullmqResult.fail === 0 &&
-    taskQueueNeo4jResourceClassResult.fail === 0;
+    taskQueueNeo4jResourceClassResult.fail === 0 &&
+    entrypointTemplateRenderingResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/tools/render-conf-template.js
+++ b/tools/render-conf-template.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Render a config template to stdout by substituting ${VAR_NAME} against process.env.
+ * Story #16 / ADR 0014.
+ *
+ * Usage:  node tools/render-conf-template.js <template-path>
+ * Output: substituted template on stdout. Exit 0 on success.
+ * Errors:
+ *   - Exit 1 + stderr message on missing argv, file-read failure.
+ *   - Exit 2 + stderr message on unknown ${VAR} references (one or more env vars
+ *     referenced in the template but undefined in process.env).
+ *
+ * Substitution rules: ${VAR_NAME} only.
+ *   - Bare $VAR (no braces) is LEFT AS LITERAL.
+ *   - $(cmd) is LEFT AS LITERAL — this renderer is NOT a shell evaluator.
+ *   - `cmd` (backticks) is LEFT AS LITERAL.
+ *   - ${VAR:-default} is LEFT AS LITERAL (future enhancement if operator need surfaces).
+ *
+ * The narrow substitution surface is deliberate: the brainstorm.conf template
+ * has plain ${VAR_NAME} references and nothing else (verified at ADR 0014 time).
+ * Adopting shell-power here would open an injection class for repo-controlled
+ * content without any current need.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const templatePath = process.argv[2];
+if (!templatePath) {
+  console.error('Usage: render-conf-template.js <template-path>');
+  process.exit(1);
+}
+
+let content;
+try {
+  content = fs.readFileSync(templatePath, 'utf8');
+} catch (e) {
+  console.error('Failed to read template ' + templatePath + ': ' + e.message);
+  process.exit(1);
+}
+
+const VAR_REF = /\$\{([A-Z_][A-Z0-9_]*)\}/g;
+const missing = [];
+const rendered = content.replace(VAR_REF, function (_match, name) {
+  if (Object.prototype.hasOwnProperty.call(process.env, name)) {
+    return process.env[name];
+  }
+  missing.push(name);
+  return '';
+});
+
+if (missing.length) {
+  const unique = Array.from(new Set(missing));
+  console.error(
+    'RenderError: missing env vars in ' + path.basename(templatePath) + ': ' + unique.join(', ')
+  );
+  process.exit(2);
+}
+
+process.stdout.write(rendered);


### PR DESCRIPTION
## Promoting

Story #16 — Conf templates are the source of truth for fresh containers.

Closes a latent class-of-bug where `docker/entrypoint.sh` regenerated `/etc/brainstorm.conf` on every container start from an 80-line heredoc embedded in the entrypoint script, while `config/brainstorm.conf.template` (the bare-metal install path's authoritative copy) had silently drifted to be missing ~25 of those variables. Story #13's `TASK_QUEUE_ENABLED=false` was inert at Docker runtime for the same reason.

After this promotion:
- `config/brainstorm.conf.template` is the single source of truth for `/etc/brainstorm.conf` on fresh containers.
- New `tools/render-conf-template.js` performs `${VAR_NAME}` substitution against `process.env`; fails the boot loudly on missing vars.
- New `config/brainstorm-task-queue.json.template` ships with story #15's deploy-safe defaults; entrypoint installs it on fresh containers via the existing copy-if-absent pattern.
- Drift sentinels (T7, T8) trip if a future commit re-introduces a heredoc or moves off exactly-one renderer invocation.

## Linked artifacts

- Story: `engineering-team/stories/16-entrypoint-conf-templates-source-of-truth.md`
- ADR: `engineering-team/decisions/0014-entrypoint-template-rendering.md`
- Test plan: `engineering-team/stories/16-entrypoint-conf-templates-source-of-truth.test-plan.md`
- Review: `engineering-team/reviews/16-entrypoint-conf-templates-source-of-truth.md` — **PASS** end-to-end

## Staging smoke (just completed)

- `https://staging.brainstorm.world/` → HTTP 200, 0.39s
- `/api/status` → strfryDomain: "staging.brainstorm.world", neo4jBrowserUrl: "http://staging.brainstorm.world:7474" (both substituted correctly by the new renderer — direct evidence the bare + composed `${DOMAIN_NAME}` substitution works in production)
- `/api/concept-graph/summaries` → success: true, 36 summaries (Neo4j + Redis healthy)
- `/admin/queues` → SPA shell (TASK_QUEUE_ENABLED=false default reached fresh container — exactly the gap story #16 closes)
- `/api/run-task POST` → 400 (endpoint exists, expects body)
- `/api/auth/status` → 200
- Container booted with no missing-env errors → all 9 exported vars were present at entrypoint time.

## Prod test plan

- [ ] `deploy-brainstorm.yml` runs green on merge.
- [ ] `brainstorm.world/` returns HTTP 200.
- [ ] `/api/status` shows `strfryDomain: "brainstorm.world"` and `neo4jBrowserUrl: "http://brainstorm.world:7474"` (template substitution working in prod env).
- [ ] `/api/concept-graph/summaries` returns success: true with non-zero count.
- [ ] `/admin/queues` serves SPA shell (TASK_QUEUE_ENABLED defaults to false in fresh container).
- [ ] `/api/run-task POST` responds (endpoint exists).
- [ ] No "RenderError: missing env vars" in deploy logs.

## Operator path after merge

This story changes Docker entrypoint behavior. Prod is currently running with `TASK_QUEUE_ENABLED=true` (manually flipped during story #15 rollout). After the prod deploy:

1. The new entrypoint will regenerate `/etc/brainstorm.conf` from the template, which has `TASK_QUEUE_ENABLED=false`.
2. **The operator's previous manual edit will be lost** (this is the existing trap, now documented in OPERATIONS.md §11).
3. To restore the queue flag on prod, use the existing append-if-absent recipe from §10.1 / §11.
4. Fresh containers going forward will get `/etc/brainstorm-task-queue.json` automatically — no more manual JSON-file creation needed (the gap from story #15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)