### PR TITLE
Story #19: Admin tools dashboard panel + Neo4j-URL bug fix + BullBoard back-link

### DIFF
--- a/engineering-team/decisions/0017-admin-tools-dashboard-panel.md
+++ b/engineering-team/decisions/0017-admin-tools-dashboard-panel.md
@@ -1,0 +1,299 @@
+# ADR 0017: Admin tools panel on the dashboard via `useAuth`/`useConfig`; consume `/api/status:neo4jBrowserUrl` everywhere
+
+**Status:** Accepted
+**Date:** 2026-05-21
+**Story:** `engineering-team/stories/19-admin-tools-dashboard-panel.md`
+
+## Context
+
+Story #19 bundles three coordinated changes:
+1. A new "Admin tools" panel on the Tapestry dashboard, visible only to owner-or-admin sessions, containing cards/links to BullBoard and Neo4j Browser.
+2. A bug fix to the existing "Open Neo4j Browser" button at `/tapestry/databases/neo4j` (hardcoded `http://localhost:8080/browser/preview/`) so it uses the environment-aware URL the backend already exposes.
+3. A `miscLinks` entry in BullBoard's mount config so operators can navigate back from BullBoard to the Tapestry dashboard.
+
+### Grounded facts after reading source
+
+- **UI auth state is fully available**: [`ui/src/context/AuthContext.jsx`](../../ui/src/context/AuthContext.jsx) exposes `useAuth()` which returns `{ user: { pubkey, classification, profile } }`. The `classification` field is one of `'owner' | 'admin' | 'guest' | …` (resolved via `/api/auth/user-classification`).
+- **Established idiom for "is operator-tier"**: three current sites use the same shape ([`Layout.jsx:137`](../../ui/src/components/Layout.jsx#L137), [`BrainstormUserMenu.jsx:80`](../../ui/src/components/BrainstormUserMenu.jsx#L80), [`Dashboard.jsx:58`](../../ui/src/pages/Dashboard.jsx#L58)):
+  ```js
+  user?.classification === 'owner' || user?.classification === 'admin'
+  ```
+  No new API endpoint needed. The story #18 backend gate (`requireOwnerOrAdmin`) and this UI gate consult the same underlying `BRAINSTORM_ADMIN_PUBKEYS` source-of-truth via different paths (server middleware vs `/api/auth/user-classification`).
+- **`neo4jBrowserUrl` is in `/api/status`** at [`src/api/status/queries/system.js:19`](../../src/api/status/queries/system.js#L19), computed from `BRAINSTORM_NEO4J_BROWSER_URL` in `/etc/brainstorm.conf` (template-rendered per story #16 as `http://${DOMAIN_NAME}:7474`). The UI does not currently consume this field; both the new panel and the existing Neo4j Overview button need it.
+- **`useConfig()`** at [`ConfigContext.jsx`](../../ui/src/context/ConfigContext.jsx) is the existing UI surface for app-wide config. Currently fetches three endpoints in parallel at mount (`/api/assistant/pubkey`, `/api/owner/pubkey`, `/api/relays`). Natural place to add a fourth small fetch for `/api/status`.
+- **Dashboard layout** at [`Dashboard.jsx`](../../ui/src/pages/Dashboard.jsx) is a top-to-bottom sequence: `WelcomeCard`, `OnboardingChecklist`, `StatsRow`, `HealthRow`, `ConstraintsCheck`, `RecentActivity`. The story's preferred placement (between HealthRow and below-the-fold sections) maps to "after HealthRow, before ConstraintsCheck."
+- **BullBoard mount** at [`bullBoardMount.js:42-49`](../../src/manage/taskQueue/queue/bullBoardMount.js#L42) already has `miscLinks: []` as the customization slot — empty today. BullBoard renders entries as clickable links in its header.
+- **Tapestry Dashboard URL** is `/tapestry` (index route under the Layout at [`App.jsx:104-108`](../../ui/src/App.jsx#L104)). The miscLinks back-pointer goes there.
+
+### Concept-graph impact
+
+None. No new concepts, no schema, no firmware reinstall.
+
+## Options considered
+
+### Option A — `useConfig` consumes `/api/status` + new `AdminToolsPanel` component (chosen)
+
+**Architecture:**
+- Extend [`ConfigContext.jsx`](../../ui/src/context/ConfigContext.jsx) to fetch `/api/status` in parallel with the existing three endpoints. Expose `neo4jBrowserUrl` (plucked from the response) alongside the current `taPubkey`/`ownerPubkey`/`aRelays`.
+- New component `<AdminToolsPanel />` in [`Dashboard.jsx`](../../ui/src/pages/Dashboard.jsx) (same file; matches existing pattern of component-per-section). Renders only when `(user?.classification === 'owner' || user?.classification === 'admin')` AND `neo4jBrowserUrl` is available from useConfig.
+- Inserted in `Dashboard.jsx`'s top-level JSX between HealthRow and ConstraintsCheck.
+- Visual style: one `.dashboard-card` wrapper with a heading `🛠️ Admin tools`, containing two link-buttons (BullBoard → `/admin/queues/`, Neo4j Browser → `useConfig().neo4jBrowserUrl + '/browser/preview/'`). Both `target="_blank"` with `rel="noopener noreferrer"`.
+- Edit `Neo4jOverview.jsx` lines 84-104 to consume `useConfig().neo4jBrowserUrl` and append `/browser/preview/`, instead of hardcoding.
+- Edit `bullBoardMount.js:42-49`'s `miscLinks` to `[{ text: '← Tapestry Dashboard', url: '/tapestry' }]`.
+
+**Pros**
+- **Reuses every existing idiom.** Auth check matches three other sites; useConfig matches the existing "app-wide config from small fetches" pattern; one component-per-section matches Dashboard.jsx's structure.
+- **No new API endpoints.** `/api/status` and `/api/auth/user-classification` already exist.
+- **Both Neo4j-URL consumers (new panel + existing button) flow through the same useConfig source.** Future Neo4j-URL changes happen in one place; no drift risk.
+- **Auth check is purely client-side.** No round-trip on render. The classification was resolved at sign-in.
+- **Panel visibility decision is component-internal.** No conditional Routes/routing logic; React renders `null` when the gate doesn't pass.
+- **BullBoard miscLinks change is a one-line config diff.**
+
+**Cons**
+- ConfigContext gains a 4th fetch. Trivially small; same shape as the existing three.
+- Client-side auth gate means the panel briefly doesn't render until `/api/auth/status` completes. Acceptable — same loading-flash exists today for `Layout.jsx`'s `isOwner` check; matches the established pattern.
+- Useful URL state is split between AuthContext (`user`) and ConfigContext (`neo4jBrowserUrl`). The Architect could unify these but that's a larger refactor; not warranted here.
+
+### Option B — Server-side rendered `<AdminTools />` (rejected)
+
+Have the backend render the panel HTML (or its visibility decision) into the SPA shell before serving. Removes the brief loading-flash.
+
+**Cons**
+- Tapestry's UI is a Vite-built SPA served as static assets. Server-rendered HTML insertion would require a new templating step in the Express layer — significant complexity for a tiny UX improvement.
+- Doesn't match any existing pattern in the codebase.
+- Rejected.
+
+### Option C — New dedicated `/api/dashboard/admin-tools` endpoint (rejected)
+
+Backend computes the URL list + visibility flag together; UI consumes one tailored endpoint.
+
+**Cons**
+- Splits the source-of-truth for `neo4jBrowserUrl` between `/api/status` and the new endpoint. Drift hazard.
+- The existing `useAuth()` + `useConfig()` already give us what we need. No need for new endpoints.
+- Rejected.
+
+### Option D — Inline fetch in `<AdminToolsPanel />` and `<Neo4jOverview />` (rejected)
+
+Skip the ConfigContext extension; have each consumer fetch `/api/status` directly.
+
+**Cons**
+- Two fetches for the same value; duplicated wiring.
+- The existing ConfigContext exists precisely to centralize this kind of "small config fetched once at app start" — bypassing it forks the pattern.
+- Rejected.
+
+## Decision
+
+**Chosen: Option A.** Extend `useConfig` to consume `/api/status:neo4jBrowserUrl`; add `<AdminToolsPanel />` to Dashboard.jsx; fix Neo4j Overview button to read from `useConfig`; add `miscLinks` entry in `bullBoardMount.js`.
+
+The decision is heavily constrained by precedent — every part of the design has an existing in-codebase template. The "design" is mostly choosing which slots to extend.
+
+What we trade away: a small amount of "one less fetch at app start." Acceptable — the existing useConfig already does three parallel fetches; one more is unnoticeable.
+
+## Consequences
+
+**Enabled**
+- Discoverable BullBoard + Neo4j Browser links on the dashboard for operator-tier users.
+- Neo4j Browser button at `/tapestry/databases/neo4j` now works on staging/prod (consumed from environment-aware `neo4jBrowserUrl`, not hardcoded localhost).
+- BullBoard operators can navigate back to Tapestry without typing the URL.
+- `useConfig()` becomes the canonical UI source for `neo4jBrowserUrl` (and any future cross-tool URL fields from `/api/status`).
+
+**Constrained / made harder**
+- Adding a new external-tool card requires touching `<AdminToolsPanel />` + (if it needs a new URL field) extending `useConfig`. Slightly more ceremony than hardcoding, but the point of this story.
+- The brief "panel doesn't render until auth resolves" flash on initial page load is the same UX pattern as Layout.jsx's owner-gated nav items. Operators are used to it.
+
+**Follow-up debt (out of scope here)**
+- Sidebar / nav-menu entries for admin tools (deferred).
+- Audit-log / activity-tracking on these links (not in scope).
+- Unifying `useAuth` and `useConfig` into a single context (large refactor; not warranted by story #19 alone).
+- The `/relay` browser landing page UX bug captured in `_intake.md` — separate future story.
+
+**Firmware reinstall required?** No.
+
+## Implementation notes
+
+The Implementer reads this section verbatim. Total diff: **3 modified files, 0 new files, ~50-70 lines net.**
+
+### 1. `ui/src/context/ConfigContext.jsx`
+
+Extend the existing context to fetch `/api/status` in parallel with the current three endpoints, plucking `neo4jBrowserUrl`:
+
+```js
+export function ConfigProvider({ children }) {
+  const [taPubkey, setTaPubkey] = useState(null);
+  const [ownerPubkey, setOwnerPubkey] = useState(null);
+  const [aRelays, setARelays] = useState(null);
+  const [neo4jBrowserUrl, setNeo4jBrowserUrl] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/assistant/pubkey')
+      .then(r => r.json())
+      .then(d => { if (d.success) setTaPubkey(d.pubkey); })
+      .catch(() => {});
+
+    fetch('/api/owner/pubkey')
+      .then(r => r.json())
+      .then(d => { if (d.success) setOwnerPubkey(d.pubkey); })
+      .catch(() => {});
+
+    fetch('/api/relays')
+      .then(r => r.json())
+      .then(d => { if (d.success) setARelays(d.aRelays); })
+      .catch(() => {});
+
+    fetch('/api/status')
+      .then(r => r.json())
+      .then(d => { if (d.neo4jBrowserUrl) setNeo4jBrowserUrl(d.neo4jBrowserUrl); })
+      .catch(() => {});
+  }, []);
+
+  return (
+    <ConfigContext.Provider value={{ taPubkey, ownerPubkey, aRelays, neo4jBrowserUrl }}>
+      {children}
+    </ConfigContext.Provider>
+  );
+}
+```
+
+### 2. `ui/src/pages/Dashboard.jsx`
+
+Add a new component `AdminToolsPanel` adjacent to the existing section components (next to `HealthRow`, `ConstraintsCheck`, etc.):
+
+```jsx
+function AdminToolsPanel() {
+  const { user } = useAuth();
+  const { neo4jBrowserUrl } = useConfig();
+
+  const isOperator = user?.classification === 'owner' || user?.classification === 'admin';
+  if (!isOperator) return null;
+  if (!neo4jBrowserUrl) return null; // wait for config to load
+
+  const tools = [
+    {
+      label: 'Task Queue (BullBoard)',
+      description: 'View, retry, pause, or remove queued tasks.',
+      href: '/admin/queues/',
+      emoji: '⚙️',
+    },
+    {
+      label: 'Neo4j Browser',
+      description: 'Direct access to the knowledge graph database.',
+      href: `${neo4jBrowserUrl}/browser/preview/`,
+      emoji: '🗄️',
+    },
+  ];
+
+  return (
+    <div className="dashboard-card">
+      <h3 style={{ margin: '0 0 0.75rem', fontSize: '1rem' }}>🛠️ Admin tools</h3>
+      <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+        {tools.map(t => (
+          <a
+            key={t.label}
+            href={t.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn"
+            style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}
+            title={t.description}
+          >
+            <span style={{ fontSize: '1.1rem' }}>{t.emoji}</span>
+            <span>{t.label}</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+Then insert `<AdminToolsPanel />` in the Dashboard's main return JSX, **between `<HealthRow />` and `<ConstraintsCheck />`**.
+
+### 3. `ui/src/pages/databases/Neo4jOverview.jsx` (lines 84-104)
+
+Replace the hardcoded URL with a reference to `useConfig().neo4jBrowserUrl`:
+
+```jsx
+import { useConfig } from '../../context/ConfigContext';
+
+// inside the component:
+const { neo4jBrowserUrl } = useConfig();
+const browserHref = neo4jBrowserUrl ? `${neo4jBrowserUrl}/browser/preview/` : null;
+
+// In the JSX, replace href="http://localhost:8080/browser/preview/" with:
+<a
+  href={browserHref || '#'}
+  target="_blank"
+  rel="noopener noreferrer"
+  style={{ /* …existing styles… */ opacity: browserHref ? 1 : 0.5 }}
+  onClick={browserHref ? undefined : e => e.preventDefault()}
+>
+  🔗 Open Neo4j Browser
+</a>
+```
+
+(The disabled-during-loading fallback is belt-and-suspenders; the button is non-blocking anyway.)
+
+### 4. `src/manage/taskQueue/queue/bullBoardMount.js`
+
+Change `miscLinks` from `[]` to a single entry:
+
+```js
+options: {
+  uiConfig: {
+    boardTitle: 'Tapestry Task Queue — Owner + Admin',
+    boardLogo: { path: '' },
+    miscLinks: [
+      { text: '← Tapestry Dashboard', url: '/tapestry' }
+    ]
+  }
+}
+```
+
+The arrow glyph (`←`) gives it visual hierarchy as a navigation control. URL is `/tapestry` (the canonical dashboard route).
+
+### 5. No backend changes beyond miscLinks
+
+`/api/status` already exposes `neo4jBrowserUrl`. `/api/auth/user-classification` already exposes the role. Nothing else needed.
+
+### Tests (Tester drives in Phase 3)
+
+The Tester writes source-sentinel tests at `test/admin-tools-dashboard-panel.test.js`. Coverage:
+
+- **T1**: `ui/src/pages/Dashboard.jsx` contains a function declaration matching `function AdminToolsPanel` (component exists).
+- **T2**: `AdminToolsPanel` references `useAuth` AND the owner-or-admin classification check (regex over the component body, similar to story #18's T2 isAdminPubkey check).
+- **T3**: `AdminToolsPanel` references `useConfig` and `neo4jBrowserUrl` (proves env-aware URL plumbing).
+- **T4**: `AdminToolsPanel` references both `/admin/queues/` (BullBoard) AND `browser/preview` (Neo4j Browser) — the two cards' URLs.
+- **T5**: `ui/src/context/ConfigContext.jsx` fetches `/api/status` and exposes `neo4jBrowserUrl` from the context provider value.
+- **T6**: `ui/src/pages/databases/Neo4jOverview.jsx` no longer hardcodes `localhost:8080` AND references `useConfig` (proves the bug fix).
+- **T7**: `src/manage/taskQueue/queue/bullBoardMount.js` `miscLinks` array contains an entry referencing `/tapestry` (proves the back-link).
+- **R1** (regression): `ui/src/context/ConfigContext.jsx` still exposes `taPubkey`, `ownerPubkey`, `aRelays` — the existing three fields are NOT dropped during the extension.
+- **R2** (regression): Story #18's `requireOwnerOrAdmin` middleware still exists at `src/api/admin/index.js` (the underlying server gate). Privilege-escalation guardrail T7 in `test/bullboard-admin-access.test.js` also passes (admin-management endpoints still owner-only).
+
+The auth-on-the-client check (`user.classification === 'owner' || === 'admin'`) is a defense-in-depth UI affordance, NOT the actual access control. Real access control still happens at the server middleware (story #18). The Tester does NOT need to write a test exercising "non-admin user sees the panel anyway" because (a) the source sentinel verifies the client-side gate, and (b) the server-side gate (story #18 T7) still bounces them at `/admin/queues`.
+
+### Smoke
+
+Cycle-local (Reviewer):
+- Restart brainstorm via supervisorctl + load Tapestry in browser as the owner pubkey. Verify the "Admin tools" panel appears between HealthRow and ConstraintsCheck (or wherever ConstraintsCheck would be if it weren't hidden by "all good" status).
+- Click BullBoard card → opens new tab → BullBoard UI loads (this was already working post-#18; the test is that the link works).
+- Click Neo4j Browser card → opens `http://localhost:7474/browser/preview/` in a new tab (locally).
+- Visit `/admin/queues/` directly; verify the "← Tapestry Dashboard" link appears in BullBoard's header. Click → lands on `/tapestry` (the dashboard).
+- (Auth-gate spot check) Sign out → reload dashboard → panel is absent. Sign in as a non-owner non-admin pubkey (if available) → panel still absent.
+
+Cycle-staging (Operator):
+- Sign in as the owner pubkey at `https://staging.brainstorm.world/tapestry`. Confirm the panel appears with both cards.
+- Click Neo4j Browser → opens `http://staging.brainstorm.world:7474/browser/preview/` (NOT localhost — this is the bug-fix's acid test).
+- (Optional) Sign in as a non-owner admin pubkey if a test account is available → panel still visible.
+
+### Concept handle
+
+None.
+
+## Out of scope
+
+- **Strfry landing page link.** Deferred per story #19; captured in `_intake.md`.
+- **Hide BullBoard card when `TASK_QUEUE_ENABLED=false`.** Per story #19 §Out of scope, the card linking to a 404 in the rare rollback state is acceptable.
+- **Sidebar / nav-menu entries.** Dashboard-only for now.
+- **Multi-tool admin sub-page** at `/tapestry/admin-tools` (separate route). The story is a dashboard panel; no new route.
+- **`useAuth` ↔ `useConfig` unification.** Larger refactor; not warranted by this story.
+- **Audit log of who clicked what.** Out of scope.

--- a/engineering-team/reviews/19-admin-tools-dashboard-panel.md
+++ b/engineering-team/reviews/19-admin-tools-dashboard-panel.md
@@ -1,0 +1,172 @@
+# Review: Story 19 — Admin tools panel on the dashboard + fix Neo4j-Browser link bug
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-21
+**Diff:** `git diff origin/main..HEAD` (commit `4001dd82`, 6 commits: `f3d54c6d` story, `eb71d192` intake-strfry, `59fd1927` ADR, `e961e1bf` tests, `4001dd82` impl)
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` (host) — **PASS**. `admin-tools-dashboard-panel suite: PASS (9 passed, 0 failed)`. All 15 prior suites still PASS. Overall: **PASS — 16/16**.
+- [x] `node --check src/manage/taskQueue/queue/bullBoardMount.js` — parse clean.
+- [x] **UI build** (`npm --prefix ui run build`) — **succeeded** (host build; in-container build hit a rollup-native binary mismatch which is a containerized-dev quirk, not story-#19 code). Output: 11 chunks; bundle warning about chunk size is pre-existing and not introduced by story #19.
+- [x] _Playwright not applicable — project has no E2E tests; UI is structurally sentineled._
+- [x] _Lint / typecheck not configured — skipped per house rules._
+- [x] **Cycle-local smoke** — **PASS end-to-end** (see §Cycle-local smoke verification below). Served bundle contains all expected story-#19 tokens; `localhost:8080` is gone.
+
+## Spec adherence (AC walk)
+
+| AC (story §) | Status | Notes |
+|---|---|---|
+| Panel visible to signed-in owner | ✓ source | T2 — `function AdminToolsPanel` body checks `user?.classification === 'owner'`. Behavioral verification deferred to cycle-staging. |
+| Panel visible to signed-in admin | ✓ source | T2 same body also checks `'admin'`. Same defer. |
+| Panel NOT visible to non-operator | ✓ source | Implicit from T2 — the gate returns `null` if classification fails. Cycle-local smoke (signed-out) confirms 401 fingerprint at the *server* side; the client-side `null` render is the UI side. |
+| Panel NOT visible to unauthenticated | ✓ source | Same — `user` is `null` when unauth; `user?.classification` undefined; gate fails; return null. |
+| Panel labeled "Admin tools" | ✓ smoke | Served bundle contains "Admin tools" (verified by grep on the post-deploy bundle). |
+| BullBoard card → /admin/queues/ | ✓ smoke | Served bundle contains "/admin/queues/" exactly once (in the new component; not elsewhere). |
+| Neo4j card → env-aware URL | ✓ smoke | Served bundle contains "neo4jBrowserUrl" 3× (once in ConfigContext, once in AdminToolsPanel, once in Neo4jOverview). Cycle-staging confirms the runtime substitution to staging.brainstorm.world:7474. |
+| Both cards open in new tab | ✓ source-spec | ADR pinned `target="_blank"` + `rel="noopener noreferrer"`; implementation matches at Dashboard.jsx:399-400. Cycle-staging operator confirms behaviorally. |
+| **Neo4j Overview bug fix: no localhost:8080** | ✓ smoke | **Served bundle contains 0 hits for "localhost:8080"** — direct evidence the bug is gone. |
+| Neo4j Overview button uses env URL on staging | ✓ source + smoke-deferred | T6 source sentinel + the same `neo4jBrowserUrl` plumbing. Cycle-staging operator confirms `http://staging.brainstorm.world:7474/browser/preview/` opens (not localhost). |
+| BullBoard miscLinks back-link to /tapestry | ✓ source | T7 confirms; bullBoardMount.js diff shows `[{ text: '← Tapestry Dashboard', url: '/tapestry' }]`. |
+| Placement above the fold | ✓ source-spec | Dashboard.jsx:801: `<AdminToolsPanel />` inserted between `<HealthRow />` and `<TapestryKeyStatus />`. Visually that lands after stats + health, before more-specific subsystem panels. Reasonable above-the-fold slot. |
+| No regression in 16 suites | ✓ | npm test 16/16 PASS on host AND inside container. R1 + R2 regression guards both green. |
+
+## ADR adherence
+
+- [x] **Files changed match ADR 0017 §Implementation notes exactly:**
+  - `ui/src/context/ConfigContext.jsx` — 4th fetch (`/api/status`) + 4th state field (`neo4jBrowserUrl`) + provider exposure ✓
+  - `ui/src/pages/Dashboard.jsx` — `AdminToolsPanel` component + invocation in main JSX ✓
+  - `ui/src/pages/databases/Neo4jOverview.jsx` — destructure `neo4jBrowserUrl` + replace hardcoded href with computed `browserHref` ✓
+  - `src/manage/taskQueue/queue/bullBoardMount.js` — `miscLinks` populated ✓
+- [x] **No new files, no new dependencies.** Diff stat: 4 modified source files (+~84 net lines) + new test file + engineering-team artifacts.
+- [x] **Auth check uses the established idiom**: `user?.classification === 'owner' || user?.classification === 'admin'`. Verified by grep — same shape as Layout.jsx:137, BrainstormUserMenu.jsx:80, Dashboard.jsx:58/238/517.
+- [x] **Defensive null check** — Implementer added `if (!neo4jBrowserUrl) return null` to handle the brief loading window between `useEffect` mount and `/api/status` response. Avoids broken-href flash. Beyond strict ADR spec but the right thing.
+- [x] **Neo4jOverview loading fallback** — the `browserHref || '#'` + `onClick: preventDefault` + 50% opacity is the visual signal during loading. Slightly more polish than the ADR strictly required, but matches the cycle-local skill's "graceful degradation" principle.
+
+## Concept-graph integrity
+
+- [x] No concept-graph schema changes (ADR §Consequences confirmed "no firmware reinstall").
+- [x] No concept handles touched.
+
+## Things tests can't catch — hidden-hazard audit
+
+Repo-wide audit beyond the test surface:
+
+| Hazard | Status |
+|---|---|
+| `localhost:8080` reappears elsewhere in the UI | **Closed.** `grep -rn "localhost:8080" ui/src` returns ZERO hits. The Neo4j hardcode was the only one. |
+| `useConfig` extension breaks an existing consumer | **Closed by R1.** The regression sentinel asserts `taPubkey`, `ownerPubkey`, `aRelays` and their fetches all remain. Manual `grep` confirms: ConfigContext.jsx still has all 4 state hooks + all 4 fetches; the export still includes the original 3 fields plus the new `neo4jBrowserUrl`. |
+| Story #18's server-side `requireOwnerOrAdmin` gate accidentally removed | **Closed by R2 + bullboard-admin-access T7.** Both still pass. Story #19 didn't touch any server-side auth code. |
+| `AdminToolsPanel` placement breaks Dashboard layout | **Closed by cycle-local smoke.** Container restart succeeded; Express still serves the dashboard URL (HTTP 200); index.html still references the new bundle. No JavaScript errors at container restart. |
+| Defensive `browserHref || '#'` fallback enables accidental click during loading | **Closed by onClick preventDefault.** The href becomes `'#'` AND the click handler prevents default — both belt and suspenders. Plus the 50% opacity is a clear visual signal. |
+| `neo4jBrowserUrl` null in ConfigContext provider value | **Acceptable.** `useState(null)` initial; provider value will be `null` until /api/status fetch completes. Consumers correctly guard with `!neo4jBrowserUrl` checks (AdminToolsPanel) or computed-null fallback (Neo4jOverview). |
+| `target="_blank"` without `rel="noopener noreferrer"` (tabnabbing) | **Closed.** Both anchors in AdminToolsPanel + Neo4jOverview include both attributes. Defensive. |
+| BullBoard miscLinks URL collision with other React routes | **Closed.** `/tapestry` is the canonical dashboard URL per App.jsx:104. miscLinks renders a hyperlink that navigates the BullBoard page to Tapestry — different surface entirely; no React-Router conflict. |
+| Browser caching old bundle after deploy | **Acceptable / cycle-staging concern.** Vite generates content-hashed filenames (e.g., `index-CeV3Zfzi.js`); the index.html change forces a fresh fetch. Operators may need to hard-reload once on the day of deploy — same as every other UI change. Pre-existing posture. |
+| Two `<a target="_blank">` open new tabs and lose dashboard scroll position | **Acceptable.** `target="_blank"` is what the ACs require; preserving original-tab state is the whole point. |
+| Future "remove BullBoard back-link" rollback | **Trivial:** revert miscLinks to `[]` in bullBoardMount.js. No coordination needed. |
+
+All hazards closed or accepted with reasoning.
+
+## Cycle-local smoke verification
+
+Drove the build-deploy-probe round-trip that source sentinels can't reach.
+
+### Setup
+
+The Implementer's diff touches UI source (Vite-built); the bind-mount alone doesn't update the served bundle. I ran the Vite build on the host (the in-container build hit a rollup-native binary mismatch — known containerized-dev quirk; the host build is the canonical recipe per cycle-local skill anyway), then `docker cp dist/. tapestry:/usr/local/lib/node_modules/brainstorm/dist/`, then `supervisorctl restart brainstorm`.
+
+### S1 — Bundle content verification
+
+```
+Bundle in dist/ (post-deploy):  assets/index-CeV3Zfzi.js
+  Admin tools:                  1
+  /admin/queues/:               1
+  browser/preview:              2  (AdminToolsPanel + Neo4jOverview)
+  neo4jBrowserUrl:              3  (ConfigContext + 2 consumers)
+  localhost:8080 (bug):         0  ← BUG GONE
+```
+
+**Direct evidence the new code shipped in the bundle.** Every token the ADR specified appears with the expected count; the only thing that should be absent (`localhost:8080`) is genuinely absent.
+
+### S2 — Served bundle matches deployed bundle
+
+```
+$ curl http://localhost:80/tapestry | grep -oE 'assets/index-[A-Za-z0-9]+\.js'
+assets/index-CeV3Zfzi.js
+```
+
+`index.html` references the new bundle — Express is serving what we deployed.
+
+### S3 — Dashboard SPA shell loads
+
+```
+$ curl -o /dev/null -w "%{http_code}" http://localhost:80/tapestry
+HTTP 200
+```
+
+Dashboard returns 200; no JS errors at container startup.
+
+### S4 — Existing endpoints unchanged
+
+```
+$ curl -w "%{http_code}" http://localhost:80/api/auth/status
+HTTP 200 → {"authenticated":false,"pubkey":null}
+
+$ curl -w "%{http_code}" http://localhost:80/admin/queues
+HTTP 401 → {"success":false,"error":"Not authenticated"}
+```
+
+`/api/auth/status` works (the auth-state plumbing AdminToolsPanel depends on). `/admin/queues` still gated (story #18 server contract intact — the BullBoard mount survived the bullBoardMount.js edit unscathed).
+
+### Smoke scenarios deferred to operator at cycle-staging (acceptable gaps)
+
+- **Owner-authenticated → panel visible with both cards.** Requires real session cookie. The acid test for ACs §Panel visibility owner branch.
+- **Admin-authenticated → panel visible.** Same.
+- **Non-owner non-admin → panel NOT visible.** Requires authenticated session with a non-operator pubkey.
+- **Click Neo4j Browser → opens `http://staging.brainstorm.world:7474/browser/preview/`.** The acid test for the bug fix — must NOT be `localhost`. Operator's natural browser flow validates this.
+- **Click BullBoard miscLinks ← Tapestry Dashboard → lands on /tapestry.** The acid test for the back-link.
+
+## House rules check
+
+- [x] Concept Graph API authority respected (no concept change).
+- [x] No new lint/typecheck/build tooling.
+- [x] No firmware reinstall needed.
+- [x] Per-phase commits in order: story → intake (companion docs) → ADR → tests → impl. Clean stack on top of `origin/main` (which already has story #18).
+
+## Findings
+
+### Blocking
+
+_None._
+
+### Non-blocking (recorded, do not gate)
+
+1. **Defensive loading-fallbacks (`if (!neo4jBrowserUrl) return null` in AdminToolsPanel; `browserHref || '#'` + preventDefault in Neo4jOverview) added by the Implementer.** Not in the ADR spec, but the right call — avoids "click button → broken page" during the brief config-loading window. Approved.
+
+2. **JSX comment headers (e.g., `/* ─── Admin Tools ─────── */`) added to keep visual style consistent with the existing Dashboard.jsx file.** Matches the file's convention for section components. Approved.
+
+3. **Bundle warning ("Some chunks are larger than 500 kB")** during `npm run build` — pre-existing, not introduced by story #19. Story #19 adds ~60 lines to Dashboard.jsx and ~10 lines to ConfigContext.jsx + Neo4jOverview.jsx; the existing index-CeV3Zfzi.js is 1.4 MB (mostly nostr-tools, ajv, vis-network). Story #19's contribution is rounding noise.
+
+4. **In-container Vite build failed on rollup native binary mismatch** — a containerized-dev environmental issue (host has arm64 binaries; container expects x86_64 Linux binaries or vice versa). Not a story #19 problem. The cycle-local skill's documented recipe (host build + docker cp) is the canonical path and worked cleanly.
+
+5. **Behavioral verification of the visibility branches deferred to cycle-staging.** AC §Panel visibility (owner, admin, non-operator, unauthenticated) are best validated by an operator in a real browser session. Source sentinels + cycle-local bundle inspection get us 80% there; the last 20% is the operator clicking through the dashboard with real credentials.
+
+## Verdict
+
+**PASS end-to-end.**
+
+Source-side (16/16 suites green on both host AND container — the test file structurally pins every ADR-required code shape) and behavioral-side (cycle-local bundle inspection shows the new tokens present with correct counts; the `localhost:8080` bug is gone from the served bundle; the BullBoard server-side gate is unaffected) both confirm the implementation matches ADR 0017.
+
+The 5 non-blocking observations are: defensive UX additions beyond strict spec (approved); pre-existing build warnings; environmental quirks in the dev container; deferred behavioral verification (the natural cycle-staging operator surface). None gate ship.
+
+Story #19 is ready for the deploy chain (`cycle-staging`, then on explicit confirmation `cycle-prod`).
+
+The acid test the operator can drive at cycle-staging:
+
+1. Sign in as the owner pubkey at `https://staging.brainstorm.world/tapestry`. Confirm the "🛠️ Admin tools" panel appears with both cards (BullBoard + Neo4j Browser).
+2. Click Neo4j Browser. Must open `http://staging.brainstorm.world:7474/browser/preview/` (NOT localhost). This is the **bug-fix acid test** — the visible URL in the new tab decides PASS/FAIL.
+3. Click BullBoard card → BullBoard UI loads → click "← Tapestry Dashboard" in BullBoard's header → lands back on `/tapestry`. **Navigation-loop acid test.**
+4. (If a non-operator test account is available) sign in as that pubkey → panel NOT visible → ACs §Panel visibility gating empirically confirmed.
+
+If those four pass, story #19 is fully empirically verified in addition to its 16/16 source-sentinel coverage.

--- a/engineering-team/stories/19-admin-tools-dashboard-panel.md
+++ b/engineering-team/stories/19-admin-tools-dashboard-panel.md
@@ -95,5 +95,5 @@ Deferred to Architect:
 ## Linked artifacts
 
 - ADR: [0017-admin-tools-dashboard-panel.md](../decisions/0017-admin-tools-dashboard-panel.md)
-- Test plan: (filled in after Test Design phase)
+- Test plan: [19-admin-tools-dashboard-panel.test-plan.md](19-admin-tools-dashboard-panel.test-plan.md)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/19-admin-tools-dashboard-panel.md
+++ b/engineering-team/stories/19-admin-tools-dashboard-panel.md
@@ -1,0 +1,99 @@
+# Story 19: Admin tools panel on the dashboard + fix Neo4j-Browser link bug
+
+**Status:** Approved
+**Created:** 2026-05-21
+**Type:** Feature (UI surface + bug fix bundled)
+
+## Background
+
+Stories #13 + #15 + #17 + #18 collectively shipped the BullMQ task queue + BullBoard UI at `/admin/queues` (owner-or-admin gated). Today there is **no link to BullBoard from anywhere in the Tapestry UI** — operators have to know the URL by hand and type it directly. Same gap for the Neo4j Browser at `http://${DOMAIN_NAME}:7474/browser/preview/` — there *is* a link button, but it's broken: hardcoded to `http://localhost:8080/browser/preview/` (wrong port; wrong host). The button has presumably worked for local dev but never on staging or prod.
+
+The operator's day-to-day pattern includes occasional dives into BullBoard (queue triage) and Neo4j Browser (graph inspection). Both are operator-tier tools — non-admin users have no business reaching either. They warrant a discoverable, environment-aware home in the dashboard's UI, gated to the operator audience.
+
+A small companion piece: BullBoard's UI has a built-in `miscLinks` slot for cross-tool navigation. Today it's empty. Adding a "Tapestry Dashboard" link there closes the navigation loop — operators inside BullBoard can return to Tapestry without typing the URL.
+
+## User-facing description
+
+**As the owner or an admin** of a Tapestry node, **I want** a discoverable "Admin tools" panel on the dashboard with working links to BullBoard and Neo4j Browser, **and** a way back from BullBoard to the dashboard, **so that** I can navigate the operator-tier UI cluster (Tapestry + BullBoard + Neo4j Browser) without memorizing URLs — and so that the existing Neo4j Browser link button works on staging and prod, not just localhost.
+
+**As a non-owner non-admin user** (signed in or signed out), **I want** the Admin tools panel to be invisible to me, **so that** I don't see UI affordances I can't use.
+
+## Acceptance criteria
+
+### Panel visibility (gating)
+
+- [ ] Given a signed-in **owner** session, when the dashboard loads, then the "Admin tools" panel is visible.
+- [ ] Given a signed-in pubkey that is in `BRAINSTORM_ADMIN_PUBKEYS`, when the dashboard loads, then the "Admin tools" panel is visible.
+- [ ] Given a signed-in pubkey that is **neither** the owner nor in `BRAINSTORM_ADMIN_PUBKEYS`, when the dashboard loads, then the "Admin tools" panel is **NOT** visible.
+- [ ] Given an **unauthenticated** visitor, when the dashboard loads, then the "Admin tools" panel is **NOT** visible.
+
+### Panel contents
+
+- [ ] The panel is labeled "Admin tools" with a recognizable icon/emoji at the operator's discretion (e.g., 🛠️).
+- [ ] The panel contains a card/link to **BullBoard** at `/admin/queues/` (same-origin; relative URL is sufficient).
+- [ ] The panel contains a card/link to **Neo4j Browser** at the environment-aware URL (e.g., `http://staging.brainstorm.world:7474/browser/preview/` on staging; `http://brainstorm.world:7474/browser/preview/` on prod; `http://localhost:7474/browser/preview/` on local). The URL value flows from the existing backend-provided `neo4jBrowserUrl` field (already in `/api/status`).
+- [ ] Both cards/links open in a new tab/window (so the operator doesn't lose their place in Tapestry).
+
+### Bug fix: existing Neo4j Browser button
+
+- [ ] The "Open Neo4j Browser" button on the Neo4j Overview page (currently at `/tapestry/databases/neo4j`) no longer hardcodes `http://localhost:8080/browser/preview/`. It uses the same environment-aware `neo4jBrowserUrl` source as the new Admin tools panel.
+- [ ] Verified on staging: clicking the button from `https://staging.brainstorm.world/tapestry/databases/neo4j` opens `http://staging.brainstorm.world:7474/browser/preview/` (not `localhost`).
+- [ ] Verified on prod: same with `brainstorm.world`.
+
+### BullBoard cross-link (companion)
+
+- [ ] BullBoard's UI displays a "Tapestry Dashboard" link (or similar wording) in its `miscLinks` area.
+- [ ] Clicking the link navigates the operator from BullBoard back to the Tapestry dashboard (`/` or `/tapestry/dashboard`, whichever is the canonical dashboard route).
+
+### Placement on the dashboard
+
+- [ ] The "Admin tools" panel appears in a visually coherent location on the dashboard — Architect's call exactly where, but the panel must be discoverable above the fold for most viewport sizes, NOT buried at the bottom.
+
+### Quality
+
+- [ ] No regression in any of the 15 npm test suites.
+- [ ] No new lint/typecheck/build tooling.
+
+## Concepts touched
+
+- Tapestry dashboard UI (page at `/`)
+- Neo4j Overview UI page (`/tapestry/databases/neo4j`)
+- BullBoard mount + its `miscLinks` config
+- Existing `/api/status` payload (already provides `neo4jBrowserUrl`)
+- The session-auth surface that the UI consults to know whether the current user is owner-or-admin (Architect resolves which API/helper)
+
+## Out of scope
+
+- **A strfry landing-page link.** The strfry HTTP face is NIP-11 JSON for clients, not operator-facing. Skipped per the prior chat discussion. (A separate issue with the `/relay` browser landing page being unhelpful plaintext + the NIP-11 merge being incomplete has been captured in `_intake.md` for a future story.)
+- **Sidebar / nav-menu entries for these tools.** Dashboard-only for now. If operators want left-nav entries later, that's a future refinement.
+- **An "Admin tools" page** (separate route). The panel lives on the dashboard; no new page.
+- **Read-only-for-admins or other tier distinctions** for BullBoard access. Story #18 already settled "owner-or-admin full parity"; this story is about discoverability + visibility, not access control.
+- **Audit log of who clicked what link.** Logs are external-tool concerns, not Tapestry's.
+- **Neo4j Browser bookmarks or queries** preconfigured by Tapestry. Out of scope — we just link to the tool's landing page.
+- **Conditionally hiding the BullBoard card if `TASK_QUEUE_ENABLED=false`.** Per story #17 / ADR 0015, the default is now `=true` — the flag-off case is rare and not worth a special UI branch. If someone has it off, they'll click the BullBoard card and get a 404 from Express; that's an acceptable degradation for an admin-tier surface in the rollback state.
+- **The "back to Tapestry" link in BullBoard's `miscLinks` being session-context-aware** (e.g., taking the operator to the page they came from). Just sends them to the dashboard root — simpler, sufficient.
+- **Story-#18 follow-up auth-state work** (e.g., a `req.session.role` field) beyond what this story strictly needs. If the auth-state-for-UI mechanism turns out to want broader cleanup, that's a separate story.
+
+## Open questions
+
+Resolved at planning (2026-05-21):
+
+- **Panel name** → **"Admin tools"** with operator's choice of icon.
+- **Visibility for non-owner non-admin users** → **hidden entirely** (not greyed out or 403-on-click).
+- **Visibility for unauthenticated visitors** → **hidden entirely**.
+- **Scope of bug fix** → fix the existing Neo4j Browser button at `/tapestry/databases/neo4j` as part of this story (consumes the same environment-aware URL as the new panel).
+- **strfry inclusion** → no.
+- **Cross-link from BullBoard back to Tapestry** → yes, via BullBoard's existing `miscLinks` config.
+
+Deferred to Architect:
+
+- **Which API endpoint(s) tell the UI the user is owner-or-admin.** Today there's `/api/auth/status` and `/api/status` (and an existing `/api/owner/pubkey`). One of these likely already gives the UI enough info, or needs a small extension. Architect picks; if the existing surface is sufficient (e.g., compare session pubkey to the owner pubkey + run a `BRAINSTORM_ADMIN_PUBKEYS` membership check on the client), great — if a new endpoint or field is cleaner, that's a small addition.
+- **Exact placement on the dashboard** — between which existing rows. The PO's preference (from the prior chat): between HealthRow and any below-the-fold sections. Architect confirms or proposes better.
+- **Card visual style** — a separate small-card row, or inline with existing stat cards but visually distinct. Architect chooses to match existing dashboard idioms.
+- **Whether to fold this into one ADR** or split. Three coordinated changes (panel, miscLinks, Neo4j bug fix) — PO sees them as one coherent feature; Architect's call whether the design space warrants an ADR.
+
+## Linked artifacts
+
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/19-admin-tools-dashboard-panel.md
+++ b/engineering-team/stories/19-admin-tools-dashboard-panel.md
@@ -94,6 +94,6 @@ Deferred to Architect:
 
 ## Linked artifacts
 
-- ADR: (filled in after Architecture phase)
+- ADR: [0017-admin-tools-dashboard-panel.md](../decisions/0017-admin-tools-dashboard-panel.md)
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/19-admin-tools-dashboard-panel.md
+++ b/engineering-team/stories/19-admin-tools-dashboard-panel.md
@@ -96,4 +96,4 @@ Deferred to Architect:
 
 - ADR: [0017-admin-tools-dashboard-panel.md](../decisions/0017-admin-tools-dashboard-panel.md)
 - Test plan: [19-admin-tools-dashboard-panel.test-plan.md](19-admin-tools-dashboard-panel.test-plan.md)
-- Review: (filled in after Review phase)
+- Review: [../reviews/19-admin-tools-dashboard-panel.md](../reviews/19-admin-tools-dashboard-panel.md) — **PASS** end-to-end (16/16 suites + cycle-local bundle inspection shows new tokens present & `localhost:8080` bug eliminated from served bundle).

--- a/engineering-team/stories/19-admin-tools-dashboard-panel.test-plan.md
+++ b/engineering-team/stories/19-admin-tools-dashboard-panel.test-plan.md
@@ -1,0 +1,127 @@
+# Test Plan: Story 19 — Admin tools panel on the dashboard + fix Neo4j-Browser link bug
+
+**Story:** `engineering-team/stories/19-admin-tools-dashboard-panel.md`
+**ADR:** `engineering-team/decisions/0017-admin-tools-dashboard-panel.md`
+**Date:** 2026-05-21
+
+## Test posture
+
+Source/structural **sentinels** in a new file `test/admin-tools-dashboard-panel.test.js` pin the ADR-required UI shape: `<AdminToolsPanel />` declared in `Dashboard.jsx`, gated by `useAuth` + the owner-or-admin classification idiom, consuming `useConfig().neo4jBrowserUrl` for the env-aware Neo4j Browser URL, and referencing both `/admin/queues/` and `browser/preview` as card destinations. Companion sentinels cover the `ConfigContext` extension (4th fetch + 4th field), the `Neo4jOverview` bug fix (no more hardcoded localhost), and the `bullBoardMount.js` miscLinks back-link to `/tapestry`.
+
+The **behavioral round-trip** — sign in as an owner pubkey, observe the panel appear with both cards, click them, navigate via miscLinks back from BullBoard — is reproducible only with a real browser + session cookie and is the **authoritative cycle-staging smoke** (operator-required).
+
+This project has **no Playwright tests in CI**, so client-side behavior (panel visibility branches, click handlers) is covered structurally via source sentinels. The "user.classification check appears in the component" sentinel is defense-in-depth: the actual access control for BullBoard is the story #18 server middleware, which has its own test suite (`bullboard-admin-access` 9 sentinels, all still green).
+
+## Coverage map
+
+| Criterion (story §) | Test name | Test file | Level |
+|---|---|---|---|
+| AC: owner sees the panel | T1 (component declared) + T2 (useAuth + classification check matches 'owner') | `test/admin-tools-dashboard-panel.test.js` | source sentinels |
+| AC: admin sees the panel | T2 (classification check matches 'admin' too) | `test/admin-tools-dashboard-panel.test.js` | source sentinel |
+| AC: non-operator does NOT see the panel | T2 (early `return null` branches on the gate failing — verified by the existence of the gate-check tokens; behavioral verification deferred to cycle-staging) | `test/admin-tools-dashboard-panel.test.js` | source sentinel + smoke |
+| AC: unauthenticated does NOT see the panel | Same as above — `user?.classification` is undefined when unauth, so the gate falls through; verified structurally via T2 | `test/admin-tools-dashboard-panel.test.js` | source sentinel + smoke |
+| AC: panel labeled "Admin tools" | T1's spec requires the panel; the literal text + emoji come for free if T1 passes (implementation has the heading inline). No separate sentinel — visual confirmation is a smoke step. | — | smoke |
+| AC: BullBoard card → /admin/queues/ | T4 (BullBoard URL referenced) | `test/admin-tools-dashboard-panel.test.js` | source sentinel |
+| AC: Neo4j card → env-aware URL | T3 (useConfig + neo4jBrowserUrl referenced) + T4 (browser/preview referenced) | `test/admin-tools-dashboard-panel.test.js` | source sentinel |
+| AC: both cards open in a new tab | Implementation detail — `target="_blank"`. Not separately sentineled (ADR spec is in the Implementation notes; deviating is highly unlikely). Cycle-staging operator confirms behaviorally. | — | smoke |
+| AC: Neo4j Overview bug fix (no localhost:8080 hardcode) | T6 (assert hardcoded URL is gone AND useConfig is consumed) | `test/admin-tools-dashboard-panel.test.js` | source sentinel |
+| AC: Neo4j Overview button uses env URL — verified on staging + prod | Cycle-staging smoke: clicking the button from `https://staging.brainstorm.world/tapestry/databases/neo4j` opens `http://staging.brainstorm.world:7474/browser/preview/` (NOT localhost). | — | smoke (operator/Reviewer) |
+| AC: BullBoard "Tapestry Dashboard" miscLinks entry | T7 (miscLinks contains /tapestry URL) | `test/admin-tools-dashboard-panel.test.js` | source sentinel |
+| AC: clicking miscLinks navigates to /tapestry | Behavioral — cycle-staging smoke. Source sentinel pins the URL string; click behavior is BullBoard's native behavior. | — | smoke |
+| AC: placement above the fold (between HealthRow and ConstraintsCheck) | ADR §Implementation §2 specifies the slot; no separate sentinel (placement is hard to source-grep meaningfully — the Implementer puts `<AdminToolsPanel />` at the right spot and the Reviewer eyeballs). | — | smoke |
+| AC: no regression in 15 prior suites | `npm test` overall PASS post-impl. The two regression sentinels (R1, R2) belt-and-suspenders specific contracts. | (full gate) | gate |
+| AC: ConfigContext extension consumes /api/status + exposes neo4jBrowserUrl | T5 + R1 | `test/admin-tools-dashboard-panel.test.js` | source sentinels |
+| AC: existing 3 ConfigContext fields preserved | R1 (taPubkey + ownerPubkey + aRelays still referenced AND still fetched) | `test/admin-tools-dashboard-panel.test.js` | source sentinel (regression) |
+| AC: story #18's server-side gate intact | R2 (requireOwnerOrAdmin still declared in admin/index.js) + bullboard-admin-access suite's existing 9 sentinels all still pass | `test/admin-tools-dashboard-panel.test.js` + `test/bullboard-admin-access.test.js` | source sentinels (regression) |
+
+## Edge cases
+
+| Case | Status |
+|---|---|
+| `useConfig().neo4jBrowserUrl` is null during initial load | **Documented & handled.** ADR §Implementation §2 specifies the panel returns `null` when `neo4jBrowserUrl` is missing — wait for config to load. No flash of broken Neo4j link. Verified structurally via T3. |
+| User signs out while looking at the dashboard | **Handled.** `useAuth` returns `user: null` → classification check returns false → panel returns null on next render. No additional code needed. |
+| Admin removed from `BRAINSTORM_ADMIN_PUBKEYS` while their session is open | **Acceptable.** The UI gate uses `classification`, which was resolved at sign-in. They'll still see the panel until next reload — at which point the gate recomputes. The real access control is the server middleware (story #18), which re-checks every request. Same trade-off as story #18's "session cookie reuse after admin removal" — documented there. |
+| `TASK_QUEUE_ENABLED=false` (rare rollback state) | **Per story #19 §Out of scope**: card linking to a 404 is acceptable. Not separately tested. Cycle-staging Reviewer doesn't exercise this. |
+| Neo4j Browser at `http://${host}:7474` is unreachable (firewall, port closed) | **Acceptable.** The card links there; whether the browser can actually reach the port is a deploy-environment concern, not a UI concern. Same trade-off as the prior `Open Neo4j Browser` button (story #19 just makes the URL correct; reachability was pre-existing). |
+| BullBoard mount fails (e.g., Redis down at boot, TASK_QUEUE_ENABLED=true but no queue) | **Acceptable.** Card links to a 404; operator can navigate back. The story's narrow scope is dashboard discoverability — handling backend failure modes is out of scope. |
+| Future change accidentally removes the `useConfig` extension | **Caught by R1.** The regression sentinel asserts the 3 existing fields AND the 3 existing fetches remain. If a future cleanup removes any of them, R1 trips loudly. |
+
+## Test infrastructure
+
+- **Framework:** Node built-in runner via `npm test` (entry: `test/test.js`).
+- **New test file:** `test/admin-tools-dashboard-panel.test.js`, registered in `test/test.js` (four-spot wiring: require, run, log, ok-check).
+- **No new test infrastructure.** Same plain-Node sentinel pattern stories #13/#15/#16/#17/#18 used.
+- **No Playwright** — the project doesn't have it; UI is structurally sentineled, behaviorally smoked.
+- **Concept Graph API:** not required.
+- **Firmware reinstall:** no.
+
+## How to run
+
+```
+npm test
+```
+
+The new suite registers as `admin-tools-dashboard-panel suite:` after `bullboard-admin-access suite:` in `test/test.js`. Post-implementation expected: `PASS (9 passed, 0 failed)`.
+
+For Reviewer cycle-local smoke (behavioral round-trip):
+
+```bash
+# 1. Inside the tapestry container, rebuild the UI bundle:
+docker exec tapestry bash -c 'cd /usr/local/lib/node_modules/brainstorm/ui && npm run build && cp -r ../dist/. ../dist-prev/' 2>&1 | tail -3
+docker exec tapestry supervisorctl restart brainstorm
+# 2. Open Tapestry in browser, sign in as the owner pubkey.
+#    Verify: "🛠️ Admin tools" panel visible between HealthRow and below sections.
+#    Click "Task Queue (BullBoard)" → new tab → BullBoard UI loads.
+#    Click "Neo4j Browser" → new tab → http://localhost:7474/browser/preview/ loads.
+# 3. From /admin/queues/, verify the "← Tapestry Dashboard" miscLinks entry is
+#    visible in BullBoard's header. Click → navigates to /tapestry.
+# 4. Sign out → reload dashboard → panel ABSENT.
+```
+
+For operator cycle-staging smoke (the acid test):
+
+1. Sign in to `https://staging.brainstorm.world/tapestry` as the owner pubkey.
+2. Confirm the "Admin tools" panel appears with both cards.
+3. Click "Neo4j Browser" — must open `http://staging.brainstorm.world:7474/browser/preview/` in a new tab. **NOT localhost** (this is the bug-fix acid test).
+4. Click "Task Queue (BullBoard)" — opens BullBoard at `/admin/queues/` with the "← Tapestry Dashboard" link in its header. Click the back-link → lands on `/tapestry`.
+5. (Optional) Sign in as a non-owner admin pubkey if available → panel still visible.
+
+## Verification
+
+The new tests fail with the pre-implementation code (no `<AdminToolsPanel />`, no ConfigContext extension, hardcoded Neo4j URL, empty miscLinks). Confirmed on 2026-05-21 at commit `59fd1927`:
+
+```
+admin-tools-dashboard-panel suite:
+  ✗ T1: Dashboard.jsx declares function AdminToolsPanel
+      ui/src/pages/Dashboard.jsx does not declare `function AdminToolsPanel`...
+  ✗ T2: AdminToolsPanel consumes useAuth and gates on owner-or-admin
+      AdminToolsPanel function declaration not found — T1 must pass first.
+  ✗ T3: AdminToolsPanel consumes useConfig + neo4jBrowserUrl
+      AdminToolsPanel function declaration not found — T1 must pass first.
+  ✗ T4: AdminToolsPanel references both /admin/queues/ + browser/preview
+      AdminToolsPanel function declaration not found — T1 must pass first.
+  ✗ T5: ConfigContext fetches /api/status + exposes neo4jBrowserUrl
+      ConfigContext.jsx does not fetch /api/status...
+  ✗ T6: Neo4jOverview no longer hardcodes localhost:8080 + consumes useConfig
+      Neo4jOverview.jsx still hardcodes `localhost:8080/browser/preview/`...
+  ✗ T7: bullBoardMount.js miscLinks includes /tapestry back-link
+      bullBoardMount.js miscLinks does not contain a /tapestry back-link...
+  ✓ R1: ConfigContext.jsx still exposes existing 3 fields (additive extension)
+  ✓ R2: src/api/admin/index.js still declares requireOwnerOrAdmin (story #18 contract)
+
+Test Results
+-------------
+admin-tools-dashboard-panel suite:               FAIL (2 passed, 7 failed)
+Overall:                                         FAIL
+```
+
+The 15 prior suites continue to PASS — no collateral damage. Each of the 7 failures carries a right-reason message pointing the Implementer at a specific edit per ADR 0017 §Implementation:
+- T1 → add the component to Dashboard.jsx
+- T2 → in the new component body, useAuth + classification checks
+- T3 → in the new component body, useConfig + neo4jBrowserUrl
+- T4 → in the new component body, the two card URLs
+- T5 → extend ConfigContext.jsx with the 4th fetch + 4th field
+- T6 → replace the hardcoded URL in Neo4jOverview.jsx with useConfig
+- T7 → populate miscLinks in bullBoardMount.js
+
+R1 + R2 are passing now and must continue to pass — they guard the ConfigContext additivity AND the story #18 server-side gate.

--- a/engineering-team/stories/_intake.md
+++ b/engineering-team/stories/_intake.md
@@ -168,3 +168,43 @@ Option 1 is structurally cleaner; option 2 is a one-line fix. Architect's call.
 **Strictness:** Standard
 **Phase path:** Planning → Architecture (likely brief) → (Test Design optional — if option 2, just a sentinel that the log line isn't emitted at info level; if option 1, a sentinel that `/etc/brainstorm.conf` is parsed at most once per process lifetime) → Implementation → Review
 **Priority:** Low. Captured during the operator's 2026-05-21 plan-of-plans (steps 1 + 2 done, step 3 — this — deliberately deferred). Pick up when operator-experience polish is in season; no urgency.
+
+---
+
+## 2026-05-21 — UX: /relay public HTTP landing page is unhelpful plain-text (+ NIP-11 merge silently incomplete)
+
+**Surfaced during:** Story #19 planning chat. Operator asked why `https://staging.brainstorm.world/relay` shows "Tapestry NIP-50 Relay Proxy - connect via WebSocket" instead of the more useful HTML landing page that most strfry deployments show (e.g., the older Tapestry instance at `wss://straycat.brainstorm.social/relay`).
+
+**Architectural background:**
+- `/relay` routes (via nginx) to a custom NIP-50 search proxy at `nip50-proxy/src/index.js`, NOT directly to strfry. The proxy translates `REQ` messages containing NIP-50 search filters into Meilisearch queries with WoT scoring, and forwards everything else through to strfry on `127.0.0.1:7777`.
+- This proxy is a real differentiator — straycat doesn't have it, so its `/relay` goes straight to strfry's native HTTP face (which serves a default HTML landing page when no `Accept: application/nostr+json` header is present).
+- The current Tapestry proxy was built primarily for WebSocket clients; the HTTP/browser GET case was treated as low-priority. The fallback at [`nip50-proxy/src/index.js:74`](nip50-proxy/src/index.js#L74) just returns plain text.
+
+**Two related issues (one bug + one UX):**
+
+1. **Bug: NIP-11 merge silently drops strfry's native fields.**
+   - `nip50-proxy/src/nip11.js:18-38` fetches strfry's NIP-11 via HTTP to `127.0.0.1:7777` and is supposed to spread its fields into the merged response. But the production response carries ONLY the NIP-50-added fields (`software`, `supported_nips`, `search_capabilities`) — no `name`, `pubkey`, `contact`, `description`, `limitation`, etc.
+   - Direct comparison: straycat's `/relay` NIP-11 includes all the strfry-side fields (e.g., `"contact": "nostr: npub1...", "description": "Brainstorm: a personalized WoT relay featuring the Grapevine", "limitation": { "max_limit": 500, ... }`). Tapestry's `/relay` NIP-11 is missing all of those.
+   - Likely cause: either strfry's HTTP face isn't reachable on `127.0.0.1:7777` from inside the proxy's process, OR the request is silently failing and `fetchStrfryInfo()` falls through to its empty-object fallback at line 37. The function catches errors and logs a warning; check `nip50-proxy.log` for `[nip11] Failed to fetch strfry NIP-11 info` to confirm.
+   - Nostr clients that fetch relay info via NIP-11 currently see an incomplete document. Worth fixing regardless of the UX work.
+
+2. **UX: HTML browser landing page is bare plaintext.**
+   - When a browser GETs `/relay` (i.e., Accept header is `text/html`), the proxy returns one line: `"Tapestry NIP-50 Relay Proxy - connect via WebSocket"`.
+   - A more useful response would be a small HTML page showing: relay name, WebSocket endpoint URL (with copy-to-clipboard hint), supported NIPs (with friendly descriptions especially for the WoT-scored NIP-50 extension Tapestry adds), and possibly a discreet "About this relay" link.
+   - Straycat shows this is the natural expectation — older Tapestry instances inherited strfry's default HTML landing page; the NIP-50 proxy regressed it.
+
+**Out of scope for the immediate triage:**
+- Rewriting the proxy's WebSocket path (works fine).
+- Reorganizing how nginx routes `/relay` (the proxy is the right home; only the HTTP responses need work).
+- Multi-relay or multi-tenant relay-info documents.
+
+**Two plausible fixes for the future story (Architect to weigh):**
+1. **Minimum viable**: fix the NIP-11 merge bug (issue 1) so clients see the full document. Keep the plain-text browser fallback. Stops the bleeding for Nostr clients; punts on the UX work.
+2. **Full UX rebuild**: fix the merge bug AND replace the plain-text fallback with a proper HTML landing page (showing the NIP-11 data in a human-readable form). More work but ships a complete public-facing surface.
+
+The Architect picks the scope when the story gets planned. (1) is genuinely minimum; (2) is the "do it right" path.
+
+**Classification:** Bug (NIP-11 merge) + UX improvement (HTML landing page). Both surfaces are public — anyone on the internet hitting `/relay` sees the result. Not gated to operators.
+**Strictness:** Standard
+**Phase path:** Planning → Architecture → Test Design → Implementation → Review (the merge bug alone might fast-track if the cause is mechanical, but the combined story warrants full harness)
+**Priority:** Low-medium. No Nostr clients are broken (NIP-11 partial document still parses); the relay still works via WebSocket. Worth fixing for relay-discovery hygiene + visitor first-impression, but not blocking any operator workflow.

--- a/src/manage/taskQueue/queue/bullBoardMount.js
+++ b/src/manage/taskQueue/queue/bullBoardMount.js
@@ -46,7 +46,11 @@ function mountBullBoard(app, { queues, authMiddleware }) {
       uiConfig: {
         boardTitle: 'Tapestry Task Queue — Owner + Admin',
         boardLogo: { path: '' },
-        miscLinks: []
+        // Story #19 / ADR 0017 — back-link from BullBoard's header to the
+        // Tapestry dashboard so operators close the navigation loop.
+        miscLinks: [
+          { text: '← Tapestry Dashboard', url: '/tapestry' }
+        ]
       }
     }
   });

--- a/test/admin-tools-dashboard-panel.test.js
+++ b/test/admin-tools-dashboard-panel.test.js
@@ -1,0 +1,251 @@
+/**
+ * Story #19 / ADR 0017 — Admin tools panel on the Tapestry dashboard.
+ *
+ * Three coordinated changes:
+ *   1. New <AdminToolsPanel /> in Dashboard.jsx, client-side-gated by
+ *      useAuth().user.classification ∈ {owner, admin}; renders BullBoard
+ *      and Neo4j Browser as link-cards.
+ *   2. ConfigContext extended to fetch /api/status and expose
+ *      neo4jBrowserUrl; both the new panel and the existing Neo4j
+ *      Overview button consume it.
+ *   3. bullBoardMount.js miscLinks gains a "← Tapestry Dashboard"
+ *      entry pointing to /tapestry.
+ *
+ * Source/structural sentinels pin the ADR-required code shape. The
+ * behavioral round-trip — signed-in owner sees the panel; non-admin
+ * does not; Neo4j Browser link uses the environment-aware URL — is
+ * reproducible only with a real session cookie + browser and is the
+ * authoritative cycle-staging smoke (operator-required).
+ *
+ * T1..T7 : FAIL pre-implementation, PASS post.
+ * R1, R2 : PASS pre AND post — regression guards on ConfigContext's
+ *          existing 3 fields and story #18's requireOwnerOrAdmin
+ *          server-side contract.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const DASHBOARD_JSX       = path.join(ROOT, 'ui/src/pages/Dashboard.jsx');
+const CONFIG_CONTEXT_JSX  = path.join(ROOT, 'ui/src/context/ConfigContext.jsx');
+const NEO4J_OVERVIEW_JSX  = path.join(ROOT, 'ui/src/pages/databases/Neo4jOverview.jsx');
+const BULLBOARD_MOUNT     = path.join(ROOT, 'src/manage/taskQueue/queue/bullBoardMount.js');
+const ADMIN_INDEX         = path.join(ROOT, 'src/api/admin/index.js');
+
+function readSafe(p) {
+  try { return fs.readFileSync(p, 'utf8'); }
+  catch (_e) { return null; }
+}
+
+/**
+ * Extract a substring around the first match of `marker` in `src`. Used to
+ * narrow regex assertions to "inside the component body" rather than the
+ * whole file, so sentinels don't accidentally match unrelated code elsewhere.
+ */
+function regionAround(src, marker, before = 0, after = 1500) {
+  const idx = src.indexOf(marker);
+  if (idx === -1) return '';
+  return src.slice(Math.max(0, idx - before), idx + after);
+}
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+
+// ---------------------------------------------------------------------------
+// Failing tests — FAIL now, PASS once story #19 is implemented per ADR 0017.
+// ---------------------------------------------------------------------------
+
+test('T1: ui/src/pages/Dashboard.jsx declares function AdminToolsPanel (story #19 / ADR 0017 §Implementation §2)', () => {
+  const src = readSafe(DASHBOARD_JSX);
+  assert(src !== null, 'Dashboard.jsx missing at expected path — re-baseline.');
+  assert(
+    /function\s+AdminToolsPanel\b/.test(src),
+    'ui/src/pages/Dashboard.jsx does not declare `function AdminToolsPanel` (story #19 / ADR 0017 ' +
+      '§Implementation §2). Add the new component adjacent to the other section components ' +
+      '(StatsRow, HealthRow, ConstraintsCheck). The component must (1) read useAuth() + useConfig(), ' +
+      '(2) gate on classification ∈ {owner, admin}, (3) gate on neo4jBrowserUrl being available, ' +
+      '(4) render a .dashboard-card with two link-buttons (BullBoard + Neo4j Browser). Both links ' +
+      'target="_blank" with rel="noopener noreferrer".'
+  );
+});
+
+test('T2: AdminToolsPanel consumes useAuth and gates on owner-or-admin classification (story #19 ACs + ADR 0017 §Implementation §2)', () => {
+  const src = readSafe(DASHBOARD_JSX);
+  assert(src !== null, 'Dashboard.jsx missing — T1 must pass first.');
+  const region = regionAround(src, 'function AdminToolsPanel', 0, 2000);
+  assert(
+    region.length > 0,
+    'AdminToolsPanel function declaration not found — T1 must pass first.'
+  );
+  assert(
+    /useAuth/.test(region),
+    'AdminToolsPanel does not call useAuth (story #19 ACs §Panel visibility + ADR 0017 §Implementation §2). ' +
+      'The visibility gate must read session.pubkey classification from useAuth() — that hook returns ' +
+      '{user: {pubkey, classification, profile}}. Same idiom as Layout.jsx:137 and BrainstormUserMenu.jsx:80.'
+  );
+  // Must check classification against both 'owner' and 'admin'. Allow either single-quoted, double-quoted,
+  // or backticks for the string literals.
+  assert(
+    /classification[\s\S]{0,100}['"`]owner['"`]/.test(region) &&
+    /classification[\s\S]{0,100}['"`]admin['"`]/.test(region),
+    'AdminToolsPanel does not check user.classification against both "owner" AND "admin" (story #19 ACs ' +
+      '§Panel visibility — both owners and admins see the panel; non-operators do not). The established ' +
+      'idiom across Layout.jsx, BrainstormUserMenu.jsx, and Dashboard.jsx (OnboardingChecklist) is ' +
+      '`user?.classification === \'owner\' || user?.classification === \'admin\'`. Use the same shape.'
+  );
+});
+
+test('T3: AdminToolsPanel consumes useConfig and references neo4jBrowserUrl for the env-aware Neo4j Browser link (story #19 ACs + ADR 0017 §Implementation §2)', () => {
+  const src = readSafe(DASHBOARD_JSX);
+  assert(src !== null, 'Dashboard.jsx missing — T1 must pass first.');
+  const region = regionAround(src, 'function AdminToolsPanel', 0, 2000);
+  assert(
+    /useConfig/.test(region),
+    'AdminToolsPanel does not call useConfig (story #19 ACs + ADR 0017 §Implementation §2). The ' +
+      'env-aware Neo4j Browser URL must come from useConfig().neo4jBrowserUrl, not from a hardcoded value. ' +
+      'This is the same plumbing the fixed Neo4jOverview button uses — single source of truth in ' +
+      'ConfigContext.'
+  );
+  assert(
+    /neo4jBrowserUrl/.test(region),
+    'AdminToolsPanel does not reference neo4jBrowserUrl (story #19 ACs + ADR 0017 §Implementation §2). ' +
+      'The Neo4j Browser card\'s href must be built from useConfig().neo4jBrowserUrl (e.g., ' +
+      '`${neo4jBrowserUrl}/browser/preview/`). Hardcoding localhost or any other URL re-creates the bug ' +
+      'this story fixes.'
+  );
+});
+
+test('T4: AdminToolsPanel references both /admin/queues/ (BullBoard) AND browser/preview (Neo4j) — the two card destinations (story #19 ACs + ADR 0017 §Implementation §2)', () => {
+  const src = readSafe(DASHBOARD_JSX);
+  assert(src !== null, 'Dashboard.jsx missing — T1 must pass first.');
+  const region = regionAround(src, 'function AdminToolsPanel', 0, 2000);
+  assert(
+    /\/admin\/queues\/?/.test(region),
+    'AdminToolsPanel does not reference /admin/queues/ (story #19 ACs — BullBoard card). Add a card/link ' +
+      'with href="/admin/queues/" (same-origin; relative URL is sufficient — BullBoard mount is on the ' +
+      'same Tapestry origin).'
+  );
+  assert(
+    /browser\/preview/.test(region),
+    'AdminToolsPanel does not reference browser/preview (story #19 ACs — Neo4j Browser card). Add a ' +
+      'card/link whose href is `${neo4jBrowserUrl}/browser/preview/` (Neo4j Browser\'s landing path).'
+  );
+});
+
+test('T5: ui/src/context/ConfigContext.jsx fetches /api/status and exposes neo4jBrowserUrl (story #19 ACs + ADR 0017 §Implementation §1)', () => {
+  const src = readSafe(CONFIG_CONTEXT_JSX);
+  assert(src !== null, 'ConfigContext.jsx missing at expected path — re-baseline.');
+  assert(
+    /['"`]\/api\/status['"`]/.test(src),
+    'ConfigContext.jsx does not fetch /api/status (story #19 / ADR 0017 §Implementation §1). Add a 4th ' +
+      'parallel fetch alongside the existing three (/api/assistant/pubkey, /api/owner/pubkey, /api/relays). ' +
+      'Pluck neo4jBrowserUrl from the response and expose it in the context provider value. This is the ' +
+      'centralized source-of-truth for the env-aware Neo4j URL — both AdminToolsPanel and the fixed ' +
+      'Neo4jOverview button read from here.'
+  );
+  assert(
+    /neo4jBrowserUrl/.test(src),
+    'ConfigContext.jsx does not reference neo4jBrowserUrl (story #19 / ADR 0017 §Implementation §1). The ' +
+      'context must add neo4jBrowserUrl to its useState + setter pair AND include it in the provider ' +
+      'value object so useConfig() consumers can destructure it. Without exposing it, T3 and T6 cannot ' +
+      'pass.'
+  );
+});
+
+test('T6: ui/src/pages/databases/Neo4jOverview.jsx no longer hardcodes localhost:8080 and consumes useConfig (story #19 bug-fix AC + ADR 0017 §Implementation §3)', () => {
+  const src = readSafe(NEO4J_OVERVIEW_JSX);
+  assert(src !== null, 'Neo4jOverview.jsx missing — re-baseline.');
+  assert(
+    !/localhost:8080\/browser\/preview/.test(src),
+    'Neo4jOverview.jsx still hardcodes `localhost:8080/browser/preview/` (story #19 bug-fix AC). The ' +
+      'fix is to consume useConfig().neo4jBrowserUrl and append `/browser/preview/`. The hardcoded URL ' +
+      'is the bug — it points to a port (8080) that does not exist on staging/prod (where Tapestry is ' +
+      'on 80/443 via nginx and Neo4j Browser is on 7474). Story #19 explicitly bundles this fix.'
+  );
+  assert(
+    /useConfig/.test(src),
+    'Neo4jOverview.jsx does not call useConfig (story #19 / ADR 0017 §Implementation §3). The button\'s ' +
+      'href must read from useConfig().neo4jBrowserUrl — same source as AdminToolsPanel. This is the ' +
+      'plumbing change that makes the bug fix landed.'
+  );
+  assert(
+    /neo4jBrowserUrl/.test(src),
+    'Neo4jOverview.jsx does not reference neo4jBrowserUrl (story #19 / ADR 0017 §Implementation §3). ' +
+      'Destructure { neo4jBrowserUrl } from useConfig() and use it to build the button\'s href.'
+  );
+});
+
+test('T7: src/manage/taskQueue/queue/bullBoardMount.js miscLinks includes a /tapestry back-link (story #19 ACs + ADR 0017 §Implementation §4)', () => {
+  const src = readSafe(BULLBOARD_MOUNT);
+  assert(src !== null, 'bullBoardMount.js missing — re-baseline.');
+  // Find the miscLinks region; assert the /tapestry URL appears within it.
+  const miscIdx = src.indexOf('miscLinks');
+  assert(
+    miscIdx !== -1,
+    'bullBoardMount.js no longer references miscLinks (story #18 / ADR 0016 regression). The miscLinks ' +
+      'slot was added during story #18; story #19 populates it. Restore the miscLinks key in the ' +
+      'uiConfig options.'
+  );
+  // Allow ~400 chars after miscLinks to find the entry (multi-line arrays).
+  const miscRegion = src.slice(miscIdx, miscIdx + 400);
+  assert(
+    /['"`]\/tapestry['"`]/.test(miscRegion),
+    'bullBoardMount.js miscLinks does not contain a /tapestry back-link (story #19 ACs §BullBoard ' +
+      'cross-link + ADR 0017 §Implementation §4). Change miscLinks from [] to [{ text: \'← Tapestry ' +
+      'Dashboard\', url: \'/tapestry\' }] so operators inside BullBoard can navigate back to the Tapestry ' +
+      'dashboard. URL is /tapestry (the canonical dashboard route per App.jsx:108).'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Regression sentinels — PASS now AND post-implementation.
+// ---------------------------------------------------------------------------
+
+test('R1: ConfigContext.jsx still exposes the existing three fields (taPubkey, ownerPubkey, aRelays) — extension is additive (story #19 ADR 0017 §Implementation §1)', () => {
+  const src = readSafe(CONFIG_CONTEXT_JSX);
+  assert(src !== null, 'ConfigContext.jsx missing — re-baseline.');
+  for (const field of ['taPubkey', 'ownerPubkey', 'aRelays']) {
+    assert(
+      new RegExp('\\b' + field + '\\b').test(src),
+      'R1: ConfigContext.jsx no longer references the existing field `' + field + '` (story #19 ' +
+        'regression). The story-#19 extension is purely ADDITIVE: it adds a 4th fetch + a 4th field ' +
+        '(neo4jBrowserUrl). The existing three fields (taPubkey, ownerPubkey, aRelays) must remain ' +
+        'untouched — multiple other pages consume them.'
+    );
+  }
+  // Also pin that the existing three fetches still happen.
+  for (const endpoint of ['/api/assistant/pubkey', '/api/owner/pubkey', '/api/relays']) {
+    assert(
+      new RegExp(endpoint.replace(/\//g, '\\/')).test(src),
+      'R1: ConfigContext.jsx no longer fetches `' + endpoint + '` (story #19 regression). The story-#19 ' +
+        'extension adds a parallel /api/status fetch; the existing three fetches must remain.'
+    );
+  }
+});
+
+test('R2: src/api/admin/index.js still declares requireOwnerOrAdmin (story #18 / ADR 0016 contract preserved)', () => {
+  const src = readSafe(ADMIN_INDEX);
+  assert(src !== null, 'src/api/admin/index.js missing — re-baseline.');
+  assert(
+    /function\s+requireOwnerOrAdmin\b/.test(src),
+    'R2: src/api/admin/index.js no longer declares function requireOwnerOrAdmin (story #18 / ADR 0016 ' +
+      'regression caused by story #19). The story #18 server-side gate is the REAL access control for ' +
+      'BullBoard; the story #19 UI gate is defense-in-depth only. Removing requireOwnerOrAdmin breaks ' +
+      'the BullBoard mount\'s auth (Express middleware) AND the privilege-escalation guardrail in ' +
+      'test/bullboard-admin-access.test.js T7. Story #19 must NOT touch the server-side auth.'
+  );
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try { await t.fn(); console.log(`  ✓ ${t.name}`); pass++; }
+    catch (err) { console.log(`  ✗ ${t.name}`); console.log(`      ${err.message}`); fail++; }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -38,6 +38,7 @@ const taskQueueBullmq = require('./task-queue-bullmq.test.js');
 const taskQueueNeo4jResourceClass = require('./task-queue-neo4j-resource-class.test.js');
 const entrypointTemplateRendering = require('./entrypoint-template-rendering.test.js');
 const bullboardAdminAccess = require('./bullboard-admin-access.test.js');
+const adminToolsDashboardPanel = require('./admin-tools-dashboard-panel.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -90,6 +91,9 @@ async function main() {
   console.log('\nbullboard-admin-access suite:');
   const bullboardAdminAccessResult = await bullboardAdminAccess.run();
 
+  console.log('\nadmin-tools-dashboard-panel suite:');
+  const adminToolsDashboardPanelResult = await adminToolsDashboardPanel.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -138,6 +142,9 @@ async function main() {
   console.log(
     `bullboard-admin-access suite:                    ${bullboardAdminAccessResult.fail === 0 ? 'PASS' : 'FAIL'} (${bullboardAdminAccessResult.pass} passed, ${bullboardAdminAccessResult.fail} failed)`
   );
+  console.log(
+    `admin-tools-dashboard-panel suite:               ${adminToolsDashboardPanelResult.fail === 0 ? 'PASS' : 'FAIL'} (${adminToolsDashboardPanelResult.pass} passed, ${adminToolsDashboardPanelResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -155,7 +162,8 @@ async function main() {
     taskQueueBullmqResult.fail === 0 &&
     taskQueueNeo4jResourceClassResult.fail === 0 &&
     entrypointTemplateRenderingResult.fail === 0 &&
-    bullboardAdminAccessResult.fail === 0;
+    bullboardAdminAccessResult.fail === 0 &&
+    adminToolsDashboardPanelResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/ui/src/context/ConfigContext.jsx
+++ b/ui/src/context/ConfigContext.jsx
@@ -10,6 +10,12 @@ export function ConfigProvider({ children }) {
   const [taPubkey, setTaPubkey] = useState(null);
   const [ownerPubkey, setOwnerPubkey] = useState(null);
   const [aRelays, setARelays] = useState(null);
+  // neo4jBrowserUrl flows from /api/status:neo4jBrowserUrl which is computed
+  // server-side from BRAINSTORM_NEO4J_BROWSER_URL in /etc/brainstorm.conf
+  // (template-rendered as http://${DOMAIN_NAME}:7474 per story #16).
+  // Consumed by AdminToolsPanel in Dashboard.jsx and the Open Neo4j Browser
+  // button in pages/databases/Neo4jOverview.jsx. Story #19 / ADR 0017.
+  const [neo4jBrowserUrl, setNeo4jBrowserUrl] = useState(null);
 
   useEffect(() => {
     fetch('/api/assistant/pubkey')
@@ -26,10 +32,15 @@ export function ConfigProvider({ children }) {
       .then(r => r.json())
       .then(d => { if (d.success) setARelays(d.aRelays); })
       .catch(() => {});
+
+    fetch('/api/status')
+      .then(r => r.json())
+      .then(d => { if (d.neo4jBrowserUrl) setNeo4jBrowserUrl(d.neo4jBrowserUrl); })
+      .catch(() => {});
   }, []);
 
   return (
-    <ConfigContext.Provider value={{ taPubkey, ownerPubkey, aRelays }}>
+    <ConfigContext.Provider value={{ taPubkey, ownerPubkey, aRelays, neo4jBrowserUrl }}>
       {children}
     </ConfigContext.Provider>
   );

--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -344,6 +344,65 @@ function ConstraintsCheck({ onStatusChange }) {
   );
 }
 
+/* ─── Admin Tools ─────────────────────────────────────────── */
+/**
+ * Operator-tier escape hatch to external admin UIs: BullBoard (task queue
+ * inspector) and Neo4j Browser. Hidden entirely unless the signed-in user
+ * is the owner OR in BRAINSTORM_ADMIN_PUBKEYS.
+ *
+ * The client-side classification check is defense-in-depth — actual access
+ * control happens at the server middleware (story #18 / ADR 0016's
+ * requireOwnerOrAdmin guards /admin/queues). Non-operators can't reach
+ * either tool even if they bypass this UI gate.
+ *
+ * Story #19 / ADR 0017.
+ */
+function AdminToolsPanel() {
+  const { user } = useAuth();
+  const { neo4jBrowserUrl } = useConfig();
+
+  const isOperator = user?.classification === 'owner' || user?.classification === 'admin';
+  if (!isOperator) return null;
+  if (!neo4jBrowserUrl) return null; // wait for config to load — avoids broken Neo4j href flash
+
+  const tools = [
+    {
+      label: 'Task Queue (BullBoard)',
+      description: 'View, retry, pause, or remove queued tasks.',
+      href: '/admin/queues/',
+      emoji: '⚙️',
+    },
+    {
+      label: 'Neo4j Browser',
+      description: 'Direct access to the knowledge graph database.',
+      href: `${neo4jBrowserUrl}/browser/preview/`,
+      emoji: '🗄️',
+    },
+  ];
+
+  return (
+    <div className="dashboard-card">
+      <h3 style={{ margin: '0 0 0.75rem', fontSize: '1rem' }}>🛠️ Admin tools</h3>
+      <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+        {tools.map(t => (
+          <a
+            key={t.label}
+            href={t.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn"
+            style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}
+            title={t.description}
+          >
+            <span style={{ fontSize: '1.1rem' }}>{t.emoji}</span>
+            <span>{t.label}</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 /* ─── Recent Activity ─────────────────────────────────────── */
 
 function RecentActivity() {
@@ -739,6 +798,7 @@ export default function Dashboard() {
       <ConstraintsCheck onStatusChange={setConstraintsOk} />
       <StatsRow />
       <HealthRow />
+      <AdminToolsPanel />
       <TapestryKeyStatus />
       <RecentActivity />
     </div>

--- a/ui/src/pages/databases/Neo4jOverview.jsx
+++ b/ui/src/pages/databases/Neo4jOverview.jsx
@@ -10,7 +10,8 @@ function shortPubkey(pk) {
 }
 
 export default function Neo4jOverview() {
-  const { taPubkey: TA_PUBKEY, ownerPubkey } = useConfig();
+  const { taPubkey: TA_PUBKEY, ownerPubkey, neo4jBrowserUrl } = useConfig();
+  const browserHref = neo4jBrowserUrl ? `${neo4jBrowserUrl}/browser/preview/` : null;
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -82,9 +83,10 @@ export default function Neo4jOverview() {
           <p className="subtitle">Overview of data stored in the Neo4j knowledge graph.</p>
         </div>
         <a
-          href="http://localhost:8080/browser/preview/"
+          href={browserHref || '#'}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={browserHref ? undefined : (e) => e.preventDefault()}
           style={{
             display: 'inline-flex',
             alignItems: 'center',
@@ -98,7 +100,10 @@ export default function Neo4jOverview() {
             fontWeight: 600,
             whiteSpace: 'nowrap',
             marginTop: '0.5rem',
+            opacity: browserHref ? 1 : 0.5,
+            cursor: browserHref ? 'pointer' : 'default',
           }}
+          title={browserHref ? 'Open Neo4j Browser in a new tab' : 'Neo4j Browser URL is loading…'}
         >
           🔗 Open Neo4j Browser
         </a>


### PR DESCRIPTION
## Summary

Story #19 bundles three coordinated UI changes:

1. **New "🛠️ Admin tools" panel** on the Tapestry dashboard (between HealthRow and TapestryKeyStatus), gated to owner-or-admin via `useAuth()`. Contains two cards: BullBoard (`/admin/queues/`) and Neo4j Browser (env-aware URL).

2. **Bug fix**: the existing "Open Neo4j Browser" button at `/tapestry/databases/neo4j` no longer hardcodes `http://localhost:8080/browser/preview/`. It now consumes `useConfig().neo4jBrowserUrl` — same source as the new panel.

3. **BullBoard miscLinks** populated with a `← Tapestry Dashboard` back-link (URL: `/tapestry`), closing the navigation loop.

Plus: ConfigContext extended with a 4th parallel fetch (`/api/status`) and a 4th exposed field (`neo4jBrowserUrl`) — same pattern as the existing 3 fields.

4 source files, +84/-4 lines.

## Linked artifacts

- Story: `engineering-team/stories/19-admin-tools-dashboard-panel.md`
- ADR: `engineering-team/decisions/0017-admin-tools-dashboard-panel.md`
- Test plan: `engineering-team/stories/19-admin-tools-dashboard-panel.test-plan.md`
- Review: `engineering-team/reviews/19-admin-tools-dashboard-panel.md` — **PASS** end-to-end

This branch also includes a separate intake-log entry (commit `eb71d192`) capturing the `/relay` browser landing page UX issue + NIP-11 merge bug — deferred for a future story.

## Test plan

- [x] `npm test` (host) — 16/16 suites PASS, including new `admin-tools-dashboard-panel suite: 9/9`.
- [x] UI build (host `npm --prefix ui run build`) — succeeded.
- [x] Cycle-local: served bundle contains 1× "Admin tools", 1× "/admin/queues/", 2× "browser/preview", 3× "neo4jBrowserUrl", **0× "localhost:8080"** (bug eliminated).
- [x] Cycle-local: `/api/auth/status` 200 + `/admin/queues` 401 (story #18 gate intact).
- [ ] **Staging operator acid test (4 checks below).**

## Operator acid test on staging

1. Sign in as owner pubkey at `https://staging.brainstorm.world/tapestry`. Confirm "🛠️ Admin tools" panel appears with both cards (between HealthRow and TapestryKeyStatus).
2. Click "Neo4j Browser" — must open `http://staging.brainstorm.world:7474/browser/preview/` (NOT localhost — this is the **bug-fix acid test**).
3. Click "Task Queue (BullBoard)" → BullBoard UI → click "← Tapestry Dashboard" in BullBoard's header → lands on `/tapestry` (the back-link acid test).
4. (Optional, if a non-operator test pubkey is available) sign in as that pubkey → panel NOT visible.

## Privilege-escalation guardrail (story #18 preserved)

The client-side classification check is defense-in-depth only. The real access control for BullBoard is the server-side `requireOwnerOrAdmin` middleware (story #18). Admins still cannot manage the admin list itself — `/api/admin/list|add|remove` stay on the strict `requireOwnerOnly` gate. Verified by R2 regression sentinel + the existing 9 sentinels in `test/bullboard-admin-access.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)