### PR TITLE
Reconciliation: recent/all/author modes + yargs fix (story #21)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,12 @@ dist/
 !.claude/agents/
 
 .pi/
+
+# Reconciliation pipeline runtime output (story #21 / ADR 0018) — regenerated each run
+src/pipeline/reconciliation/currentRelationshipsFromNeo4j/
+src/pipeline/reconciliation/currentRelationshipsFromStrfry/
+src/pipeline/reconciliation/allKind*EventsStripped.json
+src/pipeline/reconciliation/currentFollowsFromStrfry.json
+src/pipeline/reconciliation/currentMutesFromStrfry.json
+src/pipeline/reconciliation/currentReportsFromStrfry.json
+src/pipeline/reconciliation/json/*.json

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -593,11 +593,11 @@ A future reviewer who sees these tests fail should stop and ask whether the chan
 
 Reconciliation repairs drift between strfry (canonical nostr event store) and the Neo4j social graph (FOLLOWS / MUTES / REPORTS from kind 3 / 10000 / 1984). One engine — `src/pipeline/reconciliation/reconciliation.sh` — runs in three author-scoped modes, exposed as three task-registry keys (all invoke the same script with a different `--mode`):
 
-| Task | Command | Authors covered | Schedule | `neo4j-heavy`? |
+| Task | Command | Authors covered | Triggered | `neo4j-heavy`? |
 |---|---|---|---|---|
-| `reconcileRecent` | `reconciliation.sh --mode recent` | only authors with an event since the watermark | **~every 10 min** | yes |
-| `reconcileAll` | `reconciliation.sh --mode all` | every author (today's full sweep) | **weekly** + incident recovery | yes |
-| `reconcileAuthor` | `reconciliation.sh --mode author --pubkey <hex>` | one author | on demand | no |
+| `reconcileRecent` | `reconciliation.sh --mode recent` | only authors with an event since the watermark | manually (see §12.3) | yes |
+| `reconcileAll` | `reconciliation.sh --mode all` | every author (today's full sweep) | manually + incident recovery (§12.3) | yes |
+| `reconcileAuthor` | `reconciliation.sh --mode author --pubkey <hex>` | one author | on demand (§12.3) | no |
 
 `recent` is the routine sweep and the default (running `reconciliation.sh` with no `--mode` is `recent`). `all` is the correctness oracle and the weekly drift-recovery fallback — it stays slow (hours) but catches drift that `recent` can't see (e.g. a bad edge with no corresponding recent event). `author` is a tiny point repair; it is deliberately **not** `neo4j-heavy` so an interactive "reconcile me" trigger never queues behind a multi-hour sweep.
 
@@ -612,7 +612,8 @@ Reconciliation repairs drift between strfry (canonical nostr event store) and th
 ```
 
 - Each `recent` run scans strfry `since (lastRunStartedAt - RECONCILIATION_OVERLAP_SECONDS)` and restricts the Neo4j extraction to the same authors.
-- **First run / lost watermark:** if `state.json` is missing, `reconcileRecent` **bootstraps with one full pass** (logged with `"bootstrap": true`), then writes the watermark. Delete `state.json` to force a re-bootstrap.
+- **Seeding the watermark (recommended first step on a fresh instance):** run `reconcileAll` **once**. It establishes the baseline and writes the watermark, after which `reconcileRecent` runs genuinely incrementally. `reconcileAll`'s task timeout (8 h) accommodates the full sweep.
+- **First run / lost watermark (self-healing fallback):** if `reconcileRecent` is triggered with no `state.json`, it **self-bootstraps with one full pass** (logged with `"bootstrap": true`), then writes the watermark. Caveat: a bootstrap takes hours, which exceeds `reconcileRecent`'s shorter task timeout, so it is *reported* as a timeout (exit 124) — but the task runs with `forceKill: false`, so it is **not killed**; it completes in the background and writes the watermark. Prefer seeding via `reconcileAll` to avoid that misleading status. Delete `state.json` to force a re-bootstrap.
 - `author` mode does **not** read or advance the watermark.
 - A failed run does **not** advance the watermark (next run re-covers the window).
 - Inspect: `cat /var/lib/brainstorm/pipeline/reconciliation/state.json | jq`.
@@ -621,9 +622,16 @@ Reconciliation repairs drift between strfry (canonical nostr event store) and th
 
 - `RECONCILIATION_OVERLAP_SECONDS` (default `3600`) — safety window re-scanned on top of the watermark so events that landed during the prior run are re-covered. Re-scanning is idempotent (the diff finds no change).
 
-### 12.3 Cadence lives in the scheduler
+### 12.3 Triggering & scheduling
 
-There is no in-script cadence: schedule `reconcileRecent` (~10 min) and `reconcileAll` (weekly) as two independent tasks. The `neo4j-heavy` semaphore (ADR 0013) guarantees they never run concurrently — a running `reconcileAll` holds the slot and queued `reconcileRecent` triggers harmlessly dedup behind it. The bulk sweeps also serialize against `calculateOwner{Hops,PageRank,GrapeRank}`, which was the original reconciliation-vs-recalculation Neo4j-contention pain.
+**Today these three tasks are manual-trigger only** — via the Task Explorer or `POST /api/run-task` (which routes through the BullMQ queue, so the `neo4j-heavy` semaphore applies and the bulk sweeps serialize against `calculateOwner{Hops,PageRank,GrapeRank}` — the original reconciliation-vs-recalculation contention). No per-task cadence is wired into this story by design: the three tasks are deliberately **frequency-agnostic** — `reconcileRecent`'s watermark makes its scan window self-adjusting, so it is correct at any interval, and `reconcileAll`/`reconcileAuthor` don't depend on cadence at all.
+
+Automated scheduling is deferred to a future **generalized Task Scheduler** — the documented phase 2 of the task queue (story #13), built on **BullMQ repeatable/cron jobs**. It will schedule any registered task, support sub-hour intervals, survive process restarts, and route through the queue (and thus the semaphore). The three reconcile tasks will slot into it as ordinary schedulable tasks with no bespoke per-task code.
+
+**Deprecated / superseded scheduling mechanisms — do NOT use for reconciliation:**
+- The host `systemd/reconcile.timer` (every 5 min → runs `reconciliation.sh` *directly*) is **deprecated**: it bypasses the queue and the `neo4j-heavy` semaphore. Confirm it is disabled (`systemctl is-enabled reconcile.timer`). Full removal (unit files + the control-panel references in `src/api/export/services/commands/control.js` & `queries/status.js` + the sudoers grant in `setup/configure-control-panel-sudo.sh`) is tracked as a follow-up.
+- The in-process scheduler (`src/api/scheduled-tasks/index.js`) has a **1-hour minimum interval** and a hardcoded task set that excludes the reconcile tasks — not used here; itself slated for replacement by the BullMQ scheduler.
+- The legacy `reconciliation` registry key is retained only for back-compat (still invoked by `processAllTasks.sh`; now defaults to `--mode recent`). It is **deprecated** in favor of the three explicit keys; its removal (and repointing/decoupling `processAllTasks`) is a tracked follow-up.
 
 ### 12.4 Force a full run (incident recovery)
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -588,3 +588,47 @@ docker exec tapestry bash -c '
 - The `render-conf-template.js` invocation count moves off exactly one (T8 — second write-path, or lost integration).
 
 A future reviewer who sees these tests fail should stop and ask whether the change is reintroducing the very drift class story #16 closed.
+
+## 12. Reconciliation — `recent` / `all` / `author` modes (story #21 / ADR 0018)
+
+Reconciliation repairs drift between strfry (canonical nostr event store) and the Neo4j social graph (FOLLOWS / MUTES / REPORTS from kind 3 / 10000 / 1984). One engine — `src/pipeline/reconciliation/reconciliation.sh` — runs in three author-scoped modes, exposed as three task-registry keys (all invoke the same script with a different `--mode`):
+
+| Task | Command | Authors covered | Schedule | `neo4j-heavy`? |
+|---|---|---|---|---|
+| `reconcileRecent` | `reconciliation.sh --mode recent` | only authors with an event since the watermark | **~every 10 min** | yes |
+| `reconcileAll` | `reconciliation.sh --mode all` | every author (today's full sweep) | **weekly** + incident recovery | yes |
+| `reconcileAuthor` | `reconciliation.sh --mode author --pubkey <hex>` | one author | on demand | no |
+
+`recent` is the routine sweep and the default (running `reconciliation.sh` with no `--mode` is `recent`). `all` is the correctness oracle and the weekly drift-recovery fallback — it stays slow (hours) but catches drift that `recent` can't see (e.g. a bad edge with no corresponding recent event). `author` is a tiny point repair; it is deliberately **not** `neo4j-heavy` so an interactive "reconcile me" trigger never queues behind a multi-hour sweep.
+
+### 12.1 The watermark
+
+`recent` mode persists a watermark at `/var/lib/brainstorm/pipeline/reconciliation/state.json`:
+
+```json
+{ "lastRunStartedAt": 1716300000, "lastRunCompletedAt": 1716300420,
+  "lastRunMode": "recent", "lastFullRunCompletedAt": 1715700000,
+  "edgeCounts": { "follows": 11900000, "mutes": 240000, "reports": 38000 } }
+```
+
+- Each `recent` run scans strfry `since (lastRunStartedAt - RECONCILIATION_OVERLAP_SECONDS)` and restricts the Neo4j extraction to the same authors.
+- **First run / lost watermark:** if `state.json` is missing, `reconcileRecent` **bootstraps with one full pass** (logged with `"bootstrap": true`), then writes the watermark. Delete `state.json` to force a re-bootstrap.
+- `author` mode does **not** read or advance the watermark.
+- A failed run does **not** advance the watermark (next run re-covers the window).
+- Inspect: `cat /var/lib/brainstorm/pipeline/reconciliation/state.json | jq`.
+
+### 12.2 Config (`/etc/brainstorm.conf`)
+
+- `RECONCILIATION_OVERLAP_SECONDS` (default `3600`) — safety window re-scanned on top of the watermark so events that landed during the prior run are re-covered. Re-scanning is idempotent (the diff finds no change).
+
+### 12.3 Cadence lives in the scheduler
+
+There is no in-script cadence: schedule `reconcileRecent` (~10 min) and `reconcileAll` (weekly) as two independent tasks. The `neo4j-heavy` semaphore (ADR 0013) guarantees they never run concurrently — a running `reconcileAll` holds the slot and queued `reconcileRecent` triggers harmlessly dedup behind it. The bulk sweeps also serialize against `calculateOwner{Hops,PageRank,GrapeRank}`, which was the original reconciliation-vs-recalculation Neo4j-contention pain.
+
+### 12.4 Force a full run (incident recovery)
+
+Trigger `reconcileAll` (or `reconciliation.sh --mode all`). Use this whenever you suspect drift that the incremental sweep wouldn't catch — a partial write, a botched migration, or after any direct Neo4j surgery.
+
+### 12.5 Observability
+
+`reconciliation.log` + `events.jsonl` carry, per run: the `mode`, the `watermark` consumed and `watermark_advanced_to`, per-kind `drift` (`added` / `deleted`), per-kind `edge_counts_before`/`edge_counts_after`, and per-stage `duration`. A `recent` run with nothing to do emits `phase: "no_drift"` and exits in the sub-minute fast-path. The precise "how much drift did we catch" answer is the per-kind `added`/`deleted` totals.

--- a/engineering-team/decisions/0018-reconciliation-incremental-mode.md
+++ b/engineering-team/decisions/0018-reconciliation-incremental-mode.md
@@ -1,0 +1,210 @@
+# ADR 0018: Reconciliation — author-restricted extraction with `recent` / `all` / `author` modes
+
+**Status:** Accepted
+**Date:** 2026-05-21
+**Story:** `engineering-team/stories/21-reconciliation-incremental-mode.md`
+**Builds on:** ADR 0013 (neo4j-heavy resource-class semaphore), ADR 0012 / ADR 0015 (task queue behind `/api/run-task`, on by default)
+
+## Context
+
+`reconciliation` (orchestrated by `src/pipeline/reconciliation/reconciliation.sh`, 591 lines) repairs drift between strfry (canonical nostr event store) and the Neo4j social graph — FOLLOWS / MUTES / REPORTS edges derived from kind 3 / 10000 / 1984 events. It runs three phases sequentially: A=mutes ([reconciliation.sh:154](src/pipeline/reconciliation/reconciliation.sh:154)), C=reports ([:283](src/pipeline/reconciliation/reconciliation.sh:283)), B=follows ([:413](src/pipeline/reconciliation/reconciliation.sh:413)). Each phase: extract current state from Neo4j → dump+convert strfry events → diff → apply via APOC. It currently takes **6–8 hours** because every run does a **full** strfry rescan and a **full** Neo4j scan with an N+1 query pattern.
+
+Drift exists in the first place because the live ingest path — `src/pipeline/stream/updateNostrRelationships.sh` (the redis-consumer stream) — applies relationship updates in real time but can lag or miss events. Reconciliation is the periodic **sweep** that reconverges Neo4j to strfry truth. That framing matters: it tells us the *steady-state* delta between runs is small (only what the stream missed plus genuinely new activity), which is exactly what an author-restricted design exploits.
+
+### Grounded facts from the source (these make the design cheap)
+
+1. **All three strfry dumpers already support a `--recent <seconds>` flag** that sets `"since": <ts>` on the scan filter — [strfryToKind3Events.sh:5-11](src/pipeline/reconciliation/strfryToKind3Events.sh:5), and identical in `strfryToKind10000Events.sh` / `strfryToKind1984Events.sh`. The orchestrator currently calls them with **no args** ([reconciliation.sh:210](src/pipeline/reconciliation/reconciliation.sh:210), [:340](src/pipeline/reconciliation/reconciliation.sh:340), [:470](src/pipeline/reconciliation/reconciliation.sh:470)), so `SINCE_TIMESTAMP=0` → full history every run.
+
+2. **The diff is a per-author set-membership comparison, driven by the union of per-pubkey files** in `currentRelationshipsFromStrfry/<kind>/` and `currentRelationshipsFromNeo4j/<kind>/`. In [calculateFollowsUpdates.js](src/pipeline/reconciliation/calculateFollowsUpdates.js) the comparison is a `Set` diff of followed pubkeys ([:181-201](src/pipeline/reconciliation/calculateFollowsUpdates.js:181)): STEP 1 emits *adds* by walking the strfry dir (a rater present in strfry but absent in Neo4j → **all** their edges added, [:130](src/pipeline/reconciliation/calculateFollowsUpdates.js:130)); STEP 2 emits *deletes* by walking the Neo4j dir (a rater present in Neo4j but absent in strfry → **all** their edges deleted, [:276](src/pipeline/reconciliation/calculateFollowsUpdates.js:276)). It is **not** a follow-*count* comparison — equal counts can hide compensating changes (unfollow A + follow B keeps the count fixed but needs two edge fixes). **This logic is reusable verbatim** provided both directories are populated with the *same* author set.
+
+3. **Neo4j already stores a per-user last-event watermark.** `apocCypherCommand2_follows` does `SET z.kind3CreatedAt = event.created_at, z.kind3EventId = event.id`; mutes/reports counterparts set `kind10000CreatedAt` / `kind1984CreatedAt`. So every apply already maintains a per-user "latest event seen" timestamp + id.
+
+4. **The N+1 pattern** lives in all three extractors: `getRaters()` returns *every* rater ([getCurrentFollowsFromNeo4j.js:151](src/pipeline/reconciliation/getCurrentFollowsFromNeo4j.js:151)), then a per-pubkey session query in a loop ([getFollowsForRater():187](src/pipeline/reconciliation/getCurrentFollowsFromNeo4j.js:187), loop at [:308](src/pipeline/reconciliation/getCurrentFollowsFromNeo4j.js:308)) — hundreds of thousands of round-trips at full-graph scale.
+
+5. **`cleanup()` wipes the per-pubkey dirs at the start of every run** ([reconciliation.sh:114-130](src/pipeline/reconciliation/reconciliation.sh:114)), so each run begins from empty directories — no stale-file contamination between runs.
+
+6. **The APOC apply is already batched** via `apoc.periodic.iterate` (batchSize 100–1000) — not a bottleneck; left untouched.
+
+7. **reconciliation is a registered task** ([taskRegistry.json:317](src/manage/taskQueue/taskRegistry.json:317)) and now flows through the BullMQ queue (on by default, ADR 0015). ADR 0013 introduced a Redis-backed `neo4j-heavy` counted semaphore that serializes Neo4j-heavy tasks — the bulk sweeps are textbook members of that class.
+
+8. **State-dir convention** is `/var/lib/brainstorm/pipeline/<area>/` (e.g. [processReconciliationQueue.js:25](src/pipeline/reconcile/processReconciliationQueue.js:25), `src/pipeline/stream/.../queue/`).
+
+9. **Per-rater debug logging** in [getCurrentFollowsFromNeo4j.js:299-335](src/pipeline/reconciliation/getCurrentFollowsFromNeo4j.js:299) does ~6 `fs.appendFileSync` calls per pubkey to `reconciliation_currentRaterBatch.log` — pure overhead.
+
+10. **The deprecated `src/pipeline/reconcile/` directory** (`note.md`: "being deprecated in favor of the newer reconciliation module") was an earlier attempt at exactly the single-author case — a per-pubkey queue ([createReconciliationQueue.js](src/pipeline/reconcile/createReconciliationQueue.js), [processReconciliationQueue.js](src/pipeline/reconcile/processReconciliationQueue.js)). The `author` mode below delivers that intent inside the live module.
+
+### Concept-graph impact
+
+None. Reconciliation/strfry/Neo4j relationships are operational/ETL plumbing, not domain concepts in the graph. **Firmware reinstall: no.**
+
+## Options considered
+
+### Option A — Author-restricted extraction with three modes (chosen)
+
+All three modes are the *same operation* — reconcile Neo4j against strfry — differing only in **which authors** they cover:
+
+| Task (registry key) | Mode | Authors covered | Cadence | `neo4j-heavy`? |
+|---|---|---|---|---|
+| `reconcileRecent` | `--mode recent` | authors with an event since the watermark | scheduled ~10 min | yes |
+| `reconcileAll` | `--mode all` | every author (today's behavior) | scheduled weekly | yes |
+| `reconcileAuthor` | `--mode author --pubkey <pk>` | one author | on-demand | **no** (point write; stays responsive) |
+
+`reconcileRecent` mechanism, per phase:
+1. Read a persisted watermark `T` (last successful `recent`/`all` run start, minus a safety overlap).
+2. Run the strfry dumper with `--recent (now − T)` → `allKind<K>EventsStripped.json` holds only the latest replaceable event for **changed** authors. Convert to per-pubkey files (existing converter, unchanged) → `currentRelationshipsFromStrfry/<kind>/` holds only changed authors.
+3. Extract Neo4j current state **only for those same authors** (read the pubkey set from the strfry dir; skip `getRaters()`/`getRaterCount()`).
+4. Run the existing diff (`calculate<Kind>Updates.js`, unchanged) — now over the small, symmetric author set.
+5. Apply via the existing APOC commands (unchanged).
+6. On success, advance the watermark.
+
+`reconcileAll` is exactly today's pipeline (no `--recent`, all raters). `reconcileAuthor` is the same machinery with the author set fixed to `{pubkey}`, no watermark, no `since` filter — fetch that author's latest events, diff against their Neo4j edges, apply.
+
+**The correctness invariant (recent + author modes):** both directories must be restricted to the *identical* author set. If Neo4j were extracted fully while strfry were extracted for a subset, STEP 2 of the diff would treat every uncovered rater (Neo4j file present, no strfry file) as "delete all their edges" — a catastrophic graph wipe. Restricting both sides to the covered set makes the existing diff correct: a covered author appears in both dirs (→ true set-diff), or strfry-only (→ new rater, all adds), or — for an author who cleared their list — strfry file present but empty (→ all deletes). Uncovered authors appear in neither dir and are correctly left alone.
+
+**Pros**
+- Reuses the diff and apply stages **verbatim**; converters unchanged. The only code changes are the orchestrator's mode/watermark logic and a restricted-author path in the three extractors.
+- `reconcileRecent` work is proportional to *recent activity*, not graph size → minutes (or a sub-minute no-op), not hours.
+- The N+1 loop becomes a non-issue for `recent`/`author` (they iterate a small set), so we don't need to rewrite it now.
+- The bulk sweeps plug into the `neo4j-heavy` semaphore (ADR 0013) — a one-line registry tag — addressing the original "reconciliation crashes Neo4j / contends with GrapeRank" motivation. `reconcileAuthor` stays *off* that class so an interactive "reconcile my profile" trigger never queues behind an 8-hour sweep.
+- `reconcileAll` is untouched, so we retain a provably-correct oracle to validate `reconcileRecent` against (the story's testability hinge).
+
+**Cons**
+- `recent` relies on strfry's `since` filter, which keys on event `created_at` (client-set, can be back-dated). A back-dated or late-arriving event whose `created_at < T` is missed by that run. Mitigated — by design — by the periodic `reconcileAll`, which is exactly why the story mandates it.
+- Adds a watermark state file and mode branching → more orchestrator logic to reason about.
+- Three code paths (recent/all/author) to keep behaviorally consistent (all share the same diff+apply, which limits divergence risk).
+
+### Option B — Optimize the *full* run only (no recent mode, no watermark)
+
+Leave reconciliation single-mode but make the full run fast: replace the N+1 with a single streamed paged Cypher query (`MATCH (u)-[:FOLLOWS]->(t) RETURN u.pubkey, collect(t.pubkey)`), batch the apply with `UNWIND`, parallelize the three kinds.
+
+**Pros:** one code path; no watermark; no drift-miss window; conceptually simplest.
+**Cons:** even fully optimized, a full strfry dump + full Neo4j scan + full diff is inherently O(graph) every run. On a 12M-edge / 100K–250K-rater graph this lands in tens of minutes to low hours, not "minutes," and still hammers Neo4j every run. Does not meet the headline bar. Rejected as primary, but its ideas are the right *future* optimization for `reconcileAll` (see Out of scope).
+
+### Option C — Lean entirely on the live event stream (eliminate the batch sweep)
+
+Push all reconciliation into `src/pipeline/stream/updateNostrRelationships.sh` so Neo4j is updated per-event in real time, removing the periodic batch.
+
+**Pros:** near-zero steady-state drift; no batch job at all.
+**Cons:** the live stream is precisely the component whose lag/misses *create* the drift this task repairs — it cannot also be the thing that guarantees convergence. No oracle/sweep to catch what the stream dropped, no repair path for drift already in the graph, correctness hard to reason about. Rejected as a primary strategy; a more reliable stream is a complementary, separate effort.
+
+## Decision
+
+**We chose Option A.** One engine (`reconciliation.sh`), three author-scoped modes exposed as three task-registry keys: `reconcileRecent` (incremental sweep), `reconcileAll` (full sweep — today's behavior, the oracle and weekly fallback), and `reconcileAuthor` (single author). `recent` and `author` restrict **both** the strfry dump and the Neo4j extraction to the same covered author set, reusing the existing diff and APOC apply unchanged. The bulk sweeps are tagged `neo4j-heavy`; `reconcileAuthor` is not.
+
+**Cadence lives in the scheduler, not the script.** `reconcileRecent` and `reconcileAll` are two independent scheduled tasks (~10 min and weekly). This is cleaner than a single self-promoting task: each task has a predictable runtime profile (the 10-min task never silently turns into an 8-hour run), and the `neo4j-heavy` semaphore already guarantees they never execute concurrently (a running `reconcileAll` holds the slot; queued `reconcileRecent` triggers harmlessly dedup behind it). The **only** in-script auto-promotion is the first-run bootstrap: `reconcileRecent` with no watermark performs one full pass to establish a baseline, then writes the watermark.
+
+We are trading away single-path simplicity (Option B) and accepting a bounded `recent`-mode drift-miss window, in exchange for the only design that reliably reaches minutes-scale steady-state runs. The miss window is closed by the weekly `reconcileAll`. We are explicitly **not** optimizing `reconcileAll`'s N+1 in this story — it stays slow but correct, runs weekly, and remains the oracle; its optimization is a clean follow-up (Option B's techniques) once `reconcileRecent` is proven.
+
+## Consequences
+
+**Enabled**
+- `reconcileRecent` in minutes (sub-minute when nothing changed), unblocking the operator from scheduling reconciliation routinely — and, per story #13's note, from trusting Neo4j enough to resume scheduled per-customer recalculations.
+- `reconcileAuthor` gives an interactive, targeted repair primitive (the future profile-page "reconcile me" button, customer-scoped scheduling) without the cost or contention of a sweep.
+- Bulk sweeps serialize with `calculateOwner{Hops,PageRank,GrapeRank}` via the existing `neo4j-heavy` semaphore — no more reconciliation-vs-recalculation Neo4j contention.
+- A persisted watermark + per-run drift counts give the operator real drift observability for the first time.
+
+**Constrained / made harder**
+- `recent` can miss drift not reflected in a recent strfry event (back-dated/late events; non-event corruption). Bounded by the weekly `reconcileAll`; documented as expected behavior.
+- Three modes to keep consistent. The test plan must pin `recent`-vs-`all` equivalence (oracle test) to prevent silent divergence.
+- The watermark file becomes operational state: if deleted/corrupted, the next `reconcileRecent` safely bootstraps with a full pass (covered below).
+
+**Follow-up debt (out of scope here)**
+- Optimize `reconcileAll` (Option B techniques: single streamed Cypher query to kill the N+1, `UNWIND` apply, parallelize the three kinds). Biggest lever for the weekly run's cost.
+- The `reconcileAuthor` **trigger surfaces** — profile-page button, API endpoint, customer-scoped scheduling — are a separate story (UI/API), this ADR only builds the engine mode.
+- Replace per-pubkey JSON file fanout with sorted JSONL + merge-join.
+- **Event-id fast-path for `reconcileRecent`** (deferred optimization — deliberately *not* the default). Neo4j stores `kind3EventId` / `kind10000EventId` / `kind1984EventId`, and a nostr event id is a SHA-256 over the event's tags, so an author whose stored id equals strfry's latest id has a provably-identical relationship set → an O(1) skip of the per-author set diff. We intentionally do **not** enable this: the set diff re-derives ground truth from the actual edges, whereas the event-id check trusts recorded bookkeeping as a proxy. A partial-write bug that advanced the id but left one or more FOLLOWS/MUTES/REPORTS edges wrong would be **invisible** to the fast-path (caught only by the weekly `reconcileAll`), whereas the set diff catches it on the next `reconcileRecent` that covers the author. Since the per-author set diff is microseconds (never the bottleneck), the honest comparison wins. Revisit only if profiling shows the per-author Neo4j extraction is a real cost — and if enabled, document this correctness tradeoff at the call site.
+- Harden the live stream (`updateNostrRelationships.sh`) to reduce the drift the sweeps must repair.
+
+**Firmware reinstall required?** No.
+
+## Implementation notes
+
+The Implementer reads this section verbatim. Default behavior change: the routine reconciliation task (`reconcileRecent`) becomes author-restricted, bootstrapping with a full pass on first run.
+
+### 1. Watermark state (new)
+
+- File: `/var/lib/brainstorm/pipeline/reconciliation/state.json`. Shape:
+  ```json
+  {
+    "lastRunStartedAt": 1716300000,
+    "lastRunCompletedAt": 1716300420,
+    "lastRunMode": "recent",
+    "lastFullRunCompletedAt": 1715700000,
+    "edgeCounts": { "follows": 11900000, "mutes": 240000, "reports": 38000 }
+  }
+  ```
+- New helper (bash + `jq`, consistent with the rest of the pipeline) to read/write atomically (`write tmp + mv`). Suggested: `src/pipeline/reconciliation/reconciliationState.sh` exposing `read_state`, `write_state`, `get_watermark`.
+- Missing/unparseable file ⇒ "no watermark" ⇒ `reconcileRecent` bootstraps with a full pass.
+- `reconcileAuthor` does **not** read or advance this watermark — it is targeted and orthogonal to the sweep cadence.
+
+### 2. Orchestrator changes — `reconciliation.sh`
+
+- Accept `--mode recent|all|author` (default `recent`) and `--pubkey <hex>` (required for `author`).
+- **`recent`:** read watermark `T = lastRunStartedAt_previous − RECONCILIATION_OVERLAP_SECONDS` (overlap re-scans a safety window; re-scanning already-reconciled authors is idempotent — the diff finds no change). If no watermark exists, run as `all` this once (bootstrap), then write the watermark.
+- **`all`:** today's behavior — no `--recent`, all raters. Sets `lastFullRunCompletedAt` on success.
+- **`author`:** restrict to `{--pubkey}`; no watermark; fetch that author's latest kind 3/10000/1984 events (e.g. `strfry scan` with an `authors` filter), diff against their Neo4j edges, apply. Does not touch `state.json`.
+- **Reorder per phase in `recent`/`author`:** run the strfry dump+convert *first* (so the covered-author set exists), then the Neo4j extraction restricted to that set, then diff, then apply. `all` keeps today's order.
+- Pass `--recent $(( now - T ))` to each `strfryToKind<K>Events.sh` in `recent`; pass nothing (full history) in `all`.
+- **No-op fast-path (`recent` only, optional):** before extraction, `strfry scan --count` for kinds `[3,10000,1984]` since `T`. If total is `0`, emit `phase=no_drift` (see §6), advance the watermark, `exit 0`. (An empty window already no-ops naturally; this just skips spinning up the Node stages — keep if cheap, drop if it complicates.)
+- **Drift signal (observability, not a gate):** the precise per-run drift is the diff's own add/delete counts — log those per kind. Optionally also log Neo4j relationship counts (`MATCH ()-[r:FOLLOWS]->() RETURN count(r)`, cheap via count store) next to strfry's per-kind **author** count (`strfry scan --count {kinds:[K]}` = authors with that kind, *not* an edge total) as a coarse rater-count trend. Persist edge counts in `state.json`.
+- On success, write `state.json` (set `lastFullRunCompletedAt` only when mode was `all` or a bootstrap full pass).
+- Keep `set -e`/`set -o pipefail`. On failure, do **not** advance the watermark (next `reconcileRecent` re-covers the window). Existing `emit_function_error` / `TASK_ERROR` handling stays.
+- `cleanup()` ([:88](src/pipeline/reconciliation/reconciliation.sh:88)) unchanged, runs at start/end.
+- Step 6B `projectFollowsGraphIntoMemory.sh` ([:558](src/pipeline/reconciliation/reconciliation.sh:558)) runs after follows in `recent`/`all` (cheap relative to the rest; leave as-is). For `author`, skip it (a single-author change doesn't warrant a full GDS reprojection) — or defer to a batched reprojection; Implementer's call, note it.
+
+### 3. Restricted-author path — `getCurrentFollowsFromNeo4j.js`, `getCurrentMutesFromNeo4j.js`, `getCurrentReportsFromNeo4j.js`
+
+- Add option `--authorsFromDir <path>` (the matching `currentRelationshipsFromStrfry/<kind>/` dir). When present:
+  - Skip `getRaterCount()` and `getRaters()`.
+  - Build the rater list from `fs.readdirSync(dir)` filtered to `*.json` (excluding `_summary.json`), stripping `.json` to recover pubkeys.
+  - Run the **existing** per-author loop (`getFollowsForRater` etc.) over just that set. No change to the per-author query or file-writing.
+- When absent, behavior is exactly as today (`all` mode).
+- Uniform across all three extractors (mutes/reports mirror follows at the same line offsets).
+
+### 4. Remove per-rater debug log
+
+- Delete the `reconciliation_currentRaterBatch.log` `fs.appendFileSync` calls in [getCurrentFollowsFromNeo4j.js:299-335](src/pipeline/reconciliation/getCurrentFollowsFromNeo4j.js:299) (and equivalents in mutes/reports if present). Keep the real `log()` lines to `reconciliation.log`.
+
+### 5. Task registry + config
+
+- `taskRegistry.json` ([:317](src/manage/taskQueue/taskRegistry.json:317)): replace the single `reconciliation` entry with three, all pointing at the **same** `reconciliation.sh`:
+  - `reconcileRecent` → `--mode recent`, `"resourceClass": "neo4j-heavy"`.
+  - `reconcileAll` → `--mode all`, `"resourceClass": "neo4j-heavy"`.
+  - `reconcileAuthor` → `--mode author` (+ a `pubkey` argument; follow the existing customer/pubkey-arg convention used by `calculateCustomer*`), **no** `resourceClass`.
+  - Keep a `reconciliation` alias mapping to `reconcileAll` if anything external still references the old key, or update those callers. Implementer verifies no systemd/scheduler entry references the bare key without being updated.
+- Ensure `neo4j-heavy` is present in `resourceClassCaps` in `/etc/brainstorm-task-queue.json` (ADR 0013 establishes `"neo4j-heavy": 1`).
+- New `brainstorm.conf` setting (default baked into the orchestrator so a missing value is safe): `RECONCILIATION_OVERLAP_SECONDS` (default `3600` = 1 hour). (No full-interval setting — cadence is the scheduler's job now.)
+- Scheduling (operator-configured, documented, not hard-coded in the script): `reconcileRecent` ~every 10 min; `reconcileAll` weekly. `reconcileAuthor` is on-demand (its trigger surfaces are a follow-up story).
+
+### 6. Structured logging vocabulary
+
+Extend the existing bash `emit_task_event` usage (sourced at [reconciliation.sh:12](src/pipeline/reconciliation/reconciliation.sh:12)):
+- `TASK_START` metadata gains `"mode": "recent"|"all"|"author"`, `"watermark": <ts>` (recent/all), `"pubkey": <hex>` (author), and `"bootstrap": true` when `recent` promoted to a full pass.
+- New `PROGRESS` tokens: `"phase":"no_drift"` (early-exit); on completion `"drift": {"<kind>": {"added": N, "deleted": N}}` plus optional `"edge_counts_before"/"edge_counts_after"`.
+- `TASK_END` metadata gains `"mode"`, `"watermark_advanced_to": <ts>` (recent/all), and per-kind drift totals.
+
+### 7. Documentation — `OPERATIONS.md`
+
+New subsection covering: the three tasks (`reconcileRecent` / `reconcileAll` / `reconcileAuthor`) and `--mode`/`--pubkey`; the recommended schedule (10-min recent, weekly all); the watermark file and how to inspect/reset it; `RECONCILIATION_OVERLAP_SECONDS`; how to force a full run for incident recovery (`reconcileAll`); which tasks are `neo4j-heavy` and why `reconcileAuthor` is not; the new structured-event tokens.
+
+### Tests (for the Tester, Phase 3)
+
+- **Oracle equivalence:** seed a known strfry+Neo4j state with drift; run `reconcileAll`, snapshot Neo4j edge sets; reset Neo4j to a pre-state; run `reconcileRecent` from a fresh watermark over the same window; assert identical FOLLOWS/MUTES/REPORTS edge sets.
+- **No spurious deletes (the invariant):** with both dirs restricted to the covered set, assert an uncovered rater present in Neo4j but *not* in the covered set is never emitted to `*ToDeleteFromNeo4j.json`.
+- **Set-diff not count:** an author whose follow *count* is unchanged but whose membership changed (drop A, add B) yields exactly one add and one delete.
+- **Drift-detection regression:** inject a bogus FOLLOWS edge directly (no corresponding event); assert `reconcileRecent` does **not** repair it but `reconcileAll` does. Both are passing behaviors.
+- **First-run bootstrap:** absent watermark ⇒ `reconcileRecent` runs a full pass and writes the watermark.
+- **No-op:** zero events since watermark ⇒ early-exit, watermark advanced, no diff files written.
+- **`reconcileAuthor`:** given a pubkey, reconciles only that author's edges, touches no other author, does not read/advance `state.json`.
+- **Idempotency:** two `reconcileRecent` runs back-to-back with no new events ⇒ no adds/deletes on the second.
+- **Failure leaves watermark intact:** a forced mid-run failure does not advance `lastRunStartedAt`.
+- **Source-sentinel/regression:** `strfryToKind*` invoked with `--recent` in `recent` mode; extractors honor `--authorsFromDir`; registry has `reconcileRecent`/`reconcileAll` tagged `neo4j-heavy` and `reconcileAuthor` untagged; per-rater debug log gone.
+
+## Out of scope
+
+- **Optimizing `reconcileAll`'s N+1 / parallelizing the three kinds** (Option B techniques). Separate follow-up ADR.
+- **`reconcileAuthor` trigger surfaces** — profile-page button, API endpoint, customer-scoped scheduling. Separate follow-up story (UI/API); this ADR delivers only the engine mode.
+- **Replacing per-pubkey file fanout with sorted JSONL + merge-join.**
+- **Hardening the live event stream** (`src/pipeline/stream/updateNostrRelationships.sh`).
+- **Deleting the deprecated `src/pipeline/reconcile/` directory.** Housekeeping; now functionally superseded by `reconcileAuthor`, so it becomes a safe cleanup target — tracked separately.
+- **Changing the Neo4j data model, the APOC apply commands, or the converters.** Reused unchanged.

--- a/engineering-team/reviews/21-reconciliation-incremental-mode.md
+++ b/engineering-team/reviews/21-reconciliation-incremental-mode.md
@@ -1,0 +1,74 @@
+# Review: Story 21 — Speed up reconciliation (recent / all / author modes)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-21
+**Diff:** `git diff origin/staging...HEAD` (impl commit `c83ccc2a`; story `b2e8bc62`, ADR `5ac95656`, tests `c92f47aa`)
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **PASS**. `reconciliation-incremental-mode` 15/15 (T1–T10 flipped to PASS, R1–R5 hold). All 16 prior suites green, including `task-queue-bullmq` 18/18 and `task-queue-neo4j-resource-class` 14/14 (confirms the processor.js/runTask.js edits did not regress story #13/#15). Overall: PASS.
+- [ ] `npm run test:playwright` — n/a (no frontend in this story; the `reconcileAuthor` UI is a separate follow-up).
+- [x] _Lint / typecheck / build — not configured; skipped per project rules._
+- [x] Bash `bash -n` + `node --check` + `jq empty` clean on all modified scripts/JSON.
+
+## Spec adherence
+
+Source/sentinel level — verified now:
+- [x] AC-2 (modes) → `reconciliation.sh` parses `--mode recent|all|author` + `--pubkey`; three registry keys (T2, T8).
+- [x] AC-3 (watermark) → `reconciliationState.sh` + `state.json`, `--recent` from `lastRunStartedAt − overlap` (T1, T3).
+- [x] AC-5 (full fallback + first-run) → `reconcileAll`; first-run bootstrap (T5, T8).
+- [x] AC-6 (same script, existing surface) → three keys → one `reconciliation.sh` (T2, T8).
+- [x] AC-7 (no-drift cheap) → `no_drift` early-exit via `strfry scan --count` (T4).
+- [x] AC-8 (logging) → `mode`/`watermark`/per-kind `added`/`deleted`/`edge_counts_before`/`edge_counts_after`/`duration` (T9).
+- [x] AC-10 (docs) → OPERATIONS.md §12 (T10).
+
+Behavioral level — **NOT yet verified** (see Verdict condition): AC-1 (runtime < 15 min), AC-4 (incremental output == full output, the oracle), AC-7 (real sub-minute no-op), AC-9 (full-run drift detection) are validated only by cycle-local smoke **S1–S10**, which require a live strfry + Neo4j stack and the production-only node deps. They are unrunnable in this dev checkout and remain the authoritative gate.
+
+## ADR adherence
+
+- [x] Author-restricted extraction reuses the diff + APOC apply + converters **verbatim** (R1–R5 green; `reconciliation.sh` calls the unchanged `calculate*Updates.js` / `apocCypherCommand*` / `kind*EventsTo*.js`).
+- [x] The correctness invariant is implemented: in `recent`/`author`, `extract_and_dump` (reconciliation.sh) dumps strfry **first**, then runs the Neo4j extractor with `--authorsFromDir` pointing at the **same** `currentRelationshipsFromStrfry/<label>/` dir — both sides restricted to the identical covered author set. `cleanup()` wipes the dirs each run (R4), so no stale-file leakage.
+- [x] `neo4j-heavy` tagging matches ADR: `reconcileRecent`/`reconcileAll` tagged, `reconcileAuthor` not.
+- [x] Cadence in the scheduler (no in-script cadence); first-run bootstrap is the only in-script auto-promotion.
+- [x] No new external dependencies. No lint/typecheck/build tooling added.
+- [⚠] **One disclosed deviation beyond the ADR's file list** — see Finding NB-1.
+
+## Concept-graph integrity
+- [x] N/A — operational/ETL plumbing, no domain concepts touched. No firmware reinstall (ADR 0018 §Concept-graph impact confirms). No BIBLE.md re-derivation.
+
+## Things tests can't catch
+- [x] No secrets committed. No leftover debug logging — the per-rater `currentRaterBatch` log is gone from the follows extractor (T7); the remaining `console.log` at `getCurrentFollowsFromNeo4j.js:98` is the pre-existing `log()` helper (console+file), consistent with the mutes/reports extractors.
+- [x] No commented-out code; the rewrite removed the old `COMMENT_BLOCK` heredoc and dead Step-5B block.
+- [x] Concurrency: with the queue on (ADR 0015), reconcileRecent runs at per-task concurrency 1 with jobId dedup, so overlapping scheduled triggers don't spawn concurrent runs; the `neo4j-heavy` semaphore serializes the sweeps against owner recalcs.
+- [x] Error path: `set -e`/`pipefail` retained; on failure the watermark is **not** advanced (write_state only runs after the phases), so a failed run re-covers its window. The `no_drift_since` parser returns "uncertain" (proceed) rather than early-exiting on an unparseable count — fail-safe.
+- [⚠] Timeout sizing — see Finding NB-2.
+
+## Findings
+
+### Blocking
+_None._
+
+### Non-blocking
+
+1. **NB-1 — `staticArgs` mechanism added beyond the ADR's file list.** `src/manage/taskQueue/queue/processor.js:21` (`buildChildArgs`) and `src/api/manage/commands/runTask.js:80` (`buildTaskCommand`) gained a `taskDef.staticArgs` channel (word-split, prepended to args). ADR 0018 §Impl 5 said the registry entries invoke `reconciliation.sh --mode X` but did not specify the arg-passing mechanism — neither runner had one (only `customer`/`limit`/`warmStart`), and `launchChildTask` validates the script path as a file so args can't be smuggled into it. The addition is the minimal way to realize the ADR's explicit design: additive, gated on `taskDef.staticArgs` presence (no behavior change for existing tasks), correct on the read-through (`processor.js` joins → launchChildTask.sh:344 `bash "$child_script" $child_args` word-splits), and the 32 task-queue tests stay green. **Accepted.** Recommend the Architect add a one-line note to ADR 0018 §Impl 5 recording the `staticArgs` channel so the contract matches reality.
+
+2. **NB-2 — `reconcileRecent` timeout (30 min) is smaller than a first-run bootstrap (full pass, hours).** `taskRegistry.json` sets `reconcileRecent` timeout to 1,800,000 ms, but the ADR-mandated first-run bootstrap performs a `--mode all` pass that can take 6–8 h. This is **not** a correctness break: the registry timeout uses `forceKill: false`, and `launchChildTask.sh:403–412` only `kill -9`s when `forceKill == true` — so a timed-out bootstrap is marked "timeout" (exit 124) for reporting but keeps running to completion and writes the watermark; with the queue on, concurrency-1 + dedup prevent an overlapping trigger from interrupting it. The artifact is a **misleading "timeout" status** on the first-deploy bootstrap run. Recommend either (a) size `reconcileRecent`'s timeout to accommodate a bootstrap (e.g. match `reconcileAll`), or (b) document in OPERATIONS.md §12.1 that a fresh deploy should run `reconcileAll` once to seed the watermark (its 8 h timeout fits), after which `reconcileRecent` runs incrementally. Either is a small change; flagging for the Implementer/operator to pick.
+
+3. **NB-3 — legacy `reconciliation` key is not `neo4j-heavy`.** Kept unchanged for back-compat (`processAllTasks.sh:152` calls it; now defaults to `recent`). Within `processAllTasks` it runs sequentially so there's no contention, but a *manual* trigger of the legacy key during an owner recalc would not serialize. Minor hardening opportunity: tag it `neo4j-heavy` too, or point `processAllTasks` at `reconcileRecent`. Non-blocking.
+
+4. **NB-4 (pre-existing, out of scope) — reports converter append semantics.** `kind1984EventsToReports.js` (reused verbatim) `appendFileSync`s one object per event; kind 1984 is not replaceable, so an author with multiple reports yields multiple newline-separated objects in one per-pubkey file, which `calculateReportsUpdates.js`'s `JSON.parse(readFileSync(...))` may not handle. This behavior is unchanged by story #21 (converters reused), so `recent` mode is no worse than today's `all` mode for reports. Noting only so a future story can verify reports reconciliation independently.
+
+## House rules check
+- [x] Concept Graph API authority respected (N/A — no concepts).
+- [x] No new lint/typecheck/build tooling.
+- [x] Per-phase commits followed; commit messages reference story #21 + ADR 0018.
+
+## Verdict
+
+**PASS** (source/design audit), with one mandatory pre-production condition.
+
+The diff faithfully implements ADR 0018: author-restricted incremental reconciliation with the correctness invariant intact, the diff/apply/converters reused verbatim, correct `neo4j-heavy` tagging, and clean quality gates. The single ADR deviation (NB-1) is minimal, necessary, correct, and disclosed. NB-2/3/4 are non-blocking.
+
+**Mandatory before promoting to production:** run the cycle-local smoke **S1–S10** from the test plan against a live stack (via `cycle-local`, then validated again on staging via `cycle-staging`) — these are the authoritative behavioral gate that `npm test` cannot cover. The headline checks are **S1 (incremental output == full output, the oracle)**, **S4 (recent misses non-event drift, all catches)**, and **S6 (first-run bootstrap)** — the last of which will also surface the NB-2 timeout-status behavior in practice.
+
+Mergeable to `staging` as-is; **not** to be promoted to `main` until S1–S10 pass on the live stack.

--- a/engineering-team/stories/14-reconciliation-incremental-mode.md
+++ b/engineering-team/stories/14-reconciliation-incremental-mode.md
@@ -1,6 +1,6 @@
 # Story 14: Speed up reconciliation — incremental mode with periodic full fallback
 
-**Status:** Draft
+**Status:** Approved
 **Created:** 2026-05-20
 **Type:** Feature
 

--- a/engineering-team/stories/14-reconciliation-incremental-mode.md
+++ b/engineering-team/stories/14-reconciliation-incremental-mode.md
@@ -1,0 +1,98 @@
+# Story 14: Speed up reconciliation — incremental mode with periodic full fallback
+
+**Status:** Draft
+**Created:** 2026-05-20
+**Type:** Feature
+
+## Background
+
+The `reconciliation` task — orchestrated by `src/pipeline/reconciliation/reconciliation.sh` — exists to detect and fix drift between strfry (the canonical nostr event store) and the Neo4j-derived social graph (FOLLOWS, MUTES, REPORTS edges derived from kind 3 / 10000 / 1984 events). On nostr, follows and mutes can be revoked (so Neo4j edges may need to be both added and deleted), reports are append-only (only added).
+
+It currently takes **6–8 hours per run** end-to-end. That cost is high enough that the operator has stopped running it on a schedule. Story #13 captures this directly in its 2026-05-20 operational note: *"reconciliation is unreliable and there's no point recalculating against a possibly-stale Neo4j."* In other words, slow reconciliation is now blocking the operator from confidently scheduling per-customer GrapeRank / PageRank recalculations — without periodic drift detection, there's no trust that the graph is in sync to begin with.
+
+**Investigation findings** (from the conversation that produced this story — included here as informational context for the Architect, not as a prescribed solution):
+
+- *Full strfry rescan on every run.* `strfryToKind3Events.sh` (and the kind-10000 / kind-1984 equivalents) already supports a `--recent <seconds>` flag that sets `"since": $timestamp` on the strfry filter, but the orchestrator `reconciliation.sh` invokes them with no args, so `SINCE_TIMESTAMP=0` and every kind-3 event ever is re-dumped on every run.
+- *N+1 Cypher pattern.* `getCurrentFollowsFromNeo4j.js` (and the mutes/reports counterparts) loops over every rater pubkey and opens a fresh Neo4j session per pubkey with a 60s timeout race. With ~12M follow edges across an estimated 100K–250K raters, that's hundreds of thousands of round-trips per run.
+- *Three event kinds run sequentially* in the orchestrator (mutes → reports → follows); they share no state.
+- *Six sequential `cypher-shell` APOC invocations per kind* (adds, deletes, second pass), all serial.
+- *Hundreds of thousands of tiny per-pubkey JSON files* are written then re-read by the diff step.
+- *Hot-loop per-rater debug logging* (~6 `fs.appendFileSync` calls per pubkey) — pure overhead.
+- *No early-exit pre-check.* A cheap edge-count comparison between strfry and Neo4j could let the task no-op when the graph is already in sync.
+
+**Strategic directions** the Architect may consider (in roughly descending expected impact; informational, not binding):
+
+1. Incremental mode — track a `lastReconciledAt` watermark and only inspect events / pubkeys changed since the prior successful run.
+2. Cheap count pre-check — early-exit when strfry and Neo4j edge counts agree within tolerance.
+3. Eliminate the N+1 — replace the per-pubkey Cypher loop with a single streamed paged query.
+4. Parallelize the three event kinds in the orchestrator (they're independent).
+5. Strip the per-rater debug log.
+6. (Stretch) Replace per-pubkey JSON file fanout with a sorted JSONL + merge-join diff.
+
+**Correctness constraint.** Incremental mode would miss drift caused by anything that is *not* a recent strfry event — e.g., a prior partial-write to Neo4j, a corrupted relationship from an earlier bug, a botched migration, or any prior incident that left the graph out of sync without leaving a strfry-side trace. The story therefore requires a periodic **full reconciliation fallback** that runs on a slower cadence and recovers from any such accumulated drift. Fast incremental is the routine default; full is the safety net.
+
+**Scope boundary.** The older `src/pipeline/reconcile/` directory's `note.md` says it is "being deprecated in favor of the newer reconciliation module." This story works in `src/pipeline/reconciliation/`, not `reconcile/`. Whether to delete the deprecated directory is out of scope.
+
+## User-facing description
+
+**As the operator,** I want reconciliation to complete in minutes (not 6–8 hours) on a steady-state graph, while still catching any accumulated drift on a periodic basis, **so that** I can confidently schedule routine reconciliation runs and resume scheduled per-customer recalculations against a Neo4j I trust to be in sync with strfry.
+
+## Acceptance criteria
+
+- [ ] On a steady-state graph (strfry and Neo4j already in sync), reconciliation completes in **dramatically less time than the current 6–8 hour baseline** — concretely, in **minutes, not hours**. The exact target (e.g., < 15 minutes) is an open question for the Architect to propose in the ADR and the operator to ratify at the architecture gate.
+- [ ] Reconciliation has two modes: a fast **incremental** mode (the routine default) and a **full** mode (current behavior; runs against the entire graph). Full mode is preserved as the correctness baseline and the periodic drift-recovery fallback.
+- [ ] Incremental mode persists a watermark (e.g., `lastReconciledAt`, or equivalent state) across runs, so each incremental run only inspects events / pubkeys changed since the prior successful run.
+- [ ] After an incremental run completes successfully, a subsequent full reconciliation against the same strfry + Neo4j state produces **identical** Neo4j edge sets (FOLLOWS, MUTES, REPORTS) — i.e., incremental mode is provably correct against the existing full-mode oracle.
+- [ ] Reconciliation supports a periodic **full reconciliation** as the drift-recovery fallback. Both the cadence (e.g., weekly) and the first-run-after-deploy behavior (auto-promote to full, vs initialize watermark to deploy time, vs other) are open questions for the Architect to propose in the ADR and the operator to ratify at the architecture gate. Whatever the Architect chooses, the behavior must be documented and observable from logs.
+- [ ] The operator can trigger either mode explicitly from the existing reconciliation surface (Task Registry / `/api/run-task`). Naming and parameters are the Architect's call, but the operator must not have to invoke a different shell script or learn a new entry point.
+- [ ] When strfry and Neo4j are already in sync, reconciliation completes cheaply and reports "no drift detected" rather than running the full diff machinery. Whether this is a hard early-exit or just an observability log is the Architect's call.
+- [ ] Reconciliation logs include: which mode ran, the watermark consumed and emitted, edge counts before and after for each of the three kinds, drift detected (adds/deletes), and per-stage timing. The log surface must be sufficient that the operator can answer "is my reconciliation actually catching drift, and how much?" from `/var/log/brainstorm/reconciliation.log` alone.
+- [ ] No regression in detected-drift outcomes: any drift that a **full** reconciliation today would catch and fix, the new pipeline must still catch and fix on a full run.
+- [ ] Operator documentation (`OPERATIONS.md` or equivalent) covers: the two modes, the watermark, the default cadence for each, how to force a full run for incident recovery, and how to inspect the watermark state.
+
+## Concepts touched
+
+To be resolved by the Architect via `/api/concept-graph/summaries`:
+
+- Reconciliation pipeline (`src/pipeline/reconciliation/`)
+- strfry event store (kinds 3 = contact lists, 10000 = mute lists, 1984 = reports)
+- Neo4j social graph (FOLLOWS, MUTES, REPORTS relationships; NostrUser nodes)
+- Task Registry entry for reconciliation
+- `/api/run-task` (the operator-facing trigger surface — see story #13)
+
+## Out of scope
+
+- **Deleting the deprecated `src/pipeline/reconcile/` directory.** `note.md` says it's being deprecated; cleanup is a separate housekeeping task.
+- **Changing the underlying Neo4j data model** (relationship types, NostrUser node shape).
+- **Routing reconciliation through the new BullMQ task queue** (story #13). Reconciliation continues to use whatever invocation path it uses today. If story #13 ships first, reconciliation will naturally benefit, but this story does not depend on it and must not be blocked by it.
+- **A UI surface for triggering or monitoring reconciliation.** Operator continues to use the existing trigger paths (Task Explorer, direct `/api/run-task`, systemd).
+- **Adding new Neo4j indexes or schema constraints** — if the Architect believes one is needed for the streaming paged query to be fast enough, that becomes a sub-decision in the ADR.
+- **Reconciling event kinds beyond 3 / 10000 / 1984.** Only the three kinds the current pipeline covers.
+- **Pruning or rotating the per-pubkey JSON intermediate files** beyond what the Architect's chosen design naturally requires.
+
+## Open questions
+
+To resolve at the architecture gate (the operator has explicitly deferred these to the Architect):
+
+1. **Steady-state runtime target.** "Minutes" — exact upper bound (e.g., < 5, < 15, < 30 minutes) is the Architect's recommendation; operator ratifies.
+2. **Default full-reconciliation cadence.** Weekly automatic? Daily at low-traffic hour? Manual-only? Architect proposes; operator ratifies.
+3. **First-run-after-deploy behavior.** Auto-promote to full vs initialize watermark to deploy-time vs other. Architect proposes; operator ratifies.
+4. **Cheap-pre-check semantics.** Hard early-exit on count-match, or always log a warning when counts match but still run the diff? Architect proposes.
+5. **Story #13 (BullMQ task queue) interaction.** This story does not strictly depend on story #13, but the operator note in #13 (2026-05-20) calls out reconciliation reliability as what's gating their willingness to resume scheduled per-customer recalculations. Captured in Background; no decision required.
+
+## Testability notes
+
+How we'll know it works (informational; the Tester writes the actual test plan in Phase 3):
+
+- **Correctness oracle:** the existing full reconciliation is the oracle. A test fixture that seeds a known-drift state in strfry + Neo4j, runs full reconciliation, snapshots Neo4j, then runs incremental from a fresh watermark against the same fixture — and asserts identical Neo4j state.
+- **Drift-detection regression:** a fixture that introduces drift in a way that no *recent* strfry event signals (e.g., directly corrupt a Neo4j FOLLOWS edge without producing a corresponding event). Incremental should miss it; full should catch it. Both are passing behaviors — the test asserts the expected difference, demonstrating why the periodic full fallback is necessary.
+- **Runtime measurement:** a benchmarked run on a snapshot of (or the closest staging equivalent to) the production-scale graph demonstrating sub-target steady-state runtime. The headline metric should be a logged measurement in the test plan, not just a unit assertion.
+- **First-run-after-deploy:** a fresh-install fixture asserts the first run takes the documented path (full-promotion or watermark-initialization, whichever the Architect picks).
+- **Idempotency:** running incremental twice in a row with no intervening events does not double-write, double-delete, or advance the watermark in a way that creates a gap.
+- **No-drift no-op:** with strfry and Neo4j perfectly in sync, the cheap-pre-check (if adopted by the Architect) returns in the documented fast-path budget and emits a "no drift detected" log line with edge counts.
+
+## Linked artifacts
+
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/21-reconciliation-incremental-mode.md
+++ b/engineering-team/stories/21-reconciliation-incremental-mode.md
@@ -102,5 +102,5 @@ How we'll know it works (informational; the Tester writes the actual test plan i
 ## Linked artifacts
 
 - ADR: [0018-reconciliation-incremental-mode.md](../decisions/0018-reconciliation-incremental-mode.md)
-- Test plan: (filled in after Test Design phase)
+- Test plan: [21-reconciliation-incremental-mode.test-plan.md](21-reconciliation-incremental-mode.test-plan.md)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/21-reconciliation-incremental-mode.md
+++ b/engineering-team/stories/21-reconciliation-incremental-mode.md
@@ -1,4 +1,4 @@
-# Story 14: Speed up reconciliation — incremental mode with periodic full fallback
+# Story 21: Speed up reconciliation — incremental mode with periodic full fallback
 
 **Status:** Approved
 **Created:** 2026-05-20
@@ -65,14 +65,22 @@ To be resolved by the Architect via `/api/concept-graph/summaries`:
 - **Deleting the deprecated `src/pipeline/reconcile/` directory.** `note.md` says it's being deprecated; cleanup is a separate housekeeping task.
 - **Changing the underlying Neo4j data model** (relationship types, NostrUser node shape).
 - **Routing reconciliation through the new BullMQ task queue** (story #13). Reconciliation continues to use whatever invocation path it uses today. If story #13 ships first, reconciliation will naturally benefit, but this story does not depend on it and must not be blocked by it.
-- **A UI surface for triggering or monitoring reconciliation.** Operator continues to use the existing trigger paths (Task Explorer, direct `/api/run-task`, systemd).
+- **A UI surface for triggering or monitoring reconciliation**, including the `reconcileAuthor` trigger surfaces (profile-page button, API endpoint, customer-scoped scheduling) — a **follow-up story** (see ADR 0018). Operator continues to use the existing trigger paths (Task Explorer, direct `/api/run-task`, systemd) for the sweep tasks.
 - **Adding new Neo4j indexes or schema constraints** — if the Architect believes one is needed for the streaming paged query to be fast enough, that becomes a sub-decision in the ADR.
 - **Reconciling event kinds beyond 3 / 10000 / 1984.** Only the three kinds the current pipeline covers.
 - **Pruning or rotating the per-pubkey JSON intermediate files** beyond what the Architect's chosen design naturally requires.
 
 ## Open questions
 
-To resolve at the architecture gate (the operator has explicitly deferred these to the Architect):
+**Resolved at the architecture gate (2026-05-21) — see [ADR 0018](../decisions/0018-reconciliation-incremental-mode.md).** Summary:
+- Q1 runtime target → acceptance bar **< 15 min** steady-state (typically seconds–minutes).
+- Q2 cadence → two **independent scheduled tasks**: incremental ~10 min, full **weekly**. Cadence lives in the scheduler, not the script.
+- Q3 first-run → `reconcileRecent` with no watermark **bootstraps with one full pass**.
+- Q4 pre-check → **hard early-exit** when zero events since the watermark; coarse Neo4j-vs-strfry count comparison logged as a drift *signal*, not a gate. (The per-author check is a **set diff**, never a count.)
+- Q5 queue interaction → bulk sweeps tagged **`neo4j-heavy`** (ADR 0013 semaphore); stays behind the queue (ADR 0015).
+- **Scope refinement:** landed as **three** author-scoped tasks — `reconcileRecent` (incremental), `reconcileAll` (full/oracle), `reconcileAuthor` (single author). The single-author *engine mode* is in scope here; its trigger surfaces (profile button, API endpoint, customer scheduling) are a **follow-up story**.
+
+Original deferred questions (kept for traceability):
 
 1. **Steady-state runtime target.** "Minutes" — exact upper bound (e.g., < 5, < 15, < 30 minutes) is the Architect's recommendation; operator ratifies.
 2. **Default full-reconciliation cadence.** Weekly automatic? Daily at low-traffic hour? Manual-only? Architect proposes; operator ratifies.
@@ -93,6 +101,6 @@ How we'll know it works (informational; the Tester writes the actual test plan i
 
 ## Linked artifacts
 
-- ADR: (filled in after Architecture phase)
+- ADR: [0018-reconciliation-incremental-mode.md](../decisions/0018-reconciliation-incremental-mode.md)
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/21-reconciliation-incremental-mode.md
+++ b/engineering-team/stories/21-reconciliation-incremental-mode.md
@@ -103,4 +103,4 @@ How we'll know it works (informational; the Tester writes the actual test plan i
 
 - ADR: [0018-reconciliation-incremental-mode.md](../decisions/0018-reconciliation-incremental-mode.md)
 - Test plan: [21-reconciliation-incremental-mode.test-plan.md](21-reconciliation-incremental-mode.test-plan.md)
-- Review: (filled in after Review phase)
+- Review: [../reviews/21-reconciliation-incremental-mode.md](../reviews/21-reconciliation-incremental-mode.md) — PASS (source/design audit; cycle-local smoke S1–S10 required before prod)

--- a/engineering-team/stories/21-reconciliation-incremental-mode.test-plan.md
+++ b/engineering-team/stories/21-reconciliation-incremental-mode.test-plan.md
@@ -1,0 +1,110 @@
+# Test Plan: Story 21 — Speed up reconciliation (recent / all / author modes)
+
+**Story:** `engineering-team/stories/21-reconciliation-incremental-mode.md`
+**ADR:** `engineering-team/decisions/0018-reconciliation-incremental-mode.md`
+**Date:** 2026-05-21
+
+## Approach
+
+Same precedent as #5/#6/#8/#10/#11/#12/#13/#15. The implementation is bash (`reconciliation.sh`) plus small Node deltas (the three extractors gain `--authorsFromDir`) and a `taskRegistry.json` change — so the `npm test` layer uses **source/structural sentinels** that pin the ADR-required code shape, and the **behavioral heart runs as cycle-local smoke** against the live strfry + Neo4j Docker stack.
+
+The behavioral round-trips are not reproducible at the `npm test` layer for two reasons: (1) they need real strfry events + a real Neo4j graph; (2) the reconciliation Node scripts `require('yargs/yargs')` and friends, which exist only in the production install (`/usr/local/lib/node_modules/brainstorm`), **not** in this dev checkout (`yargs` is neither a declared dep nor in `node_modules`). So even a hermetic subprocess invocation of `calculateFollowsUpdates.js` fails at `npm test` with `MODULE_NOT_FOUND`. The set-diff behavior (and everything else behavioral) is therefore the **authoritative cycle-local smoke** (Reviewer-required). `R1` pins the set-based shape at the source level as the npm-test guard.
+
+- **T1..T10** — FAIL pre-implementation, PASS post. The ADR-required new code shape.
+- **R1..R5** — PASS pre AND post. Regression guards on the machinery ADR 0018 reuses **verbatim**: the per-author set diff, the converters, the APOC apply, `cleanup()`, and the strfry `--recent` capability. If the Implementer "optimizes" any of these (e.g. turns the set diff into a count check), these trip.
+- **S1..S10** — cycle-local smoke. The correctness oracle, the runtime target, drift detection, isolation, idempotency, and the neo4j-heavy serialization.
+
+## Coverage map
+
+| AC | Test / mechanism | File | Level |
+|---|---|---|---|
+| AC-1 (minutes not hours; target < 15 min) | **T3** (recent passes `--recent` from watermark+overlap) + **T6** (author-restricted Neo4j extraction kills the N+1) + **R5** (strfry `--recent` capability preserved). **S2** = runtime measurement | test/reconciliation-incremental-mode.test.js | source + smoke |
+| AC-2 (modes: recent default, all fallback — landed as 3) | **T2** (`reconciliation.sh --mode recent\|all\|author`) + **T8** (three registry keys) | same | source |
+| AC-3 (incremental persists a watermark) | **T1** (state.json + watermark field) + **T3** (overlap window) | same | source |
+| AC-4 (incremental output == full output; oracle) | **R1** (set-diff shape) + **T6** (same-author-set restriction). **S1** = oracle equivalence (authoritative) | same | source + smoke |
+| AC-5 (periodic full fallback; first-run; cadence) | **T5** (first-run bootstrap) + **T8** (`reconcileAll`) + **T10** (docs cadence). Cadence lives in scheduler → **S6** | same | source + smoke |
+| AC-6 (trigger either mode from existing surface; same script) | **T2** + **T8** (one `reconciliation.sh`, three registry keys, `--mode`) | same | source |
+| AC-7 (no-drift → cheap, "no drift detected") | **T4** (`no_drift` early-exit + `strfry scan --count` gate). **S3** = no-op smoke | same | source + smoke |
+| AC-8 (logs: mode, watermark, edge counts, drift adds/deletes, timing) | **T9** (mode / watermark / added / deleted vocabulary). **S1/S3** confirm real log content | same | source + smoke |
+| AC-9 (no regression in full-run drift detection) | **R1**–**R5** + full `npm test` green. **S4** = drift regression (recent misses non-event drift, all catches) | same + full gate | source + smoke |
+| AC-10 (OPERATIONS.md documents modes/watermark/cadence/force-full) | **T10** | OPERATIONS.md | source |
+
+**Totals:** T1..T10 = **10 failing sentinels** (flip to PASS post-impl). R1..R5 = **5 regression guards** (PASS pre AND post). Confirmed `{pass: 5, fail: 10}` pre-implementation.
+
+## Edge cases
+
+- [x] **Set diff, not count** — the correctness property the operator specifically probed. `R1` pins `new Set(...)` + `.has(...)` at the source level; **S10** exercises same-count-different-membership (→ exactly one add + one delete) against the live diff.
+- [x] **The no-spurious-deletes invariant** — a rater present in Neo4j but absent from the covered strfry set means "delete all their follows." That is correct ONLY because recent mode restricts the Neo4j extraction to the same covered set (**T6**). **S1/S5** verify uncovered authors are never touched.
+- [x] **`reconcileAuthor` is NOT neo4j-heavy** — `T8` asserts `entry.resourceClass !== 'neo4j-heavy'` so an interactive trigger never queues behind an 8-hour sweep.
+- [x] **First-run / lost-watermark bootstrap** — `T5` (source) + **S6** (end-to-end fresh deploy → full pass + watermark written).
+- [x] **Debug-log removal scoped to follows only** — `T7` targets `getCurrentFollowsFromNeo4j.js`; the mutes/reports extractors never had the per-rater log (verified: 0 occurrences).
+- [x] **Defensive reads** — `readSafe`/`readJsonSafe` return null on missing/malformed files; sentinels emit a "re-baseline" message rather than a parse crash.
+- [ ] **Real strfry `since` semantics, real Neo4j edge counts, real APOC apply, real watermark advance/rollback, neo4j-heavy serialization under contention** — not catchable in source; **cycle-local smoke is authoritative**.
+
+## Not covered (deferred to cycle-local smoke — authoritative, Reviewer-required)
+
+Run on the live Docker stack (`http://localhost:8080`) with seeded strfry events + a populated Neo4j graph:
+
+**S1 — AC-4 oracle equivalence (the headline test):** Seed a known drift state. Run `reconcileAll`; snapshot the FOLLOWS/MUTES/REPORTS edge sets. Reset Neo4j to the pre-state. Run `reconcileRecent` from a fresh watermark covering the same window. Assert the resulting edge sets are **identical** to the `reconcileAll` snapshot.
+
+**S2 — AC-1 runtime:** On a staging-scale (or closest available) graph already in sync, `reconcileRecent` completes in **minutes (target < 15)**, vs the 6–8 h `reconcileAll` baseline. Capture the logged per-stage timing.
+
+**S3 — AC-7 no-drift no-op:** With strfry and Neo4j in sync (no events since the watermark), `reconcileRecent` exits in the sub-minute fast-path, emits a `no_drift` event + a "no drift detected" log line, and advances the watermark without writing diff files.
+
+**S4 — AC-9 / ADR constraint, drift regression:** Inject drift with NO corresponding recent event (e.g. directly delete a FOLLOWS edge in Neo4j whose author has published nothing since the watermark). Assert `reconcileRecent` does **not** repair it (the author isn't in the covered set) but `reconcileAll` does. Both are passing behaviors — this demonstrates *why* the weekly full run exists.
+
+**S5 — `reconcileAuthor` isolation:** `reconcileAuthor --pubkey <X>` reconciles only X's edges; assert a different author Y's edges are untouched and `state.json` (the sweep watermark) is unchanged.
+
+**S6 — AC-5 first-run bootstrap:** With no `state.json` (fresh deploy), `reconcileRecent` performs a full pass, then writes the watermark. The subsequent run is genuinely incremental.
+
+**S7 — idempotency:** Two `reconcileRecent` runs back-to-back with no intervening events → the second produces zero adds/deletes and does not create a watermark gap.
+
+**S8 — failure leaves watermark intact:** Kill `reconcileRecent` mid-run (or force a stage failure). Assert `state.json`'s `lastRunStartedAt` is NOT advanced, so the next run re-covers the same window.
+
+**S9 — AC-5 neo4j-heavy serialization (ADR 0013 interaction):** Trigger `reconcileAll` and `calculateOwnerGrapeRank` back-to-back with the queue on; assert they serialize (events.jsonl `resource_class_wait_*`). Trigger `reconcileAuthor` concurrently with a sweep; assert it does **not** wait on the `neo4j-heavy` class.
+
+**S10 — set diff not count (behavioral):** Construct a fixture where an author's follow *count* is unchanged but membership changed (drop A, add B). Assert the live diff emits exactly one add (B) and one delete (A). (This is the test that cannot run at the `npm test` layer due to the `yargs` dep; it runs here against the production install.)
+
+## Test infrastructure
+
+- Existing hand-rolled Node runner (`npm test` → `test/test.js`); no new deps (house rule).
+- Registered: `reconciliationIncrementalMode`, last in `test/test.js`'s suite list (after `adminToolsDashboardPanel`).
+- Asserts only against in-repo files: `src/pipeline/reconciliation/{reconciliation.sh, reconciliationState.sh, getCurrent*FromNeo4j.js, calculateFollowsUpdates.js, kind3EventsToFollows.js, apocCypherCommands/*, strfryToKind*Events.sh}`, `src/manage/taskQueue/taskRegistry.json`, `OPERATIONS.md`.
+- No live API needed for the sentinel layer (concept-graph at `localhost:8877` not required). The behavioral layer is strfry + Neo4j + bash — cycle-local smoke territory; no Playwright (nothing pure-frontend in this story; the `reconcileAuthor` UI is a separate follow-up story).
+
+## How to run
+
+```
+npm test
+```
+
+Targeted: `node -e "require('./test/reconciliation-incremental-mode.test.js').run()"`
+
+## Verification
+
+New tests fail on the pre-implementation tree (atop ADR commit `5ac95656`); all 16 prior suites stay green. Confirmed 2026-05-21:
+
+```
+reconciliation-incremental-mode suite:
+  ✗ T1: reconciliation persists a watermark in state.json across runs (AC-3)
+  ✗ T2: reconciliation.sh accepts --mode recent|all|author (+ --pubkey) (AC-2, AC-6)
+  ✗ T3: reconcileRecent passes --recent from watermark+overlap to strfry dumpers (AC-1, AC-3)
+  ✗ T4: reconcileRecent has a cheap no-drift early-exit (AC-7)
+  ✗ T5: reconcileRecent bootstraps with a full pass when no watermark exists (AC-5)
+  ✗ T6: the three Neo4j extractors honor --authorsFromDir (AC-1, AC-4)
+  ✗ T7: per-rater debug log removed from the follows extractor (AC-1)
+  ✗ T8: registry has reconcileRecent + reconcileAll (neo4j-heavy) and reconcileAuthor (not) (AC-2, AC-5, AC-6)
+  ✗ T9: reconciliation.sh emits mode/watermark/per-kind drift vocabulary (AC-8)
+  ✗ T10: OPERATIONS.md documents the three tasks/watermark/overlap/neo4j-heavy (AC-10)
+  ✓ R1: the diff still compares follow sets by membership (Set.has), not count
+  ✓ R2: the kind-3 → follows converter still maps events to per-pubkey files
+  ✓ R3: the APOC apply still MERGEs / DELETEs FOLLOWS relationships
+  ✓ R4: reconciliation.sh cleanup() still wipes the per-pubkey dirs at run start
+  ✓ R5: all three strfry dumpers still support --recent
+
+reconciliation-incremental-mode suite:           FAIL (5 passed, 10 failed)
+Overall:                                          FAIL
+```
+
+All 16 prior suites continue to PASS (no regressions from registering the new suite):
+`treasure-maps`, `scheduled-search`, `strfry-router-first-boot`, `per-query-neo4j-timeout`, `nip05-checkmark`, `publish-export`, `community-reference-stub`, `header-conceptgraph-tag`, `community-reference-superset-link`, `graperank-shared-csv-race`, `community-class-thread-pull`, `task-queue-bullmq`, `task-queue-neo4j-resource-class`, `entrypoint-template-rendering`, `bullboard-admin-access`, `admin-tools-dashboard-panel`.

--- a/engineering-team/stories/_intake.md
+++ b/engineering-team/stories/_intake.md
@@ -208,3 +208,48 @@ The Architect picks the scope when the story gets planned. (1) is genuinely mini
 **Strictness:** Standard
 **Phase path:** Planning → Architecture → Test Design → Implementation → Review (the merge bug alone might fast-track if the cause is mechanical, but the combined story warrants full harness)
 **Priority:** Low-medium. No Nostr clients are broken (NIP-11 partial document still parses); the relay still works via WebSocket. Worth fixing for relay-discovery hygiene + visitor first-impression, but not blocking any operator workflow.
+
+## 2026-05-21 — Feature: generalized Task Scheduler (BullMQ repeatable jobs) — task-queue phase 2
+
+Replace the in-process `setInterval` scheduler (`src/api/scheduled-tasks/index.js`) with a durable, generalized scheduler built on **BullMQ repeatable/cron jobs**. This is the documented phase 2 of the task queue (story #13).
+
+Why now: story #21 built three manually-triggerable reconciliation tasks (`reconcileRecent`/`reconcileAll`/`reconcileAuthor`) and deliberately did NOT wire any cadence — because the current scheduler can't serve them. Limitations of `src/api/scheduled-tasks/index.js` this would remove:
+- **1-hour minimum interval** (`index.js:258`) — can't do sub-hour.
+- **Hardcoded task set** (`DEFAULTS` = `updateAllScoresForOwner`, `refreshSearchIndex`) — can't schedule arbitrary registered tasks without code edits.
+- **In-process `setInterval`** — dies with the control-panel process; a missed fire is silently skipped (flagged in story #13 background).
+- The only existing sub-hour workaround is a host `systemd` timer, which bypasses the BullMQ queue and the `neo4j-heavy` semaphore.
+
+Target: any registered task schedulable by interval/cron; durable in Redis (survives restarts); routes through the queue (semaphore + BullBoard observability for free); sub-hour intervals. The three reconcile tasks then slot in with no bespoke per-task code — the tasks are already frequency-agnostic by design.
+
+Out of scope: event/dependency-driven triggers (`processAllTasks` already handles chaining); per-customer fan-out scheduling (separate concern).
+
+**Classification:** Feature (task-queue phase 2)
+**Strictness:** Standard
+**Phase path:** Planning → Architecture → Test Design → Implementation → Review
+**Priority:** Medium. Unblocks automated reconciliation cadence and generalizes scheduling for all tasks; until then reconciliation is manual.
+
+## 2026-05-21 — Cleanup: deprecate legacy `reconciliation` task + `reconcile.timer` (superseded by story #21)
+
+Story #21 replaced the single `reconciliation` flow with three explicit task keys. Two now-superseded mechanisms remain for back-compat and should be removed once the new tasks are in routine use:
+
+1. **Legacy `reconciliation` registry key** — retained because `processAllTasks.sh:152` still calls it (now defaults to `--mode recent`). Removal requires deciding whether reconciliation stays in the `processAllTasks` chain (repoint `:152` → `reconcileRecent`) or is decoupled and scheduled independently via the generalized scheduler. Ordering dependency to preserve: reconciliation should run before the owner score calcs so they operate on a synced graph.
+2. **`systemd/reconcile.timer` + `reconcile.service`** — runs `reconciliation.sh` directly every 5 min, bypassing the queue and the `neo4j-heavy` semaphore. Operator reports it has been disabled for a long time. Full removal touches: the unit files; control-panel references (`src/api/export/services/commands/control.js:40`, `queries/status.js:35`); and the sudoers grant (`setup/configure-control-panel-sudo.sh:68-71`).
+
+**Classification:** Refactor / cleanup (removing superseded mechanisms; no new user-facing behavior)
+**Strictness:** Standard
+**Phase path:** Architecture (the `processAllTasks` decoupling decision) → Implementation → Review; the timer-file removal alone could fast-track.
+**Priority:** Low-medium. No correctness issue today; hygiene to avoid two reconciliation paths drifting. Best done alongside or after the generalized scheduler.
+
+## 2026-05-21 — Feature: `reconcileAuthor` trigger surfaces (profile button + API + per-customer scheduling)
+
+Story #21 / ADR 0018 built the `reconcileAuthor` engine mode (`reconciliation.sh --mode author --pubkey <hex>`) but explicitly deferred its trigger surfaces. This story delivers them:
+- A profile-page "reconcile this user" button (frontend).
+- An API endpoint to trigger a single-author reconcile by pubkey (the `--pubkey` value is supplied here; today the registry entry carries only `--mode author`).
+- Optional per-customer scheduling (reconcile customers' authors periodically but not the whole network) — follows the existing `calculateCustomer*` customer-scoped pattern.
+
+Note: `reconcileAuthor` is intentionally NOT `neo4j-heavy` so an interactive trigger stays responsive (never queues behind a sweep).
+
+**Classification:** Feature (UI + API + scheduling)
+**Strictness:** Standard
+**Phase path:** Planning → Architecture → Test Design → Implementation → Review
+**Priority:** Low-medium. The engine works; this is the operator/user-facing surface.

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "typescript": "^5.8.2",
         "websocket": "^1.0.35",
         "websocket-polyfill": "^0.0.3",
-        "ws": "^8.18.1"
+        "ws": "^8.18.1",
+        "yargs": "^18.0.0"
       },
       "bin": {
         "brainstorm-control-panel": "bin/control-panel.js",
@@ -1250,6 +1251,60 @@
         "date-fns": ">=2.0.0"
       }
     },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -2145,6 +2200,15 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2502,6 +2566,27 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4373,6 +4458,15 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yaeti": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
@@ -4380,6 +4474,55 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.32"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yauzl": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "typescript": "^5.8.2",
     "websocket": "^1.0.35",
     "websocket-polyfill": "^0.0.3",
-    "ws": "^8.18.1"
+    "ws": "^8.18.1",
+    "yargs": "^18.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.40.0"

--- a/src/api/manage/commands/runTask.js
+++ b/src/api/manage/commands/runTask.js
@@ -81,6 +81,12 @@ async function buildTaskCommand(task, customerArgs = null, queryParams = {}) {
 
     let args = [];
 
+    // Static args declared on the registry entry (e.g. reconciliation "--mode all").
+    // Word-split so each token becomes its own argv element downstream.
+    if (task.staticArgs) {
+        args.push(...String(task.staticArgs).trim().split(/\s+/).filter(Boolean));
+    }
+
     // Handle customer arguments if required
     if (task.arguments && task.arguments.customer && customerArgs) {
         args = [customerArgs.pubkey, customerArgs.customerId, customerArgs.customerName];

--- a/src/manage/taskQueue/queue/processor.js
+++ b/src/manage/taskQueue/queue/processor.js
@@ -20,6 +20,12 @@ const brainstormConfig = require('../../../utils/brainstormConfig');
  */
 function buildChildArgs(taskDef, customerArgs, queryParams) {
   const args = [];
+  // Static args declared on the registry entry (e.g. reconciliation "--mode all").
+  // Word-split so each token becomes its own argv element when launchChildTask
+  // runs `bash "$child_script" $child_args`.
+  if (taskDef.staticArgs) {
+    args.push(...String(taskDef.staticArgs).trim().split(/\s+/).filter(Boolean));
+  }
   if (taskDef.arguments && taskDef.arguments.customer && customerArgs) {
     args.push(customerArgs.pubkey, customerArgs.customerId, customerArgs.customerName);
   }

--- a/src/manage/taskQueue/taskRegistry.json
+++ b/src/manage/taskQueue/taskRegistry.json
@@ -341,7 +341,100 @@
           }
         }
       },
-      "notes": "Phase 2 structured logging implemented - comprehensive 3-phase reconciliation tracking with TASK_START/END, detailed PROGRESS events for each phase (A: mutes, B: follows, C: reports), operation-specific tracking with timing and status"
+      "notes": "Legacy key (back-compat). With story #21 / ADR 0018 the script defaults to --mode recent (incremental). Prefer reconcileRecent / reconcileAll / reconcileAuthor for explicit modes."
+    },
+
+    "reconcileRecent": {
+      "name": "Reconcile (recent)",
+      "categories": ["network"],
+      "description": "Incremental reconciliation: only authors with a relevant event since the last successful run. Bootstraps with a full pass if no watermark exists. The routine sweep — schedule ~every 10 minutes.",
+      "scripts": [
+        "$BRAINSTORM_MODULE_SRC_DIR/pipeline/reconciliation/reconciliation.sh"
+      ],
+      "script": "$BRAINSTORM_MODULE_SRC_DIR/pipeline/reconciliation/reconciliation.sh",
+      "script_relative_path": "pipeline/reconciliation/reconciliation.sh",
+      "staticArgs": "--mode recent",
+      "arguments": false,
+      "parent": "processAllTasks",
+      "scope": "system",
+      "priority": "medium",
+      "frequency": "frequent",
+      "status": "active",
+      "structuredLogging": true,
+      "resourceClass": "neo4j-heavy",
+      "options": {
+        "completion": {
+          "failure": {
+            "timeout": {
+              "comments": "1800000 = 30 minutes (incremental run is minutes; generous ceiling)",
+              "duration": 1800000,
+              "forceKill": false
+            }
+          }
+        }
+      },
+      "notes": "Story #21 / ADR 0018. Author-restricted incremental sweep; neo4j-heavy (serializes with GrapeRank/PageRank/Hops via ADR 0013)."
+    },
+
+    "reconcileAll": {
+      "name": "Reconcile (full)",
+      "categories": ["network"],
+      "description": "Full reconciliation over every author (the correctness oracle and periodic drift-recovery fallback). Schedule weekly; also the incident-recovery / force-full path.",
+      "scripts": [
+        "$BRAINSTORM_MODULE_SRC_DIR/pipeline/reconciliation/reconciliation.sh"
+      ],
+      "script": "$BRAINSTORM_MODULE_SRC_DIR/pipeline/reconciliation/reconciliation.sh",
+      "script_relative_path": "pipeline/reconciliation/reconciliation.sh",
+      "staticArgs": "--mode all",
+      "arguments": false,
+      "scope": "system",
+      "priority": "medium",
+      "frequency": "weekly",
+      "status": "active",
+      "structuredLogging": true,
+      "resourceClass": "neo4j-heavy",
+      "options": {
+        "completion": {
+          "failure": {
+            "timeout": {
+              "comments": "28800000 = 8 hours (full graph sweep)",
+              "duration": 28800000,
+              "forceKill": false
+            }
+          }
+        }
+      },
+      "notes": "Story #21 / ADR 0018. Full-graph sweep — today's behavior, retained as oracle + weekly fallback; neo4j-heavy."
+    },
+
+    "reconcileAuthor": {
+      "name": "Reconcile (single author)",
+      "categories": ["network"],
+      "description": "Reconcile a single author's relationships on demand. Requires --pubkey <hex>. NOT neo4j-heavy: a tiny point write that stays responsive for interactive triggers (does not queue behind a sweep). Trigger surfaces (profile button, API, customer scheduling) are a follow-up story.",
+      "scripts": [
+        "$BRAINSTORM_MODULE_SRC_DIR/pipeline/reconciliation/reconciliation.sh"
+      ],
+      "script": "$BRAINSTORM_MODULE_SRC_DIR/pipeline/reconciliation/reconciliation.sh",
+      "script_relative_path": "pipeline/reconciliation/reconciliation.sh",
+      "staticArgs": "--mode author",
+      "arguments": false,
+      "scope": "system",
+      "priority": "medium",
+      "frequency": "manual",
+      "status": "active",
+      "structuredLogging": true,
+      "options": {
+        "completion": {
+          "failure": {
+            "timeout": {
+              "comments": "600000 = 10 minutes (single author)",
+              "duration": 600000,
+              "forceKill": false
+            }
+          }
+        }
+      },
+      "notes": "Story #21 / ADR 0018. Single-author engine mode (--mode author --pubkey). Intentionally NOT neo4j-heavy. The --pubkey value is supplied by the trigger surface (follow-up story)."
     },
 
     "processNpubsUpToMaxNumBlocks": {

--- a/src/pipeline/reconciliation/getCurrentFollowsFromNeo4j.js
+++ b/src/pipeline/reconciliation/getCurrentFollowsFromNeo4j.js
@@ -52,6 +52,11 @@ const argv = yargs(hideBin(process.argv))
     type: 'number',
     default: 1000
   })
+  .option('authorsFromDir', {
+    describe: 'Incremental/author mode: restrict extraction to the <pubkey>.json files in this directory (the matching currentRelationshipsFromStrfry/<kind>/ dir) instead of scanning every rater in Neo4j',
+    type: 'string',
+    default: ''
+  })
   .help()
   .argv;
 
@@ -64,7 +69,8 @@ const config = {
   },
   outputDir: argv.outputDir,
   logFile: argv.logFile,
-  batchSize: argv.batchSize
+  batchSize: argv.batchSize,
+  authorsFromDir: argv.authorsFromDir
 };
 
 // Ensure log directory exists
@@ -165,6 +171,22 @@ async function getRaters(skip, limit) {
   } finally {
     await session.close();
   }
+}
+
+/**
+ * Incremental/author mode: read the covered rater pubkeys from the strfry
+ * relationship directory (one <pubkey>.json file per covered author) instead of
+ * scanning every rater in Neo4j. This restricts the extraction to the SAME
+ * author set as the strfry side — the reconciliation correctness invariant
+ * (ADR 0018 §Option A). No Neo4j query, no N+1 over the whole graph.
+ * @param {string} dir - the matching currentRelationshipsFromStrfry/<kind>/ dir
+ * @returns {Array<string>} rater pubkeys
+ */
+function getRatersFromDir(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .filter(f => f.endsWith('.json') && f !== '_summary.json')
+    .map(f => f.replace(/\.json$/, ''));
 }
 
 /**
@@ -291,61 +313,29 @@ async function writeFileWithTimeout(
  * @param {number} totalBatches - Total number of batches
  */
 async function processRaterBatch(raters, batchIndex, totalBatches) {
-  // await log(`Processing batch ${batchIndex}/${totalBatches} (${raters.length} raters)...`);
-  
   let processedCount = 0;
   let errorCount = 0;
-  
-  // create new log file called reconciliation_currentRaterBatch.log
-  const currentRaterBatchLogFile = path.join('/var/log/brainstorm/', `reconciliation_currentRaterBatch.log`);
-  // delete log file if it exists
-  if (fs.existsSync(currentRaterBatchLogFile)) {
-    fs.unlinkSync(currentRaterBatchLogFile);
-  }
-  // now create it
-  fs.writeFileSync(currentRaterBatchLogFile, '');
-  
+
   for (const raterPubkey of raters) {
     try {
-      // log to log file
-      fs.appendFileSync(currentRaterBatchLogFile, `\n\nProcessing rater ${raterPubkey}; processedCount: ${processedCount}; errorCount: ${errorCount}\n`);
       const followsData = await getFollowsForRater(raterPubkey);
-      fs.appendFileSync(currentRaterBatchLogFile, `Processing rater ${raterPubkey}; followsData successful\n`);
-      const filePath = path.join(config.outputDir, `${raterPubkey}.json`);    
-      
-      fs.appendFileSync(currentRaterBatchLogFile, `Processing rater ${raterPubkey}; filePath successful\n`);
+      const filePath = path.join(config.outputDir, `${raterPubkey}.json`);
 
       if (followsData) {
-        fs.appendFileSync(currentRaterBatchLogFile, `Processing rater ${raterPubkey}; filePath: ${filePath}; stringified followsData: ${JSON.stringify(followsData)}\n`);
-        // await writeFile(filePath, JSON.stringify(followsData, null, 2));
         await writeFileWithTimeout(filePath, JSON.stringify(followsData, null, 2));
-        fs.appendFileSync(currentRaterBatchLogFile, `Processing rater ${raterPubkey}; writeFile successful\n`);
         processedCount++;
       } else {
-        fs.appendFileSync(currentRaterBatchLogFile, `Processing rater ${raterPubkey}; writeFile failed\n`);
         await log(`WARNING: Empty data for rater ${raterPubkey}, skipping file write`);
       }
-      
-      // Log progress periodically
-      if (processedCount % 10 === 0 || processedCount === raters.length) {
-        const progress = Math.round((processedCount / raters.length) * 100);
-        fs.appendFileSync(currentRaterBatchLogFile, `Processing rater ${raterPubkey}; progress ${progress}%\n`);
-        // await log(`Batch ${batchIndex} of ${totalBatches} progress: ${progress}% (${processedCount}/${raters.length} Neo4j followers)`);
-      }
-      fs.appendFileSync(currentRaterBatchLogFile, `Processing rater ${raterPubkey}; completed\n`);
     } catch (error) {
-      fs.appendFileSync(currentRaterBatchLogFile, `Processing rater ${raterPubkey}; error ${error.message}\n`);
       await log(`WARNING: Failed to process rater ${raterPubkey}: ${error.message}`);
       errorCount++;
     }
-    
-    // Force garbage collection if available; log when garbage collection is about to be performed
-    if (global.gc) {
-      await log(`Garbage collection about to be performed`);
-      global.gc();
-    }
+
+    // Force garbage collection if available
+    if (global.gc) global.gc();
   }
-  
+
   await log(`Completed batch ${batchIndex} of ${totalBatches}. Processed: ${processedCount}, Errors: ${errorCount}`);
 }
 
@@ -360,18 +350,28 @@ async function main() {
     // Ensure output directory exists
     await ensureOutputDirectory();
     
+    // Incremental/author mode: restrict to the covered author set discovered in
+    // the strfry relationship dir; otherwise scan every rater in Neo4j (full mode).
+    let restrictedRaters = null;
+    if (config.authorsFromDir) {
+      restrictedRaters = getRatersFromDir(config.authorsFromDir);
+      await log(`Restricting extraction to ${restrictedRaters.length} authors from ${config.authorsFromDir}`);
+    }
+
     // Get total count of raters
-    const raterCount = await getRaterCount();
-    
+    const raterCount = restrictedRaters ? restrictedRaters.length : await getRaterCount();
+
     // Process raters in batches
-    const batchCount = Math.ceil(raterCount / config.batchSize);
-    
+    const batchCount = Math.ceil(raterCount / config.batchSize) || 1;
+
     for (let i = 0; i < raterCount; i += config.batchSize) {
       const batchIndex = Math.floor(i / config.batchSize) + 1;
-      const batchRaters = await getRaters(i, config.batchSize);
-      
+      const batchRaters = restrictedRaters
+        ? restrictedRaters.slice(i, i + config.batchSize)
+        : await getRaters(i, config.batchSize);
+
       await processRaterBatch(batchRaters, batchIndex, batchCount);
-      
+
       // Force garbage collection if available; log when garbage collection is about to be performed
       if (global.gc) {
         await log(`Garbage collection about to be performed`);

--- a/src/pipeline/reconciliation/getCurrentMutesFromNeo4j.js
+++ b/src/pipeline/reconciliation/getCurrentMutesFromNeo4j.js
@@ -52,6 +52,11 @@ const argv = yargs(hideBin(process.argv))
     type: 'number',
     default: 1000
   })
+  .option('authorsFromDir', {
+    describe: 'Incremental/author mode: restrict extraction to the <pubkey>.json files in this directory (the matching currentRelationshipsFromStrfry/<kind>/ dir) instead of scanning every rater in Neo4j',
+    type: 'string',
+    default: ''
+  })
   .help()
   .argv;
 
@@ -64,7 +69,8 @@ const config = {
   },
   outputDir: argv.outputDir,
   logFile: argv.logFile,
-  batchSize: argv.batchSize
+  batchSize: argv.batchSize,
+  authorsFromDir: argv.authorsFromDir
 };
 
 // Ensure log directory exists
@@ -165,6 +171,22 @@ async function getRaters(skip, limit) {
   } finally {
     await session.close();
   }
+}
+
+/**
+ * Incremental/author mode: read the covered rater pubkeys from the strfry
+ * relationship directory (one <pubkey>.json file per covered author) instead of
+ * scanning every rater in Neo4j. This restricts the extraction to the SAME
+ * author set as the strfry side — the reconciliation correctness invariant
+ * (ADR 0018 §Option A). No Neo4j query, no N+1 over the whole graph.
+ * @param {string} dir - the matching currentRelationshipsFromStrfry/<kind>/ dir
+ * @returns {Array<string>} rater pubkeys
+ */
+function getRatersFromDir(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .filter(f => f.endsWith('.json') && f !== '_summary.json')
+    .map(f => f.replace(/\.json$/, ''));
 }
 
 /**
@@ -313,18 +335,28 @@ async function main() {
     // Ensure output directory exists
     await ensureOutputDirectory();
     
+    // Incremental/author mode: restrict to the covered author set discovered in
+    // the strfry relationship dir; otherwise scan every rater in Neo4j (full mode).
+    let restrictedRaters = null;
+    if (config.authorsFromDir) {
+      restrictedRaters = getRatersFromDir(config.authorsFromDir);
+      await log(`Restricting extraction to ${restrictedRaters.length} authors from ${config.authorsFromDir}`);
+    }
+
     // Get total count of raters
-    const raterCount = await getRaterCount();
-    
+    const raterCount = restrictedRaters ? restrictedRaters.length : await getRaterCount();
+
     // Process raters in batches
-    const batchCount = Math.ceil(raterCount / config.batchSize);
-    
+    const batchCount = Math.ceil(raterCount / config.batchSize) || 1;
+
     for (let i = 0; i < raterCount; i += config.batchSize) {
       const batchIndex = Math.floor(i / config.batchSize) + 1;
-      const batchRaters = await getRaters(i, config.batchSize);
-      
+      const batchRaters = restrictedRaters
+        ? restrictedRaters.slice(i, i + config.batchSize)
+        : await getRaters(i, config.batchSize);
+
       await processRaterBatch(batchRaters, batchIndex, batchCount);
-      
+
       // Force garbage collection if available
       if (global.gc) global.gc();
     }

--- a/src/pipeline/reconciliation/getCurrentReportsFromNeo4j.js
+++ b/src/pipeline/reconciliation/getCurrentReportsFromNeo4j.js
@@ -52,6 +52,11 @@ const argv = yargs(hideBin(process.argv))
     type: 'number',
     default: 1000
   })
+  .option('authorsFromDir', {
+    describe: 'Incremental/author mode: restrict extraction to the <pubkey>.json files in this directory (the matching currentRelationshipsFromStrfry/<kind>/ dir) instead of scanning every rater in Neo4j',
+    type: 'string',
+    default: ''
+  })
   .help()
   .argv;
 
@@ -64,7 +69,8 @@ const config = {
   },
   outputDir: argv.outputDir,
   logFile: argv.logFile,
-  batchSize: argv.batchSize
+  batchSize: argv.batchSize,
+  authorsFromDir: argv.authorsFromDir
 };
 
 // Ensure log directory exists
@@ -165,6 +171,22 @@ async function getRaters(skip, limit) {
   } finally {
     await session.close();
   }
+}
+
+/**
+ * Incremental/author mode: read the covered rater pubkeys from the strfry
+ * relationship directory (one <pubkey>.json file per covered author) instead of
+ * scanning every rater in Neo4j. This restricts the extraction to the SAME
+ * author set as the strfry side — the reconciliation correctness invariant
+ * (ADR 0018 §Option A). No Neo4j query, no N+1 over the whole graph.
+ * @param {string} dir - the matching currentRelationshipsFromStrfry/<kind>/ dir
+ * @returns {Array<string>} rater pubkeys
+ */
+function getRatersFromDir(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .filter(f => f.endsWith('.json') && f !== '_summary.json')
+    .map(f => f.replace(/\.json$/, ''));
 }
 
 /**
@@ -316,18 +338,28 @@ async function main() {
     // Ensure output directory exists
     await ensureOutputDirectory();
     
+    // Incremental/author mode: restrict to the covered author set discovered in
+    // the strfry relationship dir; otherwise scan every rater in Neo4j (full mode).
+    let restrictedRaters = null;
+    if (config.authorsFromDir) {
+      restrictedRaters = getRatersFromDir(config.authorsFromDir);
+      await log(`Restricting extraction to ${restrictedRaters.length} authors from ${config.authorsFromDir}`);
+    }
+
     // Get total count of raters
-    const raterCount = await getRaterCount();
-    
+    const raterCount = restrictedRaters ? restrictedRaters.length : await getRaterCount();
+
     // Process raters in batches
-    const batchCount = Math.ceil(raterCount / config.batchSize);
-    
+    const batchCount = Math.ceil(raterCount / config.batchSize) || 1;
+
     for (let i = 0; i < raterCount; i += config.batchSize) {
       const batchIndex = Math.floor(i / config.batchSize) + 1;
-      const batchRaters = await getRaters(i, config.batchSize);
-      
+      const batchRaters = restrictedRaters
+        ? restrictedRaters.slice(i, i + config.batchSize)
+        : await getRaters(i, config.batchSize);
+
       await processRaterBatch(batchRaters, batchIndex, batchCount);
-      
+
       // Force garbage collection if available
       if (global.gc) global.gc();
     }

--- a/src/pipeline/reconciliation/reconciliation.sh
+++ b/src/pipeline/reconciliation/reconciliation.sh
@@ -3,7 +3,21 @@ set -e          # Exit immediately on command failure
 set -o pipefail # Fail if any pipeline command fails
 
 # reconciliation.sh
-# Main orchestrator script for the Neo4j database reconciliation process
+# Main orchestrator for reconciling the Neo4j social graph with strfry
+# (the canonical nostr event store) — FOLLOWS / MUTES / REPORTS edges derived
+# from kind 3 / 10000 / 1984 events.
+#
+# Story #21 / ADR 0018 — one engine, three author-scoped modes:
+#   --mode recent           Incremental sweep: only authors with an event since
+#                           the persisted watermark. The routine (~10 min) task.
+#                           Bootstraps with a full pass if no watermark exists.
+#   --mode all              Full sweep over every author (today's behavior). The
+#                           correctness oracle and weekly drift-recovery fallback.
+#   --mode author --pubkey  Reconcile a single author. No watermark; on-demand.
+#
+# recent/author restrict BOTH the strfry dump AND the Neo4j extraction to the
+# SAME covered author set (the correctness invariant — see ADR 0018 §Option A),
+# then reuse the existing diff + APOC apply verbatim.
 
 # Source environment configuration
 source /etc/brainstorm.conf
@@ -11,25 +25,36 @@ source /etc/brainstorm.conf
 # Source structured logging utility
 source /usr/local/lib/node_modules/brainstorm/src/utils/structuredLogging.sh
 
-# Create necessary directory structure
-# SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-# BASE_DIR="${SCRIPT_DIR}"
 BASE_DIR_RECONCILIATION="/usr/local/lib/node_modules/brainstorm/src/pipeline/reconciliation"
-# TODO: define BASE_DIR_RECONCILIATION in brainstorm.conf
 BASE_DIR=${BASE_DIR_RECONCILIATION:-"/usr/local/lib/node_modules/brainstorm/src/pipeline/reconciliation"}
 LOG_DIR=${BRAINSTORM_LOG_DIR:-"/var/log/brainstorm"}
 APOC_COMMANDS_DIR="${BASE_DIR}/apocCypherCommands"
 
-# Make sure directories exist
-# mkdir -p "${LOG_DIR}"
+# Persisted watermark helper (get_watermark / write_state / get_last_full_completed)
+source "${BASE_DIR}/reconciliationState.sh"
+
 mkdir -p "${APOC_COMMANDS_DIR}"
 
-# Log file path
 LOG_FILE="${LOG_DIR}/reconciliation.log"
-
-# Create log file and set permissions
 touch $LOG_FILE
 chown brainstorm:brainstorm $LOG_FILE
+
+# -----------------------------------------------------------------------------
+# Argument parsing — mode + pubkey
+# -----------------------------------------------------------------------------
+MODE="recent"
+PUBKEY=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)   MODE="$2"; shift 2 ;;
+    --pubkey) PUBKEY="$2"; shift 2 ;;
+    *)        shift ;;
+  esac
+done
+
+# Overlap window (seconds) re-scanned on top of the watermark so events that
+# landed during the prior run are re-covered; re-scanning is idempotent.
+RECONCILIATION_OVERLAP_SECONDS="${RECONCILIATION_OVERLAP_SECONDS:-3600}"
 
 # Function for logging
 log() {
@@ -40,26 +65,20 @@ log() {
 check_disk_space() {
   local label=$1
   log "${label} - Checking disk space"
-  
-  # Overall disk usage
   log "${label} - Overall disk usage:"
   df -h / | tee -a "${LOG_FILE}"
-  
-  # Neo4j data directory size
   log "${label} - Neo4j data directory size:"
   du -sh /var/lib/neo4j/data | tee -a "${LOG_FILE}"
-  
-  # Neo4j transaction logs size
   log "${label} - Neo4j transaction logs size:"
   du -sh /var/lib/neo4j/data/transactions | tee -a "${LOG_FILE}"
 }
 
 emit_function_error() {
   local function_name="$1"
-  local line_number="$2" 
+  local line_number="$2"
   local exit_code="$3"
   local last_command="${BASH_COMMAND}"
-  
+
   local error_metadata=$(jq -n \
     --arg message "Function failure in reconciliation script" \
     --arg function "$function_name" \
@@ -86,14 +105,11 @@ emit_function_error() {
 
 # create function for cleaning up
 function cleanup() {
-  # clean up neo4j import folder
   log "Starting cleanup"
-
-  # Trap errors within this function
   set -e
   trap 'emit_function_error "cleanup" "$LINENO" "$?"' ERR
 
-  # clean up mutes (use -f to avoid errors if files don't exist)
+  # clean up mutes
   rm -f /var/lib/neo4j/import/mutesToAddToNeo4j.json
   rm -f /var/lib/neo4j/import/allKind10000EventsStripped.json
   rm -f /var/lib/neo4j/import/mutesToDeleteFromNeo4j.json
@@ -104,488 +120,268 @@ function cleanup() {
   # clean up reports
   rm -f /var/lib/neo4j/import/reportsToAddToNeo4j.json
   rm -f /var/lib/neo4j/import/allKind1984EventsStripped.json
-  # rm -f /var/lib/neo4j/import/reportsToDeleteFromNeo4j.json
 
   # clean up current relationships from base directory
   rm -f $BASE_DIR/currentMutesFromStrfry.json
   rm -f $BASE_DIR/currentFollowsFromStrfry.json
   rm -f $BASE_DIR/currentReportsFromStrfry.json
 
-  # clean up reconciliation/currentRelationshipsFromStrfry
+  # clean up reconciliation/currentRelationshipsFromStrfry (fresh per run)
   rm -rf $BASE_DIR/currentRelationshipsFromStrfry
-  # recreate currentRelationshipsFromStrfry/follows, currentRelationshipsFromStrfry/mutes, and currentRelationshipsFromStrfry/reports
   mkdir -p $BASE_DIR/currentRelationshipsFromStrfry/follows
   mkdir -p $BASE_DIR/currentRelationshipsFromStrfry/mutes
   mkdir -p $BASE_DIR/currentRelationshipsFromStrfry/reports
-
   chown -R brainstorm:brainstorm $BASE_DIR/currentRelationshipsFromStrfry
 
-  # clean up reconciliation/currentRelationshipsFromNeo4j
+  # clean up reconciliation/currentRelationshipsFromNeo4j (fresh per run)
   rm -rf $BASE_DIR/currentRelationshipsFromNeo4j
-  # recreate currentRelationshipsFromNeo4j/follows, currentRelationshipsFromNeo4j/mutes, and currentRelationshipsFromNeo4j/reports
   mkdir -p $BASE_DIR/currentRelationshipsFromNeo4j/follows
   mkdir -p $BASE_DIR/currentRelationshipsFromNeo4j/mutes
   mkdir -p $BASE_DIR/currentRelationshipsFromNeo4j/reports
-
   chown -R brainstorm:brainstorm $BASE_DIR/currentRelationshipsFromNeo4j
 
   log "Completed cleanup"
-  trap - ERR  # Remove trap
+  trap - ERR
 }
 
-# Start reconciliation process
-log "Starting reconciliation"
+# -----------------------------------------------------------------------------
+# Helpers (story #21 / ADR 0018)
+# -----------------------------------------------------------------------------
 
-# Start structured logging
-emit_task_event "TASK_START" "reconciliation" "system" '{
-    "description": "Neo4j database reconciliation process",
-    "phases": 3,
-    "targets": ["mutes", "follows", "reports"],
-    "process_type": "database_reconciliation",
-    "database": "neo4j"
-}'
+# Count the JSONL lines (= edges) in a diff output file; 0 if absent.
+count_lines() {
+  if [[ -f "$1" ]]; then wc -l < "$1" | tr -d ' '; else echo 0; fi
+}
+
+# Cheap Neo4j relationship count via the count store; 0 on any failure.
+neo4j_rel_count() {
+  local rel="$1" out
+  out=$(cypher-shell -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" -a "$NEO4J_URI" --format plain \
+        "MATCH ()-[r:${rel}]->() RETURN count(r) AS c;" 2>/dev/null | grep -oE '[0-9]+' | head -1 || true)
+  echo "${out:-0}"
+}
+
+# Extract current Neo4j state + dump/convert strfry events for one kind, ordered
+# by mode. In all mode: Neo4j-first (full). In recent/author: strfry-first so the
+# covered author set exists before the (restricted) Neo4j extraction runs.
+#   $1 extractor.js   $2 strfryToKind*.sh   $3 converter.js   $4 label(follows|mutes|reports)
+extract_and_dump() {
+  local extractor="$1" strfry_script="$2" converter="$3" label="$4"
+  local strfry_args="" extractor_args=""
+
+  case "$MODE" in
+    recent) strfry_args="--recent ${SINCE_SECONDS}" ;;
+    author) strfry_args="--author ${PUBKEY}" ;;
+  esac
+  if [[ "$MODE" != "all" ]]; then
+    extractor_args="--authorsFromDir=${BASE_DIR}/currentRelationshipsFromStrfry/${label}"
+  fi
+
+  if [[ "$MODE" == "all" ]]; then
+    node "${extractor}" --neo4jUri="${NEO4J_URI}" --neo4jUser="${NEO4J_USER}" --neo4jPassword="${NEO4J_PASSWORD}" --logFile="${LOG_FILE}"
+    bash "${strfry_script}" ${strfry_args}
+    node "${converter}"
+  else
+    bash "${strfry_script}" ${strfry_args}
+    node "${converter}"
+    node "${extractor}" --neo4jUri="${NEO4J_URI}" --neo4jUser="${NEO4J_USER}" --neo4jPassword="${NEO4J_PASSWORD}" --logFile="${LOG_FILE}" ${extractor_args}
+  fi
+}
+
+# Cheap no-drift pre-check (recent mode). True (0) only when all three kinds
+# parse to zero events since the watermark — otherwise proceed normally.
+no_drift_since() {
+  local since_ts="$1" total=0 k c
+  for k in 3 10000 1984; do
+    c=$(strfry scan --count "{ \"kinds\": [${k}], \"since\": ${since_ts} }" 2>/dev/null | grep -oE '[0-9]+' | tail -1 || true)
+    [[ -z "$c" ]] && return 1   # parse uncertain → do NOT early-exit
+    total=$(( total + c ))
+  done
+  [[ "$total" -eq 0 ]]
+}
+
+# -----------------------------------------------------------------------------
+# Mode resolution + watermark
+# -----------------------------------------------------------------------------
+NOW_UNIX=$(date +%s)
+REQUESTED_MODE="$MODE"
+BOOTSTRAP="false"
+WATERMARK="$(get_watermark)"
+SINCE_SECONDS=0
+
+if [[ "$MODE" == "author" ]]; then
+  if [[ -z "$PUBKEY" ]]; then
+    log "ERROR: --mode author requires --pubkey <hex>"
+    exit 1
+  fi
+elif [[ "$MODE" == "recent" ]]; then
+  if [[ -z "$WATERMARK" ]]; then
+    # First run after deploy (or lost/corrupt watermark): bootstrap with a full
+    # pass to establish a baseline, then the watermark is written on success.
+    BOOTSTRAP="true"
+    MODE="all"
+    log "No watermark found — bootstrapping with a full reconciliation pass (mode=all)"
+  else
+    SINCE_SECONDS=$(( NOW_UNIX - WATERMARK + RECONCILIATION_OVERLAP_SECONDS ))
+  fi
+elif [[ "$MODE" != "all" ]]; then
+  log "ERROR: unknown --mode '${MODE}' (expected recent|all|author)"
+  exit 1
+fi
+
+log "Starting reconciliation (requested mode=${REQUESTED_MODE}, effective mode=${MODE}, bootstrap=${BOOTSTRAP}, watermark=${WATERMARK:-none})"
+
+emit_task_event "TASK_START" "reconciliation" "system" "{
+    \"description\": \"Neo4j <-> strfry reconciliation\",
+    \"mode\": \"${MODE}\",
+    \"requested_mode\": \"${REQUESTED_MODE}\",
+    \"bootstrap\": ${BOOTSTRAP},
+    \"watermark\": ${WATERMARK:-0},
+    \"pubkey\": \"${PUBKEY}\",
+    \"targets\": [\"mutes\", \"reports\", \"follows\"],
+    \"database\": \"neo4j\"
+}"
 
 check_disk_space "Before reconciliation"
 
-# cleanup, to cover possibility that the prior reconciliation process was interrupted
+# Cheap no-drift early-exit (recent mode only).
+if [[ "$MODE" == "recent" ]] && no_drift_since "$(( WATERMARK - RECONCILIATION_OVERLAP_SECONDS ))"; then
+  log "No events since watermark — no drift detected; advancing watermark and exiting"
+  emit_task_event "PROGRESS" "reconciliation" "system" "{\"phase\":\"no_drift\",\"mode\":\"recent\",\"watermark\":${WATERMARK},\"description\":\"no events since watermark — no drift detected\"}"
+  write_state "$NOW_UNIX" "$(date +%s)" "recent"
+  emit_task_event "TASK_END" "reconciliation" "system" "{\"mode\":\"recent\",\"bootstrap\":false,\"watermark_advanced_to\":${NOW_UNIX},\"no_drift\":true,\"status\":\"success\"}"
+  exit 0
+fi
+
+# cleanup, to cover the possibility that the prior run was interrupted
 cleanup
 
 #############################################
-# A: PROCESS MUTES
+# A: PROCESS MUTES (kind 10000)
 #############################################
+emit_task_event "PROGRESS" "reconciliation" "system" "{\"phase\":\"A\",\"phase_name\":\"process_mutes\",\"mode\":\"${MODE}\",\"operation\":\"phase_start\"}"
+PHASE_START=$(date +%s)
+MUTES_BEFORE=$(neo4j_rel_count "MUTES")
 
-# Phase A: Process Mutes
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "A",
-    "phase_name": "process_mutes",
-    "step": "1A",
-    "description": "Starting mutes reconciliation phase",
-    "operation": "phase_start"
-}'
+log "Phase A: mutes — extract + dump (mode=${MODE})"
+extract_and_dump \
+  "${BASE_DIR}/getCurrentMutesFromNeo4j.js" \
+  "${BASE_DIR}/strfryToKind10000Events.sh" \
+  "${BASE_DIR}/kind10000EventsToMutes.js" \
+  "mutes"
 
-# Step 1A: Extract current mutes from Neo4j
-# populates currentRelationshipsFromNeo4j/mutes
-log "Step 1A: Extracting current mutes from Neo4j"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "A",
-    "phase_name": "process_mutes",
-    "step": "1A",
-    "operation": "extract_neo4j_mutes",
-    "description": "Extracting current mutes from Neo4j database",
-    "data_source": "neo4j"
-}'
-START_TIME=$(date +%s)
-node "${BASE_DIR}/getCurrentMutesFromNeo4j.js" \
-  --neo4jUri="${NEO4J_URI}" \
-  --neo4jUser="${NEO4J_USER}" \
-  --neo4jPassword="${NEO4J_PASSWORD}" \
-  --logFile="${LOG_FILE}"
-END_TIME=$(date +%s)
-DURATION=$((END_TIME - START_TIME))
-log "Completed extracting Neo4j mutes in ${DURATION} seconds"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "A",
-    "phase_name": "process_mutes",
-    "step": "1A",
-    "operation": "extract_neo4j_mutes",
-    "duration": '$DURATION',
-    "status": "completed",
-    "description": "Neo4j mutes extraction completed",
-    "data_source": "neo4j"
-}'
-# check_disk_space "After Neo4j mutes extraction"
-
-# Step 2A: convert kind 10000 events to mutes
-# populates currentRelationshipsFromStrfry/mutes
-log "Step 2Aa: Converting kind 10000 events to mutes"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "A",
-    "phase_name": "process_mutes",
-    "step": "2A",
-    "operation": "convert_kind10000_to_mutes",
-    "description": "Converting kind 10000 events to mutes format",
-    "data_source": "strfry",
-    "event_kind": 10000
-}'
-bash ${BASE_DIR}/strfryToKind10000Events.sh
-log "Step 2Ab: Completed strfry to kind 10000 events"
-node "${BASE_DIR}/kind10000EventsToMutes.js"
-log "Step 2Ac: Completed kind 10000 events to mutes"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "A",
-    "phase_name": "process_mutes",
-    "step": "2A",
-    "operation": "convert_kind10000_to_mutes",
-    "status": "completed",
-    "description": "Kind 10000 events to mutes conversion completed",
-    "data_source": "strfry",
-    "event_kind": 10000
-}'
-# check_disk_space "After kind 10000 events to mutes"
-
-# Step 3A: create json files for adding and deleting mutes
-# populates json/mutesToAddToNeo4j.json and json/mutesToDeleteFromNeo4j.json
-log "Step 3A: Creating json files for adding and deleting mutes"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "A",
-    "phase_name": "process_mutes",
-    "step": "3A",
-    "operation": "create_mutes_json",
-    "description": "Creating JSON files for mutes updates",
-    "output_files": ["mutesToAddToNeo4j.json", "mutesToDeleteFromNeo4j.json"]
-}'
+log "Phase A: computing mutes diff"
 node "${BASE_DIR}/calculateMutesUpdates.js"
-log "Completed creating json files for adding and deleting mutes"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "A",
-    "phase_name": "process_mutes",
-    "step": "3A",
-    "operation": "create_mutes_json",
-    "status": "completed",
-    "description": "Mutes JSON files creation completed",
-    "output_files": ["mutesToAddToNeo4j.json", "mutesToDeleteFromNeo4j.json"]
-}'
-# check_disk_space "After creating json files for adding and deleting mutes"
+MUTES_ADDED=$(count_lines "${BASE_DIR}/json/mutesToAddToNeo4j.json")
+MUTES_DELETED=$(count_lines "${BASE_DIR}/json/mutesToDeleteFromNeo4j.json")
 
-# Step 4A: Apply mutes to Neo4j
-log "Step 4A: Applying mutes to Neo4j"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "A",
-    "phase_name": "process_mutes",
-    "step": "4A",
-    "operation": "apply_mutes_to_neo4j",
-    "description": "Applying mutes updates to Neo4j database",
-    "database": "neo4j",
-    "operations": ["add_mutes", "delete_mutes"]
-}'
-# add MUTES relationships from mutesToAddToNeo4j.json
-# move mutesToAddToNeo4j.json from json folder to /var/lib/neo4j/import
+log "Phase A: applying mutes to Neo4j (added=${MUTES_ADDED}, deleted=${MUTES_DELETED})"
 mv $BASE_DIR/json/mutesToAddToNeo4j.json /var/lib/neo4j/import/mutesToAddToNeo4j.json
 cypher-shell -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" -a "$NEO4J_URI" -f "$BASE_DIR/apocCypherCommands/apocCypherCommand1_mutesToAddToNeo4j" > /dev/null
-# delete MUTES relationships from mutesToDeleteFromNeo4j.json
 mv $BASE_DIR/json/mutesToDeleteFromNeo4j.json /var/lib/neo4j/import/mutesToDeleteFromNeo4j.json
 cypher-shell -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" -a "$NEO4J_URI" -f "$BASE_DIR/apocCypherCommands/apocCypherCommand1_mutesToDeleteFromNeo4j" > /dev/null
-# move allKind10000EventsStripped.json from base folder to /var/lib/neo4j/import
 mv $BASE_DIR/allKind10000EventsStripped.json /var/lib/neo4j/import/allKind10000EventsStripped.json
 cypher-shell -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" -a "$NEO4J_URI" -f "$BASE_DIR/apocCypherCommands/apocCypherCommand2_mutes" > /dev/null
-log "Step 4A completed applying mutes to Neo4j"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "A",
-    "phase_name": "process_mutes",
-    "step": "4A",
-    "operation": "apply_mutes_to_neo4j",
-    "status": "completed",
-    "description": "Mutes application to Neo4j completed",
-    "database": "neo4j",
-    "operations": ["add_mutes", "delete_mutes"]
-}'
+
+MUTES_AFTER=$(neo4j_rel_count "MUTES")
+emit_task_event "PROGRESS" "reconciliation" "system" "{\"phase\":\"A\",\"phase_name\":\"process_mutes\",\"mode\":\"${MODE}\",\"operation\":\"drift\",\"added\":${MUTES_ADDED},\"deleted\":${MUTES_DELETED},\"edge_counts_before\":${MUTES_BEFORE},\"edge_counts_after\":${MUTES_AFTER},\"duration\":$(( $(date +%s) - PHASE_START )),\"status\":\"completed\"}"
 
 #############################################
-# C: PROCESS REPORTS
+# C: PROCESS REPORTS (kind 1984) — append-only, no deletes
 #############################################
+emit_task_event "PROGRESS" "reconciliation" "system" "{\"phase\":\"C\",\"phase_name\":\"process_reports\",\"mode\":\"${MODE}\",\"operation\":\"phase_start\"}"
+PHASE_START=$(date +%s)
+REPORTS_BEFORE=$(neo4j_rel_count "REPORTS")
 
-# Phase C: Process Reports
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "C",
-    "phase_name": "process_reports",
-    "step": "1C",
-    "description": "Starting reports reconciliation phase",
-    "operation": "phase_start"
-}'
+log "Phase C: reports — extract + dump (mode=${MODE})"
+extract_and_dump \
+  "${BASE_DIR}/getCurrentReportsFromNeo4j.js" \
+  "${BASE_DIR}/strfryToKind1984Events.sh" \
+  "${BASE_DIR}/kind1984EventsToReports.js" \
+  "reports"
 
-# Step 1C: Extract current reports from Neo4j
-# populates currentRelationshipsFromNeo4j/reports
-log "Step 1C: Extracting current reports from Neo4j"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "C",
-    "phase_name": "process_reports",
-    "step": "1C",
-    "operation": "extract_neo4j_reports",
-    "description": "Extracting current reports from Neo4j database",
-    "data_source": "neo4j"
-}'
-START_TIME=$(date +%s)
-node "${BASE_DIR}/getCurrentReportsFromNeo4j.js" \
-  --neo4jUri="${NEO4J_URI}" \
-  --neo4jUser="${NEO4J_USER}" \
-  --neo4jPassword="${NEO4J_PASSWORD}" \
-  --logFile="${LOG_FILE}"
-END_TIME=$(date +%s)
-DURATION=$((END_TIME - START_TIME))
-log "Completed extracting Neo4j reports in ${DURATION} seconds"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "C",
-    "phase_name": "process_reports",
-    "step": "1C",
-    "operation": "extract_neo4j_reports",
-    "duration": '$DURATION',
-    "status": "completed",
-    "description": "Neo4j reports extraction completed",
-    "data_source": "neo4j"
-}'
-# check_disk_space "After Neo4j reports extraction"
-
-# Step 2C: convert kind 1984 events to reports
-# populates currentRelationshipsFromStrfry/reports
-log "Step 2Ca: Converting kind 1984 events to reports"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "C",
-    "phase_name": "process_reports",
-    "step": "2C",
-    "operation": "convert_kind1984_to_reports",
-    "description": "Converting kind 1984 events to reports format",
-    "data_source": "strfry",
-    "event_kind": 1984
-}'
-bash ${BASE_DIR}/strfryToKind1984Events.sh
-log "Step 2Cb: Completed strfry to kind 1984 events"
-node "${BASE_DIR}/kind1984EventsToReports.js"
-log "Step 2Cc: Completed kind 1984 events to reports"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "C",
-    "phase_name": "process_reports",
-    "step": "2C",
-    "operation": "convert_kind1984_to_reports",
-    "status": "completed",
-    "description": "Kind 1984 events to reports conversion completed",
-    "data_source": "strfry",
-    "event_kind": 1984
-}'
-# check_disk_space "After kind 1984 events to reports"
-
-# Step 3C: create json files for adding and deleting reports
-# populates json/reportsToAddToNeo4j.json and json/reportsToDeleteFromNeo4j.json
-log "Step 3C: Creating json files for adding and deleting reports"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "C",
-    "phase_name": "process_reports",
-    "step": "3C",
-    "operation": "create_reports_json",
-    "description": "Creating JSON files for reports updates",
-    "output_files": ["reportsToAddToNeo4j.json", "reportsToDeleteFromNeo4j.json"]
-}'
+log "Phase C: computing reports diff"
 node "${BASE_DIR}/calculateReportsUpdates.js"
-log "Completed creating json files for adding and deleting reports"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "C",
-    "phase_name": "process_reports",
-    "step": "3C",
-    "operation": "create_reports_json",
-    "status": "completed",
-    "description": "Reports JSON files creation completed",
-    "output_files": ["reportsToAddToNeo4j.json", "reportsToDeleteFromNeo4j.json"]
-}'
-# check_disk_space "After creating json files for adding and deleting reports"
+REPORTS_ADDED=$(count_lines "${BASE_DIR}/json/reportsToAddToNeo4j.json")
+REPORTS_DELETED=0
 
-# Step 4C: Apply reports to Neo4j
-log "Step 4C: Applying reports to Neo4j"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "C",
-    "phase_name": "process_reports",
-    "step": "4C",
-    "operation": "apply_reports_to_neo4j",
-    "description": "Applying reports updates to Neo4j database",
-    "database": "neo4j",
-    "operations": ["add_reports"]
-}'
-# add REPORTS relationships from reportsToAddToNeo4j.json
-# move reportsToAddToNeo4j.json from json folder to /var/lib/neo4j/import
+log "Phase C: applying reports to Neo4j (added=${REPORTS_ADDED})"
 mv $BASE_DIR/json/reportsToAddToNeo4j.json /var/lib/neo4j/import/reportsToAddToNeo4j.json
 cypher-shell -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" -a "$NEO4J_URI" -f "$BASE_DIR/apocCypherCommands/apocCypherCommand1_reportsToAddToNeo4j" > /dev/null
-# delete REPORTS relationships from reportsToDeleteFromNeo4j.json
-# mv $BASE_DIR/json/reportsToDeleteFromNeo4j.json /var/lib/neo4j/import/reportsToDeleteFromNeo4j.json
-# cypher-shell -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" -a "$NEO4J_URI" -f "$BASE_DIR/apocCypherCommands/apocCypherCommand1_reportsToDeleteFromNeo4j" > /dev/null
-# move allKind1984EventsStripped.json from base folder to /var/lib/neo4j/import
 mv $BASE_DIR/allKind1984EventsStripped.json /var/lib/neo4j/import/allKind1984EventsStripped.json
 cypher-shell -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" -a "$NEO4J_URI" -f "$BASE_DIR/apocCypherCommands/apocCypherCommand2_reports" > /dev/null
-log "Step 4C completed applying reports to Neo4j"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "C",
-    "phase_name": "process_reports",
-    "step": "4C",
-    "operation": "apply_reports_to_neo4j",
-    "status": "completed",
-    "description": "Reports application to Neo4j completed",
-    "database": "neo4j",
-    "operations": ["add_reports"]
-}'
+
+REPORTS_AFTER=$(neo4j_rel_count "REPORTS")
+emit_task_event "PROGRESS" "reconciliation" "system" "{\"phase\":\"C\",\"phase_name\":\"process_reports\",\"mode\":\"${MODE}\",\"operation\":\"drift\",\"added\":${REPORTS_ADDED},\"deleted\":${REPORTS_DELETED},\"edge_counts_before\":${REPORTS_BEFORE},\"edge_counts_after\":${REPORTS_AFTER},\"duration\":$(( $(date +%s) - PHASE_START )),\"status\":\"completed\"}"
 
 #############################################
-# B: PROCESS FOLLOWS
+# B: PROCESS FOLLOWS (kind 3)
 #############################################
+emit_task_event "PROGRESS" "reconciliation" "system" "{\"phase\":\"B\",\"phase_name\":\"process_follows\",\"mode\":\"${MODE}\",\"operation\":\"phase_start\"}"
+PHASE_START=$(date +%s)
+FOLLOWS_BEFORE=$(neo4j_rel_count "FOLLOWS")
 
-# Phase B: Process Follows
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "B",
-    "phase_name": "process_follows",
-    "step": "1B",
-    "description": "Starting follows reconciliation phase",
-    "operation": "phase_start"
-}'
+log "Phase B: follows — extract + dump (mode=${MODE})"
+extract_and_dump \
+  "${BASE_DIR}/getCurrentFollowsFromNeo4j.js" \
+  "${BASE_DIR}/strfryToKind3Events.sh" \
+  "${BASE_DIR}/kind3EventsToFollows.js" \
+  "follows"
 
-# Step 1B: Extract current follows from Neo4j
-# populates currentRelationshipsFromNeo4j/follows
-log "Step 1B: Extracting current follows from Neo4j"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "B",
-    "phase_name": "process_follows",
-    "step": "1B",
-    "operation": "extract_neo4j_follows",
-    "description": "Extracting current follows from Neo4j database",
-    "data_source": "neo4j"
-}'
-START_TIME=$(date +%s)
-node "${BASE_DIR}/getCurrentFollowsFromNeo4j.js" \
-  --neo4jUri="${NEO4J_URI}" \
-  --neo4jUser="${NEO4J_USER}" \
-  --neo4jPassword="${NEO4J_PASSWORD}" \
-  --logFile="${LOG_FILE}"
-END_TIME=$(date +%s)
-DURATION=$((END_TIME - START_TIME))
-log "Completed extracting Neo4j follows in ${DURATION} seconds"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "B",
-    "phase_name": "process_follows",
-    "step": "1B",
-    "operation": "extract_neo4j_follows",
-    "duration": '$DURATION',
-    "status": "completed",
-    "description": "Neo4j follows extraction completed",
-    "data_source": "neo4j"
-}'
-# check_disk_space "After Neo4j follows extraction"
-
-# Step 2B: convert kind 3 events to follows
-# populates currentRelationshipsFromStrfry/follows
-log "Step 2Ba: Converting kind 3 events to follows"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "B",
-    "phase_name": "process_follows",
-    "step": "2B",
-    "operation": "convert_kind3_to_follows",
-    "description": "Converting kind 3 events to follows format",
-    "data_source": "strfry",
-    "event_kind": 3
-}'
-bash ${BASE_DIR}/strfryToKind3Events.sh
-log "Step 2Bb: Completed strfry to kind 3 events"
-node "${BASE_DIR}/kind3EventsToFollows.js"
-log "Step 2Bc: Completed kind 3 events to follows"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "B",
-    "phase_name": "process_follows",
-    "step": "2B",
-    "operation": "convert_kind3_to_follows",
-    "status": "completed",
-    "description": "Kind 3 events to follows conversion completed",
-    "data_source": "strfry",
-    "event_kind": 3
-}'
-# check_disk_space "After kind 3 events to follows"
-
-# Step 3B: create json files for adding and deleting follows
-# populates json/followsToAddToNeo4j.json and json/followsToDeleteFromNeo4j.json
-log "Step 3B: Creating json files for adding and deleting follows"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "B",
-    "phase_name": "process_follows",
-    "step": "3B",
-    "operation": "create_follows_json",
-    "description": "Creating JSON files for follows updates",
-    "output_files": ["followsToAddToNeo4j.json", "followsToDeleteFromNeo4j.json"]
-}'
+log "Phase B: computing follows diff"
 node "${BASE_DIR}/calculateFollowsUpdates.js"
-log "Completed creating json files for adding and deleting follows"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "B",
-    "phase_name": "process_follows",
-    "step": "3B",
-    "operation": "create_follows_json",
-    "status": "completed",
-    "description": "Follows JSON files creation completed",
-    "output_files": ["followsToAddToNeo4j.json", "followsToDeleteFromNeo4j.json"]
-}'
-# check_disk_space "After creating json files for adding and deleting follows"
+FOLLOWS_ADDED=$(count_lines "${BASE_DIR}/json/followsToAddToNeo4j.json")
+FOLLOWS_DELETED=$(count_lines "${BASE_DIR}/json/followsToDeleteFromNeo4j.json")
 
-# Step 4B: Apply follows to Neo4j
-log "Step 4B: Applying follows to Neo4j"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "B",
-    "phase_name": "process_follows",
-    "step": "4B",
-    "operation": "apply_follows_to_neo4j",
-    "description": "Applying follows updates to Neo4j database",
-    "database": "neo4j",
-    "operations": ["add_follows", "delete_follows"]
-}'
-# add FOLLOWS relationships from followsToAddToNeo4j.json
-# move followsToAddToNeo4j.json from json folder to /var/lib/neo4j/import
+log "Phase B: applying follows to Neo4j (added=${FOLLOWS_ADDED}, deleted=${FOLLOWS_DELETED})"
 mv $BASE_DIR/json/followsToAddToNeo4j.json /var/lib/neo4j/import/followsToAddToNeo4j.json
 cypher-shell -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" -a "$NEO4J_URI" -f "$BASE_DIR/apocCypherCommands/apocCypherCommand1_followsToAddToNeo4j" > /dev/null
-# delete FOLLOWS relationships from followsToDeleteFromNeo4j.json
 mv $BASE_DIR/json/followsToDeleteFromNeo4j.json /var/lib/neo4j/import/followsToDeleteFromNeo4j.json
 cypher-shell -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" -a "$NEO4J_URI" -f "$BASE_DIR/apocCypherCommands/apocCypherCommand1_followsToDeleteFromNeo4j" > /dev/null
-# move allKind3EventsStripped.json from base folder to /var/lib/neo4j/import
 mv $BASE_DIR/allKind3EventsStripped.json /var/lib/neo4j/import/allKind3EventsStripped.json
 cypher-shell -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" -a "$NEO4J_URI" -f "$BASE_DIR/apocCypherCommands/apocCypherCommand2_follows" > /dev/null
-log "Step 4B completed applying follows to Neo4j"
-emit_task_event "PROGRESS" "reconciliation" "system" '{
-    "phase": "B",
-    "phase_name": "process_follows",
-    "step": "4B",
-    "operation": "apply_follows_to_neo4j",
-    "status": "completed",
-    "description": "Follows application to Neo4j completed",
-    "database": "neo4j",
-    "operations": ["add_follows", "delete_follows"]
-}'
 
-# moving this step to processAllTasks.sh
-# Step 5B: Run processNpubsUpToMaxNumBlocks until all npubs are processed
-# MAX_ITERATIONS=5
-# log "Step 5B: Running processNpubsUpToMaxNumBlocks until all npubs are processed"
-# bash $BRAINSTORM_MODULE_SRC_DIR/manage/nostrUsers/processNpubsUpToMaxNumBlocks.sh $MAX_ITERATIONS
-# log "Step 5B completed running processNpubsUpToMaxNumBlocks until all npubs are processed"
+FOLLOWS_AFTER=$(neo4j_rel_count "FOLLOWS")
+emit_task_event "PROGRESS" "reconciliation" "system" "{\"phase\":\"B\",\"phase_name\":\"process_follows\",\"mode\":\"${MODE}\",\"operation\":\"drift\",\"added\":${FOLLOWS_ADDED},\"deleted\":${FOLLOWS_DELETED},\"edge_counts_before\":${FOLLOWS_BEFORE},\"edge_counts_after\":${FOLLOWS_AFTER},\"duration\":$(( $(date +%s) - PHASE_START )),\"status\":\"completed\"}"
 
-# Step 6B: Project followsGraph into memory
-log "Step 6B: Projecting followsGraph into memory"
-emit_task_event "PROGRESS" "reconciliation" \
-    "system" \
-    "phase=B" \
-    "step=6B" \
-    "operation=project_follows_graph" \
-    "description=Projecting followsGraph into memory"
-bash $BRAINSTORM_MODULE_SRC_DIR/algos/projectFollowsGraphIntoMemory.sh
-log "Step 6B completed projecting followsGraph into memory"
-emit_task_event "PROGRESS" "reconciliation" \
-    "system" \
-    "phase=B" \
-    "step=6B" \
-    "operation=project_follows_graph" \
-    "status=completed" \
-    "description=FollowsGraph projection into memory completed"
+# Project followsGraph into memory. A single-author reconcile does not warrant a
+# full GDS reprojection, so it is skipped in author mode (ADR 0018 §Impl 2).
+if [[ "$MODE" != "author" ]]; then
+  log "Projecting followsGraph into memory"
+  bash $BRAINSTORM_MODULE_SRC_DIR/algos/projectFollowsGraphIntoMemory.sh
+  log "Completed projecting followsGraph into memory"
+fi
 
 # CLEAN UP
-
 cleanup
-
-: <<'COMMENT_BLOCK'
-# foo
-COMMENT_BLOCK
-
 check_disk_space "At end of reconciliation"
 
-log "Finished reconciliation"
+# -----------------------------------------------------------------------------
+# Persist the watermark on success. author mode is orthogonal — it does NOT
+# touch the sweep watermark (ADR 0018 §Impl 1).
+# -----------------------------------------------------------------------------
+RUN_COMPLETED=$(date +%s)
+if [[ "$MODE" == "all" ]]; then
+  write_state "$NOW_UNIX" "$RUN_COMPLETED" "all" "$RUN_COMPLETED" "$FOLLOWS_AFTER" "$MUTES_AFTER" "$REPORTS_AFTER"
+elif [[ "$MODE" == "recent" ]]; then
+  write_state "$NOW_UNIX" "$RUN_COMPLETED" "recent" "" "$FOLLOWS_AFTER" "$MUTES_AFTER" "$REPORTS_AFTER"
+fi
 
-# End structured logging
-emit_task_event "TASK_END" "reconciliation" "system" '{
-    "phases_completed": 3,
-    "targets_processed": ["mutes", "follows", "reports"],
-    "status": "success",
-    "description": "Neo4j database reconciliation process completed successfully",
-    "process_type": "database_reconciliation",
-    "database": "neo4j"
-}'
+log "Finished reconciliation (mode=${MODE}, bootstrap=${BOOTSTRAP})"
+
+emit_task_event "TASK_END" "reconciliation" "system" "{
+    \"mode\": \"${MODE}\",
+    \"requested_mode\": \"${REQUESTED_MODE}\",
+    \"bootstrap\": ${BOOTSTRAP},
+    \"watermark_advanced_to\": ${NOW_UNIX},
+    \"drift\": {
+        \"follows\": { \"added\": ${FOLLOWS_ADDED}, \"deleted\": ${FOLLOWS_DELETED} },
+        \"mutes\":   { \"added\": ${MUTES_ADDED},   \"deleted\": ${MUTES_DELETED} },
+        \"reports\": { \"added\": ${REPORTS_ADDED}, \"deleted\": ${REPORTS_DELETED} }
+    },
+    \"status\": \"success\",
+    \"database\": \"neo4j\"
+}"
 
 # Explicit success exit code for parent script orchestration
 exit 0

--- a/src/pipeline/reconciliation/reconciliationState.sh
+++ b/src/pipeline/reconciliation/reconciliationState.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# reconciliationState.sh
+#
+# Persisted watermark for incremental reconciliation (story #21 / ADR 0018).
+# Sourced by reconciliation.sh. State lives at:
+#   /var/lib/brainstorm/pipeline/reconciliation/state.json
+#
+# Shape:
+#   {
+#     "lastRunStartedAt":      <unix seconds>,   # the recent-mode watermark
+#     "lastRunCompletedAt":    <unix seconds>,
+#     "lastRunMode":           "recent" | "all",
+#     "lastFullRunCompletedAt":<unix seconds>,
+#     "edgeCounts":            { "follows": N, "mutes": N, "reports": N }
+#   }
+
+RECON_STATE_DIR="${RECON_STATE_DIR:-/var/lib/brainstorm/pipeline/reconciliation}"
+RECON_STATE_FILE="${RECON_STATE_FILE:-${RECON_STATE_DIR}/state.json}"
+
+# Echo the lastRunStartedAt watermark (unix seconds); empty when no state exists.
+get_watermark() {
+  [[ -f "$RECON_STATE_FILE" ]] || return 0
+  jq -r '.lastRunStartedAt // empty' "$RECON_STATE_FILE" 2>/dev/null
+}
+
+# Echo lastFullRunCompletedAt (unix seconds); empty when unknown.
+get_last_full_completed() {
+  [[ -f "$RECON_STATE_FILE" ]] || return 0
+  jq -r '.lastFullRunCompletedAt // empty' "$RECON_STATE_FILE" 2>/dev/null
+}
+
+# write_state <startedAt> <completedAt> <mode> [fullCompletedAt] [followsCount] [mutesCount] [reportsCount]
+# Atomic (write tmp + mv). Preserves lastFullRunCompletedAt unless a new one is given.
+write_state() {
+  local started="$1" completed="$2" mode="$3" fullCompleted="$4"
+  local follows="${5:-0}" mutes="${6:-0}" reports="${7:-0}"
+
+  mkdir -p "$RECON_STATE_DIR"
+  if [[ -z "$fullCompleted" ]]; then
+    fullCompleted="$(get_last_full_completed)"
+  fi
+  [[ -z "$fullCompleted" ]] && fullCompleted=0
+
+  local tmp="${RECON_STATE_FILE}.tmp.$$"
+  jq -n \
+    --argjson started "$started" \
+    --argjson completed "$completed" \
+    --arg mode "$mode" \
+    --argjson fullCompleted "$fullCompleted" \
+    --argjson follows "$follows" \
+    --argjson mutes "$mutes" \
+    --argjson reports "$reports" \
+    '{
+      lastRunStartedAt: $started,
+      lastRunCompletedAt: $completed,
+      lastRunMode: $mode,
+      lastFullRunCompletedAt: $fullCompleted,
+      edgeCounts: { follows: $follows, mutes: $mutes, reports: $reports }
+    }' > "$tmp" && mv "$tmp" "$RECON_STATE_FILE"
+  chown brainstorm:brainstorm "$RECON_STATE_FILE" 2>/dev/null || true
+}

--- a/src/pipeline/reconciliation/strfryToKind10000Events.sh
+++ b/src/pipeline/reconciliation/strfryToKind10000Events.sh
@@ -1,14 +1,29 @@
 #!/bin/bash
 
 SINCE_TIMESTAMP=0
+AUTHORS_FILTER=""
 
-if [[ "$1" == "--recent" ]]; then
-    CURRENT_TIME_UNIX=$(date +"%s")
-    HOW_LONG_AGO="$2"
-    SINCE_TIMESTAMP=$((CURRENT_TIME_UNIX - HOW_LONG_AGO))
-fi
+# --recent <seconds>  → only events newer than (now - seconds)  [recent mode]
+# --author  <pubkey>  → restrict to a single author            [author mode]
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --recent)
+            CURRENT_TIME_UNIX=$(date +"%s")
+            HOW_LONG_AGO="$2"
+            SINCE_TIMESTAMP=$((CURRENT_TIME_UNIX - HOW_LONG_AGO))
+            shift 2
+            ;;
+        --author)
+            AUTHORS_FILTER=", \"authors\": [\"$2\"]"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
 
-filter="{ \"kinds\": [10000], \"since\": $SINCE_TIMESTAMP }"
+filter="{ \"kinds\": [10000], \"since\": $SINCE_TIMESTAMP$AUTHORS_FILTER }"
 
 command1="strfry scan --count '$filter'"
 eval "$command1"

--- a/src/pipeline/reconciliation/strfryToKind1984Events.sh
+++ b/src/pipeline/reconciliation/strfryToKind1984Events.sh
@@ -1,14 +1,29 @@
 #!/bin/bash
 
 SINCE_TIMESTAMP=0
+AUTHORS_FILTER=""
 
-if [[ "$1" == "--recent" ]]; then
-    CURRENT_TIME_UNIX=$(date +"%s")
-    HOW_LONG_AGO="$2"
-    SINCE_TIMESTAMP=$((CURRENT_TIME_UNIX - HOW_LONG_AGO))
-fi
+# --recent <seconds>  → only events newer than (now - seconds)  [recent mode]
+# --author  <pubkey>  → restrict to a single author            [author mode]
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --recent)
+            CURRENT_TIME_UNIX=$(date +"%s")
+            HOW_LONG_AGO="$2"
+            SINCE_TIMESTAMP=$((CURRENT_TIME_UNIX - HOW_LONG_AGO))
+            shift 2
+            ;;
+        --author)
+            AUTHORS_FILTER=", \"authors\": [\"$2\"]"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
 
-filter="{ \"kinds\": [1984], \"since\": $SINCE_TIMESTAMP }"
+filter="{ \"kinds\": [1984], \"since\": $SINCE_TIMESTAMP$AUTHORS_FILTER }"
 
 command1="strfry scan --count '$filter'"
 eval "$command1"

--- a/src/pipeline/reconciliation/strfryToKind3Events.sh
+++ b/src/pipeline/reconciliation/strfryToKind3Events.sh
@@ -1,14 +1,29 @@
 #!/bin/bash
 
 SINCE_TIMESTAMP=0
+AUTHORS_FILTER=""
 
-if [[ "$1" == "--recent" ]]; then
-    CURRENT_TIME_UNIX=$(date +"%s")
-    HOW_LONG_AGO="$2"
-    SINCE_TIMESTAMP=$((CURRENT_TIME_UNIX - HOW_LONG_AGO))
-fi
+# --recent <seconds>  → only events newer than (now - seconds)  [recent mode]
+# --author  <pubkey>  → restrict to a single author            [author mode]
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --recent)
+            CURRENT_TIME_UNIX=$(date +"%s")
+            HOW_LONG_AGO="$2"
+            SINCE_TIMESTAMP=$((CURRENT_TIME_UNIX - HOW_LONG_AGO))
+            shift 2
+            ;;
+        --author)
+            AUTHORS_FILTER=", \"authors\": [\"$2\"]"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
 
-filter="{ \"kinds\": [3], \"since\": $SINCE_TIMESTAMP }"
+filter="{ \"kinds\": [3], \"since\": $SINCE_TIMESTAMP$AUTHORS_FILTER }"
 
 command1="strfry scan --count '$filter'"
 eval "$command1"

--- a/test/reconciliation-incremental-mode.test.js
+++ b/test/reconciliation-incremental-mode.test.js
@@ -1,0 +1,362 @@
+/**
+ * Story #21 / ADR 0018 — Reconciliation: author-restricted extraction with
+ * `recent` / `all` / `author` modes.
+ *
+ * Source/structural sentinels pin the ADR-required code shape. The behavioral
+ * heart — does `reconcileRecent` produce Neo4j edge sets identical to
+ * `reconcileAll` (the oracle); does the no-drift no-op return cheaply; does
+ * `reconcileAuthor` touch only one author; does an injected non-event drift get
+ * missed by `recent` but caught by `all`; does the watermark survive a failed
+ * run — is reproducible only against the live strfry + Neo4j Docker stack with
+ * seeded data, and is the **authoritative cycle-local smoke** (Reviewer-required,
+ * per project precedent #5/#6/#8/#10/#11/#12/#13/#15). See the test plan's
+ * "Not covered (deferred to cycle-local smoke)" section.
+ *
+ * T1..T10 : FAIL pre-implementation, PASS post.
+ * R1..R5  : PASS pre AND post — regression guards on the machinery ADR 0018
+ *           reuses verbatim (the per-author SET diff, the converters, the APOC
+ *           apply, cleanup(), and the strfry `--recent` capability).
+ *
+ * NOTE on behavioral coverage: the reconciliation Node scripts require runtime
+ * deps (e.g. `yargs`) that live only in the production install
+ * (/usr/local/lib/node_modules/brainstorm), not in this dev checkout — so they
+ * cannot be invoked from `npm test`. The behavioral set-diff verification
+ * (same-count-different-membership → one add + one delete; missing-side → all
+ * adds / all deletes) is therefore exercised in cycle-local smoke against the
+ * live stack. R1 pins the set-based shape at the source level here.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const RECON            = path.join(ROOT, 'src/pipeline/reconciliation');
+const RECON_SH         = path.join(RECON, 'reconciliation.sh');
+const STATE_HELPER     = path.join(RECON, 'reconciliationState.sh'); // ADR-suggested; may live inline in reconciliation.sh
+const EXTRACT_FOLLOWS  = path.join(RECON, 'getCurrentFollowsFromNeo4j.js');
+const EXTRACT_MUTES    = path.join(RECON, 'getCurrentMutesFromNeo4j.js');
+const EXTRACT_REPORTS  = path.join(RECON, 'getCurrentReportsFromNeo4j.js');
+const DIFF_FOLLOWS     = path.join(RECON, 'calculateFollowsUpdates.js');
+const CONVERTER_FOLLOWS= path.join(RECON, 'kind3EventsToFollows.js');
+const APOC_ADD         = path.join(RECON, 'apocCypherCommands/apocCypherCommand1_followsToAddToNeo4j');
+const APOC_DEL         = path.join(RECON, 'apocCypherCommands/apocCypherCommand1_followsToDeleteFromNeo4j');
+const STRFRY = [
+  path.join(RECON, 'strfryToKind3Events.sh'),
+  path.join(RECON, 'strfryToKind10000Events.sh'),
+  path.join(RECON, 'strfryToKind1984Events.sh'),
+];
+const TASK_REGISTRY = path.join(ROOT, 'src/manage/taskQueue/taskRegistry.json');
+const OPERATIONS_MD = path.join(ROOT, 'OPERATIONS.md');
+
+function readSafe(p) {
+  try { return fs.readFileSync(p, 'utf8'); }
+  catch (_e) { return null; }
+}
+function readJsonSafe(p) {
+  const s = readSafe(p);
+  if (s === null) return null;
+  try { return JSON.parse(s); }
+  catch (_e) { return null; }
+}
+// Watermark logic may live in reconciliation.sh directly or in a sibling
+// helper — search both so the sentinel doesn't over-constrain file layout.
+function reconSource() {
+  return [readSafe(RECON_SH) || '', readSafe(STATE_HELPER) || ''].join('\n');
+}
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+
+// ---------------------------------------------------------------------------
+// Failing sentinels — FAIL now, PASS once Story #21 is implemented per ADR 0018.
+// ---------------------------------------------------------------------------
+
+test('T1: reconciliation persists a watermark in state.json across runs (AC-3; ADR 0018 §Impl 1)', () => {
+  const src = reconSource();
+  assert(
+    /state\.json/.test(src),
+    'Reconciliation does not reference a persisted state.json watermark file (AC-3; ADR 0018 §Implementation ' +
+      'notes 1). `reconcileRecent` must persist a watermark across runs at ' +
+      '/var/lib/brainstorm/pipeline/reconciliation/state.json so each run only inspects authors changed since ' +
+      'the prior successful run. Add the read/write helper (reconciliationState.sh) or inline it in ' +
+      'reconciliation.sh.'
+  );
+  assert(
+    /lastRunStartedAt|watermark/.test(src),
+    'Reconciliation references no watermark field (e.g. lastRunStartedAt) (AC-3; ADR 0018 §Impl 1). The state ' +
+      'file records the last successful run start so the next `recent` run can compute its --recent window.'
+  );
+});
+
+test('T2: reconciliation.sh accepts --mode recent|all|author (+ --pubkey for author) (AC-2, AC-6; ADR 0018 §Impl 2)', () => {
+  const src = readSafe(RECON_SH);
+  assert(src !== null, 'reconciliation.sh missing — re-baseline this sentinel.');
+  assert(
+    /--mode/.test(src),
+    'reconciliation.sh does not parse a --mode flag (AC-2, AC-6; ADR 0018 §Impl 2). One engine, three ' +
+      'author-scoped modes: recent (incremental), all (full/oracle), author (single pubkey). The operator ' +
+      'must reach all three via the same script.'
+  );
+  for (const mode of ['recent', 'author']) {
+    assert(
+      new RegExp('\\b' + mode + '\\b').test(src),
+      'reconciliation.sh has no handling for `--mode ' + mode + '` (AC-2, AC-6; ADR 0018 §Impl 2). The three ' +
+        'modes are recent / all / author.'
+    );
+  }
+  assert(
+    /--mode\s+all\b|\ball\)/.test(src) || /\ball\b/.test(src),
+    'reconciliation.sh has no handling for `--mode all` (AC-2; ADR 0018 §Impl 2). `all` is today\'s full-graph ' +
+      'sweep — the correctness oracle and weekly fallback.'
+  );
+  assert(
+    /--pubkey/.test(src),
+    'reconciliation.sh does not accept --pubkey (AC-6; ADR 0018 §Impl 2). `--mode author` reconciles a single ' +
+      'author identified by --pubkey <hex>.'
+  );
+});
+
+test('T3: reconcileRecent passes --recent (computed from the watermark + overlap) to the strfry dumpers (AC-1, AC-3; ADR 0018 §Impl 2)', () => {
+  const src = readSafe(RECON_SH);
+  assert(src !== null, 'reconciliation.sh missing — re-baseline this sentinel.');
+  assert(
+    /--recent/.test(src),
+    'reconciliation.sh never invokes the strfry dumpers with --recent (AC-1, AC-3; ADR 0018 §Impl 2). Today it ' +
+      'calls strfryToKind*Events.sh with no args (full history). In `recent` mode it must pass ' +
+      '`--recent $(( now - T ))` so only events since the watermark are scanned — the single biggest lever ' +
+      'behind the minutes-not-hours target.'
+  );
+  assert(
+    /RECONCILIATION_OVERLAP_SECONDS/.test(src),
+    'reconciliation.sh does not use RECONCILIATION_OVERLAP_SECONDS (AC-3; ADR 0018 §Impl 2,5). The scan window ' +
+      'is `lastRunStartedAt - RECONCILIATION_OVERLAP_SECONDS` (default 3600) so events that landed during the ' +
+      'prior run are re-covered; re-scanning already-reconciled authors is idempotent.'
+  );
+});
+
+test('T4: reconcileRecent has a cheap no-drift early-exit when no events since the watermark (AC-7; ADR 0018 §Impl 2,6)', () => {
+  const src = readSafe(RECON_SH);
+  assert(src !== null, 'reconciliation.sh missing — re-baseline this sentinel.');
+  assert(
+    /no_drift/.test(src),
+    'reconciliation.sh has no `no_drift` early-exit path (AC-7; ADR 0018 §Impl 2,6). When `strfry scan --count` ' +
+      'reports zero events since the watermark, emit a PROGRESS event with phase "no_drift", advance the ' +
+      'watermark, and exit 0 — reconciliation should report "no drift detected" cheaply rather than churning ' +
+      'empty pipeline stages.'
+  );
+  assert(
+    /--count/.test(src),
+    'reconciliation.sh does not use `strfry scan --count` for the no-drift pre-check (AC-7; ADR 0018 §Impl 2). ' +
+      'The early-exit is gated on the count of events since the watermark being zero.'
+  );
+});
+
+test('T5: reconcileRecent bootstraps with a full pass when no watermark exists (first-run-after-deploy) (AC-5; ADR 0018 §Decision, §Impl 2,6)', () => {
+  const src = reconSource();
+  assert(
+    /bootstrap/.test(src),
+    'Reconciliation has no first-run bootstrap (AC-5; ADR 0018 §Decision). With no state.json (fresh deploy, or ' +
+      'lost/corrupt watermark), `reconcileRecent` must run one full pass to establish a baseline, then write the ' +
+      'watermark. This is the ONLY in-script auto-promotion (cadence otherwise lives in the scheduler). The ' +
+      'ADR pins a `"bootstrap": true` marker on the TASK_START event for observability.'
+  );
+});
+
+test('T6: the three Neo4j extractors honor --authorsFromDir (restrict to the covered author set) (AC-1, AC-4; ADR 0018 §Impl 3)', () => {
+  for (const [p, label] of [[EXTRACT_FOLLOWS, 'follows'], [EXTRACT_MUTES, 'mutes'], [EXTRACT_REPORTS, 'reports']]) {
+    const src = readSafe(p);
+    assert(src !== null, label + ' extractor missing — re-baseline this sentinel.');
+    assert(
+      /authorsFromDir/.test(src),
+      'getCurrent' + label[0].toUpperCase() + label.slice(1) + 'FromNeo4j.js does not accept --authorsFromDir ' +
+        '(AC-1, AC-4; ADR 0018 §Impl 3). In recent/author mode the extractor must skip getRaters()/' +
+        'getRaterCount() and instead read the covered pubkeys from the matching ' +
+        'currentRelationshipsFromStrfry/<kind>/ directory, then run the existing per-author query over just ' +
+        'that set. This is what kills the full-graph N+1 for the routine run AND upholds the correctness ' +
+        'invariant (both sides restricted to the SAME author set).'
+    );
+  }
+});
+
+test('T7: the per-rater debug log (reconciliation_currentRaterBatch.log) is removed from the follows extractor (AC-1; ADR 0018 §Impl 4)', () => {
+  const src = readSafe(EXTRACT_FOLLOWS);
+  assert(src !== null, 'follows extractor missing — re-baseline this sentinel.');
+  assert(
+    !/currentRaterBatch/.test(src),
+    'getCurrentFollowsFromNeo4j.js still writes the per-rater debug log reconciliation_currentRaterBatch.log ' +
+      '(AC-1; ADR 0018 §Impl 4). ~6 fs.appendFileSync calls PER pubkey is pure overhead in the hot loop. Remove ' +
+      'them; keep the real log() lines that go to reconciliation.log. (The mutes/reports extractors never had ' +
+      'this log.)'
+  );
+});
+
+test('T8: taskRegistry has reconcileRecent + reconcileAll (neo4j-heavy) and reconcileAuthor (NOT neo4j-heavy), all → reconciliation.sh (AC-2, AC-5, AC-6; ADR 0018 §Impl 5)', () => {
+  const r = readJsonSafe(TASK_REGISTRY);
+  assert(r !== null && r.tasks, 'taskRegistry.json missing or malformed — re-baseline this sentinel.');
+
+  const cases = [
+    { key: 'reconcileRecent', mode: 'recent', heavy: true },
+    { key: 'reconcileAll',    mode: 'all',    heavy: true },
+    { key: 'reconcileAuthor', mode: 'author', heavy: false },
+  ];
+  for (const c of cases) {
+    const entry = r.tasks[c.key];
+    assert(
+      entry,
+      'taskRegistry.json has no `' + c.key + '` task (AC-2, AC-6; ADR 0018 §Impl 5). The single `reconciliation` ' +
+        'entry is replaced by three keys, all invoking the same reconciliation.sh with a different --mode. The ' +
+        'operator triggers each via the existing surface — no new shell script.'
+    );
+    const blob = JSON.stringify(entry);
+    assert(
+      /reconciliation\.sh/.test(blob),
+      'taskRegistry.json `' + c.key + '` does not point at reconciliation.sh (AC-6; ADR 0018 §Impl 5). All three ' +
+        'modes share one engine script.'
+    );
+    assert(
+      new RegExp('--mode\\s+' + c.mode + '\\b').test(blob),
+      'taskRegistry.json `' + c.key + '` does not invoke `--mode ' + c.mode + '` (AC-2; ADR 0018 §Impl 5). The ' +
+        'mode is selected by the registry entry, not by which script is called.'
+    );
+    if (c.heavy) {
+      assert(
+        entry.resourceClass === 'neo4j-heavy',
+        'taskRegistry.json `' + c.key + '` is not tagged "resourceClass": "neo4j-heavy" (AC-5; ADR 0018 §Impl 5; ' +
+          'ADR 0013). The bulk sweeps must serialize against calculateOwner{Hops,PageRank,GrapeRank} via the ' +
+          'ADR 0013 semaphore — this is the fix for the original reconciliation-vs-recalculation Neo4j ' +
+          'contention.'
+      );
+    } else {
+      assert(
+        entry.resourceClass !== 'neo4j-heavy',
+        'taskRegistry.json `' + c.key + '` is tagged neo4j-heavy but must NOT be (ADR 0018 §Decision). ' +
+          '`reconcileAuthor` is a tiny point write that backs an interactive "reconcile me" trigger; tagging it ' +
+          'neo4j-heavy would queue it behind an 8-hour sweep. It stays off the class so it runs responsively.'
+      );
+    }
+  }
+});
+
+test('T9: reconciliation.sh emits the ADR-pinned observability vocabulary (mode, watermark, per-kind drift counts) (AC-8; ADR 0018 §Impl 6)', () => {
+  const src = readSafe(RECON_SH);
+  assert(src !== null, 'reconciliation.sh missing — re-baseline this sentinel.');
+  const missing = [];
+  if (!/"mode"|\bmode\b/.test(src)) missing.push('the run mode (recent/all/author)');
+  if (!/watermark/.test(src)) missing.push('the watermark consumed/advanced');
+  if (!/added/.test(src)) missing.push('per-kind drift "added" counts');
+  if (!/deleted/.test(src)) missing.push('per-kind drift "deleted" counts');
+  assert(
+    missing.length === 0,
+    'reconciliation.sh structured logging is missing: ' + missing.join(', ') + ' (AC-8; ADR 0018 §Impl 6). ' +
+      'The operator must be able to answer "what ran and how much drift did it catch?" from ' +
+      'reconciliation.log / events.jsonl alone: TASK_START carries "mode" + "watermark"; completion carries ' +
+      'per-kind {added, deleted} drift totals; TASK_END carries "watermark_advanced_to".'
+  );
+});
+
+test('T10: OPERATIONS.md documents the three tasks, the watermark, the overlap setting, and the neo4j-heavy tagging (AC-10; ADR 0018 §Impl 7)', () => {
+  const src = readSafe(OPERATIONS_MD);
+  assert(src !== null, 'OPERATIONS.md missing — re-baseline this sentinel.');
+  const missing = [];
+  if (!/reconcileRecent/.test(src)) missing.push('reconcileRecent');
+  if (!/reconcileAll/.test(src)) missing.push('reconcileAll');
+  if (!/reconcileAuthor/.test(src)) missing.push('reconcileAuthor');
+  if (!/watermark|state\.json/.test(src)) missing.push('the watermark / state.json');
+  if (!/RECONCILIATION_OVERLAP_SECONDS/.test(src)) missing.push('RECONCILIATION_OVERLAP_SECONDS');
+  if (!/neo4j-heavy/.test(src)) missing.push('the neo4j-heavy tagging');
+  assert(
+    missing.length === 0,
+    'OPERATIONS.md does not document: ' + missing.join(', ') + ' (AC-10; ADR 0018 §Impl 7). Add a subsection ' +
+      'covering: the three tasks + --mode/--pubkey; the recommended schedule (10-min recent, weekly all); the ' +
+      'watermark file + how to inspect/reset it; RECONCILIATION_OVERLAP_SECONDS; how to force a full run for ' +
+      'incident recovery (reconcileAll); and which tasks are neo4j-heavy (and why reconcileAuthor is not).'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Regression guards — PASS now AND post-implementation. These pin the
+// machinery ADR 0018 reuses VERBATIM; the whole design rests on not breaking it.
+// ---------------------------------------------------------------------------
+
+test('R1: the diff still compares follow sets by membership (Set.has), not by count (ADR 0018 §Context 2; AC-9)', () => {
+  const src = readSafe(DIFF_FOLLOWS);
+  assert(src !== null, 'calculateFollowsUpdates.js missing — re-baseline this sentinel.');
+  assert(
+    /new Set\(/.test(src) && /\.has\(/.test(src),
+    'R1: calculateFollowsUpdates.js no longer does a Set-membership diff (ADR 0018 §Context 2; AC-9). The diff ' +
+      'MUST be a set difference of followed pubkeys, never a count comparison — equal counts can hide ' +
+      'compensating changes (unfollow A + follow B keeps the count fixed but needs two edge fixes). The whole ' +
+      'incremental design reuses this diff verbatim; do not "optimize" it into a count check.'
+  );
+});
+
+test('R2: the kind-3 → follows converter still maps events to per-pubkey files (reused verbatim) (ADR 0018 §Decision)', () => {
+  const src = readSafe(CONVERTER_FOLLOWS);
+  assert(src !== null, 'kind3EventsToFollows.js missing — re-baseline this sentinel.');
+  assert(
+    /currentRelationshipsFromStrfry\/follows/.test(src) && /appendFileSync/.test(src),
+    'R3: kind3EventsToFollows.js no longer writes per-pubkey files under currentRelationshipsFromStrfry/follows ' +
+      '(ADR 0018 §Decision). The converters are reused UNCHANGED; in recent/author mode they simply process a ' +
+      'smaller event set. The per-pubkey file convention is also how the extractor discovers the covered author ' +
+      'set (--authorsFromDir).'
+  );
+  assert(
+    /tag\[0\]\s*===\s*'p'/.test(src),
+    'R3: kind3EventsToFollows.js no longer extracts `p` tags as followed pubkeys (ADR 0018 §Decision). Reused ' +
+      'verbatim — do not change the tag-extraction semantics.'
+  );
+});
+
+test('R3: the APOC apply still MERGEs / DELETEs FOLLOWS relationships (reused verbatim) (ADR 0018 §Decision; AC-9)', () => {
+  const add = readSafe(APOC_ADD);
+  const del = readSafe(APOC_DEL);
+  assert(add !== null, 'apocCypherCommand1_followsToAddToNeo4j missing — re-baseline this sentinel.');
+  assert(del !== null, 'apocCypherCommand1_followsToDeleteFromNeo4j missing — re-baseline this sentinel.');
+  assert(
+    /MERGE/.test(add) && /FOLLOWS/.test(add),
+    'R4: the add-APOC no longer MERGEs FOLLOWS (ADR 0018 §Decision; AC-9). The apply stage is reused unchanged; ' +
+      'incremental just feeds it smaller add/delete files.'
+  );
+  assert(
+    /FOLLOWS/.test(del) && /DELETE/.test(del),
+    'R4: the delete-APOC no longer DELETEs FOLLOWS (ADR 0018 §Decision; AC-9). Reused unchanged.'
+  );
+});
+
+test('R4: reconciliation.sh cleanup() still wipes the per-pubkey dirs at run start (ADR 0018 §Context 5)', () => {
+  const src = readSafe(RECON_SH);
+  assert(src !== null, 'reconciliation.sh missing — re-baseline this sentinel.');
+  assert(
+    /rm -rf .*currentRelationshipsFromStrfry/.test(src) && /currentRelationshipsFromNeo4j/.test(src),
+    'R5: reconciliation.sh cleanup() no longer wipes currentRelationshipsFromStrfry / ' +
+      'currentRelationshipsFromNeo4j (ADR 0018 §Context 5). Every run must start from EMPTY per-pubkey dirs — ' +
+      'recent mode relies on this so the dirs hold ONLY the covered authors and no stale files leak across runs ' +
+      '(stale files would corrupt the restricted-set diff).'
+  );
+});
+
+test('R5: all three strfry dumpers still support --recent (the mechanism recent mode depends on) (ADR 0018 §Context 1; AC-1)', () => {
+  for (const p of STRFRY) {
+    const src = readSafe(p);
+    assert(src !== null, path.basename(p) + ' missing — re-baseline this sentinel.');
+    assert(
+      /--recent/.test(src) && /since/.test(src),
+      'R6: ' + path.basename(p) + ' no longer supports the --recent <seconds> flag that sets the strfry ' +
+        '`since` filter (ADR 0018 §Context 1; AC-1). recent mode drives incremental scanning entirely through ' +
+        'this flag — it must remain in all three dumpers (kind 3 / 10000 / 1984).'
+    );
+  }
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try { await t.fn(); console.log(`  ✓ ${t.name}`); pass++; }
+    catch (err) { console.log(`  ✗ ${t.name}`); console.log(`      ${err.message}`); fail++; }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/reconciliation-incremental-mode.test.js
+++ b/test/reconciliation-incremental-mode.test.js
@@ -13,17 +13,18 @@
  * "Not covered (deferred to cycle-local smoke)" section.
  *
  * T1..T10 : FAIL pre-implementation, PASS post.
- * R1..R5  : PASS pre AND post — regression guards on the machinery ADR 0018
+ * R1..R6  : PASS pre AND post — regression guards on the machinery ADR 0018
  *           reuses verbatim (the per-author SET diff, the converters, the APOC
- *           apply, cleanup(), and the strfry `--recent` capability).
+ *           apply, cleanup(), the strfry `--recent` capability) + the yargs
+ *           dependency the extractors require.
  *
- * NOTE on behavioral coverage: the reconciliation Node scripts require runtime
- * deps (e.g. `yargs`) that live only in the production install
- * (/usr/local/lib/node_modules/brainstorm), not in this dev checkout — so they
- * cannot be invoked from `npm test`. The behavioral set-diff verification
+ * NOTE on behavioral coverage: the reconciliation Node extractors require
+ * `yargs` (now declared in package.json — R6) plus neo4j-driver, and the apply
+ * step needs APOC in Neo4j; a full end-to-end run also needs the live strfry +
+ * Neo4j stack with seeded data. So the behavioral set-diff verification
  * (same-count-different-membership → one add + one delete; missing-side → all
- * adds / all deletes) is therefore exercised in cycle-local smoke against the
- * live stack. R1 pins the set-based shape at the source level here.
+ * adds / all deletes) is exercised in cycle-local smoke against the live stack,
+ * not from `npm test`. R1 pins the set-based shape at the source level here.
  */
 
 const fs = require('fs');
@@ -348,6 +349,19 @@ test('R5: all three strfry dumpers still support --recent (the mechanism recent 
         'this flag — it must remain in all three dumpers (kind 3 / 10000 / 1984).'
     );
   }
+});
+
+test('R6: package.json declares the yargs runtime dependency the extractors require (pre-existing gap surfaced by cycle-local)', () => {
+  const pkg = readJsonSafe(path.join(ROOT, 'package.json'));
+  assert(pkg && pkg.dependencies, 'package.json missing or has no dependencies block — re-baseline this sentinel.');
+  assert(
+    typeof pkg.dependencies.yargs === 'string',
+    "R6: package.json does not declare a `yargs` runtime dependency. The reconciliation extractors " +
+      "(getCurrent{Follows,Mutes,Reports}FromNeo4j.js) `require('yargs/yargs')`; without yargs declared AND " +
+      'installed, the Neo4j-extraction step throws MODULE_NOT_FOUND and reconciliation cannot run at all — a ' +
+      'pre-existing gap surfaced by the story #21 cycle-local smoke. Do not drop this dependency without first ' +
+      'removing the require from the three extractors.'
+  );
 });
 
 async function run() {

--- a/test/test.js
+++ b/test/test.js
@@ -39,6 +39,7 @@ const taskQueueNeo4jResourceClass = require('./task-queue-neo4j-resource-class.t
 const entrypointTemplateRendering = require('./entrypoint-template-rendering.test.js');
 const bullboardAdminAccess = require('./bullboard-admin-access.test.js');
 const adminToolsDashboardPanel = require('./admin-tools-dashboard-panel.test.js');
+const reconciliationIncrementalMode = require('./reconciliation-incremental-mode.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -94,6 +95,9 @@ async function main() {
   console.log('\nadmin-tools-dashboard-panel suite:');
   const adminToolsDashboardPanelResult = await adminToolsDashboardPanel.run();
 
+  console.log('\nreconciliation-incremental-mode suite:');
+  const reconciliationIncrementalModeResult = await reconciliationIncrementalMode.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -145,6 +149,9 @@ async function main() {
   console.log(
     `admin-tools-dashboard-panel suite:               ${adminToolsDashboardPanelResult.fail === 0 ? 'PASS' : 'FAIL'} (${adminToolsDashboardPanelResult.pass} passed, ${adminToolsDashboardPanelResult.fail} failed)`
   );
+  console.log(
+    `reconciliation-incremental-mode suite:           ${reconciliationIncrementalModeResult.fail === 0 ? 'PASS' : 'FAIL'} (${reconciliationIncrementalModeResult.pass} passed, ${reconciliationIncrementalModeResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -163,7 +170,8 @@ async function main() {
     taskQueueNeo4jResourceClassResult.fail === 0 &&
     entrypointTemplateRenderingResult.fail === 0 &&
     bullboardAdminAccessResult.fail === 0 &&
-    adminToolsDashboardPanelResult.fail === 0;
+    adminToolsDashboardPanelResult.fail === 0 &&
+    reconciliationIncrementalModeResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }


### PR DESCRIPTION
## Summary

Speeds up reconciliation (story #21 / ADR 0018) by making it **author-restricted and incremental**. One engine (`reconciliation.sh`), three author-scoped modes exposed as three task-registry keys: `reconcileRecent` (incremental sweep — only authors with an event since a persisted watermark; the routine task), `reconcileAll` (full sweep — today's behavior, retained as the correctness oracle + periodic fallback), and `reconcileAuthor` (single author, on-demand). `recent`/`author` restrict **both** the strfry dump and the Neo4j extraction to the same covered author set, reusing the existing diff + APOC apply + converters verbatim. Also fixes a **pre-existing** blocker found during cycle-local: the reconciliation extractors `require('yargs/yargs')` but `yargs` was never declared/installed, so the Neo4j-extraction step threw `MODULE_NOT_FOUND` — reconciliation could not run at all.

## Changes

- `src/pipeline/reconciliation/reconciliation.sh` — `--mode recent|all|author` + `--pubkey`; watermark-driven `--recent` window with overlap; strfry-first ordering in recent/author; `no_drift` early-exit; first-run bootstrap; per-kind drift + edge-count + timing logging; watermark persisted on success (author mode untouched).
- `reconciliationState.sh` (new) — watermark read/write at `/var/lib/brainstorm/pipeline/reconciliation/state.json`.
- The 3 `getCurrent*FromNeo4j.js` extractors — `--authorsFromDir` to restrict to the covered set; follows extractor's per-rater debug log removed.
- The 3 `strfryToKind*Events.sh` dumpers — added `--author` (kept `--recent`).
- `taskRegistry.json` — `reconcileRecent`/`reconcileAll` (neo4j-heavy) + `reconcileAuthor` (not); legacy `reconciliation` kept for back-compat (now defaults to recent).
- `processor.js` + `runTask.js` — generic `staticArgs` channel so registry entries can pass `--mode`.
- `package.json` + `package-lock.json` — declare `yargs ^18.0.0`.
- `OPERATIONS.md` §12, `.gitignore` (pipeline runtime output), test suite (16 sentinels).

## Test plan

- [x] `npm test` — 16/16 reconciliation suite (T1–T10 + R1–R6); all 17 suites green.
- [x] cycle-local: deploy + control-panel restart clean; new code paths (arg parsing, `--authorsFromDir`, drift logging, author-mode no-watermark invariant) verified.
- [ ] After merge: `deploy-staging.yml` runs green.
- [ ] Smoke `staging.brainstorm.world`: stability + sanity + the 3 reconcile tasks registered/triggerable.
- [ ] Behavioral (staging has APOC + data, unlike local): bounded `reconcileAuthor` on a known pubkey runs end-to-end through the APOC apply. Full S1 oracle / S4 drift / S6 bootstrap are heavy Neo4j ops — run deliberately/supervised, not as part of the automated smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)