### PR TITLE
Promote story #18 to prod: admins can use BullBoard

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -425,9 +425,11 @@ When the flag is on and Redis is unreachable, `/api/run-task` returns `503` with
 
 ### 10.2 BullBoard UI (operator queue inspector)
 
-When the flag is on, BullBoard is mounted at `https://<host>/admin/queues` behind owner-only auth (same gate as `/api/admin/*`). It shows per-task queues with active / waiting / completed / failed counts, and exposes retry / remove / **pause** controls.
+When the flag is on, BullBoard is mounted at `https://<host>/admin/queues` behind **owner-or-admin auth** (story #18 / ADR 0016, widened from owner-only in story #13). The owner and any pubkey listed in `BRAINSTORM_ADMIN_PUBKEYS` get full access — view queues, retry / remove / **pause** jobs. The board shows per-task queues with active / waiting / completed / failed counts.
 
-> **Be careful.** Retry / remove / pause directly affect running calculations. The board title says "Owner Only" as a reminder; the auth gate prevents accidental access by non-owner sessions.
+The admin-management endpoints (`/api/admin/list|add|remove`) deliberately use a stricter owner-only gate; admins cannot promote or remove other admins. Only the owner can change the admin list.
+
+> **Be careful.** Retry / remove / pause directly affect running calculations. The board title says "Owner + Admin" as a reminder; the auth gate prevents access by non-owner / non-admin sessions but does NOT prevent admins from making destructive choices.
 
 ### 10.3 Per-task concurrency config
 

--- a/engineering-team/decisions/0016-bullboard-admin-access.md
+++ b/engineering-team/decisions/0016-bullboard-admin-access.md
@@ -1,0 +1,231 @@
+# ADR 0016: Add `requireOwnerOrAdmin` middleware; widen BullBoard auth gate to admins
+
+**Status:** Accepted
+**Date:** 2026-05-21
+**Story:** `engineering-team/stories/18-bullboard-admin-access.md`
+
+## Context
+
+Story #18 widens the BullBoard auth gate from owner-only to "owner or admin" so trusted admins in `BRAINSTORM_ADMIN_PUBKEYS` can manage the BullMQ task queue with full parity to the owner (read AND mutate). Other owner-only endpoints (admin add/list/remove) must stay strictly owner-only to preserve the privilege-escalation guardrail.
+
+### Grounded facts after reading source
+
+- **Existing helper:** `getAdminPubkeys()` + `isAdminPubkey(pubkey)` at [`src/utils/config.js:94-117`](../../src/utils/config.js#L94) already encapsulate admin-list resolution. They read from `settings.json` first (runtime-editable via the admin-management page) and fall back to `BRAINSTORM_ADMIN_PUBKEYS` in `brainstorm.conf`. The same helpers are already consumed by other admin checks elsewhere in the app — this is the existing source-of-truth the story AC pinned.
+- **Existing middleware:** `requireOwnerOnly` at [`src/api/admin/index.js:86-95`](../../src/api/admin/index.js#L86). 401 if unauthenticated; 403 if session pubkey !== owner. Used at four call sites: `/api/admin/list`, `/api/admin/add`, `/api/admin/remove` (admin management — must stay owner-only per story #18), and the BullBoard mount in `api/index.js:469` (this is the one that moves).
+- **BullBoard mount:** [`src/manage/taskQueue/queue/bullBoardMount.js:22`](../../src/manage/taskQueue/queue/bullBoardMount.js#L22) declares `function mountBullBoard(app, { queues, requireOwnerOnly })` — the destructured parameter is named `requireOwnerOnly` but is otherwise a generic Express middleware. The mount calls `app.use('/admin/queues', requireOwnerOnly, serverAdapter.getRouter())` — the middleware reference is opaque to BullBoard. Swapping the actual middleware is purely a wiring change.
+- **Existing tests touching the mount middleware** — story #13's R4 sentinel ([`test/task-queue-bullmq.test.js`](../../test/task-queue-bullmq.test.js)) and story #15's R4 sentinel ([`test/task-queue-neo4j-resource-class.test.js`](../../test/task-queue-neo4j-resource-class.test.js)) both regex-match `requireOwnerOnly|requireOwner` in `bullBoardMount.js`. Both need to evolve to track the new middleware name (or relax to a generic auth-middleware-existence check).
+
+### Concept-graph impact
+
+None. No new concepts, no schema, no firmware reinstall.
+
+## Options considered
+
+### Option A — Add a sibling `requireOwnerOrAdmin` middleware (chosen)
+
+In `src/api/admin/index.js`, add a new function alongside the existing `requireOwnerOnly`:
+
+```js
+function requireOwnerOrAdmin(req, res, next) {
+  if (!req.session?.pubkey) {
+    return res.status(401).json({ success: false, error: 'Not authenticated' });
+  }
+  const sessionPubkey = req.session.pubkey;
+  const ownerPubkey = getConfigFromFile('BRAINSTORM_OWNER_PUBKEY');
+  if (sessionPubkey === ownerPubkey) {
+    return next();
+  }
+  if (isAdminPubkey(sessionPubkey)) {
+    return next();
+  }
+  return res.status(403).json({ success: false, error: 'Owner or admin access required' });
+}
+```
+
+Export from `module.exports`. Pass to the BullBoard mount in place of `requireOwnerOnly`. Rename the parameter in `bullBoardMount.js` from `requireOwnerOnly` to `authMiddleware` for accuracy. Update the boot-log line from `"Mounted at /admin/queues (owner-only)"` to `"Mounted at /admin/queues (owner+admin)"`.
+
+**Pros**
+- Smallest possible change. New middleware is ~10 lines; mount wiring change is 1 line; param rename in `bullBoardMount.js` is cosmetic but accurate.
+- **Privilege-escalation guardrail preserved by construction.** Admin-management endpoints in `api/index.js:456-458` still pass `adminApi.requireOwnerOnly` — they continue to require the owner exactly as today. The story #18 contract ("only BullBoard's mount moves to the broader gate") is enforced by *which middleware reference appears at the call site*, not by a runtime check.
+- Existing `requireOwnerOnly` callers untouched. Zero risk of accidental scope creep.
+- Pattern naturally extends to future multi-level admin tiering — add more sibling middlewares (e.g., `requireReadOnlyAdmin`) without restructuring.
+- Consumes existing helpers (`isAdminPubkey`, `getConfigFromFile`) — no new config-source plumbing.
+
+**Cons**
+- Two middlewares with similar-looking names in the same module. Mitigated by clear naming + JSDoc.
+- The `bullBoardMount.js` parameter rename ripples to one caller in `api/index.js`. Trivial; called out for completeness.
+
+### Option B — Parameterize the existing `requireOwnerOnly` into a factory
+
+Convert `requireOwnerOnly` from a plain function into a factory: `requireOwnerOnly({ allowAdmins: true })` returns a middleware. Existing callers change from `requireOwnerOnly` to `requireOwnerOnly()`; BullBoard mount calls it with `{ allowAdmins: true }`.
+
+**Pros**
+- One middleware function exists; consolidated logic.
+
+**Cons**
+- **Renames the meaning of `requireOwnerOnly` retroactively.** A function called "OwnerOnly" that sometimes admits admins is semantically misleading. New readers have to learn the option flag to know what each call site actually does.
+- **Ripples to all four existing call sites.** They have to change from `requireOwnerOnly` to `requireOwnerOnly()` (or stay as-is and rely on JS treating a function reference as the middleware — but that's the current pattern and would conflict with the factory shape). Either way, the change surface is larger.
+- Factory pattern is non-idiomatic in this codebase — no other auth middleware uses it.
+- Doesn't naturally extend to multi-level tiering (would require more option flags, more matrix-y semantics).
+
+Rejected.
+
+### Option C — Compose middlewares at the call site
+
+`app.use('/admin/queues', requireOwnerOnly, fallbackToAdmin, router)`. The first middleware rejects on non-owner via 403; an `app.use` error handler catches and tries the admin middleware.
+
+**Cons:** Express middleware chaining doesn't naturally support "if rejected, try this next" without restructuring `requireOwnerOnly` to call `next()` differently. Larger change, more subtle failure modes.
+
+Rejected.
+
+## Decision
+
+**Chosen: Option A.** New `requireOwnerOrAdmin` middleware in `src/api/admin/index.js`, used only at the BullBoard mount. Existing `requireOwnerOnly` callers (admin-management endpoints) untouched.
+
+What we trade away: a small amount of "single middleware to rule them all" minimalism. Accepted because (a) the two middlewares have clearly different responsibilities, (b) the existing-callers-untouched property is itself the privilege-escalation guardrail, and (c) the codebase already has a precedent for narrow-purpose middleware names (`requireOwnerOnly` itself).
+
+## Consequences
+
+**Enabled**
+- Admins can use BullBoard's full feature set immediately. Workflow bottleneck closed.
+- The "owner OR admin" middleware is now available for future endpoints that want that gate (none today, but the door is open).
+- Privilege-escalation guardrail enforced by construction: any future change that wires a new endpoint to `requireOwnerOnly` keeps it owner-only; a change that wires it to `requireOwnerOrAdmin` is loud + grep-able in the diff.
+
+**Constrained / made harder**
+- A future "remove admins from BullBoard" rollback is a real but mechanical change — swap the BullBoard mount's middleware reference back to `requireOwnerOnly`. The `requireOwnerOrAdmin` function can stay defined; it's just unused.
+- Auditing who-did-what for queue mutations is still per BullBoard's own logging + our `events.jsonl` (no per-pubkey attribution at the auth layer). Story #18 §Out of scope explicitly defers this.
+
+**Follow-up debt (out of scope here)**
+- **Multi-level admin tiering** (read-only-admin vs full-admin, deferred per story #18).
+- **Per-admin audit log** for queue mutations.
+- **UI signaling** that admins can now access BullBoard. Today it just works; no UI hint that admins have access. If operators want a visible "you have admin access" indicator, that's a future UX story.
+
+**Firmware reinstall required?** No.
+
+## Implementation notes
+
+The Implementer reads this section verbatim.
+
+### 1. `src/api/admin/index.js`
+
+**Add import** — adjust the existing import to also pull in `isAdminPubkey`:
+```js
+const { getConfigFromFile, getAdminPubkeys, isAdminPubkey } = require('../../utils/config');
+```
+
+**Add the new middleware** (place adjacent to `requireOwnerOnly` for discoverability):
+
+```js
+/**
+ * Middleware: require owner OR admin.
+ * Used by endpoints that admins are trusted to operate (e.g., BullBoard at
+ * /admin/queues). Admin-management endpoints (/api/admin/add etc.) still use
+ * requireOwnerOnly — see ADR 0016 §Privilege-escalation guardrail.
+ */
+function requireOwnerOrAdmin(req, res, next) {
+  if (!req.session?.pubkey) {
+    return res.status(401).json({ success: false, error: 'Not authenticated' });
+  }
+  const sessionPubkey = req.session.pubkey;
+  const ownerPubkey = getConfigFromFile('BRAINSTORM_OWNER_PUBKEY');
+  if (ownerPubkey && sessionPubkey === ownerPubkey) {
+    return next();
+  }
+  if (isAdminPubkey(sessionPubkey)) {
+    return next();
+  }
+  return res.status(403).json({ success: false, error: 'Owner or admin access required' });
+}
+```
+
+**Update `module.exports`** to include `requireOwnerOrAdmin`:
+```js
+module.exports = {
+  handleListAdmins,
+  handleAddAdmin,
+  handleRemoveAdmin,
+  requireOwnerOnly,
+  requireOwnerOrAdmin
+};
+```
+
+### 2. `src/api/index.js:467-470`
+
+Change the BullBoard mount wiring. Currently:
+```js
+mountBullBoard(app, {
+    queues: taskQueue.getAllQueues(),
+    requireOwnerOnly: adminApi.requireOwnerOnly
+});
+```
+
+Becomes:
+```js
+mountBullBoard(app, {
+    queues: taskQueue.getAllQueues(),
+    authMiddleware: adminApi.requireOwnerOrAdmin
+});
+```
+
+Also update the section-divider comment from `"BullBoard ... owner-only at /admin/queues"` to `"BullBoard ... owner+admin at /admin/queues"`.
+
+**Leave lines 456-458 (`/api/admin/list|add|remove`) UNCHANGED.** Those still use `adminApi.requireOwnerOnly` — privilege-escalation guardrail preserved.
+
+### 3. `src/manage/taskQueue/queue/bullBoardMount.js`
+
+Rename the destructured parameter for accuracy:
+
+```js
+function mountBullBoard(app, { queues, authMiddleware }) {
+  if (!Array.isArray(queues) || queues.length === 0) {
+    console.warn('[bull-board] mountBullBoard called with no queues — skipping mount.');
+    return;
+  }
+  if (typeof authMiddleware !== 'function') {
+    throw new Error('mountBullBoard requires authMiddleware function');
+  }
+
+  // ... [unchanged lazy-require block] ...
+
+  app.use('/admin/queues', authMiddleware, serverAdapter.getRouter());
+  console.log('[bull-board] Mounted at /admin/queues (owner+admin)');
+}
+```
+
+Update the file's header docblock to reference ADR 0016 alongside ADR 0010, and update the boardTitle in the BullBoard config from `'Tapestry Task Queue — Owner Only'` to `'Tapestry Task Queue — Owner + Admin'` (visible in the UI).
+
+### 4. `OPERATIONS.md` §10.2
+
+Update the "BullBoard UI" section's auth description. Current text (around line 425-428) says the mount is owner-only. New text: explain that as of story #18 / ADR 0016, the gate is "owner or any pubkey in `BRAINSTORM_ADMIN_PUBKEYS`." Implementer picks minimal wording.
+
+### 5. Tests (Tester drives in Phase 3)
+
+The Tester will:
+
+- **Update R4 in `test/task-queue-bullmq.test.js`** (story #13's BullBoard-mount sentinel, around line 315) to assert the new middleware reference (e.g., regex now matches `authMiddleware|requireOwnerOrAdmin` instead of `requireOwnerOnly|requireOwner`).
+- **Update R4 in `test/task-queue-neo4j-resource-class.test.js`** (story #15's same sentinel, around line 315) likewise.
+- **Add a new positive-case sentinel** that asserts `src/api/admin/index.js` contains the literal `requireOwnerOrAdmin` function declaration AND that the function body references `isAdminPubkey` (proves the admin list is actually consulted).
+- **Add a new privilege-escalation guardrail sentinel** that asserts `src/api/index.js` STILL wires `/api/admin/list`, `/api/admin/add`, `/api/admin/remove` to `adminApi.requireOwnerOnly` (and NOT to `requireOwnerOrAdmin`). This is the test that catches the scariest possible regression.
+
+The Tester decides whether these new sentinels live in one of the existing suites (story #13's BullBoard suite is a natural home) or in a new suite for story #18.
+
+### Smoke
+
+Cycle-local (Reviewer):
+- Verify the new boot-log line `[bull-board] Mounted at /admin/queues (owner+admin)` appears after `supervisorctl restart brainstorm`.
+- (If feasible without too much ceremony) authenticate as an admin pubkey in a browser and confirm `/admin/queues/` returns the BullBoard UI. If that requires standing up a second test pubkey, defer to cycle-staging where the operator has real admin accounts.
+- Verify `/api/admin/list` still returns 403 for a non-owner authenticated request — privilege-escalation guardrail intact.
+
+Cycle-staging (Operator):
+- The acid test: sign in as an admin (not the owner) via the browser; navigate to `https://staging.brainstorm.world/admin/queues/`; confirm the BullBoard UI loads with full functionality (can see jobs, can retry, can pause).
+
+### Concept handle
+
+None.
+
+## Out of scope
+
+- **Multi-level admin tiering** (read-only-admin vs full-admin). Future story.
+- **Per-admin audit log** for queue mutations.
+- **UI hint** that admins now have BullBoard access — no signal in the SPA today, none added in this story.
+- **Removing the admin from `BRAINSTORM_ADMIN_PUBKEYS` while a tab is open.** Sessions don't auto-expire on role change. If the operator removes an admin via `/api/admin/remove`, that admin's session-cookie still validates for whatever session-secret lifetime applies, but their next `/admin/queues` request will hit the middleware fresh and get bounced. Acceptable. (If we ever want strict "remove → immediate cutoff," that's a session-invalidation story.)

--- a/engineering-team/reviews/18-bullboard-admin-access.md
+++ b/engineering-team/reviews/18-bullboard-admin-access.md
@@ -1,0 +1,152 @@
+# Review: Story 18 — Admins can use BullBoard (parity with owner for queue management)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-21
+**Diff:** `git diff origin/main..HEAD` (commit `4c715ab4`, 4 commits: `4d27bc9f` story, `85e7816d` ADR, `d10e7f34` tests, `4c715ab4` impl)
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` (host) — **PASS**. `bullboard-admin-access suite: PASS (9 passed, 0 failed)`. All 14 prior suites still PASS, including `task-queue-bullmq` (18) and `task-queue-neo4j-resource-class` (14) whose evolved R4/T7 sentinels now match the new `authMiddleware` parameter name. Overall: **PASS**.
+- [x] `npm test` (live tapestry container, bind-mounted source) — **PASS**. Same 15/15 green as host.
+- [x] `node --check` parse — `src/api/admin/index.js`, `src/api/index.js`, `src/manage/taskQueue/queue/bullBoardMount.js` all parse cleanly.
+- [x] _Playwright not applicable — no UI surface changed (BullBoard UI is third-party React)._
+- [x] _Lint / typecheck / build not configured — skipped per house rules._
+- [x] **Cycle-local smoke** — **PASS end-to-end** (see §Cycle-local smoke verification below). Direct boot-log evidence the new gate is active; unauth-request fingerprints match expectation on both BullBoard and `/api/admin/list`.
+
+## Spec adherence (AC walk)
+
+| AC (story §) | Status | Notes |
+|---|---|---|
+| Admin → BullBoard UI HTTP 200 | smoke-deferred (cycle-staging) | Source side: T1-T4 prove the new middleware exists, consults the admin list, is exported, and is wired to the mount. Behavioral side requires a real admin session cookie; the cycle-local smoke shows the unauth 401 fingerprint, but the admin-authenticated 200 path is best validated by the operator at cycle-staging. |
+| Admin → queue-mutating actions succeed | smoke-deferred (cycle-staging) | Same reasoning. The auth gate runs once at mount time; once past, all of BullBoard's routes inherit the gate. T4 + cycle-local boot log are structural proof; operator validates behaviorally. |
+| Owner → unchanged access | ✓ | Source side: the requireOwnerOrAdmin middleware checks owner FIRST (line 123 of admin/index.js), returns next() on match. R1 confirms the existing requireOwnerOnly is intact for the four other call sites. Cycle-local would show the same 401 fingerprint on `/admin/queues` for an authenticated non-owner non-admin (deferred to cycle-staging). |
+| Non-owner non-admin → 403 with "Owner or admin access required" | ✓ source | T1's spec includes the 403 branch with literal message. Cycle-local smoke can't fabricate a session cookie for the 403 path; operator can validate at cycle-staging by signing in as a non-owner non-admin pubkey (e.g., an arbitrary visitor). |
+| Unauthenticated → 401 | ✓ proved | Cycle-local S2 — `curl /admin/queues` → `HTTP 401 + {"success":false,"error":"Not authenticated"}`. Direct fingerprint of the first branch of the new middleware. |
+| **Admin-management endpoints stay owner-only** (privilege-escalation guardrail) | ✓ proved structurally + behaviorally | **T7** (the most safety-critical sentinel in this suite) asserts `src/api/index.js` lines 456-458 are still wired with `adminApi.requireOwnerOnly`. Confirmed by my own repo-wide grep — every runtime call of `requireOwnerOnly` is at the three admin-management endpoints; no runtime use of `requireOwnerOrAdmin` anywhere except the BullBoard mount. Cycle-local S3 also confirms `/api/admin/list → HTTP 401` (same gate-active fingerprint). |
+| `BRAINSTORM_ADMIN_PUBKEYS` from existing source | ✓ | T2 proves `isAdminPubkey` is referenced; the imported helper is the same one the rest of the app uses ([`src/utils/config.js:114-117`](src/utils/config.js#L114)). No new config-source plumbing. |
+| Empty `BRAINSTORM_ADMIN_PUBKEYS` → owner-only fallback | ✓ implicit | `isAdminPubkey('anypubkey')` returns `false` when the admin list is empty (per [`src/utils/config.js:114-117`](src/utils/config.js#L114) — `getAdminPubkeys()` returns `[]`; `.includes()` returns false). Middleware falls through to 403. Existing helper contract carries the property. |
+| No regression in any 14 prior suites | ✓ | `task-queue-bullmq` 18/18 + `task-queue-neo4j-resource-class` 14/14 (the two suites whose R4/T7 evolved with broadened regexes). All 12 other suites 100% unchanged. |
+| Test sentinel scope explicit (R4 in #13 + #15 updated; new positive-case sentinel; new privilege-escalation guardrail sentinel) | ✓ | Story #13 T7 + story #15 R4 broadened in-place; T2 (positive case: `isAdminPubkey` consulted) + T7 (privilege-escalation guardrail) added in new `bullboard-admin-access` suite. Tester executed exactly as the story specified. |
+
+## ADR adherence
+
+- [x] **Files changed match ADR 0016 §Implementation notes exactly:**
+  - `src/api/admin/index.js` — added `requireOwnerOrAdmin` adjacent to `requireOwnerOnly`; imported `isAdminPubkey`; exported. ✓
+  - `src/api/index.js:467-470` — BullBoard mount wired with `authMiddleware: adminApi.requireOwnerOrAdmin`. Lines 456-458 (`/api/admin/list|add|remove`) UNCHANGED. ✓
+  - `src/manage/taskQueue/queue/bullBoardMount.js` — parameter renamed to `authMiddleware`; error message updated; boardTitle → "Owner + Admin"; boot-log → "(owner+admin)". ✓
+  - `OPERATIONS.md` §10.2 — describes new gate; references `BRAINSTORM_ADMIN_PUBKEYS`; explicitly notes admin-management endpoints stay owner-only. ✓
+- [x] **No new files. No new dependencies. No Dockerfile change.** The change is purely server-side JS + a doc paragraph.
+- [x] **Option A architecture preserved.** Two sibling middlewares (`requireOwnerOnly`, `requireOwnerOrAdmin`) coexist with distinct responsibilities. Factory pattern (Option B) not used. Composition (Option C) not used.
+- [x] **JSDoc on both middlewares** explains why each exists and points the next reader at the privilege-escalation guardrail. This is a nice bonus from the Implementer — beyond what the ADR strictly required.
+- [x] **Defensive null check on `ownerPubkey`** (`if (ownerPubkey && sessionPubkey === ownerPubkey)`) — the Implementer added an `ownerPubkey &&` guard against the "no owner configured" edge case. Not strictly in the ADR but a sensible touch.
+
+## Concept-graph integrity
+
+- [x] No concept-graph schema changes (ADR §Consequences confirmed "no firmware reinstall"). No `src/concept-graph/` edits in the diff.
+- [x] No concept handles touched.
+
+## Things tests can't catch — hidden-hazard audit
+
+This story has real security implications. Repo-wide grep audit beyond the test surface:
+
+| Hazard | Status |
+|---|---|
+| `requireOwnerOrAdmin` accidentally wired to an endpoint other than BullBoard | **Closed.** Repo-wide `grep "requireOwnerOrAdmin" src/ --include="*.js" \| grep -v test` finds exactly: (a) function declaration in admin/index.js, (b) module.exports in admin/index.js, (c) BullBoard mount in api/index.js, (d) docblock in bullBoardMount.js. **No runtime call site outside the BullBoard mount.** Scope exactly narrow. |
+| `requireOwnerOnly` accidentally removed from /api/admin/* endpoints | **Closed.** Repo-wide `grep "requireOwnerOnly" src/api/index.js` shows lines 456, 457, 458 still wire `/api/admin/list|add|remove` to `adminApi.requireOwnerOnly`. T7 sentinel asserts this; my own grep confirms it. |
+| `isAdminPubkey('')` returns true (empty-string admin pubkey edge case) | **Closed.** [`src/utils/config.js:114-117`](src/utils/config.js#L114): `isAdminPubkey(pubkey)` has `if (!pubkey) return false` as its first line. Empty string short-circuits. |
+| Owner pubkey also listed in BRAINSTORM_ADMIN_PUBKEYS (config redundancy) | **Acceptable.** Middleware checks owner first (line 123), short-circuits with next(). Admin check never runs. No bug; no double-grant. |
+| Session-cookie reuse after admin removed from BRAINSTORM_ADMIN_PUBKEYS | **Acceptable, documented.** ADR §Out of scope flagged this — next middleware hit re-checks isAdminPubkey fresh; admin's cookie alone doesn't grant access after removal. Operator action: remove + tell the admin to close their tab. No silent-grant-after-removal risk. |
+| New middleware throws on `req.session` missing | **Closed.** Uses `req.session?.pubkey` (optional chaining) — undefined session → falsy → 401 branch. Same shape as existing `requireOwnerOnly`. |
+| Race between admin-list edit + active session validation | **Acceptable.** `getAdminPubkeys()` is sync; reads from `settings.json` first, falls back to `/etc/brainstorm.conf`. Cache-bypass on every request (no in-process cache). Worst case: an admin who was JUST removed makes a final request before the file write completes; their request validates against the old list. Operator-acceptable. |
+| BullBoard mount's `app.use('/admin/queues', authMiddleware, router)` middleware chain order | **Confirmed correct.** Auth runs first, BullBoard's router runs second. Express applies middleware left-to-right. Behavioral check: `curl /admin/queues → HTTP 401` confirms auth fires before any BullBoard internals. |
+| Future endpoint accidentally uses `requireOwnerOrAdmin` thinking it's "the new admin gate" | **Caught by T7.** If anyone broadens `/api/admin/list|add|remove` to the new middleware, T7 trips loudly with a long error message walking them through the security implication. |
+| `/admin/queues` path collision with the React SPA | **Closed.** The mount is added BEFORE the SPA fallback (mount registration happens in setup; SPA static-serve registration happens later). Express's middleware order ensures BullBoard's router wins for `/admin/queues/*`. Pre-existing property from story #13. |
+| `authMiddleware` parameter name collision with anything else | **Cleared by grep.** No other file uses this name as a destructured parameter; the rename is local to `bullBoardMount.js`. |
+
+The audit is thorough — I went beyond the source sentinels to confirm the privilege-escalation guardrail at the repo-wide grep level.
+
+## Cycle-local smoke verification
+
+Drove the behavioral validation source sentinels can't reach. The local `tapestry` Docker container has a bind-mount of the repo at `/usr/local/lib/node_modules/brainstorm/`, so Implementation-phase JS edits are live in-container after `supervisorctl restart brainstorm`.
+
+### Setup
+
+The local container's `/etc/brainstorm.conf` predates story #17 and still had `TASK_QUEUE_ENABLED=false`. To exercise the BullBoard mount, I flipped it (same recipe the operator used on staging/prod during stories #15 + #16): `sed + echo + supervisorctl restart brainstorm`. **This is local-dev hygiene only** — staging and prod already have `=true` from prior work.
+
+### S1 — boot log shows `(owner+admin)`
+
+```
+Reading config for TASK_QUEUE_ENABLED from /etc/brainstorm.conf
+Found TASK_QUEUE_ENABLED=true (unquoted)
+[task-queue] Initialized 51 queues + workers (defaultConcurrency=1, resourceClasses=neo4j-heavy)
+Task queue initialized (TASK_QUEUE_ENABLED=true)
+[bull-board] Mounted at /admin/queues (owner+admin)
+```
+
+**Direct evidence the new code is loaded.** The mount-time log line transitions from "(owner-only)" → "(owner+admin)" as ADR 0016 §Implementation §3 specified. The other lines (resourceClasses=neo4j-heavy, etc.) confirm story #13 + #15 contracts are still operating on top.
+
+### S2 — `/admin/queues` returns 401 with `{"success":false,"error":"Not authenticated"}`
+
+```
+$ curl -sS -o /tmp/aq -w "HTTP %{http_code}\n" http://localhost:80/admin/queues
+HTTP 401
+{"success":false,"error":"Not authenticated"}
+```
+
+**Direct fingerprint of the new middleware's first branch firing.** An unauthenticated curl request can't distinguish between `requireOwnerOnly` and `requireOwnerOrAdmin` at this branch (both return the same 401 + JSON), but: (a) the mount is active, (b) the auth chain runs before the BullBoard router, (c) the new code didn't break the 401-on-unauth contract.
+
+### S3 — `/api/admin/list` returns 401 (privilege-escalation guardrail behavioral check)
+
+```
+$ curl -sS -o /tmp/al -w "HTTP %{http_code}\n" http://localhost:80/api/admin/list
+HTTP 401
+{"success":false,"error":"Not authenticated"}
+```
+
+**The privilege-escalation guardrail is intact at the behavioral level too.** Admin-management endpoints still bounce unauthenticated requests with the same 401 JSON. The 403-on-authenticated-admin path can't be tested without a session cookie; that's deferred to operator cycle-staging.
+
+### Smoke scenarios deferred to operator at cycle-staging (acceptable gaps)
+
+- **Admin-authenticated → BullBoard 200 + full UI.** Requires real session cookie. Operator validates by signing in as a non-owner admin pubkey at `https://staging.brainstorm.world/admin/queues/` and confirming the UI loads with the "Owner + Admin" title.
+- **Admin-authenticated → mutate (retry / pause) on a queue.** Same — requires admin session. Operator confirms during staging smoke if they want belt-and-suspenders.
+- **Non-owner non-admin authenticated → 403 with "Owner or admin access required".** Requires a session cookie for an arbitrary visitor pubkey. Operator can validate by signing in with a fresh test pubkey not on the admin list.
+
+## House rules check
+
+- [x] Concept Graph API authority respected (no concept change).
+- [x] No new lint/typecheck/build tooling.
+- [x] No firmware reinstall needed.
+- [x] Per-phase commits in order: story → ADR → tests → impl. Clean stack on top of `origin/main` (which already has story #17).
+
+## Findings
+
+### Blocking
+
+_None._
+
+### Non-blocking (recorded, do not gate)
+
+1. **Defensive `ownerPubkey &&` guard added by the Implementer at admin/index.js:123.** Not in the ADR spec but a sensible touch — if `BRAINSTORM_OWNER_PUBKEY` somehow becomes empty/null at runtime (early bootstrap; corrupted conf), the owner-check skips rather than treating empty string as a match. Same defensive style as the existing `requireOwnerOnly` (which has the equivalent check at line 97). Approved.
+
+2. **JSDoc on both middlewares warns the next reader about the privilege-escalation guardrail.** The JSDoc on `requireOwnerOnly` explicitly says "Allowing admins to manage the admin list itself would be a privilege-escalation surface (an admin could promote or remove other admins). See story #18 / ADR 0016 §Decision." This is more than the ADR asked for. Long-form documentation in code rarely survives long, but for a security-critical guardrail like this, the explicit "here's why this stays owner-only" comment is the right call. Approved.
+
+3. **OPERATIONS.md §10.2 wording adds a sentence about admins not being prevented from destructive choices** ("the auth gate prevents access by non-owner / non-admin sessions but does NOT prevent admins from making destructive choices"). This is honest documentation of the trust model — admins are trusted; if they retry the wrong job or pause something they shouldn't, that's an operator-level mistake, not a system bug. Approved.
+
+4. **Local dev container's `/etc/brainstorm.conf` was still =false pre-restart** (predates story #17). I flipped it for the cycle-local smoke. This is a local-dev quirk, not a production concern — staging and prod already have =true from prior cycles. Worth noting for any future Reviewer doing cycle-local on a freshly-built local image: if the queue isn't running, BullBoard isn't mounted, and you'll see "[bull-board] Mounted at /admin/queues (owner-only)" from the PRIOR restart in the log tail. Not a regression.
+
+5. **Behavioral verification of admin-authenticated access deferred.** AC #1 + AC #2 (admin sees BullBoard, admin can mutate) are best validated by the operator at cycle-staging with a real admin pubkey. Source sentinels + cycle-local structural fingerprints get us 90% of the way there; the last 10% is the deploy chain doing its natural job.
+
+## Verdict
+
+**PASS end-to-end.**
+
+Source-side (15/15 suites green on both host and container) and behavioral-side (cycle-local boot log shows the new `(owner+admin)` mount; both `/admin/queues` and `/api/admin/list` 401 cleanly on unauthenticated requests) both confirm the implementation matches ADR 0016. The privilege-escalation guardrail is intact at structural, sentinel, and behavioral levels — every runtime use of `requireOwnerOnly` is at an admin-management endpoint; every runtime use of `requireOwnerOrAdmin` is at the BullBoard mount; no leak.
+
+The 5 non-blocking observations are documentation polish or operator-experience nuances; none gate ship.
+
+Story #18 is ready for the deploy chain (`cycle-staging`, then on explicit confirmation `cycle-prod`). The behavioral round-trip (admin pubkey in browser → /admin/queues/ → BullBoard UI loads with "Owner + Admin" title) is the natural staging-smoke acid test for AC #1 + AC #2.
+
+Operator path forward:
+- Staging deploy → fresh container picks up the new code via container restart → admin can use BullBoard immediately, no manual ceremony.
+- Prod deploy (after explicit approval) → same on `brainstorm.world`.
+- No conf-file changes needed on staging or prod; the `BRAINSTORM_ADMIN_PUBKEYS` value is already in place from prior deployments.

--- a/engineering-team/stories/18-bullboard-admin-access.md
+++ b/engineering-team/stories/18-bullboard-admin-access.md
@@ -82,5 +82,5 @@ Deferred to Architect:
 ## Linked artifacts
 
 - ADR: [0016-bullboard-admin-access.md](../decisions/0016-bullboard-admin-access.md)
-- Test plan: (filled in after Test Design phase)
+- Test plan: [18-bullboard-admin-access.test-plan.md](18-bullboard-admin-access.test-plan.md)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/18-bullboard-admin-access.md
+++ b/engineering-team/stories/18-bullboard-admin-access.md
@@ -1,0 +1,86 @@
+# Story 18: Admins can use BullBoard (parity with owner for queue management)
+
+**Status:** Approved
+**Created:** 2026-05-21
+**Type:** Feature (auth-gate broadening with operator + security implications)
+
+## Background
+
+Story #13 introduced BullBoard at `/admin/queues` (owner-only), gated behind a strict `requireOwnerOnly` middleware that compares `req.session.pubkey === BRAINSTORM_OWNER_PUBKEY`. At the time the choice was deliberate — BullBoard's controls include retry, remove, and pause for in-flight jobs (real side-effects on running calculations), and story #13's review §10.6 captured the decision to err on the side of a narrower gate during the queue's phase-1 rollout.
+
+Stories #15 + #16 + #17 then matured the queue to the point where it's now the default-on path for fresh containers (story #17 / ADR 0015). With the queue as a routine part of operations, the owner-only gate on BullBoard has become a workflow bottleneck: every queue inspection or mutation has to flow through one pubkey, even when trusted admins are otherwise available to help triage.
+
+The deployment already maintains a list of trusted admin pubkeys in `BRAINSTORM_ADMIN_PUBKEYS` (set via the entrypoint, exported into `/etc/brainstorm.conf` per story #16's template-rendering contract). These admins already have other operator-level permissions throughout the app. Extending their reach to include BullBoard's queue management is the natural next step.
+
+This story does **not** rework the admin permissioning model. It changes exactly one gate — the BullBoard mount — from `requireOwnerOnly` to a new "owner or admin" posture. Other owner-only endpoints (admin add/list/remove in `/api/admin/*`) stay strictly owner-only, because those endpoints are about *managing the admin list itself* and granting admins the ability to add or remove other admins would be a privilege-escalation surface.
+
+## User-facing description
+
+**As an owner** of a Tapestry node who has trusted admins listed in `BRAINSTORM_ADMIN_PUBKEYS`, **I want** those admins to be able to use the BullBoard UI at `/admin/queues/` with the same access I have — full read AND mutate (retry / remove / pause jobs), **so that** routine queue operations can be shared across the trusted operator group instead of bottlenecking through my single pubkey.
+
+## Acceptance criteria
+
+### Behavior
+
+- [ ] Given a pubkey listed in `BRAINSTORM_ADMIN_PUBKEYS` is signed in, when they navigate to `https://<host>/admin/queues/`, then the BullBoard UI loads (HTTP 200 with the BullBoard interface, NOT a 403).
+- [ ] Given an admin is signed in and viewing BullBoard, when they perform a queue-mutating action (retry / remove / pause a job), then the operation succeeds with the same observable outcome as if the owner had performed it.
+- [ ] Given the owner pubkey (the value of `BRAINSTORM_OWNER_PUBKEY`) is signed in, when they navigate to or operate on `/admin/queues/`, then nothing changes from today — full access remains.
+- [ ] Given an authenticated pubkey that is **neither** the owner nor in `BRAINSTORM_ADMIN_PUBKEYS`, when they request `/admin/queues`, then they get HTTP 403 with an error message indicating owner-or-admin access is required (Architect picks exact wording).
+- [ ] Given an **unauthenticated** request to `/admin/queues`, when it is received, then it returns HTTP 401 — unchanged from today.
+
+### Privilege-escalation guardrail (the "admins can NOT bootstrap themselves" property)
+
+- [ ] **Admin-management endpoints remain owner-only.** `POST /api/admin/add`, `POST /api/admin/remove`, `GET /api/admin/list` continue to return 403 for admins. Only the owner can manage the admin list. Without this guarantee, an admin could promote arbitrary pubkeys to admin, defeating the whole authority hierarchy.
+
+### Config plumbing
+
+- [ ] **`BRAINSTORM_ADMIN_PUBKEYS` is read from the same source** the existing app-wide admin checks already use (i.e., from `/etc/brainstorm.conf` via the existing config-loading pattern). No new env var, no new config file, no new source of truth.
+- [ ] **The `BRAINSTORM_ADMIN_PUBKEYS` format follows the existing convention** (comma-separated hex pubkeys). Empty value behaves the same as today's empty-admin-list state — no admins, owner-only access (which preserves the pre-story-#18 behavior for nodes that don't configure admins).
+
+### Test sentinel scope (explicit)
+
+- [ ] **Existing regression sentinels updated, not deleted.** The BullBoard-mount sentinels in story #13's `task-queue-bullmq` suite (R4 region, ~line 315) and story #15's `task-queue-neo4j-resource-class` suite (R4, ~line 315) currently assert the mount uses `requireOwnerOnly`. Both are updated to assert the new middleware shape post-story-#18, while preserving the *underlying contract* (BullBoard is mounted at `/admin/queues` behind SOME auth middleware that protects mutate ops). The exact middleware name is the Architect's call; the sentinels must track whatever name lands.
+
+- [ ] **New positive-case sentinel:** the new middleware's source carries the literal `BRAINSTORM_ADMIN_PUBKEYS` reference (or the existing `getAdminPubkeys`-style helper), proving the admin list is actually consulted. Catches a future regression where someone "fixes" the middleware by hardcoding it to owner-only or admin-only.
+
+- [ ] **New privilege-escalation guardrail sentinel:** `/api/admin/list`, `/api/admin/add`, `/api/admin/remove` are still wired to `requireOwnerOnly` in `src/api/index.js` (and NOT to the new "owner-or-admin" middleware). This is the sentinel that catches a future change where someone too aggressively swaps `requireOwnerOnly` for the new broader middleware across the codebase. The story #18 contract is **narrow** — only BullBoard's mount moves to the broader gate.
+
+- [ ] **No regression in any of the existing 14 npm test suites.** Specifically: story #13's task-queue-bullmq suite (18 sentinels) and story #15's task-queue-neo4j-resource-class suite (14 sentinels) continue to pass — the underlying contract holds even as the middleware name evolves. All 12 other suites untouched.
+
+## Concepts touched
+
+- The `requireOwnerOnly` middleware in the admin auth module
+- The BullBoard mount in the task-queue module (`/admin/queues`)
+- `BRAINSTORM_OWNER_PUBKEY` and `BRAINSTORM_ADMIN_PUBKEYS` — the two pubkey lists in `/etc/brainstorm.conf` that drive the auth gate
+- (Architect should resolve concept handles via the Concept Graph API if applicable — none expected since this is server-side auth plumbing, but worth checking)
+
+## Out of scope
+
+- **Multi-level admin tiering.** The operator explicitly noted this is a future story ("perhaps in the future we can have multiple levels of admin"). For now there are just two levels: owner (full power including admin-list management) and admin (full power except admin-list management).
+- **Other owner-only endpoints staying owner-only by design.** Specifically `/api/admin/list`, `/api/admin/add`, `/api/admin/remove` continue to require the owner. Story #18 does NOT touch those.
+- **Read-only-for-admins / mutate-only-for-owner posture.** The user explicitly chose full parity (option 2 from the prior chat). A read-only admin tier was the rejected option 1; if it ever surfaces as a need, that's the future "multi-level admin tiering" story.
+- **UI surface changes.** BullBoard is BullBoard — we're not redesigning the page; we're widening who can reach it.
+- **Audit log / who-did-what tracking.** BullBoard's own logs and our `events.jsonl` already capture per-job state changes. If we ever want to attribute queue mutations to specific admin pubkeys, that's a separate observability story.
+- **Per-environment admin-list configuration knobs.** `BRAINSTORM_ADMIN_PUBKEYS` is per-deployment via `/etc/brainstorm.conf`. Same mechanism as today; no new override surfaces.
+- **Sweeping `requireOwnerOnly` → "owner-or-admin" across the codebase.** Only the BullBoard mount moves. Every other current `requireOwnerOnly` caller stays put.
+
+## Open questions
+
+Resolved at planning (2026-05-21):
+
+- **Access level for admins** → **full parity with owner** (read + mutate). Option 1 (read-only) explicitly rejected by the operator.
+- **Other owner-only endpoints** → **stay owner-only.** Admin add/list/remove remain owner-gated.
+- **Audit / who-did-what** → **not in this story.** Existing logging is sufficient for now.
+- **Test-update scope** → **explicit in the ACs above.** Tester updates the existing R4 sentinels in suites #13 and #15, adds a new positive-case sentinel (admin-list reference) and a new privilege-escalation guardrail sentinel (admin-management endpoints remain owner-only).
+
+Deferred to Architect:
+
+- **Where the new middleware lives.** Likely in the same module as `requireOwnerOnly`; PO has no opinion on the function name (e.g., `requireOwnerOrAdmin`, `requireAdminAccess`, or extending `requireOwnerOnly` with an option flag are all plausible).
+- **Exact 403 error-message wording** for the "authenticated but not owner/admin" case.
+- **Whether to fold this into an ADR** or fast-track as a small change. The PO sees real design choices (middleware shape, where the admin-list parse lives, how to keep the existing `requireOwnerOnly` callers safe) and recommends a brief ADR — but defers to the Architect.
+
+## Linked artifacts
+
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/18-bullboard-admin-access.md
+++ b/engineering-team/stories/18-bullboard-admin-access.md
@@ -81,6 +81,6 @@ Deferred to Architect:
 
 ## Linked artifacts
 
-- ADR: (filled in after Architecture phase)
+- ADR: [0016-bullboard-admin-access.md](../decisions/0016-bullboard-admin-access.md)
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/18-bullboard-admin-access.md
+++ b/engineering-team/stories/18-bullboard-admin-access.md
@@ -83,4 +83,4 @@ Deferred to Architect:
 
 - ADR: [0016-bullboard-admin-access.md](../decisions/0016-bullboard-admin-access.md)
 - Test plan: [18-bullboard-admin-access.test-plan.md](18-bullboard-admin-access.test-plan.md)
-- Review: (filled in after Review phase)
+- Review: [../reviews/18-bullboard-admin-access.md](../reviews/18-bullboard-admin-access.md) — **PASS** end-to-end (15/15 suites + cycle-local boot log shows `(owner+admin)` mount + privilege-escalation guardrail intact at structural, sentinel, and behavioral levels).

--- a/engineering-team/stories/18-bullboard-admin-access.test-plan.md
+++ b/engineering-team/stories/18-bullboard-admin-access.test-plan.md
@@ -1,0 +1,145 @@
+# Test Plan: Story 18 — Admins can use BullBoard (parity with owner for queue management)
+
+**Story:** `engineering-team/stories/18-bullboard-admin-access.md`
+**ADR:** `engineering-team/decisions/0016-bullboard-admin-access.md`
+**Date:** 2026-05-21
+
+## Test posture
+
+Source/structural **sentinels** in a new file `test/bullboard-admin-access.test.js` pin the ADR-required code shape: `requireOwnerOrAdmin` middleware added, BullBoard mount wired to it, `bullBoardMount.js` parameter renamed to `authMiddleware`, boot-log line updated, OPERATIONS.md documented, **and most critically the privilege-escalation guardrail** that `/api/admin/list|add|remove` still use `requireOwnerOnly` (NOT the new broader middleware).
+
+The **behavioral round-trip** — sign in as a non-owner admin pubkey via the browser, navigate to `/admin/queues/`, and confirm full BullBoard functionality including mutate controls (retry / pause / remove) — is reproducible only against a running stack with real session cookies and is the **authoritative cycle-staging smoke** (operator-required).
+
+Existing R4 sentinels in sibling suites (story #13's `task-queue-bullmq` T7, story #15's `task-queue-neo4j-resource-class` R4) are updated in-place to track the evolving middleware name — the regex broadens from `/requireOwnerOnly|requireOwner/` to `/requireOwnerOnly|requireOwnerOrAdmin|authMiddleware/` so they pass under both the pre- and post-story-#18 shape. This is the same evolution pattern story #17 used to migrate the T10 sentinel.
+
+## Coverage map
+
+| Criterion (story §) | Test name | Test file | Level |
+|---|---|---|---|
+| AC: admin gets BullBoard UI at /admin/queues | T1 + T2 + T3 + T4 collectively prove the new middleware exists, consults the admin list, is exported, and is wired to the mount | `test/bullboard-admin-access.test.js` | source sentinels |
+| AC: admin can perform queue-mutating actions | Implicit from T4 + T5 (mount uses the new middleware → mutate routes are inside the mount → all mutate paths get the same gate). Direct test would require running Express in-process; deferred to cycle-staging smoke. | — | smoke |
+| AC: owner retains full access | R1 (existing `requireOwnerOnly` declaration preserved) + T1's spec for the new middleware's logic (owner-pubkey check is the first branch) | `test/bullboard-admin-access.test.js` | source sentinel |
+| AC: non-owner non-admin gets 403 | T1 spec includes the 403-with-message-`Owner or admin access required` behavior. Behavioral verification deferred to cycle-staging if feasible. | — | source sentinel + smoke |
+| AC: unauthenticated → 401 | T1 spec includes the 401-if-no-session-pubkey branch | — | source sentinel |
+| AC: PRIVILEGE-ESCALATION GUARDRAIL | **T7 — `src/api/index.js` still wires `/api/admin/list|add|remove` to `requireOwnerOnly`** | `test/bullboard-admin-access.test.js` | source sentinel (regression guard, passing now and forever) |
+| AC: `BRAINSTORM_ADMIN_PUBKEYS` is read from existing source | T2 (middleware references `isAdminPubkey` from utils/config — same helper the rest of the app uses) | `test/bullboard-admin-access.test.js` | source sentinel |
+| AC: empty admin list → owner-only behavior preserved | Implicit from `isAdminPubkey()` returning `false` on empty admin list (existing helper behavior, [`src/utils/config.js:114-117`](../../src/utils/config.js#L114)). Verified by direct read of the helper; no separate test needed. | — | implicit (existing helper contract) |
+| AC: no regression in any of the 14 npm test suites | npm test passes 15/15 post-impl (the new suite + 14 prior) | (full gate) | gate |
+| AC: existing R4/T7 sentinels updated to track new middleware name | T7 in story #13's suite + R4 in story #15's suite both relax their regex to match `requireOwnerOnly|requireOwnerOrAdmin|authMiddleware` | `test/task-queue-bullmq.test.js`, `test/task-queue-neo4j-resource-class.test.js` | source sentinels (already updated as part of this phase) |
+| AC: positive-case sentinel that admin list is actually consulted | T2 in new suite — proves `isAdminPubkey` is imported, which proves the admin list is in scope | `test/bullboard-admin-access.test.js` | source sentinel |
+| AC: new privilege-escalation guardrail sentinel | T7 in new suite (described above) | `test/bullboard-admin-access.test.js` | source sentinel |
+
+### Suite layout decision
+
+The new sentinels could have lived in story #13's existing `task-queue-bullmq` suite. The Tester chose to put them in a new suite (`test/bullboard-admin-access.test.js`) because:
+- The story's contract is cohesive and self-contained — a single file lets a future maintainer find "what does story #18 cover?" by file name.
+- The story #13 suite is already 18 sentinels; adding 9 more would balloon it.
+- The privilege-escalation guardrail (T7) is the most safety-critical sentinel in the codebase — it deserves prominent placement in its own dedicated suite rather than buried in a 27-sentinel pile.
+
+## Edge cases
+
+| Case | Status |
+|---|---|
+| Admin pubkey removed from `BRAINSTORM_ADMIN_PUBKEYS` while their tab is open | **Documented in ADR §Out of scope.** Their session cookie still validates until next middleware hit; that hit lands fresh and returns 403. Acceptable. (Strict "remove → immediate cutoff" would be a session-invalidation story.) |
+| `BRAINSTORM_ADMIN_PUBKEYS` empty | **Implicit:** `isAdminPubkey()` returns `false` on empty list → admin check fails → falls through to 403 unless session pubkey === owner. Functionally equivalent to pre-story-#18 owner-only behavior. No separate test needed; existing helper contract carries the property. |
+| Future change broadens `/api/admin/add` to `requireOwnerOrAdmin` | **CAUGHT by T7.** The privilege-escalation guardrail trips loudly with an error message that walks the next reader through the security implication. |
+| Session pubkey === owner AND owner is also in `BRAINSTORM_ADMIN_PUBKEYS` (config redundancy) | Implicit from middleware logic: owner check fires first, returns next(). Admin check never runs. No bug. Acceptable. |
+| Future "remove admins from BullBoard" rollback | **Documented in ADR §Consequences.** Swap the BullBoard mount's middleware reference back to `requireOwnerOnly`; flip T1-T6 (or remove them); `requireOwnerOrAdmin` function can stay defined but unused. Mechanically straightforward. |
+| Reviewer / Operator wants to verify admin actually CAN see BullBoard in browser | **Deferred to cycle-staging smoke.** Source sentinels can't easily fake a session cookie; the live-stack test is the right surface. |
+
+## Test infrastructure
+
+- **Framework:** Node built-in runner via `npm test` (entry: `test/test.js`).
+- **New test file:** `test/bullboard-admin-access.test.js`, registered in `test/test.js` (four-spot wiring: require, run, log, ok-check).
+- **Updated test files** (in-place evolution of existing sentinels):
+  - `test/task-queue-bullmq.test.js` T7 — regex broadened.
+  - `test/task-queue-neo4j-resource-class.test.js` R4 — regex broadened.
+- **No new test infrastructure.** Same plain-Node sentinel pattern story #13/#15/#16/#17 used.
+- **Concept Graph API:** not required.
+- **Firmware reinstall:** no.
+
+## How to run
+
+```
+npm test
+```
+
+The new suite registers as `bullboard-admin-access suite:` after `entrypoint-template-rendering suite:` in `test/test.js`. Post-implementation expected: `PASS (9 passed, 0 failed)`.
+
+For Reviewer cycle-local smoke (behavioral round-trip):
+
+```bash
+docker exec tapestry supervisorctl restart brainstorm
+sleep 10
+docker exec tapestry tail -30 /var/log/supervisor/brainstorm.log | grep -E "bull-board|TASK_QUEUE_ENABLED"
+# Expected (with =true and the new gate):
+#   [task-queue] Initialized 51 queues + workers (...)
+#   Task queue initialized (TASK_QUEUE_ENABLED=true)
+#   [bull-board] Mounted at /admin/queues (owner+admin)
+```
+
+For operator cycle-staging smoke (the acid test):
+
+1. Sign in to `https://staging.brainstorm.world/` as a pubkey listed in `BRAINSTORM_ADMIN_PUBKEYS` (NOT the owner).
+2. Navigate to `https://staging.brainstorm.world/admin/queues/`.
+3. Confirm the BullBoard UI loads with `Tapestry Task Queue — Owner + Admin` in the title.
+4. Confirm at least one queue is visible.
+5. (Optional / careful) Use the retry or pause UI on a non-critical queue to confirm mutate access works.
+
+If admin sees BullBoard with full functionality, AC #1 + AC #2 are empirically satisfied.
+
+## Verification
+
+The flipped + new tests fail with the pre-implementation code (still requireOwnerOnly-gated). Confirmed on 2026-05-21 at commit `85e7816d`:
+
+```
+bullboard-admin-access suite:
+  ✗ T1: src/api/admin/index.js declares function requireOwnerOrAdmin
+      src/api/admin/index.js does not declare `function requireOwnerOrAdmin` ... Add the new middleware
+      adjacent to requireOwnerOnly. The function must: (1) return 401 if !req.session?.pubkey, (2) return
+      next() if session pubkey === BRAINSTORM_OWNER_PUBKEY, (3) return next() if isAdminPubkey(session
+      pubkey), (4) otherwise return 403 with body {success:false, error:"Owner or admin access required"}.
+  ✗ T2: requireOwnerOrAdmin consults the admin list via isAdminPubkey
+      src/api/admin/index.js does not reference isAdminPubkey ... The requireOwnerOrAdmin middleware
+      must consume the existing isAdminPubkey helper from src/utils/config.js — that helper already
+      encapsulates the settings.json → /etc/brainstorm.conf fallback for the admin list.
+  ✗ T3: requireOwnerOrAdmin is exported from src/api/admin/index.js
+      src/api/admin/index.js does not export requireOwnerOrAdmin ...
+  ✗ T4: src/api/index.js wires the BullBoard mount with requireOwnerOrAdmin
+      src/api/index.js does not wire the BullBoard mount with requireOwnerOrAdmin ... Update the
+      mountBullBoard call to `mountBullBoard(app, { queues: ..., authMiddleware: adminApi.requireOwnerOrAdmin })`.
+  ✗ T5: src/manage/taskQueue/queue/bullBoardMount.js destructures authMiddleware
+      ... The destructured parameter must be renamed from requireOwnerOnly to authMiddleware so the
+      parameter name accurately describes what is being passed in.
+  ✗ T6: bullBoardMount.js boot log announces (owner+admin) posture
+      ... Update the console.log line from "[bull-board] Mounted at /admin/queues (owner-only)" to
+      "[bull-board] Mounted at /admin/queues (owner+admin)". Also update the BullBoard `boardTitle` UI
+      field from "Tapestry Task Queue — Owner Only" to "Tapestry Task Queue — Owner + Admin".
+  ✓ T7: PRIVILEGE-ESCALATION GUARDRAIL — /api/admin/list|add|remove still wired to requireOwnerOnly
+      (passes pre AND post — guardrail in place from story #13's original wiring, story #18 must
+      preserve.)
+  ✗ T8: OPERATIONS.md documents the new owner+admin BullBoard gate
+      OPERATIONS.md §10.2 does not document the new BullBoard auth posture ... A short paragraph or
+      bullet is sufficient — the Implementer picks minimal wording.
+  ✓ R1: src/api/admin/index.js still declares function requireOwnerOnly
+      (passes pre AND post — regression guard. Story #18 is additive; this preserves the existing
+      function for the four other call sites.)
+
+Test Results
+-------------
+bullboard-admin-access suite:                    FAIL (2 passed, 7 failed)
+Overall:                                         FAIL
+```
+
+The 14 pre-existing suites continue to PASS — the in-place updates to T7 (in story #13's suite) and R4 (in story #15's suite) successfully evolved their regexes to match both pre- and post-story-#18 middleware names. No collateral damage.
+
+Each of the 7 failures carries a right-reason message that points the Implementer at a specific edit:
+- T1 specifies the exact 4-branch middleware logic.
+- T2 specifies the exact helper import.
+- T3 specifies the export.
+- T4 specifies the exact `mountBullBoard` call form.
+- T5 specifies the parameter rename.
+- T6 specifies both the boot-log line AND the BullBoard `boardTitle` update.
+- T8 specifies the OPERATIONS.md §10.2 update.
+
+T7 + R1 are passing now and must continue passing post-impl. T7 is the privilege-escalation guardrail (the most safety-critical sentinel in the codebase); R1 is the additive-not-replacement guarantee.

--- a/src/api/admin/index.js
+++ b/src/api/admin/index.js
@@ -6,7 +6,7 @@
  * Admins cannot manage other admins — only the owner can.
  */
 
-const { getConfigFromFile, getAdminPubkeys } = require('../../utils/config');
+const { getConfigFromFile, getAdminPubkeys, isAdminPubkey } = require('../../utils/config');
 const { getSettings, updateOverrides } = require('../../config/settings');
 const { nip19 } = require('nostr-tools');
 
@@ -82,6 +82,12 @@ async function resolveIdentifier(identifier) {
 
 /**
  * Middleware: require owner ONLY (not admin).
+ *
+ * Used by endpoints where admins must not have access — specifically the
+ * admin-management endpoints (/api/admin/list, /api/admin/add,
+ * /api/admin/remove). Allowing admins to manage the admin list itself
+ * would be a privilege-escalation surface (an admin could promote or
+ * remove other admins). See story #18 / ADR 0016 §Decision.
  */
 function requireOwnerOnly(req, res, next) {
   if (!req.session?.pubkey) {
@@ -92,6 +98,35 @@ function requireOwnerOnly(req, res, next) {
     return res.status(403).json({ success: false, error: 'Owner access required' });
   }
   next();
+}
+
+/**
+ * Middleware: require owner OR admin.
+ *
+ * Used by endpoints that trusted admins are allowed to operate — currently
+ * the BullBoard mount at /admin/queues (story #18 / ADR 0016). Admin list
+ * is resolved via isAdminPubkey() from utils/config, which consults
+ * settings.json first and falls back to BRAINSTORM_ADMIN_PUBKEYS in
+ * brainstorm.conf — the same source-of-truth used by admin checks
+ * elsewhere in the app.
+ *
+ * Admin-management endpoints (/api/admin/add etc.) deliberately do NOT use
+ * this middleware; they stay on requireOwnerOnly to preserve the
+ * privilege-escalation guardrail.
+ */
+function requireOwnerOrAdmin(req, res, next) {
+  if (!req.session?.pubkey) {
+    return res.status(401).json({ success: false, error: 'Not authenticated' });
+  }
+  const sessionPubkey = req.session.pubkey;
+  const ownerPubkey = getConfigFromFile('BRAINSTORM_OWNER_PUBKEY');
+  if (ownerPubkey && sessionPubkey === ownerPubkey) {
+    return next();
+  }
+  if (isAdminPubkey(sessionPubkey)) {
+    return next();
+  }
+  return res.status(403).json({ success: false, error: 'Owner or admin access required' });
 }
 
 /**
@@ -211,4 +246,5 @@ module.exports = {
   handleAddAdmin,
   handleRemoveAdmin,
   requireOwnerOnly,
+  requireOwnerOrAdmin,
 };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -457,16 +457,20 @@ async function register(app) {
     app.post('/api/admin/add', adminApi.requireOwnerOnly, adminApi.handleAddAdmin);
     app.post('/api/admin/remove', adminApi.requireOwnerOnly, adminApi.handleRemoveAdmin);
 
-    // ── BullBoard (task queue operations UI) — owner-only at /admin/queues ──
-    // Story #13 / ADR 0010. Mounted only when TASK_QUEUE_ENABLED=true; when
-    // the flag is off, the queue isn't initialized and the route isn't mounted.
+    // ── BullBoard (task queue operations UI) — owner+admin at /admin/queues ──
+    // Story #13 / ADR 0010 (mount). Story #18 / ADR 0016 widened the gate from
+    // owner-only to owner+admin via requireOwnerOrAdmin. Admin-management
+    // endpoints above (/api/admin/list|add|remove) still use requireOwnerOnly —
+    // see ADR 0016 §Decision §privilege-escalation guardrail.
+    // Mounted only when TASK_QUEUE_ENABLED=true; when the flag is off, the
+    // queue isn't initialized and the route isn't mounted.
     if (brainstormConfig.get('TASK_QUEUE_ENABLED') === 'true') {
         try {
             const taskQueue = require('../manage/taskQueue/queue');
             const { mountBullBoard } = require('../manage/taskQueue/queue/bullBoardMount');
             mountBullBoard(app, {
                 queues: taskQueue.getAllQueues(),
-                requireOwnerOnly: adminApi.requireOwnerOnly
+                authMiddleware: adminApi.requireOwnerOrAdmin
             });
         } catch (e) {
             console.warn(`[api] Skipping BullBoard mount: ${e.message}`);

--- a/src/manage/taskQueue/queue/bullBoardMount.js
+++ b/src/manage/taskQueue/queue/bullBoardMount.js
@@ -1,11 +1,14 @@
 /**
  * BullBoard mount — operator-facing UI at /admin/queues.
- * Story #13 / ADR 0010.
+ * Story #13 / ADR 0010 introduced the mount; story #18 / ADR 0016 widened
+ * the gate from owner-only to owner+admin.
  *
- * Mounted behind requireOwnerOnly (or requireOwner — the auth middleware is
- * passed in by api/index.js to avoid a brittle relative-path import of
- * `./admin` from down here). retry / remove / pause controls can affect
- * running calculations; the owner-only gate prevents accidental damage.
+ * The auth middleware is passed in by api/index.js (as `authMiddleware`) to
+ * avoid a brittle relative-path import of `./admin` from down here. The
+ * caller is responsible for picking which middleware to pass: today it's
+ * requireOwnerOrAdmin (story #18); before story #18 it was requireOwnerOnly.
+ * retry / remove / pause controls can affect running calculations; the
+ * caller-supplied gate is what protects them.
  *
  * The BullBoard packages (`@bull-board/api`, `@bull-board/express`) are
  * required LAZILY inside `mountBullBoard` so that if the packages aren't
@@ -17,15 +20,15 @@
  * Mount BullBoard.
  *
  * @param {import('express').Application} app
- * @param {{ queues: any[], requireOwnerOnly: import('express').RequestHandler }} opts
+ * @param {{ queues: any[], authMiddleware: import('express').RequestHandler }} opts
  */
-function mountBullBoard(app, { queues, requireOwnerOnly }) {
+function mountBullBoard(app, { queues, authMiddleware }) {
   if (!Array.isArray(queues) || queues.length === 0) {
     console.warn('[bull-board] mountBullBoard called with no queues — skipping mount.');
     return;
   }
-  if (typeof requireOwnerOnly !== 'function') {
-    throw new Error('mountBullBoard requires requireOwnerOnly middleware');
+  if (typeof authMiddleware !== 'function') {
+    throw new Error('mountBullBoard requires authMiddleware function');
   }
 
   // Lazy require so module load doesn't depend on deps being installed.
@@ -41,15 +44,15 @@ function mountBullBoard(app, { queues, requireOwnerOnly }) {
     serverAdapter,
     options: {
       uiConfig: {
-        boardTitle: 'Tapestry Task Queue — Owner Only',
+        boardTitle: 'Tapestry Task Queue — Owner + Admin',
         boardLogo: { path: '' },
         miscLinks: []
       }
     }
   });
 
-  app.use('/admin/queues', requireOwnerOnly, serverAdapter.getRouter());
-  console.log('[bull-board] Mounted at /admin/queues (owner-only)');
+  app.use('/admin/queues', authMiddleware, serverAdapter.getRouter());
+  console.log('[bull-board] Mounted at /admin/queues (owner+admin)');
 }
 
 module.exports = { mountBullBoard };

--- a/test/bullboard-admin-access.test.js
+++ b/test/bullboard-admin-access.test.js
@@ -1,0 +1,232 @@
+/**
+ * Story #18 / ADR 0016 — Widen the BullBoard auth gate at /admin/queues from
+ * owner-only to "owner or admin." Adds a sibling middleware
+ * `requireOwnerOrAdmin` in src/api/admin/index.js; switches the BullBoard
+ * mount in src/api/index.js to use it; renames the destructured parameter
+ * in bullBoardMount.js from `requireOwnerOnly` to `authMiddleware` for
+ * accuracy.
+ *
+ * Source/structural sentinels pin the ADR-required code shape. The
+ * behavioral round-trip — sign in as an admin (not the owner) and confirm
+ * /admin/queues/ loads the full BullBoard UI with mutate controls — is
+ * reproducible only against a running stack with a real session cookie
+ * and is the authoritative cycle-staging smoke (Operator-required).
+ *
+ * T1..T8 : FAIL pre-implementation, PASS post.
+ * R1     : PASS pre AND post — regression guard on the existing
+ *          requireOwnerOnly function (story #13's contract preserved).
+ *
+ * The most safety-critical test is **T7 — privilege-escalation guardrail.**
+ * It asserts src/api/index.js STILL wires /api/admin/list, /api/admin/add,
+ * /api/admin/remove to adminApi.requireOwnerOnly (not to the new broader
+ * middleware). Without this guarantee, an admin could promote themselves
+ * to admin or remove other admins, defeating the whole authority hierarchy
+ * story #18 was careful to preserve.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const ADMIN_INDEX     = path.join(ROOT, 'src/api/admin/index.js');
+const API_INDEX       = path.join(ROOT, 'src/api/index.js');
+const BULLBOARD_MOUNT = path.join(ROOT, 'src/manage/taskQueue/queue/bullBoardMount.js');
+const OPERATIONS_MD   = path.join(ROOT, 'OPERATIONS.md');
+
+function readSafe(p) {
+  try { return fs.readFileSync(p, 'utf8'); }
+  catch (_e) { return null; }
+}
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+
+// ---------------------------------------------------------------------------
+// Failing tests — FAIL now, PASS once story #18 is implemented per ADR 0016.
+// ---------------------------------------------------------------------------
+
+test('T1: src/api/admin/index.js declares function requireOwnerOrAdmin (story #18 / ADR 0016 §Implementation §1)', () => {
+  const src = readSafe(ADMIN_INDEX);
+  assert(
+    src !== null,
+    'src/api/admin/index.js does not exist at the expected path — re-baseline this sentinel.'
+  );
+  assert(
+    /function\s+requireOwnerOrAdmin\b/.test(src),
+    'src/api/admin/index.js does not declare `function requireOwnerOrAdmin` (story #18 / ADR 0016 ' +
+      '§Implementation §1). Add the new middleware adjacent to requireOwnerOnly. The function must: ' +
+      '(1) return 401 if !req.session?.pubkey, (2) return next() if session pubkey === ' +
+      'BRAINSTORM_OWNER_PUBKEY, (3) return next() if isAdminPubkey(session pubkey), (4) otherwise ' +
+      'return 403 with body {success:false, error:"Owner or admin access required"}.'
+  );
+});
+
+test('T2: requireOwnerOrAdmin consults the admin list via isAdminPubkey (story #18 AC + ADR 0016 §Implementation §1)', () => {
+  const src = readSafe(ADMIN_INDEX);
+  assert(src !== null, 'src/api/admin/index.js missing — T1 must pass first.');
+  // The new middleware must consume isAdminPubkey from utils/config so the admin list flows from
+  // the same source-of-truth the rest of the app already uses (story #18 AC: "no new env var, no new
+  // config file, no new source of truth").
+  assert(
+    /isAdminPubkey/.test(src),
+    'src/api/admin/index.js does not reference isAdminPubkey (story #18 / ADR 0016 §Implementation §1). ' +
+      'The requireOwnerOrAdmin middleware must consume the existing isAdminPubkey helper from ' +
+      'src/utils/config.js — that helper already encapsulates the settings.json → /etc/brainstorm.conf ' +
+      'fallback for the admin list. Without this reference, the middleware would have to re-derive ' +
+      'admin-list resolution (forking the source-of-truth, which is exactly what the story AC ' +
+      'forbids). Import isAdminPubkey at the top of the file alongside the existing config helpers.'
+  );
+});
+
+test('T3: requireOwnerOrAdmin is exported from src/api/admin/index.js (story #18 / ADR 0016 §Implementation §1)', () => {
+  const src = readSafe(ADMIN_INDEX);
+  assert(src !== null, 'src/api/admin/index.js missing.');
+  // Look for requireOwnerOrAdmin appearing in the module.exports block. We allow either
+  // shorthand form `requireOwnerOrAdmin` or full form `requireOwnerOrAdmin: requireOwnerOrAdmin`.
+  const exportsIdx = src.indexOf('module.exports');
+  assert(
+    exportsIdx !== -1,
+    'src/api/admin/index.js has no module.exports block — re-baseline.'
+  );
+  const exportsSection = src.slice(exportsIdx);
+  assert(
+    /requireOwnerOrAdmin/.test(exportsSection),
+    'src/api/admin/index.js does not export requireOwnerOrAdmin (story #18 / ADR 0016 §Implementation §1). ' +
+      'Add it to module.exports alongside the existing requireOwnerOnly export so api/index.js can wire it ' +
+      'to the BullBoard mount.'
+  );
+});
+
+test('T4: src/api/index.js wires the BullBoard mount with requireOwnerOrAdmin (story #18 / ADR 0016 §Implementation §2)', () => {
+  const src = readSafe(API_INDEX);
+  assert(src !== null, 'src/api/index.js missing.');
+  // Look for mountBullBoard call, followed within a reasonable distance by requireOwnerOrAdmin reference.
+  // The ADR pins: `mountBullBoard(app, { queues: ..., authMiddleware: adminApi.requireOwnerOrAdmin })`.
+  assert(
+    /mountBullBoard\s*\([^)]*[\s\S]{0,400}requireOwnerOrAdmin/.test(src),
+    'src/api/index.js does not wire the BullBoard mount with requireOwnerOrAdmin (story #18 / ADR 0016 ' +
+      '§Implementation §2). The widened-gate is the entire point of story #18; the mount must consume ' +
+      'the new middleware, not requireOwnerOnly. Update the mountBullBoard call to ' +
+      '`mountBullBoard(app, { queues: taskQueue.getAllQueues(), authMiddleware: adminApi.requireOwnerOrAdmin })`.'
+  );
+});
+
+test('T5: src/manage/taskQueue/queue/bullBoardMount.js destructures authMiddleware parameter (story #18 / ADR 0016 §Implementation §3)', () => {
+  const src = readSafe(BULLBOARD_MOUNT);
+  assert(src !== null, 'bullBoardMount.js missing.');
+  // The destructured parameter is renamed from requireOwnerOnly to authMiddleware for accuracy.
+  // We check the param appears in the function signature region AND that the file uses it as a
+  // middleware in the app.use() call.
+  assert(
+    /\bauthMiddleware\b/.test(src),
+    'src/manage/taskQueue/queue/bullBoardMount.js does not reference authMiddleware (story #18 / ADR ' +
+      '0016 §Implementation §3). The destructured parameter must be renamed from requireOwnerOnly to ' +
+      'authMiddleware so the parameter name accurately describes what is being passed in. The old name ' +
+      'was misleading post-story-#18 — calling something "requireOwnerOnly" when it now admits admins ' +
+      'too is exactly the kind of stale naming that confuses future readers.'
+  );
+});
+
+test('T6: bullBoardMount.js boot log announces (owner+admin) posture (story #18 / ADR 0016 §Implementation §3)', () => {
+  const src = readSafe(BULLBOARD_MOUNT);
+  assert(src !== null, 'bullBoardMount.js missing.');
+  // The boot-log line should signal the new posture so operators reading brainstorm.log can confirm
+  // the new gate is in effect. ADR pins the form "(owner+admin)" but we accept the spaced variant too.
+  assert(
+    /owner\s*\+\s*admin/i.test(src),
+    'src/manage/taskQueue/queue/bullBoardMount.js does not announce the owner+admin posture in its ' +
+      'boot-log line (story #18 / ADR 0016 §Implementation §3). The Reviewer + operator look for this ' +
+      'literal in brainstorm.log to confirm the new gate is active. Update the console.log line from ' +
+      '"[bull-board] Mounted at /admin/queues (owner-only)" to "[bull-board] Mounted at /admin/queues ' +
+      '(owner+admin)". Also update the BullBoard `boardTitle` UI field from "Tapestry Task Queue — ' +
+      'Owner Only" to "Tapestry Task Queue — Owner + Admin".'
+  );
+});
+
+test('T7: PRIVILEGE-ESCALATION GUARDRAIL — /api/admin/list|add|remove still wired to requireOwnerOnly (story #18 AC + ADR 0016 §Decision)', () => {
+  const src = readSafe(API_INDEX);
+  assert(src !== null, 'src/api/index.js missing.');
+  // The MOST safety-critical sentinel in this suite. Without this guarantee, admins could promote
+  // themselves to admin or remove other admins — defeating the whole authority hierarchy.
+  for (const endpoint of ['/api/admin/list', '/api/admin/add', '/api/admin/remove']) {
+    const escaped = endpoint.replace(/\//g, '\\/');
+    // Match a line containing the endpoint literal AND `requireOwnerOnly` on the same line.
+    const re = new RegExp(`['"\`]${escaped}['"\`][^\\n]*requireOwnerOnly\\b`);
+    assert(
+      re.test(src),
+      'PRIVILEGE-ESCALATION GUARDRAIL TRIPPED: src/api/index.js does not wire ' + endpoint + ' to ' +
+        'requireOwnerOnly (story #18 AC; ADR 0016 §Decision; ADR 0016 §Implementation §2). The story ' +
+        '#18 contract is **narrow** — only the BullBoard mount moves to the broader gate. Admin ' +
+        'management endpoints (' + endpoint + ' and siblings) MUST remain owner-only; admins must NOT ' +
+        'be able to manage the admin list itself, or the privilege hierarchy collapses (an admin could ' +
+        'add or remove other admins). If this test is failing because someone broadened ' + endpoint + ' ' +
+        'to requireOwnerOrAdmin, REVERT that change immediately — the only legitimate way to broaden ' +
+        'these endpoints is via a separate story that explicitly weighs the security implications.'
+    );
+  }
+});
+
+test('T8: OPERATIONS.md documents the new owner+admin BullBoard gate (story #18 / ADR 0016 §Implementation §4)', () => {
+  const src = readSafe(OPERATIONS_MD);
+  assert(src !== null, 'OPERATIONS.md missing.');
+  // The BullBoard section in §10 must mention admin access alongside owner. We don't pin exact
+  // wording (Implementer's call) but we require that the BullBoard documentation acknowledges admin
+  // access — either by referencing BRAINSTORM_ADMIN_PUBKEYS, "owner+admin", or "admin" near a
+  // BullBoard mention.
+  const bullBoardSection = src.match(/###\s*10\.2[\s\S]{0,2000}/);
+  assert(
+    bullBoardSection !== null,
+    'OPERATIONS.md does not contain §10.2 (BullBoard section). Re-baseline this sentinel — the section ' +
+      'numbering may have changed.'
+  );
+  const section = bullBoardSection[0];
+  assert(
+    /BRAINSTORM_ADMIN_PUBKEYS|owner\s*\+\s*admin|owner or admin|owner and admin/i.test(section),
+    'OPERATIONS.md §10.2 does not document the new BullBoard auth posture (story #18 / ADR 0016 ' +
+      '§Implementation §4). The section currently describes the gate as owner-only; update it to ' +
+      'note that as of story #18 / ADR 0016, the gate also admits any pubkey in ' +
+      'BRAINSTORM_ADMIN_PUBKEYS. A short paragraph or bullet is sufficient — the Implementer picks ' +
+      'minimal wording. Operators reading OPERATIONS.md to triage "who can use BullBoard" land here.'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Regression sentinels — PASS now AND post-implementation.
+// ---------------------------------------------------------------------------
+
+test('R1: src/api/admin/index.js still declares function requireOwnerOnly (story #13 + #16 contracts preserved)', () => {
+  const src = readSafe(ADMIN_INDEX);
+  assert(src !== null, 'src/api/admin/index.js missing — re-baseline this sentinel.');
+  // Story #18 ADDS a sibling middleware (requireOwnerOrAdmin); it does NOT replace requireOwnerOnly.
+  // The existing function declaration must survive intact so the four other call sites (admin
+  // add/list/remove plus any future endpoints with strict owner gating) continue to work.
+  assert(
+    /function\s+requireOwnerOnly\b/.test(src),
+    'R1: src/api/admin/index.js no longer declares function requireOwnerOnly (story #13 / #16 ' +
+      'regression caused by story #18). Story #18 was explicit that the change is ADDITIVE — a sibling ' +
+      'middleware (requireOwnerOrAdmin) is added; the existing requireOwnerOnly stays. Removing it ' +
+      'breaks the four other call sites (admin add/list/remove) plus the privilege-escalation ' +
+      'guardrail in T7. Restore the function declaration with its original body.'
+  );
+  // Also pin the existing logic shape (owner pubkey check, 401/403 codes).
+  assert(
+    /BRAINSTORM_OWNER_PUBKEY/.test(src) && /401/.test(src) && /403/.test(src),
+    'R1: src/api/admin/index.js no longer references the canonical owner-pubkey + 401/403 status ' +
+      'codes (story #13 / #16 regression). The existing requireOwnerOnly contract (401 unauth, 403 ' +
+      'non-owner) must remain — story #18 only adds a sibling middleware; it does not change the ' +
+      'shape of the existing one.'
+  );
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try { await t.fn(); console.log(`  ✓ ${t.name}`); pass++; }
+    catch (err) { console.log(`  ✗ ${t.name}`); console.log(`      ${err.message}`); fail++; }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/task-queue-bullmq.test.js
+++ b/test/task-queue-bullmq.test.js
@@ -168,10 +168,15 @@ test('T6: Redis container is configured with AOF persistence (appendonly yes, ap
   );
 });
 
-test('T7: BullBoard is mounted at /admin/queues behind owner-only auth (AC-11, ADR 0010 §BullBoard mount)', () => {
+test('T7: BullBoard is mounted at /admin/queues behind some auth middleware (AC-11, ADR 0010 + ADR 0016 §BullBoard mount)', () => {
   // ADR allows the mount to live in a dedicated bullBoardMount.js module OR
   // inline in api/index.js. Either is fine; both need to satisfy: path is
-  // /admin/queues AND the route is guarded by requireOwnerOnly (or requireOwner).
+  // /admin/queues AND the route is guarded by SOME auth middleware. Story #18 /
+  // ADR 0016 broadened the gate from requireOwnerOnly to requireOwnerOrAdmin
+  // (the parameter in bullBoardMount.js was renamed from `requireOwnerOnly` to
+  // `authMiddleware` for accuracy). This sentinel now matches any of the
+  // historical or current names so it survives the evolution AND tells the
+  // next maintainer about the lineage.
   const mountModule = readSafe(BULLBOARD_MOUNT);
   const apiIndex = readSafe(API_INDEX_JS);
   assert(apiIndex !== null, 'src/api/index.js not at expected path — re-baseline this sentinel.');
@@ -183,10 +188,13 @@ test('T7: BullBoard is mounted at /admin/queues behind owner-only auth (AC-11, A
       'src/api/index.js must reference it.'
   );
   assert(
-    /requireOwnerOnly|requireOwner/.test(candidates),
-    'BullBoard route is not guarded by requireOwnerOnly or requireOwner (AC-11; ADR 0010 §BullBoard ' +
-      'mount). retry / remove / pause on a live queue can damage running calculations; the mount must ' +
-      'reuse the existing admin auth pattern (adminApi.requireOwnerOnly, per src/api/index.js:454).'
+    /requireOwnerOnly|requireOwnerOrAdmin|authMiddleware/.test(candidates),
+    'BullBoard route is not guarded by any recognized auth middleware (AC-11; ADR 0010 §BullBoard ' +
+      'mount + ADR 0016 §Implementation). retry / remove / pause on a live queue can damage running ' +
+      'calculations; the mount must reuse one of the admin-auth helpers: requireOwnerOnly (pre-story-#18 ' +
+      'name), requireOwnerOrAdmin (story-#18 widened gate), or the destructured `authMiddleware` ' +
+      'parameter name in bullBoardMount.js. If none of these tokens appear, BullBoard has been mounted ' +
+      'WITHOUT auth — that is the regression this sentinel is here to catch.'
   );
 });
 

--- a/test/task-queue-neo4j-resource-class.test.js
+++ b/test/task-queue-neo4j-resource-class.test.js
@@ -312,20 +312,23 @@ test('R3: runTask.js feature-flag branch + 503 QUEUE_UNAVAILABLE preserved (stor
   );
 });
 
-test('R4: BullBoard mount module still exists and references /admin/queues + requireOwnerOnly (story #13 / ADR 0012 contract)', () => {
+test('R4: BullBoard mount module still exists and references /admin/queues + some auth middleware (story #13 / ADR 0012 + story #18 / ADR 0016 contracts)', () => {
   const mount = readSafe(BULLBOARD_MOUNT);
   assert(mount !== null, 'bullBoardMount.js missing — re-baseline this sentinel.');
   assert(
     /['"`]\/admin\/queues['"`]/.test(mount),
     'R4: bullBoardMount.js no longer references the canonical /admin/queues path (story #13 / ADR 0012 ' +
       'regression). The mount path is part of the operator-facing contract; do not change it as a side ' +
-      'effect of story #15.'
+      'effect of story #15 or any subsequent story.'
   );
   assert(
-    /requireOwnerOnly|requireOwner/.test(mount),
-    'R4: bullBoardMount.js no longer references the owner-only auth gate (story #13 / ADR 0012 ' +
-      'regression). retry / remove / pause controls remain capable of affecting in-flight calculations; the ' +
-      'gate stays.'
+    /requireOwnerOnly|requireOwnerOrAdmin|authMiddleware/.test(mount),
+    'R4: bullBoardMount.js no longer references any recognized auth middleware token (story #13 / ADR ' +
+      '0012 + story #18 / ADR 0016 regression). retry / remove / pause controls remain capable of ' +
+      'affecting in-flight calculations; the gate stays. As of story #18 the destructured parameter is ' +
+      'named `authMiddleware` and the middleware passed in is `requireOwnerOrAdmin`; pre-story-#18 it ' +
+      'was `requireOwnerOnly`. Any of these tokens satisfies the contract. If NONE appear, the mount ' +
+      'has been wired without auth — the regression this sentinel exists to catch.'
   );
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -37,6 +37,7 @@ const communityClassThreadPull = require('./community-class-thread-pull.test.js'
 const taskQueueBullmq = require('./task-queue-bullmq.test.js');
 const taskQueueNeo4jResourceClass = require('./task-queue-neo4j-resource-class.test.js');
 const entrypointTemplateRendering = require('./entrypoint-template-rendering.test.js');
+const bullboardAdminAccess = require('./bullboard-admin-access.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -86,6 +87,9 @@ async function main() {
   console.log('\nentrypoint-template-rendering suite:');
   const entrypointTemplateRenderingResult = await entrypointTemplateRendering.run();
 
+  console.log('\nbullboard-admin-access suite:');
+  const bullboardAdminAccessResult = await bullboardAdminAccess.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -131,6 +135,9 @@ async function main() {
   console.log(
     `entrypoint-template-rendering suite:             ${entrypointTemplateRenderingResult.fail === 0 ? 'PASS' : 'FAIL'} (${entrypointTemplateRenderingResult.pass} passed, ${entrypointTemplateRenderingResult.fail} failed)`
   );
+  console.log(
+    `bullboard-admin-access suite:                    ${bullboardAdminAccessResult.fail === 0 ? 'PASS' : 'FAIL'} (${bullboardAdminAccessResult.pass} passed, ${bullboardAdminAccessResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -147,7 +154,8 @@ async function main() {
     communityClassThreadPullResult.fail === 0 &&
     taskQueueBullmqResult.fail === 0 &&
     taskQueueNeo4jResourceClassResult.fail === 0 &&
-    entrypointTemplateRenderingResult.fail === 0;
+    entrypointTemplateRenderingResult.fail === 0 &&
+    bullboardAdminAccessResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }


### PR DESCRIPTION
## Promoting

Story #18 — Admins get BullBoard parity with the owner (read + mutate). New `requireOwnerOrAdmin` middleware in `src/api/admin/index.js`; BullBoard mount in `src/api/index.js` rewired to use it; `bullBoardMount.js` param renamed to `authMiddleware` for accuracy; boot-log + boardTitle updated to "(owner+admin)" / "Owner + Admin"; OPERATIONS.md §10.2 documents the new posture.

## Linked artifacts

- Story: `engineering-team/stories/18-bullboard-admin-access.md`
- ADR: `engineering-team/decisions/0016-bullboard-admin-access.md`
- Test plan: `engineering-team/stories/18-bullboard-admin-access.test-plan.md`
- Review: `engineering-team/reviews/18-bullboard-admin-access.md` — **PASS** end-to-end

## Privilege-escalation guardrail

Admin-management endpoints (`/api/admin/list|add|remove`) stay strictly owner-only. Verified at three layers (T7 sentinel + repo-wide grep + cycle-local 401 behavioral check). Admins gain BullBoard access; they do NOT gain the ability to promote/remove other admins.

## Staging smoke (just completed)

- `/` → HTTP 200, 0.15s
- `/api/status` → renderer substituting correctly
- `/api/concept-graph/summaries` → success: true, 36 summaries
- `/admin/queues` → HTTP 401 + JSON (gate active, BullBoard mounted)
- `/api/admin/list` → HTTP 401 + JSON (privilege-escalation guardrail intact)

## Prod expectation

Admin pubkeys listed in `BRAINSTORM_ADMIN_PUBKEYS` on `brainstorm.world` gain BullBoard access immediately after the deploy completes. Owner access unchanged. No operator action required.

## Prod test plan

- [ ] `deploy-brainstorm.yml` runs green
- [ ] `brainstorm.world/` returns 200
- [ ] `/api/status` shows correct domain substitution
- [ ] `/admin/queues` returns 401 + JSON (gate still active)
- [ ] `/api/admin/list` returns 401 + JSON (privilege-escalation guardrail still intact)
- [ ] (Operator follow-up at leisure) Sign in as an admin pubkey in browser; confirm BullBoard UI loads with "Owner + Admin" title

🤖 Generated with [Claude Code](https://claude.com/claude-code)