### PR TITLE
Promote story #17 to prod: task queue on by default

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -418,8 +418,8 @@ If a droplet shows high abuse counts in the third check but the first two pass, 
 
 `TASK_QUEUE_ENABLED` in `/etc/brainstorm.conf` controls whether `/api/run-task` enqueues jobs through BullMQ or runs the legacy direct-spawn path.
 
-- `TASK_QUEUE_ENABLED=false` (default) — legacy direct-spawn. Zero queue dependency. **This is the rollback path** — flip the flag, `supervisorctl restart brainstorm`, and the queue is out of the picture.
-- `TASK_QUEUE_ENABLED=true` — `/api/run-task` enqueues per-task BullMQ jobs; in-process Workers consume them; `launchChildTask.sh` still spawns the work (its pgrep guard remains as belt-and-suspenders).
+- `TASK_QUEUE_ENABLED=true` (default since story #17 / ADR 0015) — `/api/run-task` enqueues per-task BullMQ jobs; in-process Workers consume them; `launchChildTask.sh` still spawns the work (its pgrep guard remains as belt-and-suspenders). BullBoard UI mounts at `/admin/queues` (owner-only).
+- `TASK_QUEUE_ENABLED=false` — legacy direct-spawn. Zero queue dependency. **This is the rollback path** — flip the flag in the template (or, for an in-container hotfix, in `/etc/brainstorm.conf`), `supervisorctl restart brainstorm`, and the queue is out of the picture.
 
 When the flag is on and Redis is unreachable, `/api/run-task` returns `503` with body `{success: false, error: "task queue (Redis) unreachable", code: "QUEUE_UNAVAILABLE"}` so monitoring can distinguish this failure from 4xx client errors or 5xx unhandled exceptions.
 

--- a/config/brainstorm.conf.template
+++ b/config/brainstorm.conf.template
@@ -91,10 +91,10 @@ export BRAINSTORM_SEND_EMAIL_UPDATES=0
 export BRAINSTORM_ACCESS=0
 export BRAINSTORM_CREATED_CONSTRAINTS_AND_INDEXES=0
 
-# Task queue (story #13 / ADR 0012). When true, /api/run-task enqueues jobs
-# through BullMQ instead of directly spawning launchChildTask.sh. When false
-# (default in phase 1), the legacy direct-spawn path runs unchanged — this is
-# the rollback path. Requires Redis (already a runtime dependency for sessions
-# and the strfry-stream-consumer). BullBoard UI is mounted at /admin/queues
-# (owner-only) only when this flag is true.
-export TASK_QUEUE_ENABLED=false
+# Task queue (story #13 / ADR 0012; default flipped from false to true in
+# story #17 / ADR 0015 after the queue path matured in production). When
+# true, /api/run-task enqueues jobs through BullMQ and BullBoard mounts at
+# /admin/queues (owner-only). When false, the legacy direct-spawn path runs
+# unchanged — that's the rollback path. Requires Redis (already a runtime
+# dependency for sessions and the strfry-stream-consumer).
+export TASK_QUEUE_ENABLED=true

--- a/engineering-team/decisions/0015-task-queue-on-by-default.md
+++ b/engineering-team/decisions/0015-task-queue-on-by-default.md
@@ -1,0 +1,203 @@
+# ADR 0015: Flip TASK_QUEUE_ENABLED default to `true` in the brainstorm.conf template
+
+**Status:** Accepted
+**Date:** 2026-05-21
+**Story:** `engineering-team/stories/17-task-queue-on-by-default.md`
+
+## Context
+
+Story #17 closes the operator-pain loop opened by story #16: every deploy regenerates `/etc/brainstorm.conf` from `config/brainstorm.conf.template`, and the template's `TASK_QUEUE_ENABLED=false` default resets the queue flag on every fresh container start. We just lived through the manual flip recipe twice today (staging + prod) immediately after story #16's deploy.
+
+The decision space is minimal. The implementation is mechanically one line in the template plus three tightly-scoped test/doc updates. We are writing this ADR anyway because:
+
+1. **Project policy: ADRs enabled** (per [CLAUDE.md](../../CLAUDE.md)).
+2. **Future readers will ask "why is the default true?"** This ADR is the answer they will land on. Without it, the rationale (queue path matured in prod over days; story #16 made rollback git-trackable; manual-flip dance was a chronic post-deploy chore) lives only in the story Background.
+3. **The story explicitly invited the Architect to consider skipping.** Documenting that we chose not to skip (and why) is itself a useful signal for the next adjacent decision.
+
+### Grounded facts
+
+- **Single source-of-truth line.** `config/brainstorm.conf.template:100` reads `export TASK_QUEUE_ENABLED=false`. There is exactly one such line; no other repo file declares the default.
+- **Two test touchpoints** in `test/entrypoint-template-rendering.test.js`:
+  - **T4 fixture expected pairs** at line 291: `TASK_QUEUE_ENABLED: 'false'` — the byte-equivalence rendering test expects this value to come out of the renderer.
+  - **R2 regression sentinel** at lines 429-434: asserts the template carries `TASK_QUEUE_ENABLED\s*=\s*false`.
+  Both flip together with the template. R2's purpose (catch deletion of the line) is preserved by asserting `=true` instead.
+- **OPERATIONS.md §10.1** (lines 421-422) documents the flag values with the current wording "(default)". The default annotation moves from `=false` to `=true`; the rollback-path wording inverts symmetrically.
+- **No concept-graph impact.** This is purely a config-default change. No concepts touched. **No firmware reinstall.**
+- **Story #13's rollback path remains intact.** Per [`src/api/manage/commands/runTask.js`](../../src/api/manage/commands/runTask.js) and [`bin/control-panel.js`](../../bin/control-panel.js), the `TASK_QUEUE_ENABLED=false` branch still works — operators flipping back to legacy direct-spawn use the same recipe they used today, just inverted.
+
+### Operator state after this lands
+
+- **Fresh containers + post-deploy restarts:** queue + BullBoard come up automatically.
+- **Already-running staging + prod containers** (manually flipped to `=true` earlier today): no change — they already have `=true` in `/etc/brainstorm.conf`; the next container restart will pick up `=true` from the template anyway.
+- **An operator who wants to disable the queue:** runs the inverse recipe (`sed` `=true` → `=false` + `supervisorctl restart brainstorm`). Persistent rollback is now a repo edit (`=true` → `=false` in template, commit, deploy) — story #16 made this a clean git operation.
+
+## Options considered
+
+### Option A — Flip the template default (chosen)
+
+One-line change: `=false` → `=true` in `config/brainstorm.conf.template:100`. Plus the R2 sentinel update and the OPERATIONS.md wording flip.
+
+**Pros**
+- Mechanically trivial. Single value change, two test touchpoints, one doc paragraph.
+- No new code paths, no new modules, no new dependencies.
+- Story #16's source-of-truth contract guarantees the template change propagates to every fresh `/etc/brainstorm.conf` on the next deploy.
+- Rollback is symmetric: the same template-edit-and-deploy pattern flips it back to `=false` if a future operational issue surfaces.
+- The boot-time loud-failure mode (story #13's `QUEUE_UNAVAILABLE` + `RenderError` from story #16) still catches Redis-down or env-var-missing scenarios — no new silent failure surface.
+
+**Cons**
+- The next post-deploy container restart on staging + prod will re-render the conf, which is unconditional overwrite. Operators won't notice because the rendered value matches what they manually flipped to — but it's worth knowing the unconditional regeneration still fires.
+- A future "we want the queue OFF by default again" decision would require another repo change + deploy. This is a cost we're willing to pay because the default-on case is the empirically-mature one.
+
+### Option B — Add env-var override mechanism, keep template default at false
+
+E.g., extend `docker/entrypoint.sh` to honor `${TASK_QUEUE_ENABLED:-false}` from the docker-compose environment, with the template default as fallback. Operator sets `TASK_QUEUE_ENABLED=true` via the per-environment docker-compose env_file.
+
+**Pros**
+- Per-environment override without changing the template. Different defaults for sandbox vs prod become possible.
+- Decouples "what the repo template says" from "what each environment actually runs."
+
+**Cons**
+- **Out of scope per story #17 §Out of scope** and story #16 §Out of scope. Both stories explicitly defer env-var-overlay-based override to a separate story.
+- Adds a fourth knob (template default, env var, manual edit, docker env_file) that operators have to triangulate when something is wrong. The current two-knob shape (template default + manual override) is simpler.
+- Doesn't actually solve the immediate pain — we'd still need to write the docker-compose env_file with `TASK_QUEUE_ENABLED=true` for staging + prod, which is functionally equivalent to flipping the template default but with more moving parts.
+
+Rejected. The narrower option (A) is sufficient.
+
+### (Option C considered but not detailed: detect Redis at boot and flip dynamically)
+
+Explicitly out of scope per story #17. Story #13's `QUEUE_UNAVAILABLE` 503 already covers Redis-down detection at runtime; adding boot-time Redis probing would duplicate that signal with extra complexity.
+
+## Decision
+
+**We chose Option A — flip the template default.**
+
+Reasons:
+- The queue path has been running on both staging and prod with `=true` for days (since story #15's rollout) with no reported issues.
+- Story #16 made the template a clean repo-tracked source of truth — flipping a value here is a real git operation, fully reversible.
+- The cost is one line in code + two tightly-scoped test/doc updates. The benefit is removing a chronic post-deploy operator chore that we just performed twice within hours.
+- The rollback path (Option A in reverse) is no worse than today's — and is now *better* than today's because it's repo-edit rather than fragile in-container edit.
+
+What we are trading away: a tiny amount of "explicit operator opt-in" safety margin. Acceptable given the path's maturity in production.
+
+## Consequences
+
+**Enabled**
+- Fresh containers, image rebuilds, and post-deploy container restarts automatically come up with the task queue + BullBoard + cross-task neo4j-heavy serialization (stories #13 + #15 + #16) running.
+- The operator no longer needs to remember the manual flip recipe after every deploy.
+- Story #17 is itself a self-validating round-trip — the next deploy after merging this story should NOT trigger the manual flip dance.
+
+**Constrained / made harder**
+- Operators wanting `=false` need to either edit `/etc/brainstorm.conf` in the running container (lost on next restart) or edit the template + commit + deploy (persistent). The latter is the correct path; the former is the documented trap (OPERATIONS.md §11).
+- The R2 regression sentinel now asserts `=true`; if a future change accidentally deletes the line, R2 trips. If a future change *intentionally* re-flips to `=false`, R2 needs to flip back as part of that change. This is the same kind of guard as story #13's R2; the bidirectional behavior is fine.
+
+**Follow-up debt (out of scope here)**
+- **Env-var overlay** for per-environment overrides (Option B above). A genuine future operator need if sandbox/dev environments want different defaults. Separate story.
+- **Long-running container reconciliation.** Already-deployed staging + prod containers have `=true` from manual flips; no action needed because the template value matches. If we ever flip the template back to `=false`, those manually-flipped containers won't be affected until restart — same trap §11 already documents.
+- **Per-request config-re-read spam** in `brainstorm.log` (the `Found BRAINSTORM_OWNER_PUBKEY` chatter — pre-existing, surfaced during story #17 planning). Step 3 of the operator's plan-of-plans; separate story.
+
+**Firmware reinstall required?** **No.** No concept changes.
+
+## Implementation notes
+
+The Implementer reads this section verbatim. Total diff: **5 files, ~5-10 lines net.**
+
+### 1. `config/brainstorm.conf.template:100`
+
+Change:
+```
+export TASK_QUEUE_ENABLED=false
+```
+to:
+```
+export TASK_QUEUE_ENABLED=true
+```
+
+The surrounding comment block (lines 94-99) describes the flag's purpose; that text is mostly correct but the parenthetical "default in phase 1" is now stale. Update to reflect the new posture — something like:
+
+```
+# Task queue (story #13 / ADR 0012, default flipped to true in story #17 /
+# ADR 0015). When true, /api/run-task enqueues jobs through BullMQ and
+# BullBoard mounts at /admin/queues (owner-only). When false, the legacy
+# direct-spawn path runs — that's the rollback path. Requires Redis (already
+# a runtime dependency for sessions and the strfry-stream-consumer).
+export TASK_QUEUE_ENABLED=true
+```
+
+### 2. `test/entrypoint-template-rendering.test.js`
+
+Two surgical edits.
+
+**Line 291** (T4 fixture expected map):
+```js
+TASK_QUEUE_ENABLED: 'false'
+```
+becomes:
+```js
+TASK_QUEUE_ENABLED: 'true'
+```
+
+**Lines 429-434** (R2 regression sentinel) — flip both the test name and the regex + error message:
+```js
+test('R2: config/brainstorm.conf.template still carries TASK_QUEUE_ENABLED=true (story #17 contract preserved; AC "fresh containers contain export TASK_QUEUE_ENABLED=true")', () => {
+  const src = readSafe(CONF_TEMPLATE);
+  assert(src !== null, 'brainstorm.conf.template missing — cannot check story #17 contract.');
+  assert(
+    /TASK_QUEUE_ENABLED\s*=\s*true/.test(src),
+    'R2: config/brainstorm.conf.template no longer carries TASK_QUEUE_ENABLED=true (story #17 / ADR ' +
+      '0015 regression). The flag must remain in the template at the new deploy-safe default `true`; ' +
+      'reverting to `false` re-opens the manual-flip-after-every-deploy operator chore that story #17 ' +
+      'closed. If you intentionally want to roll back to `=false`, also flip this sentinel back to its ' +
+      'pre-story-#17 form (assert =false) so it tracks the new intended default.'
+  );
+});
+```
+
+The error message intentionally walks the next reader through the bidirectional rollback story.
+
+### 3. `OPERATIONS.md` §10.1
+
+**Lines 421-422:**
+
+```markdown
+- `TASK_QUEUE_ENABLED=false` (default) — legacy direct-spawn. Zero queue dependency. **This is the rollback path** — flip the flag, `supervisorctl restart brainstorm`, and the queue is out of the picture.
+- `TASK_QUEUE_ENABLED=true` — `/api/run-task` enqueues per-task BullMQ jobs; in-process Workers consume them; `launchChildTask.sh` still spawns the work (its pgrep guard remains as belt-and-suspenders).
+```
+
+becomes (default annotation moves; rollback wording stays attached to `=false`):
+
+```markdown
+- `TASK_QUEUE_ENABLED=true` (default since story #17 / ADR 0015) — `/api/run-task` enqueues per-task BullMQ jobs; in-process Workers consume them; `launchChildTask.sh` still spawns the work (its pgrep guard remains as belt-and-suspenders). BullBoard UI mounts at `/admin/queues` (owner-only).
+- `TASK_QUEUE_ENABLED=false` — legacy direct-spawn. Zero queue dependency. **This is the rollback path** — flip the flag in the template (or, for an in-container hotfix, in `/etc/brainstorm.conf`), `supervisorctl restart brainstorm`, and the queue is out of the picture.
+```
+
+Other OPERATIONS.md mentions (§10.4 line 460, §10.6 line 470, §11 lines 546+562) reference `TASK_QUEUE_ENABLED` as state descriptions and historical narratives — leave those as-is, they remain accurate.
+
+### 4. Nothing else
+
+No new files. No source changes outside the template + test + doc. No Dockerfile change. No new dependency.
+
+### Tests
+
+The Tester writes a brief test-plan amendment to story #16's `test/entrypoint-template-rendering.test.js`. Specifically:
+
+- **T4 fixture expected map update** — folded into the R2 sentinel flip (lines 291 + 429-434 change together).
+- **No new sentinels.** The existing R2 + T4 cover the new default; the existing T2 (heredoc variable list) still passes because `TASK_QUEUE_ENABLED` is still in the template, just with a different value.
+- **Story-specific smoke (Reviewer):** verify that on a fresh container start, `/etc/brainstorm.conf` contains `TASK_QUEUE_ENABLED=true` and the boot log shows the four-line task-queue stack — story #17's AC #2 and AC #5.
+
+### Smoke
+
+Cycle-local (Reviewer) — minimal scope because the change is minimal:
+- Render the template inside the container with the same env state used for story #16's smoke. Confirm the rendered output contains `export TASK_QUEUE_ENABLED=true` instead of `=false`. No need to re-run the full byte-equivalence diff — the only value that changes is this one line.
+- Optionally: verify the `npm test` suite still goes 14/14 inside the container after the bind-mount picks up the changes.
+
+### Concept handle
+
+None. No new concepts.
+
+## Out of scope
+
+- **Removing the `TASK_QUEUE_ENABLED` flag entirely.** The flag stays as a rollback handle.
+- **Env-var-overlay-based override mechanism** (Option B). Separate story when operator need for per-environment overrides surfaces.
+- **Backfilling already-deployed staging + prod containers.** Both already have `=true` from manual flips; the template change matches their current state. No reconciliation needed.
+- **Per-request config-re-read log spam fix.** Step 3 of the operator's three-step plan; separate story.
+- **Updating prior ADRs to reflect the new default.** ADRs are historical records of the decision at their time; they should not be retroactively edited. This ADR supersedes the "default false" posture in ADR 0012 §Implementation.

--- a/engineering-team/reviews/17-task-queue-on-by-default.md
+++ b/engineering-team/reviews/17-task-queue-on-by-default.md
@@ -1,0 +1,154 @@
+# Review: Story 17 — Make task queue ENABLED-by-default in the brainstorm.conf template
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-21
+**Diff:** `git diff origin/main..HEAD` (commit `eea824c6`, 4 commits: `e7f3b9a3` story, `6477994d` ADR, `39e28162` tests, `eea824c6` impl)
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` (host) — **PASS**. `entrypoint-template-rendering suite: PASS (11 passed, 0 failed)`, `task-queue-bullmq suite: PASS (18 passed, 0 failed)`, all 12 other suites still PASS, unchanged. Overall: **PASS**.
+- [x] `npm test` (live tapestry container, bind-mounted source) — **PASS**. Same 14/14 suites green as host.
+- [x] _Playwright not applicable — no UI surface changed._
+- [x] _Lint / typecheck / build not configured — skipped per house rules._
+- [x] **Cycle-local smoke** — **PASS** (see §Cycle-local smoke verification below).
+
+## Spec adherence (AC walk)
+
+| AC (story §) | Status | Notes |
+|---|---|---|
+| AC #1 fresh container's `/etc/brainstorm.conf` contains `export TASK_QUEUE_ENABLED=true` | ✓ | R2 source sentinel + T4 fixture map both assert the new value. Plus cycle-local smoke S1 (renderer output) directly confirms. |
+| AC #2 post-deploy boot log shows the four-line task-queue stack | smoke-deferred | Source-sentinels can't reach the runtime log. Reviewer cycle-local already observed the four-line stack on staging + prod via supervisorctl restart in earlier work; the deploy chain's natural container restart on the next staging deploy is the authoritative test. |
+| AC #3 rollback path (`=false` + restart → legacy direct-spawn) still works | ✓ | No source change on the rollback path. The `TASK_QUEUE_ENABLED=false` branch in [`bin/control-panel.js:274`](../../bin/control-panel.js#L274) (legacy direct-spawn log line) is intact; the `runTask.js` flag-off branch is intact. Story #13's 18-sentinel suite (including T8, T12, T13) still green — those guard the rollback contract. |
+| AC #4 R2 sentinel updated; no other regression in 14 npm test suites | ✓ | R2 flipped to assert `=true`. T4 fixture map flipped. **Plus T10 in story #13's `task-queue-bullmq` suite needed updating** — see Findings §Non-blocking #1. The Implementer caught + fixed this via the test gate; covered by the "no other regression" AC. |
+| AC #5 post-deploy operator does NOT have to re-run the manual flip recipe | smoke-deferred | Confirmed structurally (template → R2 → /etc/brainstorm.conf contains `=true` → control-panel.js reads it → BullBoard mounts). Behavioral round-trip will be validated on the next staging container restart. |
+
+## ADR adherence
+
+- [x] Files changed match ADR 0015 §Implementation notes:
+  - `config/brainstorm.conf.template` (line 100 + comment block 94-99) ✓
+  - `test/entrypoint-template-rendering.test.js` (T4 fixture line 291 + R2 sentinel lines 429-440) ✓ — handled in Phase 3 by the Tester
+  - `OPERATIONS.md` §10.1 (lines 421-422) ✓
+- [x] **No new files. No new modules. No new dependencies.** Confirmed by `git diff --stat`: only 3 source files modified, plus the 3 engineering-team artifacts (story, ADR, test-plan, review) and 2 test files.
+- [x] Comment block in template references story #17 / ADR 0015 — future readers can trace the decision back. Format matches ADR's suggested wording.
+- [x] OPERATIONS.md §10.1: default annotation moved from `=false` to `=true`; rollback wording now references both template-edit (persistent) and in-container (transient) paths. Cleaner than the pre-story-#16 form.
+- [x] Other OPERATIONS.md references (§10.4 line 460, §10.6 line 470, §11 line 546) correctly left untouched per ADR 0015 — they're behavior descriptions or historical narratives, not default declarations.
+- [x] **Implementer's bonus fix on T10 in `test/task-queue-bullmq.test.js`** — discussed in Findings.
+
+## Concept-graph integrity
+
+- [x] No concept-graph schema changes (ADR §Consequences confirmed "no firmware reinstall"). No `src/concept-graph/` edits in the diff.
+- [x] No concept handles touched.
+
+## Things tests can't catch — hidden-hazard audit
+
+I ran a repo-wide grep for any remaining hardcoded `TASK_QUEUE_ENABLED\s*=\s*false` literals to make sure the Implementer didn't miss a stale reference. Every remaining match is correct in its context:
+
+| Location | Status |
+|---|---|
+| `OPERATIONS.md:422` — describes `=false` behavior in §10.1 | ✓ Correct: this is the rollback-path description, not a default declaration. The Implementer moved "(default)" annotation off this line. |
+| `OPERATIONS.md:460` — §10.4 drain/pause recipe references flipping to `=false` | ✓ Correct: maintenance procedure, not a default. |
+| `OPERATIONS.md:546` — §11 historical narrative ("story #13's `TASK_QUEUE_ENABLED=false`...") | ✓ Correct: historical fact about how the trap manifested before story #16 + #17 closed it. |
+| `bin/control-panel.js:274` — runtime log line emitted when flag is off | ✓ Correct: behavior description, not a config declaration. The rollback path log message stays. |
+| `engineering-team/decisions/0012-...md:214` (ADR 0012) | ✓ Correct per ADR 0015 §Out of scope: "Updating prior ADRs to reflect the new default. ADRs are historical records." |
+| `engineering-team/decisions/0013-...md:245` (ADR 0013) | ✓ Same — historical reference. |
+| `engineering-team/decisions/0014-...md:233,333,348` (ADR 0014) | ✓ Same — historical references to the value at the time. |
+| `engineering-team/stories/13-...test-plan.md`, `16-...test-plan.md` | ✓ Historical test-plan artifacts. Left as-is. |
+| `engineering-team/decisions/0015-...md:9,19,26,108,162,170` | ✓ ADR 0015 itself, which discusses both the old `=false` and the new `=true`. Self-consistent. |
+
+Conversely, the new `=true` literals exist exactly where expected: template line 100, R2 + T4 in `test/entrypoint-template-rendering.test.js`, OPERATIONS.md §10.1, and the ADR's narrative. Plus `bin/control-panel.js:268` (the `Task queue initialized (TASK_QUEUE_ENABLED=true)` log line — pre-existing) and `test/task-queue-bullmq.test.js:270` (the Redis-down test error string — pre-existing).
+
+No stale references. The audit confirms the change is fully consistent.
+
+Additional hidden-hazard checks:
+
+| Hazard | Status |
+|---|---|
+| Implementer added a leftover `console.log` or debug code | ✓ Closed — diff is 3 surgical edits, no log additions. |
+| Template comment-block change accidentally breaks the renderer's regex | ✓ Closed — the new comment text is plain Markdown-style prose with no `${...}` references. T4 (which spawns the renderer + asserts pairs) passes. |
+| OPERATIONS.md change breaks any other doc's cross-reference | ✓ Closed — the new wording adds "since story #17 / ADR 0015" which is a strict addition; no anchors or section numbers shifted. |
+| T10 relaxation in story #13's suite makes the guard too loose | **Acceptable.** T10 now matches `=true OR =false` — i.e., "the knob is present in some valid form." The value-side assertion is fully pinned by R2 in the entrypoint-template-rendering suite. The two sentinels split concerns cleanly (T10 = presence; R2 = current value), which removes a future-drift risk where they would have to be kept in lock-step. |
+| Future operator wants to revert to `=false` and forgets to flip R2 too | ✓ Closed by R2's error-message walkthrough. The last paragraph of R2's failure explicitly tells the next maintainer to flip R2 back. |
+
+## Cycle-local smoke verification
+
+The local `tapestry` Docker container has been up for 7+ days with a bind-mount of the repo, so my Implementation-phase edits to `config/brainstorm.conf.template` are live in-container without a rebuild. Drove the smoke against that bind-mount.
+
+### S1 — Render the template, verify `=true` is produced
+
+```bash
+docker exec tapestry bash -c '
+  source /etc/brainstorm.conf 2>/dev/null
+  export OWNER_PUBKEY="${BRAINSTORM_OWNER_PUBKEY}"
+  export OWNER_NPUB="${BRAINSTORM_OWNER_NPUB}"
+  export ADMIN_PUBKEYS="${BRAINSTORM_ADMIN_PUBKEYS}"
+  export DOMAIN_NAME="${STRFRY_DOMAIN}"
+  export RELAY_URL="${BRAINSTORM_RELAY_URL}"
+  node /usr/local/lib/node_modules/brainstorm/tools/render-conf-template.js \
+       /usr/local/lib/node_modules/brainstorm/config/brainstorm.conf.template \
+  | grep -E "TASK_QUEUE_ENABLED|# Task queue"
+'
+```
+
+Output:
+
+```
+# Task queue (story #13 / ADR 0012; default flipped from false to true in
+export TASK_QUEUE_ENABLED=true
+```
+
+Direct evidence the renderer produces the new default. The comment-block update is visible too — future operators inspecting `/etc/brainstorm.conf` will see the story #17 / ADR 0015 reference and can trace the decision.
+
+### S2 — npm test inside the container
+
+```
+task-queue-bullmq suite:                         PASS (18 passed, 0 failed)
+task-queue-neo4j-resource-class suite:           PASS (14 passed, 0 failed)
+entrypoint-template-rendering suite:             PASS (11 passed, 0 failed)
+Overall:                                         PASS
+```
+
+14/14 inside the container too. The bind-mount picks up the edits without an image rebuild.
+
+### Smoke scenarios NOT performed (acceptable gaps)
+
+- **Cold container boot from scratch.** Would require `docker compose down && docker compose up --build` which interrupts the operator's stack. The deploy chain (cycle-staging next) naturally exercises this on every push.
+- **Behavioral round-trip — boot a fresh container and observe the four-line task-queue stack appear WITHOUT operator intervention.** This is AC #5's true test. The deploy chain validates it on the next staging deploy; if the four-line stack appears in the boot log without manual flip ceremony, AC #5 is empirically satisfied.
+
+## House rules check
+
+- [x] Concept Graph API authority respected (no concept change).
+- [x] No new lint/typecheck/build tooling.
+- [x] No firmware reinstall needed.
+- [x] Per-phase commits in order: story → ADR → tests → impl. Clean stack on top of `origin/main` (which already has story #16's merge).
+
+## Findings
+
+### Blocking
+
+_None._
+
+### Non-blocking (recorded, do not gate)
+
+1. **T10 collision wasn't anticipated in ADR 0015.** The ADR §Implementation notes enumerated only R2 + T4 in the entrypoint-template-rendering suite as test touchpoints. Story #13's T10 sentinel in the `task-queue-bullmq` suite carried a parallel `=false` assertion that the test gate caught at impl time. The Implementer correctly extended the fix to T10 (covered by story #17 AC #4 "no other regression in any of the 14 npm test suites"). **Teachable moment for future "default value flip" ADRs:** include a repo-wide grep for the old literal value in §Implementation notes so the Implementer doesn't discover the cross-suite collisions via the gate. Worth folding into the team's Architect role notes if these kinds of value-flips become a recurring pattern. Not a blocker — the gate worked exactly as intended (caught the regression before it could ship).
+
+2. **T10's resolved shape (allow `=true OR =false`) is a deliberate looser guard than its original.** This was the right choice: pinning the value in both T10 (story #13's suite) AND R2 (story #16's suite) would require future maintainers to keep them in lock-step on any subsequent default-flip. Splitting concerns (T10 = presence guard, R2 = current value) removes that drift risk. The Implementer's comment block in T10 explicitly walks the next reader through this rationale.
+
+3. **OPERATIONS.md §10.6 line 470 still reads "Requires `TASK_QUEUE_ENABLED=true` (§10.1)."** This is correct behavior text (story #15's resource-class semaphore does require the queue to be on), and the "(§10.1)" cross-reference still resolves correctly. No edit needed; flagging only to confirm I considered it.
+
+4. **OPERATIONS.md §11 last-paragraph reference to "TASK_QUEUE_ENABLED rollout (see §10.1)"** still resolves correctly — §10.1's content changed but the section identity didn't. ✓
+
+5. **Behavioral round-trip is deferred to cycle-staging.** AC #5 ("operator does NOT have to re-run the manual flip recipe") is technically only fully validated when a fresh container actually boots from the deployed template change without intervention. The staging deploy is the natural place for that validation; if the manual flip recipe is needed, that's a real Implementer bug that we'd catch + fix before promoting to prod. Story #17 is self-validating in that respect — the deploy chain IS the test.
+
+## Verdict
+
+**PASS end-to-end.**
+
+The implementation is mechanically tiny (3 files, +22/-15) and exactly what ADR 0015 specified, plus one cross-suite test fix the gate caught (T10 in story #13's suite). Source-side: 14/14 suites green on both host and container. Behavioral-side: renderer produces `=true` as expected with the new comment-block traceability. The 5 non-blocking observations are documentation polish + a useful teachable moment about cross-suite grep in future "value flip" ADRs — none gate ship.
+
+The story is ready for the deploy chain (`cycle-staging`, then on explicit confirmation `cycle-prod`). The cycle-staging round-trip will empirically validate AC #5: if the next fresh staging container brings up the four-line task-queue stack without operator ceremony, story #17's contract is fully satisfied. If the manual flip recipe is somehow still needed, that's a real bug we'd catch + fix before promoting — but the source-sentinel + smoke evidence collected here strongly suggests it won't be.
+
+The operator path forward post-merge:
+- Staging deploy → fresh container reads `=true` from the template → BullBoard + queue come up automatically.
+- Prod deploy → same.
+- No manual flip recipe needed on either environment after this story lands.
+- If a future operational need arises to disable: edit template to `=false`, flip R2 + T10 to match (R2's error message walks through this), commit, deploy.

--- a/engineering-team/stories/17-task-queue-on-by-default.md
+++ b/engineering-team/stories/17-task-queue-on-by-default.md
@@ -67,5 +67,5 @@ Deferred to Architect:
 ## Linked artifacts
 
 - ADR: [0015-task-queue-on-by-default.md](../decisions/0015-task-queue-on-by-default.md)
-- Test plan: (filled in after Test Design phase)
+- Test plan: [17-task-queue-on-by-default.test-plan.md](17-task-queue-on-by-default.test-plan.md)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/17-task-queue-on-by-default.md
+++ b/engineering-team/stories/17-task-queue-on-by-default.md
@@ -68,4 +68,4 @@ Deferred to Architect:
 
 - ADR: [0015-task-queue-on-by-default.md](../decisions/0015-task-queue-on-by-default.md)
 - Test plan: [17-task-queue-on-by-default.test-plan.md](17-task-queue-on-by-default.test-plan.md)
-- Review: (filled in after Review phase)
+- Review: [../reviews/17-task-queue-on-by-default.md](../reviews/17-task-queue-on-by-default.md) — **PASS** end-to-end (14/14 suites + cycle-local smoke S1 renderer output + S2 in-container npm test PROVED on the live container).

--- a/engineering-team/stories/17-task-queue-on-by-default.md
+++ b/engineering-team/stories/17-task-queue-on-by-default.md
@@ -1,0 +1,71 @@
+# Story 17: Make task queue ENABLED-by-default in the brainstorm.conf template
+
+**Status:** Approved
+**Created:** 2026-05-21
+**Type:** Feature (default-behavior change with one-line implementation)
+
+## Background
+
+Story #13 shipped `TASK_QUEUE_ENABLED=false` as the phase-1 safe default — legitimate at the time because the queue was new and the rollback path needed to be the default. Stories #15 + #16 followed: cross-task neo4j-heavy serialization on top of the queue, and templates-as-source-of-truth for /etc/brainstorm.conf.
+
+The template's `TASK_QUEUE_ENABLED=false` default is now an active operator pain point:
+
+- Each deploy regenerates `/etc/brainstorm.conf` from the template (per story #16).
+- On every fresh container start, the queue flag resets to `false`.
+- The operator must run a manual `docker exec ... sed/echo` recipe + `supervisorctl restart brainstorm` on each environment after every deploy to restore the queue.
+- We just lived through this dance on both staging and prod hours ago, immediately after story #16 landed.
+
+The queue path is now mature enough to be the default:
+- Staging and prod have both run with `TASK_QUEUE_ENABLED=true` for days (since story #15's rollout).
+- Story #13's source-sentinel suite (18 tests), story #15's suite (14 tests), and story #16's suite (11 tests) all green.
+- BullBoard UI and cross-task neo4j-heavy serialization both confirmed working in production.
+- No reported runtime issues.
+
+Story #13's rollback path remains intact — operators can still flip to `false` via the inverse recipe — only the *default* is changing. And because story #16 made the template the source of truth, "rollback" is now also "edit template + commit + deploy" (a real git-trackable operation), not a fragile in-container edit.
+
+## User-facing description
+
+**As an operator** spinning up fresh Tapestry containers (new droplets, post-deploy restarts, image rebuilds), **I want** `TASK_QUEUE_ENABLED=true` to be the deploy-safe default in the brainstorm.conf template, **so that** the BullMQ task queue, BullBoard UI, and cross-task neo4j-heavy serialization come up automatically — without me having to remember the manual flip recipe on every environment after every deploy.
+
+## Acceptance criteria
+
+- [ ] Given a fresh container start, when the entrypoint renders `/etc/brainstorm.conf` from the template, then the resulting file contains `export TASK_QUEUE_ENABLED=true`.
+- [ ] Given a post-deploy `brainstorm` process start, when the boot log is inspected, then it shows the four-line task-queue stack: `Found TASK_QUEUE_ENABLED=true`, `[task-queue] Initialized N queues + workers (...)`, `Task queue initialized (TASK_QUEUE_ENABLED=true)`, `[bull-board] Mounted at /admin/queues (owner-only)`.
+- [ ] Given an operator wants to disable the queue (rollback), when they apply the inverse manual recipe (set `TASK_QUEUE_ENABLED=false` in `/etc/brainstorm.conf` + `supervisorctl restart brainstorm`), then the system falls back to the legacy direct-spawn path with `Task queue disabled (TASK_QUEUE_ENABLED=false) — legacy direct-spawn path active` in the boot log.
+- [ ] The `R2` regression sentinel in `test/entrypoint-template-rendering.test.js` (currently asserts the template carries `TASK_QUEUE_ENABLED=false`) is updated to assert the new default. No other regression in any of the 14 npm test suites.
+- [ ] On staging and prod, after this story's deploy lands, the operator does NOT have to re-run the manual flip recipe. The task queue + BullBoard come up automatically.
+
+## Concepts touched
+
+- The `TASK_QUEUE_ENABLED` feature flag (story #13 / ADR 0012)
+- `config/brainstorm.conf.template` — the conf-template source of truth (story #16 / ADR 0014)
+- `test/entrypoint-template-rendering.test.js` R2 regression sentinel (story #16 test plan)
+- Architect should resolve concept handles if any apply (Concept Graph API unreachable from host at planning time)
+
+## Out of scope
+
+- **Removing the `TASK_QUEUE_ENABLED` flag entirely / making the queue mandatory.** The flag stays as a rollback handle; this story only changes the default.
+- **Removing the flag-off branch from `src/api/manage/commands/runTask.js`** (the legacy direct-spawn path). It remains the rollback path.
+- **Auto-detecting Redis availability before enabling.** Story #13's `QUEUE_UNAVAILABLE` 503 failure mode already handles Redis-down loudly.
+- **Backfilling `TASK_QUEUE_ENABLED=true` to long-running containers.** Staging and prod were manually flipped earlier today; this story benefits future fresh containers + post-deploy restarts.
+- **Documentation rewrites in OPERATIONS.md beyond the minimum.** §10.1 (currently says "default false") needs a one-paragraph update; that's enough.
+- **Architecture exploration.** The implementation is mechanical — one line in the template. Whether this needs a formal ADR is the Architect's call; the PO sees no design space.
+
+## Open questions
+
+Resolved at planning (2026-05-21):
+
+- **Default for fresh containers** → `true`.
+- **Risk of enabling by default** → acceptable. The queue has been running with `=true` on both staging and prod since story #15's rollout (days of stability), and story #16 made rollback a clean repo-tracked operation.
+- **Test sentinel update** → R2 in `test/entrypoint-template-rendering.test.js` needs to be flipped along with the template. This is part of the implementation, not a separate story.
+
+Deferred to Architect:
+
+- **Does this change warrant a full ADR**, or is it small enough that a story + test-plan note is sufficient? The PO sees no design choices, but defers to the Architect's judgment about whether to skip Phase 2.
+- **OPERATIONS.md §10.1 wording update** — Architect or Implementer to pick the right minimal edit (currently the section describes the flag's purpose; the "default is false" wording needs to flip).
+
+## Linked artifacts
+
+- ADR: (filled in after Architecture phase — Architect may skip if no design space)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/17-task-queue-on-by-default.md
+++ b/engineering-team/stories/17-task-queue-on-by-default.md
@@ -66,6 +66,6 @@ Deferred to Architect:
 
 ## Linked artifacts
 
-- ADR: (filled in after Architecture phase — Architect may skip if no design space)
+- ADR: [0015-task-queue-on-by-default.md](../decisions/0015-task-queue-on-by-default.md)
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/17-task-queue-on-by-default.test-plan.md
+++ b/engineering-team/stories/17-task-queue-on-by-default.test-plan.md
@@ -1,0 +1,129 @@
+# Test Plan: Story 17 — Make task queue ENABLED-by-default in the brainstorm.conf template
+
+**Story:** `engineering-team/stories/17-task-queue-on-by-default.md`
+**ADR:** `engineering-team/decisions/0015-task-queue-on-by-default.md`
+**Date:** 2026-05-21
+
+## Test posture
+
+This is a default-behavior change with a one-line implementation. The ADR's design space is unusually narrow — flip the value in the template, ride story #16's source-of-truth contract into every fresh container. The Tester's job is correspondingly narrow: **flip two existing test spots in story #16's `test/entrypoint-template-rendering.test.js` so they fail right-reason against the still-`=false` template, then the Implementer's template flip makes them pass.**
+
+No new test files. No new test suite. No new sentinels. The ADR explicitly closes that scope: "The existing R2 + T4 cover the new default; the existing T2 (heredoc variable list) still passes because TASK_QUEUE_ENABLED is still in the template, just with a different value."
+
+The behavioral round-trip — boot a fresh container after the template change is deployed and observe the four-line task-queue stack in the boot log without operator ceremony — is the **authoritative cycle-local + cycle-staging smoke**, executed by the Reviewer and the operator respectively. This matches story #16's posture.
+
+## Coverage map
+
+| Criterion (story §) | Test name | Test file | Level |
+|---|---|---|---|
+| AC #1: fresh container's `/etc/brainstorm.conf` contains `export TASK_QUEUE_ENABLED=true` | `R2: config/brainstorm.conf.template carries TASK_QUEUE_ENABLED=true (story #17 / ADR 0015 default; story #13 contract preserved with the flag still present)` | `test/entrypoint-template-rendering.test.js` (line 429-440, flipped from pre-story-#17 form) | source sentinel |
+| AC #1: same, but at the rendered-output level (not just template-text) | `T4: rendering the template via render-conf-template.js with a fixture env produces the expected VAR=VALUE pairs` — specifically the `TASK_QUEUE_ENABLED: 'true'` entry in the expected map (line 291) | `test/entrypoint-template-rendering.test.js` | integration (spawns the renderer with fixture env) |
+| AC #2: post-deploy boot log shows the four-line task-queue stack | **Smoke (Reviewer cycle-local + cycle-staging)** — source-sentinels can't reach this; verified by inspecting `/var/log/supervisor/brainstorm.log` after `supervisorctl restart brainstorm` on a freshly-deployed container | — | smoke |
+| AC #3: rollback path (`=false` + restart → legacy direct-spawn) still works | **Implicit** — no code on the rollback path changes; the `=false` branch in `runTask.js` + `control-panel.js` is unchanged from story #13/#16. Source-sentinels would over-fit; the rollback path is covered by story #13's existing test suite (18 sentinels, all still green) | — | regression (covered by other suites) |
+| AC #4: R2 sentinel updated to assert the new default | The R2 sentinel itself **is** the AC. The test flip is the deliverable. | `test/entrypoint-template-rendering.test.js` (line 429-440) | source sentinel |
+| AC #4: no regression in any of the 14 npm test suites | `npm test` overall PASS post-impl. All 13 sibling suites pass; entrypoint-template-rendering suite returns 11/11. | (full suite) | gate |
+| AC #5: post-deploy operator does NOT need to re-run the manual flip recipe | **Smoke (Reviewer cycle-local + cycle-staging + cycle-prod)** — observed by deploying the template change to staging and verifying the operator does not need to intervene before BullBoard appears at `/admin/queues/`. The Reviewer's role-specific smoke confirms; the deploy chain confirms in the wild. | — | smoke |
+
+### Why only two test changes
+
+Per the ADR §Tests: T4 and R2 are the only sentinels that pin the *value* of `TASK_QUEUE_ENABLED` in the template. T2 (heredoc variable list, including `TASK_QUEUE_ENABLED` as a present variable name) passes whether the value is `true` or `false`. T3 (literal-placeholder substitution discipline) doesn't touch `TASK_QUEUE_ENABLED` (it's a literal value, not a `${VAR}` reference). T1, T5–T8, R1, R3 all unrelated.
+
+### What this test plan deliberately does NOT add
+
+- **A separate test for the comment-block rewrite in the template** (the parenthetical "default in phase 1" wording). Cosmetic. Reviewer eyeballs during the diff walk.
+- **A separate test for the OPERATIONS.md §10.1 wording flip.** Documentation prose is brittle to sentinel; Reviewer eyeballs.
+- **A separate "rollback path still works" sentinel.** Story #13's existing 18-sentinel suite already pins the rollback path (R3 in `test/task-queue-bullmq.test.js` asserts the `TASK_QUEUE_ENABLED` + `QUEUE_UNAVAILABLE` branch in `runTask.js`). Adding a story-#17-specific rollback test would over-fit and duplicate that guard.
+- **A separate sentinel for "the new comment block mentions story #17 / ADR 0015".** Comments aren't a behavioral contract.
+
+## Edge cases
+
+| Case | Status |
+|---|---|
+| Operator runs the inverse manual flip recipe in an already-deployed container | **Covered by AC #3 + implicit regression.** The `=false` branch is unchanged source-wise; no code regression possible from a config-default flip. |
+| Operator wants persistent rollback via repo edit | **Documented in OPERATIONS.md §11.** Edit template to `=false`, commit, deploy. The R2 sentinel's error message walks them through the bidirectional rollback (lines 434-440 of the test file post-flip). |
+| Fresh container restart on an environment that was previously running `=true` (manual flip, e.g., staging + prod today) | **Covered by AC #5 smoke.** The template renders `=true`; the rendered conf matches what the operator manually flipped to; no observable change. |
+| Bare-metal install (not Docker) | Out of scope per story #16 / ADR 0014 (entrypoint changes don't apply to bare-metal). The `setup/install-control-panel.sh` path reads the template directly; bare-metal installs will also get `=true` by default. Acceptable — same posture as story #16. |
+| Future change re-flips default to `=false` intentionally | **Covered by R2's error message.** Last paragraph of the error message tells the next maintainer to flip R2 back to assert `=false` as part of that change. |
+
+## Test infrastructure
+
+- **Framework:** Node built-in runner via `npm test` (entry: `test/test.js`).
+- **Test changes:** **TWO surgical edits to one existing file**, no new test files registered.
+- **No new test infrastructure.** Same suite registered in `test/test.js` as story #16.
+- **Concept Graph API:** not required for this story.
+- **Firmware reinstall:** no.
+
+## How to run
+
+```
+npm test
+```
+
+The `entrypoint-template-rendering suite:` line in the report shows the suite's pass/fail. Post-implementation expected: `PASS (11 passed, 0 failed)`.
+
+For Reviewer cycle-local smoke (behavioral round-trip):
+
+```bash
+# Inside the tapestry container (or any environment with the deployed template):
+docker exec tapestry bash -c '
+  source /etc/brainstorm.conf 2>/dev/null
+  export OWNER_PUBKEY="${BRAINSTORM_OWNER_PUBKEY}"
+  export OWNER_NPUB="${BRAINSTORM_OWNER_NPUB}"
+  export ADMIN_PUBKEYS="${BRAINSTORM_ADMIN_PUBKEYS}"
+  export DOMAIN_NAME="${STRFRY_DOMAIN}"
+  export RELAY_URL="${BRAINSTORM_RELAY_URL}"
+  node /usr/local/lib/node_modules/brainstorm/tools/render-conf-template.js \
+       /usr/local/lib/node_modules/brainstorm/config/brainstorm.conf.template \
+  | grep TASK_QUEUE_ENABLED
+'
+# Expected output:
+#   export TASK_QUEUE_ENABLED=true
+```
+
+For Reviewer cycle-staging smoke:
+
+```bash
+# After deploy-staging.yml completes, on the staging droplet:
+docker exec tapestry cat /var/log/supervisor/brainstorm.log | grep -E "task-queue|bull-board|TASK_QUEUE_ENABLED" | tail -10
+# Expected (the four-line stack, automatically, no manual flip needed):
+#   Found TASK_QUEUE_ENABLED=true (unquoted)
+#   [task-queue] Initialized 51 queues + workers (defaultConcurrency=1, resourceClasses=neo4j-heavy)
+#   Task queue initialized (TASK_QUEUE_ENABLED=true)
+#   [bull-board] Mounted at /admin/queues (owner-only)
+```
+
+If the four-line stack appears in the boot log without the operator running the manual flip recipe, AC #5 is satisfied — the deploy chain itself becomes the test.
+
+## Verification
+
+The flipped tests fail with the current (still-`=false`) template. Confirmed on 2026-05-21 at commit `6477994d`:
+
+```
+entrypoint-template-rendering suite:
+  ✓ T1: tools/render-conf-template.js exists, is parseable Node, performs ${VAR_NAME} substitution against process.env (ADR 0014 §Implementation Step 2)
+  ✓ T2: config/brainstorm.conf.template contains every variable the heredoc writes (Step 1 byte-equivalence; ADR 0014 §Implementation Step 1)
+  ✓ T3: template replaces literal placeholder values with ${VAR} references for env-var-dependent variables (Step 1 byte-equivalence; ADR 0014 §Implementation Step 1)
+  ✗ T4: rendering the template via render-conf-template.js with a fixture env produces the expected VAR=VALUE pairs (Step 1 byte-equivalence; ADR 0014 §Byte-equivalence verification)
+      Rendered template diverges from heredoc output for 1 variable(s):
+        TASK_QUEUE_ENABLED = "false" (expected "true")
+  ✓ T5: config/brainstorm-task-queue.json.template exists, parses as JSON, has resourceClassCaps.neo4j-heavy=1 (AC; ADR 0014 §Implementation Step 2)
+  ✓ T6: docker/entrypoint.sh invokes render-conf-template.js, installs brainstorm-task-queue.json from template, logs the rendering (AC; ADR 0014 §Implementation Step 2)
+  ✓ T7: docker/entrypoint.sh contains NO <<CONFEOF heredoc writing to /etc/brainstorm.conf (drift sentinel; ADR 0014 §Drift sentinel)
+  ✓ T8: docker/entrypoint.sh contains EXACTLY ONE invocation of render-conf-template.js (drift sentinel; ADR 0014 §Drift sentinel)
+  ✓ R1: docker/entrypoint.sh still installs the other conf templates (graperank/whitelist/blacklist/nip56)
+  ✗ R2: config/brainstorm.conf.template carries TASK_QUEUE_ENABLED=true (story #17 / ADR 0015 default; story #13 contract preserved with the flag still present)
+      R2: config/brainstorm.conf.template no longer carries TASK_QUEUE_ENABLED=true (story #17 / ADR 0015 regression). Story #17 flipped the default from `false` to `true` ... [full message in the test source].
+  ✓ R3: docker/entrypoint.sh still chmods /etc/brainstorm.conf to 664 after rendering (file-permissions preserved)
+
+Test Results
+-------------
+entrypoint-template-rendering suite:             FAIL (9 passed, 2 failed)
+Overall:                                         FAIL
+```
+
+The 13 sibling suites continue to PASS — no collateral damage from the test flip. Each of the 2 failures carries a right-reason message:
+
+- **T4** identifies the exact value mismatch (`"false" (expected "true")`) — the Implementer reads this and knows immediately to flip the template to `=true`.
+- **R2** carries the full bidirectional rollback story — the Implementer flips the template, R2 passes; if a future maintainer wants to roll back the default to `=false`, R2's own error message tells them to flip R2 too.
+
+Post-implementation expected: `entrypoint-template-rendering suite: PASS (11 passed, 0 failed)`. Total suite count green: 14/14.

--- a/test/entrypoint-template-rendering.test.js
+++ b/test/entrypoint-template-rendering.test.js
@@ -287,8 +287,10 @@ test('T4: rendering the template via render-conf-template.js with a fixture env 
     BRAINSTORM_SEND_EMAIL_UPDATES: '0',
     BRAINSTORM_ACCESS: '0',
     BRAINSTORM_CREATED_CONSTRAINTS_AND_INDEXES: '0',
-    // Story #13 addition — the ONE variable not in the old heredoc but required in the new template.
-    TASK_QUEUE_ENABLED: 'false'
+    // Story #13 addition that reached fresh containers via story #16. Default flipped from
+    // 'false' to 'true' in story #17 / ADR 0015 — the queue + BullBoard + cross-task
+    // neo4j-heavy serialization now come up automatically without an operator flip.
+    TASK_QUEUE_ENABLED: 'true'
   };
 
   const mismatches = [];
@@ -426,15 +428,19 @@ test('R1: docker/entrypoint.sh still installs the other conf templates (graperan
   );
 });
 
-test('R2: config/brainstorm.conf.template still carries TASK_QUEUE_ENABLED=false (story #13 contract preserved; AC "fresh containers contain export TASK_QUEUE_ENABLED=false")', () => {
+test('R2: config/brainstorm.conf.template carries TASK_QUEUE_ENABLED=true (story #17 / ADR 0015 default; story #13 contract preserved with the flag still present)', () => {
   const src = readSafe(CONF_TEMPLATE);
-  assert(src !== null, 'brainstorm.conf.template missing — cannot check story #13 contract.');
+  assert(src !== null, 'brainstorm.conf.template missing — cannot check story #17 contract.');
   assert(
-    /TASK_QUEUE_ENABLED\s*=\s*false/.test(src),
-    'R2: config/brainstorm.conf.template no longer carries TASK_QUEUE_ENABLED=false (story #13 / ADR ' +
-      '0012 regression; story #16 AC explicitly requires this line to reach fresh containers). The flag ' +
-      'must remain in the template at the deploy-safe default `false`; flipping it to `true` in template ' +
-      'defaults breaks the rollback path for fresh deploys (the entire point of having the flag).'
+    /TASK_QUEUE_ENABLED\s*=\s*true/.test(src),
+    'R2: config/brainstorm.conf.template no longer carries TASK_QUEUE_ENABLED=true (story #17 / ADR ' +
+      '0015 regression). Story #17 flipped the default from `false` to `true` because the queue path ' +
+      'matured in production over days and the manual-flip-after-every-deploy recipe was a chronic ' +
+      'operator chore. Reverting to `=false` re-opens that chore on every fresh container. The flag ' +
+      'itself stays — story #13\'s rollback branch is still wired up in runTask.js and control-panel.js ' +
+      '— only the default changes. If you intentionally want the template to default to `=false` again ' +
+      '(a real architectural change, not a test fix), also flip this sentinel back to its pre-story-#17 ' +
+      'form (assert =false) so it tracks the new intended default.'
   );
 });
 

--- a/test/task-queue-bullmq.test.js
+++ b/test/task-queue-bullmq.test.js
@@ -223,16 +223,23 @@ test('T9: docker/supervisord.conf does NOT gain a new entry for a separate task-
   );
 });
 
-test('T10: brainstorm.conf.template defines TASK_QUEUE_ENABLED=false as the default rollback-safe value (AC-15, ADR 0010 §Config)', () => {
+test('T10: brainstorm.conf.template defines the TASK_QUEUE_ENABLED knob (default value flipped from false to true in story #17 / ADR 0015; story #13 / ADR 0012 contract that the knob is *present* preserved)', () => {
   const src = readSafe(BRAINSTORM_CONF_T);
   assert(src !== null, 'config/brainstorm.conf.template not at expected path — re-baseline this sentinel.');
-  // ADR §Config pins exactly this line. The default `false` is the deploy-
-  // safe rollback — flipped on by the operator only after smoke confirms.
+  // ADR 0012 §Config originally pinned `=false` as the deploy-safe default. Story #17 /
+  // ADR 0015 flipped the default to `=true` after the queue path matured in production
+  // over days on staging + prod. The story-#13 contract that survives is "the knob is
+  // present in the template" — the flag itself remains a real toggle, only its default
+  // changed. The story-#17 specific assertion (default is `=true`) lives in R2 of
+  // test/entrypoint-template-rendering.test.js — keeping that as the single source of
+  // truth for the current default value.
   assert(
-    /export\s+TASK_QUEUE_ENABLED\s*=\s*false\b/.test(src),
-    'config/brainstorm.conf.template does not define `export TASK_QUEUE_ENABLED=false` (AC-15; ADR 0010 ' +
+    /export\s+TASK_QUEUE_ENABLED\s*=\s*(true|false)\b/.test(src),
+    'config/brainstorm.conf.template does not define `export TASK_QUEUE_ENABLED=<bool>` (AC-15; ADR 0012 ' +
       '§Config). The knob must be present in the template (deployment installs it at /etc/brainstorm.conf) ' +
-      'with the deploy-safe `false` default. Operator flips on after smoke confirms.'
+      'so the runtime flag-on/flag-off branches in runTask.js and control-panel.js still have a config ' +
+      'surface. The current deploy-safe default is `=true` (per story #17 / ADR 0015); R2 in ' +
+      'test/entrypoint-template-rendering.test.js pins the value-side assertion.'
   );
 });
 


### PR DESCRIPTION
## Promoting

Story #17 — Make task queue ENABLED-by-default in the brainstorm.conf template. Closes the operator pain of having to manually re-flip `TASK_QUEUE_ENABLED=true` on every deploy after story #16's source-of-truth contract.

Mechanically tiny: 3 source files (config/brainstorm.conf.template, OPERATIONS.md §10.1, test/task-queue-bullmq.test.js T10 sentinel relaxation), +22/-15 lines.

## Linked artifacts

- Story: `engineering-team/stories/17-task-queue-on-by-default.md`
- ADR: `engineering-team/decisions/0015-task-queue-on-by-default.md`
- Test plan: `engineering-team/stories/17-task-queue-on-by-default.test-plan.md`
- Review: `engineering-team/reviews/17-task-queue-on-by-default.md` — **PASS** end-to-end

## Staging smoke (just completed)

- `https://staging.brainstorm.world/` → HTTP 200, 0.27s
- `/api/status` → strfryDomain + neo4jBrowserUrl substituted correctly
- `/api/concept-graph/summaries` → success: true, 36 summaries
- `/admin/queues` → **HTTP 401 + `{"success":false,"error":"Not authenticated"}`** — direct fingerprint of BullBoard's auth gate active (proves TASK_QUEUE_ENABLED=true in rendered conf)
- `/api/run-task POST` → 400 (endpoint exists)
- `/api/auth/status` → 200
- **AC #5 satisfied:** no manual flip recipe was run on staging after the deploy — BullBoard came up automatically.

## Prod deploy expectation

**This deploy is a no-op from the operator's perspective.** Unlike story #16 (which regenerated /etc/brainstorm.conf from a template with `=false` and wiped the manually-flipped `=true`), story #17's template now has `=true`. The rendered conf will MATCH what the operator manually flipped to earlier today on brainstorm.world. No manual re-flip will be needed; BullBoard will continue to be visible at /admin/queues/.

## Prod test plan

- [ ] `deploy-brainstorm.yml` runs green on merge
- [ ] `brainstorm.world/` returns 200
- [ ] `/api/status` shows correct domain substitutions
- [ ] `/api/concept-graph/summaries` returns success: true
- [ ] `/admin/queues` returns HTTP 401 + JSON (BullBoard mounted)
- [ ] No "RenderError: missing env vars" in deploy logs
- [ ] **Operator does NOT need to re-run the manual flip recipe** — the story-#17 contract empirically confirmed in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)