### PR TITLE
Generalized task scheduler (durable, any-task, sub-hour)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -640,3 +640,36 @@ Trigger `reconcileAll` (or `reconciliation.sh --mode all`). Use this whenever yo
 ### 12.5 Observability
 
 `reconciliation.log` + `events.jsonl` carry, per run: the `mode`, the `watermark` consumed and `watermark_advanced_to`, per-kind `drift` (`added` / `deleted`), per-kind `edge_counts_before`/`edge_counts_after`, and per-stage `duration`. A `recent` run with nothing to do emits `phase: "no_drift"` and exits in the sub-minute fast-path. The precise "how much drift did we catch" answer is the per-kind `added`/`deleted` totals.
+
+## 13. Task scheduling — generalized scheduler (story #22 / ADR 0019)
+
+Recurring task scheduling is served by **BullMQ Job Schedulers** attached to each task's queue — not an in-process `setInterval` (which was retired). **Any** task in the registry can be scheduled; schedules are durable (persisted in Redis, survive a control-panel restart) and every fire routes through the queue, so the `neo4j-heavy` semaphore, per-task concurrency, and BullBoard all apply.
+
+### 13.1 Configuring a schedule
+
+Manage schedules from the **Scheduled Tasks** panel (Relay Settings → Scheduled Tasks) or via the API:
+- `GET /api/scheduled-tasks/list` — every schedulable (registered) task + its current schedule + next/last run.
+- `GET /api/scheduled-tasks/status?taskId=…`, `POST /api/scheduled-tasks/update`, `GET /api/scheduled-tasks/history?taskId=…`.
+
+Schedule shape in `/var/lib/brainstorm/scheduled-tasks.json` — the **source of truth** (Job Schedulers in Redis are the execution layer, reconciled from this file on boot and on every update):
+
+```json
+{ "reconcileRecent":    { "enabled": true, "intervalMinutes": 10 },
+  "reconcileAll":       { "enabled": true, "cron": "0 4 * * 0" },
+  "refreshSearchIndex": { "enabled": true, "intervalHours": 24 } }
+```
+
+- **Interval**: `intervalDays` + `intervalHours` + `intervalMinutes` (summed). **Sub-hour is allowed** — the old 1-hour floor is gone, so `intervalMinutes: 10` is valid.
+- **Cron**: a `cron` expression takes precedence over the interval fields — pin a heavy run to a low-traffic window.
+
+### 13.2 Durability & missed-fire policy
+
+Schedules live in Redis as BullMQ Job Schedulers, so they survive a control-panel restart (unlike the retired `setInterval`). **Missed-fire policy: skip-and-resume, no backfill** — a fire missed while the process was down is not replayed; the next future occurrence runs normally. For `reconcileRecent` this is harmless — the next run's watermark window simply spans the gap.
+
+### 13.3 Kill-switch
+
+Set `"scheduler": false` in `/etc/brainstorm-task-queue.json` and restart the control-panel to halt ALL scheduling (the boot reconcile upserts nothing and removes managed Job Schedulers). Default is on. Per-task `enabled: false` is the finer-grained control.
+
+### 13.4 Scheduling reconciliation — seed the watermark first
+
+Before enabling a frequent `reconcileRecent` schedule on an instance with no reconciliation watermark, **run `reconcileAll` once** in a low-traffic window to seed the watermark (§12.1). Otherwise the first scheduled `reconcileRecent` self-bootstraps a full pass (6–8h on a large graph) — it completes and logs `"bootstrap": true`, but you don't want that as a surprise inside a 10-minute schedule. Recommended cadence once seeded: `reconcileRecent` every ~10 min, `reconcileAll` weekly via cron at a low-traffic hour.

--- a/bin/control-panel.js
+++ b/bin/control-panel.js
@@ -277,9 +277,20 @@ app.use(authMiddleware);
   await api.register(app);
   console.log('API routes registered');
 
-  // Initialize the scheduled tasks timer (restores schedule from config if enabled)
-  const scheduledTasks = require('../src/api/scheduled-tasks');
-  scheduledTasks.initScheduler();
+  // Reconcile recurring schedules into BullMQ Job Schedulers (story #22 / ADR 0019).
+  // Replaces the in-process setInterval scheduler. Requires the queue, so it is
+  // gated on TASK_QUEUE_ENABLED and runs after initTaskQueue + api.register.
+  if (taskQueueEnabled) {
+    try {
+      const scheduledTasks = require('../src/api/scheduled-tasks');
+      await scheduledTasks.reconcileSchedulesFromConfig();
+      console.log('Scheduled tasks reconciled into BullMQ Job Schedulers');
+    } catch (e) {
+      console.error(`Failed to reconcile scheduled tasks: ${e.message}`);
+    }
+  } else {
+    console.log('Task queue disabled — recurring scheduler not started (scheduling requires the queue)');
+  }
 
   // SPA catch-all: any route that didn't match a static file, API endpoint, or legacy page
   // gets served the React app's index.html so client-side routing works on refresh.

--- a/engineering-team/decisions/0019-generalized-task-scheduler.md
+++ b/engineering-team/decisions/0019-generalized-task-scheduler.md
@@ -1,0 +1,126 @@
+# ADR 0019: Generalized task scheduler via BullMQ Job Schedulers
+
+**Status:** Accepted
+**Date:** 2026-05-22
+**Story:** `engineering-team/stories/22-generalized-task-scheduler.md`
+**Builds on:** ADR 0012 (BullMQ queue), ADR 0013 (neo4j-heavy semaphore), ADR 0015 (queue on by default), ADR 0018 (reconciliation modes — the motivating consumer).
+**Supersedes:** the *scheduling execution mechanism* of ADR 0003 (the in-process `setInterval` scheduler). ADR 0003's generalized per-task config shape is preserved and extended; its `setInterval` execution is replaced.
+
+## Context
+
+Recurring scheduling today is `src/api/scheduled-tasks/index.js` (ADR 0003): an in-process `setInterval` loop. Its `makeTriggerTask` ([:82](src/api/scheduled-tasks/index.js:82)) fires `fetch('http://127.0.0.1:7778/api/run-task?taskName=…', {method:'POST'})` on a `setInterval` ([startScheduler:127](src/api/scheduled-tasks/index.js:127)), restored at boot from `/var/lib/brainstorm/scheduled-tasks.json` ([initScheduler:155](src/api/scheduled-tasks/index.js:155), wired at [bin/control-panel.js:282](bin/control-panel.js:282)). Story #22's four blockers map to four facts in that file:
+
+- **1-hour floor** — [:130](src/api/scheduled-tasks/index.js:130) and [:258](src/api/scheduled-tasks/index.js:258) reject sub-hour intervals.
+- **Hardcoded task set** — `DEFAULTS` ([:19](src/api/scheduled-tasks/index.js:19)) = `updateAllScoresForOwner`, `refreshSearchIndex`; `isKnownTaskId` rejects everything else.
+- **Process-fragile** — `setInterval` lives in the control-panel process; a fire during downtime is silently lost (no persisted scheduler).
+- **The sub-hour workaround is a host `systemd` timer** that runs the script directly, bypassing the queue + `neo4j-heavy` semaphore.
+
+The good news is the heavy lifting already exists. Story #13 / ADR 0012 gave us, per registry task, **one BullMQ `Queue` + `Worker`** on a shared ioredis connection, with the `neo4j-heavy` semaphore wrap (ADR 0013) and BullBoard. The scheduler's *entire* job is to enqueue a task on a cadence — and **BullMQ 5.76.10 ships `Queue.upsertJobScheduler`** (verified in-container), a durable Job Scheduler that does exactly that: it adds a job to a queue on a cron pattern or fixed interval, with the scheduler definition persisted in Redis (which already runs AOF persistence per ADR 0012). So a scheduled fire becomes an ordinary job on the task's existing queue — automatically subject to the existing per-task concurrency, `neo4j-heavy` serialization, and BullBoard visibility.
+
+The motivating consumers are story #21's reconcile tasks: `reconcileRecent` (sub-hour/hourly), `reconcileAll` (weekly), both `neo4j-heavy`. Their `--mode` is carried by the registry `staticArgs` field (ADR 0018 / processor.buildChildArgs), so a scheduled job needs only `{taskName}` in its data — the processor pulls `staticArgs` from the registry.
+
+**Concept-graph impact:** none — operational/infra (scheduler/queue), no domain concepts. Concept Graph API was unreachable at design time; not consulted (consistent with ADR 0018). **Firmware reinstall: no.**
+
+## Options considered
+
+### Option A — BullMQ Job Schedulers on the existing per-task queues (chosen)
+
+A small scheduler layer upserts one BullMQ Job Scheduler per *enabled* scheduled task onto that task's existing `Queue`:
+
+```js
+queue.upsertJobScheduler(
+  schedulerId,                              // e.g. `sched:${taskName}`
+  cron ? { pattern: cron } : { every: ms }, // cron OR fixed interval (sub-hour OK)
+  { name: taskName, data: { taskName } }    // the job each tick adds; staticArgs come from the registry
+);
+```
+
+The operator's intent lives in an **extended `scheduled-tasks.json`** (source of truth); BullMQ Job Schedulers in Redis are the **execution layer**. On boot (and on every operator update) the scheduler **reconciles** the two: upsert a Job Scheduler for each enabled entry, `removeJobScheduler` for disabled/removed ones. Scheduled fires flow into the same Worker manual runs use → `processor.processJob` → `launchChildTask` → the semaphore + concurrency + BullBoard, for free. The in-process `setInterval` scheduler is removed.
+
+**Pros**
+- Minimal new infrastructure — reuses the per-task `Queue`+`Worker` topology from ADR 0012; no new worker, no new process.
+- Durable by construction — Job Schedulers persist in Redis (AOF); survive a control-panel restart, unlike `setInterval`.
+- Native cron + fixed-interval + sub-hour — no custom timing code, no cron library.
+- Queue-routed automatically — the `neo4j-heavy` semaphore, per-task concurrency, jobId behavior, and BullBoard apply because it's the same queue/worker as a manual `/api/run-task`.
+- Config file stays human-readable/inspectable/backup-able; reconcile-on-boot makes it authoritative over Redis (recovers cleanly even if Redis is flushed).
+
+**Cons**
+- Missed fires during downtime are **not backfilled** (BullMQ schedules the next future slot) — a deliberate, documented policy change (see Decision §3); it's actually well-suited to `reconcileRecent`'s watermark.
+- A new config↔Redis reconcile invariant to implement and keep correct.
+- If a scheduled run *chronically* exceeds its interval, ticks can queue behind it (bounded — see Consequences).
+
+### Option B — Patch the in-process scheduler (remove the floor, generalize the task set, persist next-run for crude durability)
+
+Keep `setInterval`; drop the 1-hour floor and `DEFAULTS` restriction; add a cron library; persist `nextRunAt` to disk and replay on boot for a semblance of durability.
+
+**Pros:** smaller diff; no new scheduling concept.
+**Cons:** still in-process and fundamentally fragile — real durability means reimplementing persistent scheduling, cron parsing, and missed-fire handling that BullMQ Job Schedulers already provide and battle-test. Reinvents the wheel next to a wheel we already run. Rejected.
+
+### Option C — A separate dedicated scheduler process (supervisord cron-like service enqueuing to BullMQ)
+
+**Pros:** isolates scheduling from the control-panel process.
+**Cons:** another supervisord entry — the exact operational cost ADR 0012 weighed when it chose an in-process worker over a separate process. BullMQ Job Schedulers give durability *without* a separate process. Over-engineered. Rejected.
+
+## Decision
+
+**We chose Option A.** Replace the in-process `setInterval` scheduler with BullMQ Job Schedulers attached to the existing per-task queues; `scheduled-tasks.json` (extended) is the source of truth, reconciled to Redis on boot and on every update; the Scheduled Tasks panel + its API are generalized to any registry task with interval **or** cron, sub-hour allowed.
+
+Resolutions to the story's five open questions:
+
+1. **Rollback / cutover safety.** The scheduler requires the queue, so it is gated on `TASK_QUEUE_ENABLED` (already on by default, ADR 0015) — no duplicate feature flag re-creating the in-process path (operator chose full replacement). Practical control is per-task `enabled` (disabling a task removes its Job Scheduler). As cheap coarse insurance, add a single `"scheduler": true` kill-switch to `/etc/brainstorm-task-queue.json`: when `false`, the boot reconcile upserts nothing (and removes existing schedulers), halting all scheduling without code changes. Default `true`.
+2. **Where definitions live.** `scheduled-tasks.json` is the **source of truth** (operator intent: which tasks, enabled?, interval/cron); BullMQ Job Schedulers in Redis are the **execution layer**. Reconcile file→Redis on boot and on each update. The file is authoritative — on conflict, it wins (orphan Redis schedulers are removed).
+3. **Missed-fire policy.** **Skip-and-resume, no backfill.** BullMQ Job Schedulers, on restart, schedule the next future occurrence; a fire missed during downtime is not replayed. The schedule itself is never lost (persisted), which is the real fix vs `setInterval`. Documented in OPERATIONS.md. (For `reconcileRecent`, a skipped run is harmless — the next run's watermark window simply spans the gap.)
+4. **No-surprise-bootstrap.** The generic scheduler stays **reconciliation-agnostic** — it knows nothing about watermarks (layering). Protection is: (a) **runbook** — seed the watermark with a deliberate `reconcileAll` before enabling a frequent `reconcileRecent` schedule; (b) the existing observability — `reconcileRecent`'s bootstrap already logs `"bootstrap": true` and the run is visible in BullBoard. An optional reconciliation-side guard (refuse to bootstrap on a *scheduled* trigger) belongs to the reconciliation module, not this generic scheduler — noted as a follow-up, out of scope here.
+5. **UI phasing.** Kept in this story per the operator's choice. The Implementer may land the engine/API first and the panel second within the story; the Reviewer validates the full surface.
+
+## Consequences
+
+**Enabled**
+- Durable, any-task, interval **or** cron, sub-hour scheduling that survives control-panel restarts and routes every fire through the queue (semaphore-aware, BullBoard-visible). One scheduler, no per-task code.
+- **Unblocks story #21's prod usability** — `reconcileRecent` (sub-hour/hourly) and `reconcileAll` (weekly) become schedulable and serialize via `neo4j-heavy`.
+
+**Constrained / made harder**
+- Missed fires aren't backfilled (documented policy).
+- New config↔Redis reconcile invariant; the boot reconcile must remove orphaned Job Schedulers so the file stays authoritative.
+- **Overlap/pile-up:** if a scheduled run chronically exceeds its interval, ticks can queue. Bounded by (a) per-task concurrency = 1 (the next job waits, doesn't run concurrently), (b) BullMQ Job Schedulers keep at most one upcoming delayed job per scheduler, and (c) the seed-first runbook (no hours-long *scheduled* bootstrap). Worth noting for `reconcileRecent` if its interval were ever set below its typical runtime.
+
+**Follow-up debt (out of scope here)**
+- A reconciliation-side bootstrap guard (Q4) if the runbook proves insufficient.
+- Host `systemd` `.timer` migration (task-queue phase 3).
+
+**Firmware reinstall required?** No.
+
+## Implementation notes
+
+The Implementer reads this section verbatim.
+
+### Scheduler layer
+- Add a reconcile function — a `Map<taskId, scheduleConfig>` → BullMQ Job Schedulers reconciler. It may live in `src/api/scheduled-tasks/index.js` (rewritten internals) or a small `src/manage/taskQueue/queue/scheduler.js` that the scheduled-tasks module calls. It uses the queue module's `getQueue(taskName)` (already exported, [queue/index.js:166](src/manage/taskQueue/queue/index.js:166)) to `upsertJobScheduler` / `removeJobScheduler`.
+- Reconcile on: (a) boot (replacing `initScheduler`), and (b) each `handleUpdate`. For each enabled entry → `upsertJobScheduler(`sched:${taskId}`, {pattern|every}, {name: taskId, data: {taskName: taskId}})`; for disabled/absent → `removeJobScheduler`. Then list existing schedulers (`queue.getJobSchedulers()`) and remove any not in the config (orphan cleanup).
+- Honor the `scheduler` kill-switch from `/etc/brainstorm-task-queue.json` (Q1).
+
+### Retire the in-process scheduler
+- Remove `makeTriggerTask`, `startScheduler`, `stopScheduler`, the `setInterval`, and the `totalIntervalMs`-only timing ([:78-165](src/api/scheduled-tasks/index.js:78)). Remove the in-memory `timerState`/`getTimerState` `setInterval` machinery (next/last-run now come from BullMQ + events.jsonl).
+- `bin/control-panel.js:282` calls the new boot reconcile instead of `initScheduler` — gated by `TASK_QUEUE_ENABLED` (the scheduler needs the queue initialized; sequence the call after `initTaskQueue`).
+
+### Config schema (extend, backward-compatible)
+- `scheduled-tasks.json` entries gain optional `intervalMinutes` (sub-hour) and `cron` (string); keep `enabled`, `intervalHours`, `intervalDays` working so the live `refreshSearchIndex` schedule migrates with no edit. Precedence: `cron` > (`intervalDays`/`Hours`/`Minutes` summed to `every` ms). Drop the 1-hour floor ([:130](src/api/scheduled-tasks/index.js:130), [:258](src/api/scheduled-tasks/index.js:258)) and the `isKnownTaskId`/`DEFAULTS` restriction — validate against the **task registry** instead (any registered task is schedulable; unknown task → 400).
+- Migration: on first boot, existing entries (`updateAllScoresForOwner`, `refreshSearchIndex`) reconcile straight into Job Schedulers from their current `intervalHours/Days`. No gap: the new reconcile runs at boot before the old `setInterval` would have fired (the old code is removed in the same change).
+
+### API handlers (`src/api/scheduled-tasks/index.js`, routes at [index.js:439-442](src/api/index.js:439))
+- `handleStatus` / `handleUpdate` / `handleHistory`: accept any registry task (validate against the registry, not `DEFAULTS`); accept `cron` + `intervalMinutes`; report `enabled`, schedule spec, and next/last run derived from `queue.getJobSchedulers()` + the existing `getRecentRuns` events.jsonl reader ([:169](src/api/scheduled-tasks/index.js:169), reused). Add a `GET /api/scheduled-tasks/list` (or similar) returning all schedulable registry tasks + their current schedule, to drive the UI.
+
+### UI (Scheduled Tasks panel)
+- Extend the panel (the scheduled-tasks control currently in `ui/src/pages/settings/RelaySettings.jsx` — Implementer confirms the exact component) to: list **any** registry task (from the new list endpoint), accept minutes/cron in addition to hours/days, drop the 1-hour client-side guard, and show next/last run + enabled state per task.
+
+### Config / ops
+- `/etc/brainstorm-task-queue.json`: add `"scheduler": true` (kill-switch).
+- `OPERATIONS.md`: document the new scheduler (any task, interval/cron, sub-hour), durability + skip-no-backfill policy, the kill-switch, the retirement of the in-process scheduler, and the reconciliation seed-first runbook.
+
+### Tests (for the Tester)
+- **Source sentinels:** scheduler layer calls `upsertJobScheduler` / `removeJobScheduler`; `setInterval` and the 1-hour-floor literals are gone from `scheduled-tasks/index.js`; validation is against the registry not `DEFAULTS`; the config schema accepts `cron` + `intervalMinutes`; `bin/control-panel.js` calls the new reconcile gated by `TASK_QUEUE_ENABLED`; the kill-switch is read.
+- **Regression guards:** the queue module's per-task `Queue`+`Worker` topology and `getQueue` export are intact; the `refreshSearchIndex` entry remains valid under the new schema.
+- **Behavioral (cycle-local / staging smoke — authoritative):** a task scheduled every ~2 min fires via the queue; a cron schedule fires on pattern; a schedule survives a control-panel restart (still fires after); the migrated `refreshSearchIndex` keeps firing; `reconcileRecent`/`reconcileAll` schedule and serialize via `neo4j-heavy`; the kill-switch halts scheduling.
+
+## Out of scope
+- `reconcileAuthor` trigger surfaces; legacy `reconciliation` key + `reconcile.timer` cleanup; host `systemd` `.timer` migration (phase 3); event/dependency-driven triggers; per-customer fan-out scheduling; the reconciliation-side bootstrap guard; and actually enabling the production reconcile schedules (operator action, gated by the prod-promotion decision).

--- a/engineering-team/reviews/22-generalized-task-scheduler.md
+++ b/engineering-team/reviews/22-generalized-task-scheduler.md
@@ -1,0 +1,89 @@
+# Review: Story 22 — Generalized Task Scheduler (durable, any-task, sub-hour)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-22
+**Diff:** `git diff 458a736f..HEAD` (story #22 commits `0ab48fbf`→`1b12e73c`)
+
+> **Base note:** `main` does not yet contain the PR #185 merge (`458a736f`, story #21), so `git diff main...HEAD` pulls in all of story #21's reconciliation diff. This review isolates **story #22 only** by diffing against the #185 merge commit. Story #22 touches 13 files: `OPERATIONS.md`, `bin/control-panel.js`, `src/api/index.js`, `src/api/scheduled-tasks/index.js`, `src/manage/taskQueue/queue/scheduler.js` (new), the UI panel, the new test + two re-baselined tests + the runner, and the three engineering-team artifacts.
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **PASS**. 18/18 suites green, including the new `generalized-task-scheduler` suite **12/12** (T1–T8 flipped to PASS; R1–R4 green). The re-baselined `scheduled-search-and-house-scores-refresh` (12/12) and `task-queue-bullmq` (18/18) stay green. `reconciliation-incremental-mode` 16/16 unaffected. Overall: PASS.
+- [ ] `npm run test:playwright` — not applicable at the sentinel layer (UI validation is part of the Chrome smoke, S9).
+- [x] _Lint not configured — skipped._
+- [x] _Typecheck not configured — skipped._
+- [x] _Build not configured — skipped._
+
+## Spec adherence
+
+Every acceptance criterion has source-level coverage by a passing sentinel; the behavioral guarantees are deferred to cycle-local/staging smoke per the test plan's documented (and project-standard) approach.
+
+- [x] **AC-1 any registered task schedulable** — `isRegisteredTask` validates against `taskRegistry.json` ([scheduled-tasks/index.js:42](src/api/scheduled-tasks/index.js:42)); `handleList` enumerates the registry ([:222](src/api/scheduled-tasks/index.js:222)); UI picker offers any task ([RelaySettings.jsx:1654](ui/src/pages/settings/RelaySettings.jsx:1654)). DEFAULTS gone. (T5)
+- [x] **AC-2 interval OR cron** — `toRepeatOpts`: cron wins, else days/hours/minutes summed to `every` ms ([scheduler.js:44](src/manage/taskQueue/queue/scheduler.js:44)). (T6, T7)
+- [x] **AC-3 sub-hour allowed** — 1-hour floor removed; `isValidSchedule` accepts any positive interval ([scheduler.js:54](src/manage/taskQueue/queue/scheduler.js:54)); no client-side floor ([RelaySettings.jsx:1434](ui/src/pages/settings/RelaySettings.jsx:1434)). (T4)
+- [x] **AC-4 durable across restart** — BullMQ Job Schedulers persisted in Redis; boot reconcile re-wired ([control-panel.js:283](bin/control-panel.js:283)). Mechanism is correct (T1, R4). **Behavioral proof = S3, smoke-required.**
+- [x] **AC-5 fires route through the queue** — scheduled job is an ordinary `upsertJobScheduler` add on the task's existing queue ([scheduler.js:70](src/manage/taskQueue/queue/scheduler.js:70)) → existing Worker → `processor.processJob`. Verified the processor handles a scheduled job's `{taskName,timeoutMs}` data: `buildChildArgs` guards on `customerArgs`/`queryParams` truthiness and pulls `staticArgs` from the registry ([processor.js:21-38](src/manage/taskQueue/queue/processor.js:21)), so `reconcileAll`'s `--mode all` is applied with no `customerArgs` present. (T1, R1)
+- [x] **AC-6 no regression for existing schedules** — schema is backward-compatible (`intervalHours`/`intervalDays` still summed); `refreshSearchIndex`/`updateAllScoresForOwner` remain in the registry and migrate with no edit. (re-baselined scheduled-search suite). **Continuity proof = S4, smoke-required.**
+- [x] **AC-7 in-process `setInterval` retired** — `makeTriggerTask`/`startScheduler`/`stopScheduler`/`initScheduler`/timer-polling all removed; grep finds **no dangling references** in `src/`, `bin/`, `ui/src/` (the one `DEFAULTS` hit is the unrelated `customer-schedule` module). (T3)
+- [x] **AC-8 enable/disable + change interval/cron via panel, any task, reflects state** — `handleUpdate`/`handleStatus`/`handleList` ([scheduled-tasks/index.js:141-247](src/api/scheduled-tasks/index.js:141)); UI card has toggle + d/h/m + cron + next/last-run ([RelaySettings.jsx:1390](ui/src/pages/settings/RelaySettings.jsx:1390)). (T2, R3). **S7/S9 smoke.**
+- [x] **AC-9 reconcileRecent/reconcileAll schedulable + serialize via `neo4j-heavy`** — both registered; `reconcileAll` carries `staticArgs:"--mode all"` + 8h timeout (confirmed in registry); routed through the semaphore-wrapped worker. Capability present. **Serialization proof = S5, smoke-required.**
+- [x] **AC-10 no-surprise-bootstrap documented** — OPERATIONS §13.4 seed-via-`reconcileAll`-first runbook; scheduler stays reconciliation-agnostic. (T8)
+- [x] **AC-11 OPERATIONS.md covers the scheduler** — §13 covers the mechanism, config shape, sub-hour/cron, durability + skip-no-backfill, kill-switch, retirement, runbook. (T8)
+- [x] No behavior added beyond the story. Diff is tightly scoped — no unrelated edits in the #22 commits.
+
+## ADR adherence
+
+- [x] **Option A implemented exactly** — Job Schedulers on the existing per-task queues; `scheduled-tasks.json` is source of truth, Redis is execution layer, reconciled on boot + each update ([scheduler.js:115](src/manage/taskQueue/queue/scheduler.js:115)).
+- [x] **Layout** — scheduler reconcile placed in the ADR-sanctioned sibling `src/manage/taskQueue/queue/scheduler.js`; uses the exported `getQueue`/`getAllQueues` ([queue/index.js:166,171](src/manage/taskQueue/queue/index.js:166)).
+- [x] **Boot gating** — reconcile runs only when `taskQueueEnabled`, after `initTaskQueue` + `api.register`, wrapped in a non-fatal try/catch ([control-panel.js:283-289](bin/control-panel.js:283)). Sequencing correct (queue init at :267 precedes reconcile at :286).
+- [x] **Kill-switch** — `"scheduler": false` in `/etc/brainstorm-task-queue.json` removes all managed schedulers and upserts none ([scheduler.js:28,116](src/manage/taskQueue/queue/scheduler.js:28)).
+- [x] **Missed-fire policy** — skip-and-resume is inherent to Job Schedulers; documented in OPERATIONS §13.2.
+- [x] **No-surprise-bootstrap** — generic scheduler knows nothing about watermarks (Q4 layering honored); protection is the runbook.
+- [x] **No new dependencies** — `bullmq` already declared (R2). No lint/typecheck/build tooling added (house rule respected).
+- [~] **One justified deviation:** the scheduled job's `data` is `{taskName, timeoutMs}` rather than the ADR's literal `{taskName}` ([scheduler.js:70-74](src/manage/taskQueue/queue/scheduler.js:70)). The added `timeoutMs` is read from the registry's `options.completion.failure.timeout.duration` so a scheduled fire honors the same per-task timeout a manual enqueue does (otherwise scheduled `reconcileAll` would run with `timeoutMs||0` = no timeout). This is additive and strictly better than the sketch — **non-blocking, no change required.**
+
+## Concept-graph integrity
+
+- [x] No domain concepts touched — operational/infra only (scheduler/queue). ADR documents Concept Graph API was unreachable at design time, consistent with ADR 0018. Handles N/A.
+- [x] No concept definitions changed → **firmware reinstall not required** (ADR confirms).
+- [x] New code orients via the queue module + registry, not by re-deriving from BIBLE.md.
+
+## Things tests can't catch
+
+- [x] No secrets in committed files.
+- [x] No leftover debug logging — the `[scheduler]` `console.log`s ([scheduler.js:118,150](src/manage/taskQueue/queue/scheduler.js:118)) are intentional operational logging, matching the established `[task-queue]` style.
+- [x] No commented-out code.
+- [x] Error paths handled — `handleUpdate` returns 400 on invalid input, 503 when the queue isn't initialized, 500 on unexpected error; `readConfig`/`schedulerEnabled`/`getNextRun` are defensive (return safe defaults, never throw to the caller).
+- [x] Concurrency — scheduling is idempotent (`upsertJobScheduler`); the config file is authoritative and reconcile is deterministic; orphan cleanup ([scheduler.js:136](src/manage/taskQueue/queue/scheduler.js:136)) drops any `sched:*` not enabled in the config. Single-operator UI, so the non-atomic read-modify-write in `handleUpdate` is not a realistic race.
+- [x] Security — `taskId` is validated against the registry before any scheduling (no arbitrary-task injection); intervals are clamped non-negative.
+
+## House rules check
+
+- [x] Concept Graph API authority respected (N/A — no domain concepts).
+- [x] No new lint/typecheck/build tooling without an ADR.
+- [x] Firmware reinstall correctly called out as **not** required.
+
+## Findings
+
+### Blocking
+_None._
+
+### Non-blocking (do not gate merge; optional follow-ups)
+1. **[scheduler.js:54](src/manage/taskQueue/queue/scheduler.js:54) / [scheduled-tasks/index.js:181](src/api/scheduled-tasks/index.js:181)** — `isValidSchedule` treats any non-empty `cron` string as valid; a syntactically invalid cron passes validation and only fails later at `upsertJobScheduler`, surfacing as a **503** ("Scheduling unavailable…") rather than a **400**. The operator still sees the parse error in the UI flash, so it's cosmetic. Optional: pre-validate the cron pattern in `handleUpdate` and return 400.
+2. **[scheduler.js:70-74](src/manage/taskQueue/queue/scheduler.js:70)** — `timeoutMs` is baked into the Job Scheduler template at upsert time; if a task's registry timeout later changes, the persisted scheduler carries the old value until the next reconcile (boot or operator update re-upserts it). Benign given boot reconcile refreshes it; noting for awareness.
+
+## Smoke gate (Reviewer-required before prod promotion)
+
+`npm test` proves the **mechanism** is wired (Job Schedulers, floor/DEFAULTS gone, cron/sub-hour in the schema, queue-routed, boot reconcile, kill-switch read). It does **not** prove runtime behavior. Per the test plan and ADR, the behavioral heart is the **authoritative cycle-local/staging smoke** and must be exercised during `cycle-staging` before any prod promotion — especially since this story's entire purpose is to **gate story #21's prod promotion**:
+
+- **S3 (durability — the headline AC-4):** enable a schedule, `supervisorctl restart brainstorm`, confirm the Job Scheduler persists and the next fire still occurs with no re-enable.
+- **S4 (no regression):** migrated `refreshSearchIndex` keeps firing on cadence after cutover.
+- **S5 (reconcile integration):** `reconcileRecent` (sub-hour) + `reconcileAll` (weekly) enqueue and serialize via `neo4j-heavy` (events.jsonl `resource_class_wait_*`); seed the watermark via `reconcileAll` first.
+- **S6 (kill-switch):** `"scheduler": false` halts all upserts after restart.
+- **S1/S2/S7–S9:** sub-hour fire, cron-on-pattern, disable+orphan cleanup, missed-fire skip-and-resume, UI panel.
+
+## Verdict
+
+**PASS** — The diff matches the story's acceptance criteria and ADR 0019's chosen design (Option A); the in-process `setInterval` scheduler is cleanly retired with no dangling references; all 18 test suites are green (new suite 12/12); the two re-baselined sentinels are legitimate ADR-0019 evolutions (1-hour-floor and `/api/run-task` guards correctly inverted for the phase-2 migration), not weakenings. The one ADR deviation (`timeoutMs` in job data) is a justified improvement. No blocking issues.
+
+This PASS authorizes the standard deploy chain. **The S1–S9 cycle-local/staging smoke is the authoritative behavioral gate and must pass on `staging.brainstorm.world` before `cycle-prod`** — the durability (S3), no-regression (S4), and reconcile-serialization (S5) checks in particular, since prod promotion of story #21 depends on them.

--- a/engineering-team/stories/22-generalized-task-scheduler.md
+++ b/engineering-team/stories/22-generalized-task-scheduler.md
@@ -1,0 +1,89 @@
+# Story 22: Generalized Task Scheduler (durable, any-task, sub-hour) — task-queue phase 2
+
+**Status:** Approved
+**Created:** 2026-05-22
+**Type:** Feature
+
+## Background
+
+Tapestry's recurring-task scheduling today is an **in-process `setInterval` scheduler** (`src/api/scheduled-tasks/index.js`, per ADR 0003). It works, but it has four structural limits that now block real work:
+
+- **1-hour minimum interval** — it rejects anything more frequent than hourly. Story #21's `reconcileRecent` wants to run every ~10 minutes; it can't.
+- **Hardcoded task set** — it only knows a fixed list (`updateAllScoresForOwner`, `refreshSearchIndex`). Scheduling any other registered task requires a code edit. The three new reconcile tasks (`reconcileRecent`, `reconcileAll`, `reconcileAuthor`) can't be scheduled at all.
+- **Process-fragile** — the timers live in `setInterval` inside the control-panel Node process. If that process dies between fires, the fire is silently skipped (called out as a reliability hole in story #13's background).
+- **The only sub-hour workaround is a host `systemd` timer** (e.g. `reconcile.timer`), which runs the script *directly* — bypassing the BullMQ queue (story #13 / ADR 0012) and the `neo4j-heavy` semaphore (story #15 / ADR 0013). That defeats the contention protection those stories added.
+
+**Why now:** Story #21 made reconciliation incremental and shipped three manually-triggerable tasks, but deliberately wired **no cadence** because the current scheduler can't serve them (sub-hour, arbitrary task, queue-routed). The operator has decided **not to promote story #21's reconciliation to production until it is actually usable** — i.e., the sweep tasks run automatically on a schedule. **This story is the gating dependency for that prod promotion.**
+
+This is **task-queue phase 2** — the migration story #13's background foreshadowed: *"migrate `scheduled-tasks.json` to BullMQ repeatable jobs; replace the in-process `setInterval`."* It builds on the BullMQ queue (ADR 0012), the `neo4j-heavy` semaphore (ADR 0013), and the existing Scheduled Tasks subsystem (ADR 0003).
+
+**Operator decisions captured at Planning (2026-05-22):**
+- **Full replacement.** Stand up the durable scheduler, migrate the existing schedule(s) onto it, and retire the in-process `setInterval` scheduler. One scheduler at the end — no lingering dual system.
+- **Interval + cron.** Schedules can be expressed as a simple interval *and* as a cron expression (so a heavy run like `reconcileAll` can be pinned to a low-traffic window).
+- **Managed from the existing Scheduled Tasks UI panel**, extended to cover any registered task and the new interval/cron + sub-hour capabilities.
+
+## User-facing description
+
+**As the operator,** I want to schedule **any** registered task on a **durable** scheduler that supports **sub-hour intervals and cron**, **survives control-panel restarts**, and **routes fires through the task queue** — all managed from the Scheduled Tasks panel — **so that** reconciliation (and every other task) runs automatically, with one generalized scheduler instead of per-task code or a process-fragile `setInterval` timer.
+
+## Acceptance criteria
+
+- [ ] **Any** task defined in the task registry can be scheduled — not a hardcoded subset. Given a registered task name, the operator can create/enable a recurring schedule for it.
+- [ ] A schedule can be expressed as an **interval** (every N minutes/hours/days) **or** a **cron expression**. Both forms are accepted and honored.
+- [ ] **Sub-hour intervals are allowed.** A schedule of, e.g., every 10 minutes is accepted and fires roughly every 10 minutes (the prior 1-hour floor is gone).
+- [ ] **Durability:** an enabled schedule survives a control-panel process restart — after a restart, the schedule is still active and its next fire still occurs without the operator re-enabling it. A fire missed during downtime is handled per a defined, documented policy (not silently lost without trace).
+- [ ] **Scheduled fires route through the existing task queue** — a scheduled invocation is enqueued the same way a manual `/api/run-task` call is, so per-task concurrency, `(taskName[,pubkey])` dedup, the `neo4j-heavy` semaphore, and BullBoard visibility all apply. (No direct script spawn that bypasses the queue.)
+- [ ] **No regression for existing schedules:** the currently-active schedule(s) — the Meilisearch-profiles/House-PoV-scores refresh (`refreshSearchIndex`) and `updateAllScoresForOwner` — continue to run on their existing cadence across the migration, with no gap and no operator reconfiguration.
+- [ ] **The in-process `setInterval` scheduler is retired** once the migration is complete — recurring scheduling is served by the new durable scheduler only.
+- [ ] The operator can **enable/disable** a task's schedule and **change its interval/cron** from the **Scheduled Tasks UI panel**, for any registered task. The panel reflects current schedule state (enabled?, next run, last run) for each.
+- [ ] `reconcileRecent` and `reconcileAll` can be scheduled through this surface (`reconcileRecent` at a sub-hour/hourly cadence, `reconcileAll` weekly). Because both flow through the queue, they serialize via the `neo4j-heavy` semaphore against each other and against the GrapeRank/PageRank tasks.
+- [ ] **No surprise bootstrap:** enabling a frequent `reconcileRecent` schedule on a graph that has no reconciliation watermark must not silently kick off a multi-hour full-pass bootstrap with no operator awareness. The behavior here (e.g., require/recommend seeding via a deliberate `reconcileAll` first, or surface a clear warning) is documented in an operator runbook.
+- [ ] Operator documentation (`OPERATIONS.md`) covers: the new scheduler, how to schedule any task (interval + cron), durability/restart behavior, the retirement of the in-process scheduler, and the reconciliation seeding/runbook note.
+
+## Concepts touched
+
+To be resolved by the Architect via `/api/concept-graph/summaries` (operational/infra concepts; likely none in the domain graph):
+
+- Scheduled Tasks subsystem (`src/api/scheduled-tasks/`, ADR 0003) — the thing being replaced
+- BullMQ task queue (story #13 / ADR 0012) — repeatable/cron jobs are the foundation
+- `neo4j-heavy` resource-class semaphore (story #15 / ADR 0013)
+- Task Registry (`taskRegistry.json`)
+- Scheduled Tasks UI panel (the operator surface to extend)
+- The reconcile tasks (`reconcileRecent` / `reconcileAll`, story #21 / ADR 0018) — the motivating consumers
+
+## Out of scope
+
+- **`reconcileAuthor` trigger surfaces** (profile button / API endpoint passing `--pubkey` / per-customer scheduling) — separate follow-up story.
+- **Deprecating the legacy `reconciliation` registry key and `reconcile.timer`** — separate follow-up (this story removes the *in-process* scheduler, not the host systemd timers).
+- **Migrating or retiring the host `systemd` `.timer` units** (e.g. `processAllTasks.timer`) — that's task-queue phase 3 (story #13 foreshadowed deciding each timer's fate task-by-task). This story replaces the in-process scheduler only.
+- **Event- or dependency-driven triggers** ("run X after Y completes"). `processAllTasks` already handles task chaining; this story is interval/cron recurrence only.
+- **Per-customer fan-out scheduling** (scheduling a task across many customers). Single schedule per task here.
+- **Actually enabling the production reconciliation schedules.** This story delivers the *capability* + runbook; turning on `reconcileRecent`/`reconcileAll` in prod (with deliberate watermark seeding) is an operator action, gated by the prod-promotion decision.
+
+## Open questions
+
+To resolve at the architecture gate (Architect proposes; operator ratifies):
+
+1. **Rollback safety for the cutover.** The end state is full replacement, but migrating the *active* `refreshSearchIndex` schedule without a gap is delicate. Does the Architect want a feature flag (à la `TASK_QUEUE_ENABLED` from #13) to fall back to the in-process scheduler during cutover, even though it's removed at the end?
+2. **Where schedule definitions live.** BullMQ repeatable jobs live in Redis; the operator's enable/disable/interval settings currently live in `/var/lib/brainstorm/scheduled-tasks.json`. Migrate that file, store config in Redis, or keep a config file as the source of truth with Redis as the execution layer? Architect's call.
+3. **Missed-fire policy.** When the process was down across a scheduled fire, should the scheduler run the missed job once on recovery, skip it, or surface it? Define the policy.
+4. **No-surprise-bootstrap mechanism.** Runbook-only (document "seed via `reconcileAll` first"), or a built-in guard (detect missing watermark + refuse/warn before a scheduled `reconcileRecent` bootstraps)? Architect proposes.
+5. **Scope size / phasing.** This story is large (durable scheduler engine + queue integration + cron + migration + UI). The Architect may recommend phasing the UI as a fast-follow behind the engine/API; PO to ratify if so.
+
+## Testability notes
+
+How we'll know it works (informational; the Tester writes the plan in Phase 3):
+
+- **Any-task + sub-hour:** schedule an arbitrary registered task at, e.g., every 2 minutes; observe it fire ~every 2 minutes via the queue (BullBoard / events). The prior 1-hour rejection no longer occurs.
+- **Cron:** schedule a task with a cron expression; confirm it fires at the cron-specified time, not on a fixed interval.
+- **Durability:** enable a schedule, restart the control-panel process, confirm the schedule persists and the next fire still happens (no re-enable needed).
+- **Queue routing:** confirm a scheduled fire appears as a queued job (subject to the semaphore / dedup), not a direct spawn.
+- **No regression:** confirm the migrated `refreshSearchIndex` schedule still fires on cadence after cutover.
+- **Reconcile integration:** schedule `reconcileRecent` sub-hour + `reconcileAll` weekly; confirm they enqueue and serialize via `neo4j-heavy`.
+- **No-surprise-bootstrap:** with no watermark, confirm enabling a frequent `reconcileRecent` schedule follows the defined guard/runbook behavior rather than silently launching a multi-hour bootstrap.
+
+## Linked artifacts
+
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/22-generalized-task-scheduler.md
+++ b/engineering-team/stories/22-generalized-task-scheduler.md
@@ -86,4 +86,4 @@ How we'll know it works (informational; the Tester writes the plan in Phase 3):
 
 - ADR: [0019-generalized-task-scheduler.md](../decisions/0019-generalized-task-scheduler.md)
 - Test plan: [22-generalized-task-scheduler.test-plan.md](22-generalized-task-scheduler.test-plan.md)
-- Review: (filled in after Review phase)
+- Review: [22-generalized-task-scheduler.md](../reviews/22-generalized-task-scheduler.md) — **PASS** (2026-05-22; S1–S9 cycle-local/staging smoke is the Reviewer-required behavioral gate before prod)

--- a/engineering-team/stories/22-generalized-task-scheduler.md
+++ b/engineering-team/stories/22-generalized-task-scheduler.md
@@ -85,5 +85,5 @@ How we'll know it works (informational; the Tester writes the plan in Phase 3):
 ## Linked artifacts
 
 - ADR: [0019-generalized-task-scheduler.md](../decisions/0019-generalized-task-scheduler.md)
-- Test plan: (filled in after Test Design phase)
+- Test plan: [22-generalized-task-scheduler.test-plan.md](22-generalized-task-scheduler.test-plan.md)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/22-generalized-task-scheduler.md
+++ b/engineering-team/stories/22-generalized-task-scheduler.md
@@ -84,6 +84,6 @@ How we'll know it works (informational; the Tester writes the plan in Phase 3):
 
 ## Linked artifacts
 
-- ADR: (filled in after Architecture phase)
+- ADR: [0019-generalized-task-scheduler.md](../decisions/0019-generalized-task-scheduler.md)
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/22-generalized-task-scheduler.test-plan.md
+++ b/engineering-team/stories/22-generalized-task-scheduler.test-plan.md
@@ -1,0 +1,104 @@
+# Test Plan: Story 22 — Generalized Task Scheduler (BullMQ Job Schedulers)
+
+**Story:** `engineering-team/stories/22-generalized-task-scheduler.md`
+**ADR:** `engineering-team/decisions/0019-generalized-task-scheduler.md`
+**Date:** 2026-05-22
+
+## Approach
+
+Same precedent as #5/#6/#8/#10–#13/#15/#21. The implementation rewrites a Node module (`src/api/scheduled-tasks/index.js`) plus a thin reconcile layer over the existing BullMQ queue, plus a UI panel — so the `npm test` layer uses **source/structural sentinels** that pin the ADR-required code shape, and the **behavioral heart runs as cycle-local / staging smoke**.
+
+The behavioral guarantees this story makes — a sub-hour schedule actually *fires*, a cron schedule fires *on pattern*, a schedule **survives a control-panel restart** (the durability claim), the migrated `refreshSearchIndex` keeps firing, the kill-switch halts scheduling — are all only reproducible against a live Redis + BullMQ + control-panel process. They are the **authoritative cycle-local/staging smoke** (Reviewer-required). `npm test` proves the mechanism is wired (BullMQ Job Schedulers, not `setInterval`; floor + DEFAULTS gone; cron/sub-hour in the schema), which is the precondition for the behavior.
+
+- **T1..T8** — FAIL pre-implementation, PASS post. The ADR-required new code shape.
+- **R1..R4** — PASS pre AND post. Regression guards on the BullMQ queue topology the scheduler attaches to, the `bullmq` dependency, the operator API surface, and the boot wiring.
+- **S1..S9** — cycle-local/staging smoke. The durability, cron, sub-hour, queue-routing, migration, kill-switch, and UI behavior.
+
+The reconcile logic may live inline in `scheduled-tasks/index.js` or in a sibling `src/manage/taskQueue/queue/scheduler.js` (ADR leaves layout open) — the source sentinels read a **combined source** of both so they don't over-constrain file layout.
+
+## Coverage map
+
+| AC | Test / mechanism | Level |
+|---|---|---|
+| Any registered task schedulable (not hardcoded DEFAULTS) | **T5** (validates against the registry / `getAllQueues`). **S1** = schedule a non-DEFAULTS task | source + smoke |
+| Interval **or** cron | **T6** (cron) + **T7** (`intervalMinutes`/interval). **S2** = cron fires on pattern | source + smoke |
+| Sub-hour allowed | **T4** (1-hour floor removed) + **T7** (`intervalMinutes`). **S1** = ~2-min fire | source + smoke |
+| Durable across control-panel restart | **T1** (Job Schedulers = the durable mechanism) + **R4** (boot reconcile wired). **S3** = restart, schedule persists + fires (authoritative) | source + smoke |
+| Fires route through the queue (semaphore/concurrency/BullBoard) | **T1** (upsert on the existing per-task queue) + **R1** (queue topology + getQueue). **S1/S5** | source + smoke |
+| No regression for existing schedules | **R3** (routes) . **S4** = migrated `refreshSearchIndex` keeps firing | source + smoke |
+| In-process `setInterval` scheduler retired | **T3** (no `setInterval(` in scheduled-tasks) | source |
+| Operator enable/disable + change interval/cron via the Scheduled Tasks panel | **T2** (removeJobScheduler/reconcile) + **R3** (API surface). **S7** = disable stops fires; **S9** = UI panel | source + smoke |
+| `reconcileRecent`/`reconcileAll` schedulable + serialize via `neo4j-heavy` | **T5/T6/T7** (capability). **S5** = schedule both, observe serialization | source + smoke |
+| No-surprise-bootstrap | **T8** (runbook documented). Scheduler stays reconciliation-agnostic; **S5** notes seed-first | source + smoke |
+| OPERATIONS.md documents the scheduler | **T8** | source |
+
+**Totals:** T1..T8 = **8 failing sentinels** (flip to PASS post-impl). R1..R4 = **4 regression guards** (PASS pre AND post). Confirmed `{pass: 4, fail: 8}` pre-implementation.
+
+## Edge cases
+
+- [x] **Layout-tolerant reads:** `schedulerSource()` concatenates `scheduled-tasks/index.js` + an optional `queue/scheduler.js`, so T1/T2/T5/T6/T7 pass whether the reconcile lives inline or in a sibling module.
+- [x] **T4 dual assertion:** both the operator-facing "Minimum interval is 1 hour" 400 message AND the `< 3600000` `startScheduler` guard must be gone — covers both floor sites.
+- [x] **T5 tolerance:** accepts `taskRegistry` OR `getAllQueues` (the schedulable set can come from the registry file or the queue module's loaded registry).
+- [x] **T8 token choice:** asserts `intervalMinutes` + /job scheduler/i — both absent today. Deliberately avoids `cron` (already in OPERATIONS for systemd timers), `backfill`, and `BullMQ repeatable` (both already appear in the §10 task-queue phase-2 note), so the sentinel can't pass on pre-existing text.
+- [x] **Defensive reads:** `readSafe`/`readJsonSafe` return null on missing/malformed files with a "re-baseline" message rather than a parse crash.
+- [ ] **Real Job Scheduler firing, cron timing, restart-durability, queue-routing, migration continuity, kill-switch, missed-fire policy, UI** — not catchable in source; **cycle-local/staging smoke is authoritative**.
+
+## Not covered (deferred to cycle-local / staging smoke — authoritative, Reviewer-required)
+
+Run against a live stack (`http://localhost:8080` locally, then `staging.brainstorm.world`) with Redis + the queue on:
+
+**S1 — any-task + sub-hour + queue-routed:** schedule a benign non-DEFAULTS task at `intervalMinutes: 2`; observe it produce a queued job ~every 2 min (BullBoard `/admin/queues` or `getJobSchedulers`), not a direct spawn.
+
+**S2 — cron:** schedule a task with a cron pattern; confirm it fires at the pattern time, not on a fixed interval.
+
+**S3 — durability (the headline):** enable a schedule; `supervisorctl restart brainstorm`; confirm the Job Scheduler persists (`queue.getJobSchedulers()`) and the next fire still occurs with no re-enable. This is the claim `setInterval` couldn't make.
+
+**S4 — no regression:** confirm the migrated `refreshSearchIndex` schedule still fires on its cadence after cutover (no gap, no operator reconfig).
+
+**S5 — reconcile integration:** schedule `reconcileRecent` (sub-hour) + `reconcileAll` (weekly); confirm both enqueue and serialize via the `neo4j-heavy` semaphore (events.jsonl `resource_class_wait_*`). Seed the watermark via a deliberate `reconcileAll` first (the no-surprise-bootstrap runbook).
+
+**S6 — kill-switch:** set `"scheduler": false` in `/etc/brainstorm-task-queue.json`; restart; confirm no Job Schedulers are upserted (all scheduling halted).
+
+**S7 — disable + orphan cleanup:** disable a task's schedule → `removeJobScheduler` → it stops firing. Remove an entry from the config and restart → its orphaned Job Scheduler is cleaned up on boot (file authoritative).
+
+**S8 — missed-fire policy:** stop the process across a scheduled slot, restart; confirm the next *future* occurrence fires (skip-and-resume), with no backlog flood of missed runs.
+
+**S9 — UI (Chrome visual):** the Scheduled Tasks panel lists any registered task, accepts minutes/cron (no 1-hour client guard), and shows enabled state + next/last run.
+
+## Test infrastructure
+
+- Existing hand-rolled Node runner (`npm test` → `test/test.js`); no new deps (house rule).
+- Registered: `generalizedTaskScheduler`, last in `test/test.js`'s suite list (after `reconciliationIncrementalMode`).
+- Asserts only against in-repo files: `src/api/scheduled-tasks/index.js`, `src/manage/taskQueue/queue/{index,scheduler}.js`, `src/api/index.js`, `bin/control-panel.js`, `package.json`, `OPERATIONS.md`.
+- No Playwright at the sentinel layer; the UI validation (S9) is part of the Chrome smoke.
+
+## How to run
+
+```
+npm test
+```
+
+Targeted: `node -e "require('./test/generalized-task-scheduler.test.js').run()"`
+
+## Verification
+
+New tests fail on the pre-implementation tree (atop ADR commit `82200ccf`); all 18 prior suites stay green (incl. the now-merged `reconciliation-incremental-mode` 16/16). Confirmed 2026-05-22:
+
+```
+generalized-task-scheduler suite:
+  ✗ T1: scheduling uses BullMQ Job Schedulers (upsertJobScheduler), not setInterval
+  ✗ T2: the scheduler reconciles disabled/orphan schedules (removeJobScheduler / getJobSchedulers)
+  ✗ T3: the in-process setInterval scheduler is retired from scheduled-tasks/index.js
+  ✗ T4: the 1-hour minimum-interval floor is removed
+  ✗ T5: schedulable tasks are validated against the task registry, not a hardcoded DEFAULTS set
+  ✗ T6: schedules support cron expressions
+  ✗ T7: schedules support sub-hour intervals via intervalMinutes
+  ✗ T8: OPERATIONS.md documents the generalized scheduler (sub-hour + the Job Scheduler mechanism)
+  ✓ R1: the BullMQ per-task Queue+Worker topology the scheduler attaches to is intact, and getQueue is exported
+  ✓ R2: bullmq is a declared runtime dependency
+  ✓ R3: the scheduled-tasks operator API surface remains registered
+  ✓ R4: the scheduler is still wired at control-panel boot
+
+generalized-task-scheduler suite:                FAIL (4 passed, 8 failed)
+Overall:                                          FAIL
+```

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -440,6 +440,7 @@ async function register(app) {
     app.get('/api/scheduled-tasks/status', scheduledTasks.handleStatus);
     app.post('/api/scheduled-tasks/update', scheduledTasks.handleUpdate);
     app.get('/api/scheduled-tasks/history', scheduledTasks.handleHistory);
+    app.get('/api/scheduled-tasks/list', scheduledTasks.handleList);
 
     // ── Per-Customer Scheduled Tasks API ──
     const customerSchedule = require('./customer-schedule');

--- a/src/api/scheduled-tasks/index.js
+++ b/src/api/scheduled-tasks/index.js
@@ -1,65 +1,64 @@
 /**
- * Scheduled Tasks API
+ * Scheduled Tasks API — generalized, durable scheduling (story #22 / ADR 0019).
  *
- * Manages recurring timers for one or more named tasks, keyed by taskId.
- * Config is persisted in /var/lib/brainstorm/scheduled-tasks.json.
- * Timers run in-process via setInterval and trigger their task through
- * the existing /api/run-task endpoint.
+ * Recurring scheduling is now served by BullMQ Job Schedulers attached to each
+ * task's existing queue (see ../../manage/taskQueue/queue/scheduler.js), NOT an
+ * in-process setInterval. This module owns the operator-facing config (which
+ * tasks, enabled?, interval/cron) — the SOURCE OF TRUTH — persisted in
+ * /var/lib/brainstorm/scheduled-tasks.json, and reconciles it into Job
+ * Schedulers on boot and on every update.
  *
- * Per ADR 0003 (Option A): generalized from a single hardcoded task to a
- * Map<taskId, timerState>. Handlers require taskId from req.query/body.
+ * Generalized from ADR 0003's hardcoded task set: ANY task in the registry can
+ * be scheduled. Schema (backward-compatible): per task
+ *   { enabled, intervalDays?, intervalHours?, intervalMinutes?, cron? }
+ * — cron wins; otherwise days/hours/minutes sum to an interval. No 1-hour floor.
  */
 
 const fs = require('fs');
 const path = require('path');
+const brainstormConfig = require('../../utils/brainstormConfig');
 
 const CONFIG_PATH = '/var/lib/brainstorm/scheduled-tasks.json';
 const EVENTS_PATH = '/var/log/brainstorm/taskQueue/events.jsonl';
 
-const DEFAULTS = {
-  updateAllScoresForOwner: {
-    enabled: false,
-    intervalHours: 24,
-    intervalDays: 0,
-  },
-  refreshSearchIndex: {
-    enabled: false,
-    intervalHours: 24,
-    intervalDays: 0,
-  },
-};
+// ── Task registry (the schedulable-task universe — replaces ADR 0003's DEFAULTS) ──
 
-// ── Per-task in-memory timer state ──────────────────────────
-// taskId → { schedulerTimer, nextRunAt, lastRunAt, taskRunning }
-const timerState = new Map();
-
-function getTimerState(taskId) {
-  if (!timerState.has(taskId)) {
-    timerState.set(taskId, {
-      schedulerTimer: null,
-      nextRunAt: null,
-      lastRunAt: null,
-      taskRunning: false,
-    });
+let _registry = null;
+function loadRegistry() {
+  if (_registry) return _registry;
+  try {
+    const registryPath = path.join(
+      brainstormConfig.get('BRAINSTORM_MODULE_MANAGE_DIR'),
+      'taskQueue/taskRegistry.json'
+    );
+    _registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+  } catch (e) {
+    console.error('[scheduled-tasks] Could not load taskRegistry.json:', e.message);
+    _registry = { tasks: {} };
   }
-  return timerState.get(taskId);
+  return _registry;
 }
 
-function isKnownTaskId(taskId) {
-  return Boolean(taskId) && Object.prototype.hasOwnProperty.call(DEFAULTS, taskId);
+function isRegisteredTask(taskId) {
+  const reg = loadRegistry();
+  return Boolean(taskId) && Boolean(reg.tasks && reg.tasks[taskId]);
+}
+
+// Lazy require — pulls in BullMQ via the queue module only when scheduling runs
+// (gated by TASK_QUEUE_ENABLED at the call sites), keeping module load cheap.
+function scheduler() {
+  return require('../../manage/taskQueue/queue/scheduler');
 }
 
 // ── Config read/write ───────────────────────────────────────
 
 function readConfig() {
   try {
-    if (fs.existsSync(CONFIG_PATH)) {
-      return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
-    }
+    if (fs.existsSync(CONFIG_PATH)) return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
   } catch (e) {
     console.error('[scheduled-tasks] Error reading config:', e.message);
   }
-  return { ...DEFAULTS };
+  return {};
 }
 
 function writeConfig(config) {
@@ -70,109 +69,29 @@ function writeConfig(config) {
 
 function getTaskConfig(taskId) {
   const config = readConfig();
-  return config[taskId] || DEFAULTS[taskId];
+  return config[taskId] || { enabled: false, intervalDays: 0, intervalHours: 0, intervalMinutes: 0, cron: '' };
 }
 
-// ── Scheduler logic ─────────────────────────────────────────
-
-function totalIntervalMs(cfg) {
-  return ((cfg.intervalDays || 0) * 24 + (cfg.intervalHours || 0)) * 3600000;
-}
-
-function makeTriggerTask(taskId) {
-  return async function triggerTask() {
-    const state = getTimerState(taskId);
-    if (state.taskRunning) {
-      console.log(`[scheduled-tasks] Skipping trigger — previous ${taskId} is still running (started at ${state.lastRunAt})`);
-      return;
-    }
-
-    state.lastRunAt = new Date().toISOString();
-    state.taskRunning = true;
-    const intervalMs = totalIntervalMs(getTaskConfig(taskId));
-    state.nextRunAt = new Date(Date.now() + intervalMs).toISOString();
-
-    console.log(`[scheduled-tasks] Triggering ${taskId} at ${state.lastRunAt}`);
-    try {
-      const resp = await fetch(`http://127.0.0.1:7778/api/run-task?taskName=${taskId}`, {
-        method: 'POST',
-      });
-      const data = await resp.json();
-      console.log(`[scheduled-tasks] Task trigger response (${taskId}):`, data.success ? 'success' : data.message);
-
-      // Wait for task to complete by polling its process
-      if (data.execution?.pid) {
-        const pid = data.execution.pid;
-        const { execSync } = require('child_process');
-        const checkInterval = setInterval(() => {
-          try {
-            execSync(`ps -p ${pid} > /dev/null 2>&1`);
-            // Process still running, continue waiting
-          } catch {
-            clearInterval(checkInterval);
-            state.taskRunning = false;
-            console.log(`[scheduled-tasks] ${taskId} completed (PID ${pid} exited)`);
-          }
-        }, 30000); // Check every 30 seconds
-      } else {
-        state.taskRunning = false;
-      }
-    } catch (err) {
-      console.error(`[scheduled-tasks] Error triggering ${taskId}:`, err.message);
-      state.taskRunning = false;
-    }
-  };
-}
-
-function startScheduler(taskId, cfg) {
-  stopScheduler(taskId);
-  const intervalMs = totalIntervalMs(cfg);
-  if (intervalMs < 3600000) {
-    console.warn(`[scheduled-tasks] Interval too short (< 1 hour) for ${taskId}, not starting`);
-    return;
-  }
-  const state = getTimerState(taskId);
-  state.nextRunAt = new Date(Date.now() + intervalMs).toISOString();
-  state.schedulerTimer = setInterval(makeTriggerTask(taskId), intervalMs);
-  console.log(`[scheduled-tasks] Scheduler started for ${taskId}: every ${cfg.intervalDays || 0}d ${cfg.intervalHours || 0}h (next run: ${state.nextRunAt})`);
-}
-
-function stopScheduler(taskId) {
-  const state = getTimerState(taskId);
-  if (state.schedulerTimer) {
-    clearInterval(state.schedulerTimer);
-    state.schedulerTimer = null;
-    state.nextRunAt = null;
-    console.log(`[scheduled-tasks] Scheduler stopped for ${taskId}`);
-  }
-}
+// ── Boot reconcile (replaces the old setInterval initScheduler) ──
 
 /**
- * Called once at server startup. Iterates every known taskId in DEFAULTS
- * and restores the scheduler for any task whose persisted config has
- * enabled:true. Per ADR 0003, no single task is privileged here.
+ * Read the persisted config + registry and reconcile into BullMQ Job
+ * Schedulers. Called once at control-panel boot (gated by TASK_QUEUE_ENABLED,
+ * since it needs the queue initialized).
  */
-function initScheduler() {
-  for (const taskId of Object.keys(DEFAULTS)) {
-    const cfg = getTaskConfig(taskId);
-    if (cfg.enabled) {
-      console.log(`[scheduled-tasks] Restoring enabled schedule from config: ${taskId}`);
-      startScheduler(taskId, cfg);
-    } else {
-      console.log(`[scheduled-tasks] Scheduler disabled in config for ${taskId}, not starting`);
-    }
-  }
+async function reconcileSchedulesFromConfig() {
+  const config = readConfig();
+  const registry = loadRegistry();
+  return scheduler().reconcileSchedules(config, registry);
 }
 
-// ── Task execution history ──────────────────────────────────
+// ── Task execution history (events.jsonl — unchanged from ADR 0003) ──
 
 function getRecentRuns(taskName, maxRuns = 5) {
   const runs = [];
   try {
     if (!fs.existsSync(EVENTS_PATH)) return runs;
     const lines = fs.readFileSync(EVENTS_PATH, 'utf8').trim().split('\n').filter(Boolean);
-
-    // Collect starts and ends for this task
     const starts = [];
     const ends = [];
     for (const line of lines) {
@@ -183,18 +102,12 @@ function getRecentRuns(taskName, maxRuns = 5) {
         else if (rec.eventType === 'TASK_END') ends.push(rec);
       } catch { /* skip bad lines */ }
     }
-
-    // Walk starts in reverse (most recent first), find matching end
     for (let i = starts.length - 1; i >= 0 && runs.length < maxRuns; i--) {
       const start = starts[i];
       let matchedEnd = null;
       for (const end of ends) {
-        if (new Date(end.timestamp) > new Date(start.timestamp)) {
-          matchedEnd = end;
-          break;
-        }
+        if (new Date(end.timestamp) > new Date(start.timestamp)) { matchedEnd = end; break; }
       }
-
       runs.push({
         startedAt: start.timestamp,
         endedAt: matchedEnd ? matchedEnd.timestamp : null,
@@ -209,86 +122,86 @@ function getRecentRuns(taskName, maxRuns = 5) {
   return runs;
 }
 
+// ── Helpers ─────────────────────────────────────────────────
+
+function unknownTask(res, taskId) {
+  return res.status(400).json({
+    success: false,
+    error: `Unknown or unregistered taskId: ${taskId}. Schedulable tasks come from the task registry.`,
+  });
+}
+
+async function nextRunSafe(taskId) {
+  try { return await scheduler().getNextRun(taskId); }
+  catch (_e) { return null; }
+}
+
 // ── API Handlers ────────────────────────────────────────────
 
-function handleStatus(req, res) {
+async function handleStatus(req, res) {
   const taskId = req.query.taskId;
-  if (!isKnownTaskId(taskId)) {
-    return res.status(400).json({
-      success: false,
-      error: `Unknown or missing taskId: ${taskId}. Known: ${Object.keys(DEFAULTS).join(', ')}`,
-    });
-  }
+  if (!isRegisteredTask(taskId)) return unknownTask(res, taskId);
   const cfg = getTaskConfig(taskId);
-  const state = getTimerState(taskId);
-  const totalHours = (cfg.intervalDays || 0) * 24 + (cfg.intervalHours || 0);
+  const nextRunAt = await nextRunSafe(taskId);
+  const runs = getRecentRuns(taskId, 1);
   return res.json({
     success: true,
     taskId,
     schedule: {
-      enabled: cfg.enabled,
-      intervalHours: cfg.intervalHours,
-      intervalDays: cfg.intervalDays,
-      totalIntervalHours: totalHours,
+      enabled: !!cfg.enabled,
+      intervalDays: cfg.intervalDays || 0,
+      intervalHours: cfg.intervalHours || 0,
+      intervalMinutes: cfg.intervalMinutes || 0,
+      cron: cfg.cron || '',
     },
     timer: {
-      active: state.schedulerTimer !== null,
-      nextRunAt: state.nextRunAt,
-      lastRunAt: state.lastRunAt,
+      active: !!nextRunAt,
+      nextRunAt,
+      lastRunAt: runs[0] ? runs[0].startedAt : null,
     },
   });
 }
 
 async function handleUpdate(req, res) {
   try {
-    const taskId = req.body.taskId;
-    const { enabled, intervalHours, intervalDays } = req.body;
+    const { taskId, enabled, intervalDays, intervalHours, intervalMinutes, cron } = req.body;
+    if (!isRegisteredTask(taskId)) return unknownTask(res, taskId);
 
-    if (!isKnownTaskId(taskId)) {
-      return res.status(400).json({
-        success: false,
-        error: `Unknown or missing taskId: ${taskId}. Known: ${Object.keys(DEFAULTS).join(', ')}`,
-      });
-    }
-
-    const days = parseInt(intervalDays) || 0;
-    const hours = parseInt(intervalHours) || 0;
-    const totalHours = days * 24 + hours;
-
-    if (enabled && totalHours < 1) {
-      return res.status(400).json({ success: false, error: 'Minimum interval is 1 hour' });
-    }
-    if (days < 0 || hours < 0) {
+    const entry = {
+      enabled: !!enabled,
+      intervalDays: parseInt(intervalDays) || 0,
+      intervalHours: parseInt(intervalHours) || 0,
+      intervalMinutes: parseInt(intervalMinutes) || 0,
+      cron: typeof cron === 'string' ? cron.trim() : '',
+    };
+    if (entry.intervalDays < 0 || entry.intervalHours < 0 || entry.intervalMinutes < 0) {
       return res.status(400).json({ success: false, error: 'Interval values must be non-negative' });
     }
-
-    // Save
-    const config = readConfig();
-    config[taskId] = {
-      enabled: !!enabled,
-      intervalHours: hours,
-      intervalDays: days,
-    };
-    writeConfig(config);
-
-    // Start or stop timer (per-task)
-    if (enabled) {
-      startScheduler(taskId, config[taskId]);
-    } else {
-      stopScheduler(taskId);
+    // No 1-hour floor (ADR 0019) — but an enabled schedule must specify SOMETHING.
+    if (entry.enabled && !scheduler().isValidSchedule(entry)) {
+      return res.status(400).json({ success: false, error: 'Enabled schedule needs a cron expression or a positive interval' });
     }
 
-    const state = getTimerState(taskId);
+    const config = readConfig();
+    config[taskId] = entry;
+    writeConfig(config);
+
+    // Reconcile just this task's Job Scheduler.
+    try {
+      if (entry.enabled) await scheduler().upsertSchedule(taskId, entry, loadRegistry());
+      else await scheduler().removeSchedule(taskId);
+    } catch (e) {
+      return res.status(503).json({ success: false, error: `Scheduling unavailable (task queue not initialized?): ${e.message}` });
+    }
+
+    const nextRunAt = await nextRunSafe(taskId);
+    const spec = entry.cron ? `cron "${entry.cron}"` : `every ${entry.intervalDays}d ${entry.intervalHours}h ${entry.intervalMinutes}m`;
     return res.json({
       success: true,
-      message: enabled ? `${taskId} enabled: every ${days}d ${hours}h` : `${taskId} disabled`,
+      message: entry.enabled ? `${taskId} enabled: ${spec}` : `${taskId} disabled`,
       taskId,
-      schedule: config[taskId],
-      timer: {
-        active: state.schedulerTimer !== null,
-        nextRunAt: state.nextRunAt,
-        lastRunAt: state.lastRunAt,
-      },
+      schedule: entry,
+      timer: { active: !!nextRunAt, nextRunAt, lastRunAt: null },
     });
   } catch (err) {
     console.error('[scheduled-tasks] Error updating:', err.message);
@@ -298,14 +211,49 @@ async function handleUpdate(req, res) {
 
 function handleHistory(req, res) {
   const taskId = req.query.taskId;
-  if (!isKnownTaskId(taskId)) {
-    return res.status(400).json({
-      success: false,
-      error: `Unknown or missing taskId: ${taskId}. Known: ${Object.keys(DEFAULTS).join(', ')}`,
-    });
-  }
-  const runs = getRecentRuns(taskId, 5);
-  return res.json({ success: true, taskId, runs });
+  if (!isRegisteredTask(taskId)) return unknownTask(res, taskId);
+  return res.json({ success: true, taskId, runs: getRecentRuns(taskId, 5) });
 }
 
-module.exports = { handleStatus, handleUpdate, handleHistory, initScheduler };
+/**
+ * List every schedulable (registered) task with its current schedule + next/last
+ * run. Drives the generalized Scheduled Tasks UI panel (ADR 0019).
+ */
+async function handleList(req, res) {
+  const reg = loadRegistry();
+  const config = readConfig();
+  const out = [];
+  for (const taskId of Object.keys(reg.tasks || {})) {
+    const def = reg.tasks[taskId] || {};
+    const cfg = config[taskId] || {};
+    const nextRunAt = await nextRunSafe(taskId);
+    const runs = getRecentRuns(taskId, 1);
+    out.push({
+      taskId,
+      name: def.name || taskId,
+      categories: def.categories || [],
+      resourceClass: def.resourceClass || null,
+      schedule: {
+        enabled: !!cfg.enabled,
+        intervalDays: cfg.intervalDays || 0,
+        intervalHours: cfg.intervalHours || 0,
+        intervalMinutes: cfg.intervalMinutes || 0,
+        cron: cfg.cron || '',
+      },
+      timer: { active: !!nextRunAt, nextRunAt, lastRunAt: runs[0] ? runs[0].startedAt : null },
+    });
+  }
+  return res.json({ success: true, tasks: out });
+}
+
+module.exports = {
+  handleStatus,
+  handleUpdate,
+  handleHistory,
+  handleList,
+  reconcileSchedulesFromConfig,
+  // exported for testability / reuse
+  readConfig,
+  isRegisteredTask,
+  getRecentRuns,
+};

--- a/src/manage/taskQueue/queue/scheduler.js
+++ b/src/manage/taskQueue/queue/scheduler.js
@@ -1,0 +1,164 @@
+/**
+ * Generalized task scheduler — BullMQ Job Schedulers on the per-task queues.
+ * Story #22 / ADR 0019. Replaces the in-process setInterval scheduler.
+ *
+ * Recurring scheduling = a durable BullMQ Job Scheduler attached to each
+ * scheduled task's existing queue (from ADR 0012). On each tick BullMQ adds a
+ * job to that queue → the existing Worker → processor.processJob →
+ * launchChildTask, so the neo4j-heavy semaphore, per-task concurrency, jobId
+ * behavior, and BullBoard all apply for free.
+ *
+ * The schedule config file (scheduled-tasks.json, owned by
+ * src/api/scheduled-tasks) is the SOURCE OF TRUTH; Job Schedulers in Redis are
+ * the EXECUTION layer. reconcileSchedules() upserts/removes schedulers to match
+ * the config and cleans up orphans, so the file stays authoritative across
+ * restarts and even a Redis flush.
+ */
+
+const fs = require('fs');
+const taskQueue = require('./index'); // getQueue, getAllQueues — the per-task BullMQ queues (ADR 0012)
+
+const QUEUE_CONFIG_PATH = '/etc/brainstorm-task-queue.json';
+const SCHEDULER_PREFIX = 'sched:';
+
+/**
+ * Kill-switch (ADR 0019 Q1). /etc/brainstorm-task-queue.json { "scheduler": false }
+ * halts all scheduling. Default true (absent/unreadable → on).
+ */
+function schedulerEnabled() {
+  try {
+    if (fs.existsSync(QUEUE_CONFIG_PATH)) {
+      const raw = JSON.parse(fs.readFileSync(QUEUE_CONFIG_PATH, 'utf8'));
+      if (raw && raw.scheduler === false) return false;
+    }
+  } catch (_e) { /* default on */ }
+  return true;
+}
+
+function schedulerId(taskId) { return `${SCHEDULER_PREFIX}${taskId}`; }
+
+/**
+ * Convert a schedule config entry to BullMQ repeat options.
+ *   cron wins; otherwise sum days/hours/minutes → `every` ms (sub-hour OK).
+ */
+function toRepeatOpts(cfg) {
+  if (cfg && cfg.cron && String(cfg.cron).trim()) return { pattern: String(cfg.cron).trim() };
+  const minutes =
+    (Number(cfg && cfg.intervalDays) || 0) * 24 * 60 +
+    (Number(cfg && cfg.intervalHours) || 0) * 60 +
+    (Number(cfg && cfg.intervalMinutes) || 0);
+  return { every: minutes * 60000 };
+}
+
+/** A config entry is a runnable schedule iff it has a cron or a positive interval. No 1-hour floor. */
+function isValidSchedule(cfg) {
+  if (cfg && cfg.cron && String(cfg.cron).trim()) return true;
+  return toRepeatOpts(cfg).every > 0;
+}
+
+/** Upsert one task's Job Scheduler on its queue. */
+async function upsertSchedule(taskId, cfg, registry) {
+  const queue = taskQueue.getQueue(taskId);
+  if (!queue) throw new Error(`No BullMQ queue for task '${taskId}' (not a registered task, or queue not initialized)`);
+  const taskDef = registry && registry.tasks && registry.tasks[taskId];
+  const timeoutMs =
+    (taskDef && taskDef.options && taskDef.options.completion &&
+      taskDef.options.completion.failure && taskDef.options.completion.failure.timeout &&
+      taskDef.options.completion.failure.timeout.duration) || 0;
+  // The scheduled job carries only taskName + timeoutMs; the Worker's closed-over
+  // taskDef + processor.buildChildArgs supply staticArgs (e.g. reconcileAll's --mode all).
+  await queue.upsertJobScheduler(
+    schedulerId(taskId),
+    toRepeatOpts(cfg),
+    { name: taskId, data: { taskName: taskId, timeoutMs } }
+  );
+}
+
+/** Remove one task's Job Scheduler (no-op if absent). */
+async function removeSchedule(taskId) {
+  const queue = taskQueue.getQueue(taskId);
+  if (!queue) return;
+  try { await queue.removeJobScheduler(schedulerId(taskId)); } catch (_e) { /* not present */ }
+}
+
+/** Next-run ISO timestamp for a task (from its Job Scheduler), or null. */
+async function getNextRun(taskId) {
+  const queue = taskQueue.getQueue(taskId);
+  if (!queue) return null;
+  try {
+    const schedulers = await queue.getJobSchedulers();
+    const mine = schedulers.find(s => (s.key || s.id) === schedulerId(taskId));
+    return mine && mine.next ? new Date(Number(mine.next)).toISOString() : null;
+  } catch (_e) { return null; }
+}
+
+/** Remove every sched:* Job Scheduler this module manages, across all queues. */
+async function removeAllManaged() {
+  for (const queue of taskQueue.getAllQueues()) {
+    try {
+      const schedulers = await queue.getJobSchedulers();
+      for (const s of schedulers) {
+        const key = s.key || s.id || '';
+        if (key.startsWith(SCHEDULER_PREFIX)) await queue.removeJobScheduler(key).catch(() => {});
+      }
+    } catch (_e) { /* skip */ }
+  }
+}
+
+/**
+ * Reconcile the persisted config → Job Schedulers (file is authoritative).
+ *   - kill-switch off → remove all managed schedulers, upsert none.
+ *   - enabled + valid + registered entry → upsert.
+ *   - disabled/invalid/unregistered entry → remove.
+ *   - orphan sched:* schedulers not enabled in the config → remove.
+ */
+async function reconcileSchedules(config, registry) {
+  if (!schedulerEnabled()) {
+    await removeAllManaged();
+    console.log('[scheduler] kill-switch off (brainstorm-task-queue.json scheduler:false) — scheduling halted');
+    return { upserted: 0, removed: 'all' };
+  }
+
+  const entries = Object.entries(config || {});
+  let upserted = 0;
+  const enabledIds = new Set();
+  for (const [taskId, cfg] of entries) {
+    const registered = !!(registry && registry.tasks && registry.tasks[taskId]);
+    if (cfg && cfg.enabled && isValidSchedule(cfg) && registered) {
+      await upsertSchedule(taskId, cfg, registry);
+      enabledIds.add(taskId);
+      upserted++;
+    } else {
+      await removeSchedule(taskId);
+    }
+  }
+
+  // Orphan cleanup: drop any sched:* scheduler not currently enabled in the config.
+  for (const queue of taskQueue.getAllQueues()) {
+    try {
+      const schedulers = await queue.getJobSchedulers();
+      for (const s of schedulers) {
+        const key = s.key || s.id || '';
+        if (key.startsWith(SCHEDULER_PREFIX)) {
+          const taskId = key.slice(SCHEDULER_PREFIX.length);
+          if (!enabledIds.has(taskId)) await queue.removeJobScheduler(key).catch(() => {});
+        }
+      }
+    } catch (_e) { /* skip */ }
+  }
+
+  console.log(`[scheduler] reconciled ${upserted} enabled schedule(s) into BullMQ Job Schedulers`);
+  return { upserted };
+}
+
+module.exports = {
+  schedulerEnabled,
+  schedulerId,
+  toRepeatOpts,
+  isValidSchedule,
+  upsertSchedule,
+  removeSchedule,
+  getNextRun,
+  reconcileSchedules,
+  removeAllManaged,
+};

--- a/test/generalized-task-scheduler.test.js
+++ b/test/generalized-task-scheduler.test.js
@@ -1,0 +1,218 @@
+/**
+ * Story #22 / ADR 0019 — Generalized task scheduler via BullMQ Job Schedulers.
+ *
+ * Source/structural sentinels pin the ADR-required code shape: the in-process
+ * `setInterval` scheduler is replaced by BullMQ Job Schedulers
+ * (`upsertJobScheduler` / `removeJobScheduler`) on the existing per-task queues,
+ * the 1-hour floor and hardcoded DEFAULTS restriction are gone, and the config
+ * schema gains cron + sub-hour (`intervalMinutes`).
+ *
+ * The behavioral heart — does a sub-hour schedule actually fire via the queue;
+ * does a cron schedule fire on pattern; does a schedule SURVIVE a control-panel
+ * restart (durability); does the migrated `refreshSearchIndex` keep firing;
+ * does the kill-switch halt scheduling — is reproducible only against a live
+ * Redis + BullMQ + control-panel, and is the **authoritative cycle-local /
+ * staging smoke** (Reviewer-required, per project precedent). See the test
+ * plan's "Not covered (deferred to smoke)" section.
+ *
+ * T1..T8 : FAIL pre-implementation, PASS post.
+ * R1..R4 : PASS pre AND post — regression guards on the BullMQ queue topology
+ *          the scheduler attaches to, the bullmq dependency, the operator API
+ *          surface, and the boot wiring.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const SCHEDULED_TASKS  = path.join(ROOT, 'src/api/scheduled-tasks/index.js');
+const SCHEDULER_MODULE = path.join(ROOT, 'src/manage/taskQueue/queue/scheduler.js'); // ADR-optional: reconcile may live here or inline in scheduled-tasks
+const QUEUE_INDEX      = path.join(ROOT, 'src/manage/taskQueue/queue/index.js');
+const API_INDEX        = path.join(ROOT, 'src/api/index.js');
+const CONTROL_PANEL    = path.join(ROOT, 'bin/control-panel.js');
+const PACKAGE_JSON     = path.join(ROOT, 'package.json');
+const OPERATIONS_MD    = path.join(ROOT, 'OPERATIONS.md');
+
+function readSafe(p) {
+  try { return fs.readFileSync(p, 'utf8'); }
+  catch (_e) { return null; }
+}
+function readJsonSafe(p) {
+  const s = readSafe(p);
+  if (s === null) return null;
+  try { return JSON.parse(s); }
+  catch (_e) { return null; }
+}
+// The reconcile logic may live inline in scheduled-tasks/index.js OR in a
+// sibling scheduler module — search both so the sentinel doesn't over-constrain
+// file layout (ADR 0019 §Implementation notes leaves this open).
+function schedulerSource() {
+  return [readSafe(SCHEDULED_TASKS) || '', readSafe(SCHEDULER_MODULE) || ''].join('\n');
+}
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+
+// ---------------------------------------------------------------------------
+// Failing sentinels — FAIL now, PASS once Story #22 is implemented per ADR 0019.
+// ---------------------------------------------------------------------------
+
+test('T1: scheduling uses BullMQ Job Schedulers (upsertJobScheduler), not setInterval (AC durability/queue-routed; ADR 0019 §Decision)', () => {
+  const src = schedulerSource();
+  assert(
+    /upsertJobScheduler/.test(src),
+    'The scheduler does not call BullMQ `upsertJobScheduler` (ADR 0019 §Decision). Recurring scheduling must ' +
+      'be served by durable BullMQ Job Schedulers attached to each task\'s existing queue — that is what makes ' +
+      'schedules survive a control-panel restart and routes every fire through the queue (semaphore + ' +
+      'concurrency + BullBoard). Replace the in-process setInterval with `queue.upsertJobScheduler(...)`.'
+  );
+});
+
+test('T2: the scheduler reconciles disabled/orphan schedules (removeJobScheduler / getJobSchedulers) (AC enable-disable + file-authoritative; ADR 0019 §Decision Q2)', () => {
+  const src = schedulerSource();
+  assert(
+    /removeJobScheduler|getJobSchedulers/.test(src),
+    'The scheduler does not remove/reconcile Job Schedulers (ADR 0019 §Decision Q2). Disabling a task must ' +
+      '`removeJobScheduler`, and the boot reconcile must drop orphaned schedulers not present in the config so ' +
+      'the config file stays authoritative over Redis. Use `removeJobScheduler` (and `getJobSchedulers` to ' +
+      'enumerate for orphan cleanup).'
+  );
+});
+
+test('T3: the in-process setInterval scheduler is retired from scheduled-tasks/index.js (AC: in-process scheduler retired; ADR 0019 §Impl)', () => {
+  const src = readSafe(SCHEDULED_TASKS);
+  assert(src !== null, 'src/api/scheduled-tasks/index.js missing — re-baseline this sentinel.');
+  assert(
+    !/setInterval\(/.test(src),
+    'src/api/scheduled-tasks/index.js still uses setInterval (AC: in-process scheduler retired; ADR 0019 §Impl). ' +
+      'The setInterval scheduling loop AND the PID-polling setInterval must both go — BullMQ Job Schedulers ' +
+      'handle recurrence, and the Worker handles completion. A timer that dies with the control-panel process ' +
+      'is exactly the fragility this story removes.'
+  );
+});
+
+test('T4: the 1-hour minimum-interval floor is removed (AC: sub-hour allowed; ADR 0019 §Impl)', () => {
+  const src = readSafe(SCHEDULED_TASKS);
+  assert(src !== null, 'src/api/scheduled-tasks/index.js missing — re-baseline this sentinel.');
+  assert(
+    !/Minimum interval is 1 hour/.test(src),
+    'src/api/scheduled-tasks/index.js still rejects sub-hour intervals with "Minimum interval is 1 hour" ' +
+      '(AC: sub-hour allowed; ADR 0019 §Impl). reconcileRecent wants ~10-minute cadence — the floor must go.'
+  );
+  assert(
+    !/<\s*3600000/.test(src),
+    'src/api/scheduled-tasks/index.js still guards on `< 3600000` (the 1-hour floor in startScheduler) ' +
+      '(AC: sub-hour allowed; ADR 0019 §Impl). Remove the floor; BullMQ accepts any `every` interval.'
+  );
+});
+
+test('T5: schedulable tasks are validated against the task registry, not a hardcoded DEFAULTS set (AC: any registered task; ADR 0019 §Impl)', () => {
+  const src = schedulerSource();
+  assert(
+    /taskRegistry|getAllQueues/.test(src),
+    'The scheduler does not consult the task registry (AC: any registered task; ADR 0019 §Impl). Today only ' +
+      'the hardcoded DEFAULTS (updateAllScoresForOwner, refreshSearchIndex) are schedulable. The schedulable ' +
+      'set must come from the registry (taskRegistry.json) — any registered task can be scheduled and the UI ' +
+      'list endpoint enumerates them. Validate `taskId` against the registry (unknown → 400), not DEFAULTS.'
+  );
+});
+
+test('T6: schedules support cron expressions (AC: interval + cron; ADR 0019 §Decision)', () => {
+  const src = schedulerSource();
+  assert(
+    /cron/.test(src),
+    'The scheduler config/handlers have no notion of `cron` (AC: interval + cron; ADR 0019 §Decision). A ' +
+      'schedule must be expressible as a cron expression (→ `upsertJobScheduler(id, { pattern: cron }, ...)`), ' +
+      'so a heavy run like reconcileAll can be pinned to a low-traffic window.'
+  );
+});
+
+test('T7: schedules support sub-hour intervals via intervalMinutes (AC: sub-hour; ADR 0019 §Impl config schema)', () => {
+  const src = schedulerSource();
+  assert(
+    /intervalMinutes/.test(src),
+    'The scheduler config schema has no `intervalMinutes` (AC: sub-hour; ADR 0019 §Impl). The schema extends ' +
+      'backward-compatibly with `intervalMinutes` (and `cron`) so reconcileRecent can run every ~10 minutes; ' +
+      'existing intervalHours/intervalDays keep working.'
+  );
+});
+
+test('T8: OPERATIONS.md documents the generalized scheduler (sub-hour + the Job Scheduler mechanism) (AC-10; ADR 0019 §Impl docs)', () => {
+  const src = readSafe(OPERATIONS_MD);
+  assert(src !== null, 'OPERATIONS.md missing — re-baseline this sentinel.');
+  const missing = [];
+  if (!/intervalMinutes/.test(src)) missing.push('the sub-hour `intervalMinutes` config field');
+  if (!/job scheduler/i.test(src)) missing.push('the BullMQ Job Scheduler mechanism');
+  assert(
+    missing.length === 0,
+    'OPERATIONS.md does not document: ' + missing.join(', ') + ' (AC-10; ADR 0019 §Impl). Add a scheduler ' +
+      'section covering: scheduling any registered task by interval or cron; sub-hour (`intervalMinutes`); ' +
+      'durability + the skip-and-resume (no-backfill) missed-fire policy; the kill-switch; the retirement of ' +
+      'the in-process scheduler; and the reconciliation seed-via-reconcileAll-first runbook note.'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Regression guards — PASS now AND post-implementation.
+// ---------------------------------------------------------------------------
+
+test('R1: the BullMQ per-task Queue+Worker topology the scheduler attaches to is intact, and getQueue is exported (ADR 0012/0019)', () => {
+  const src = readSafe(QUEUE_INDEX);
+  assert(src !== null, 'queue/index.js missing — re-baseline this sentinel.');
+  assert(
+    /new Queue\(/.test(src) && /new Worker\(/.test(src),
+    'R1: queue/index.js no longer instantiates per-task BullMQ Queue + Worker (ADR 0012/0019 regression). The ' +
+      'scheduler attaches Job Schedulers to these existing queues so scheduled fires reuse the existing ' +
+      'Worker + neo4j-heavy semaphore. The per-task topology must survive.'
+  );
+  assert(
+    /getQueue\b/.test(src) && /module\.exports/.test(src),
+    'R1: queue/index.js no longer exports getQueue (ADR 0019 regression). The scheduler reconcile needs ' +
+      'getQueue(taskName) to upsert/remove a Job Scheduler on each task\'s queue.'
+  );
+});
+
+test('R2: bullmq is a declared runtime dependency (the scheduler is built on its Job Schedulers) (ADR 0019)', () => {
+  const pkg = readJsonSafe(PACKAGE_JSON);
+  assert(pkg && pkg.dependencies, 'package.json missing or has no dependencies block.');
+  assert(
+    typeof pkg.dependencies.bullmq === 'string',
+    'R2: package.json does not declare `bullmq` (ADR 0019 regression). Job Schedulers (upsertJobScheduler) are ' +
+      'a BullMQ 5.x feature; the dependency must remain declared/installed or the scheduler cannot run.'
+  );
+});
+
+test('R3: the scheduled-tasks operator API surface remains registered (AC: operator manages schedules; ADR 0019)', () => {
+  const src = readSafe(API_INDEX);
+  assert(src !== null, 'src/api/index.js missing — re-baseline this sentinel.');
+  assert(
+    /scheduled-tasks\/status/.test(src) && /scheduled-tasks\/update/.test(src),
+    'R3: src/api/index.js no longer registers the /api/scheduled-tasks status + update routes (ADR 0019 ' +
+      'regression). These are the operator surface the UI panel drives (generalized here to any task + ' +
+      'cron/sub-hour); they must remain registered.'
+  );
+});
+
+test('R4: the scheduler is still wired at control-panel boot (AC: durability/restore on boot; ADR 0019 §Impl)', () => {
+  const src = readSafe(CONTROL_PANEL);
+  assert(src !== null, 'bin/control-panel.js missing — re-baseline this sentinel.');
+  assert(
+    /scheduled-tasks/.test(src),
+    'R4: bin/control-panel.js no longer references the scheduled-tasks module at boot (ADR 0019 §Impl ' +
+      'regression). The boot path must reconcile the persisted schedule config into BullMQ Job Schedulers on ' +
+      'startup (replacing the old initScheduler), so enabled schedules are restored after a restart.'
+  );
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try { await t.fn(); console.log(`  ✓ ${t.name}`); pass++; }
+    catch (err) { console.log(`  ✗ ${t.name}`); console.log(`      ${err.message}`); fail++; }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/scheduled-search-and-house-scores-refresh.test.js
+++ b/test/scheduled-search-and-house-scores-refresh.test.js
@@ -27,21 +27,21 @@ const tests = [];
 function test(name, fn) { tests.push({ name, fn }); }
 function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
 
-// ── AC-2, AC-6: defaults / persistence shape ─────────────────
-test('scheduler DEFAULTS includes refreshSearchIndex with enabled:false and intervalHours:24', () => {
+// ── AC-2, AC-6 — RE-BASELINED for ADR 0019 (supersedes ADR 0003's hardcoded DEFAULTS) ──
+// ADR 0019 retired the hardcoded DEFAULTS task set: ANY registered task is schedulable,
+// validated against the task registry. The intent (refreshSearchIndex + updateAllScoresForOwner
+// remain schedulable) survives — now via the registry rather than a DEFAULTS literal.
+test('refreshSearchIndex + updateAllScoresForOwner are schedulable via the task registry (ADR 0019)', () => {
   const src = fs.readFileSync(SCHEDULER_PATH, 'utf8');
   assert(
-    /refreshSearchIndex\s*:\s*\{[\s\S]{0,200}enabled\s*:\s*false/.test(src),
-    'src/api/scheduled-tasks/index.js DEFAULTS must include `refreshSearchIndex: { enabled: false, intervalHours: 24, intervalDays: 0 }` (per ADR 0003 implementation notes)'
+    /taskRegistry|loadRegistry|isRegisteredTask/.test(src),
+    'scheduled-tasks/index.js must validate schedulable tasks against the task registry (ADR 0019), not a hardcoded DEFAULTS set.'
   );
-  assert(
-    /refreshSearchIndex[\s\S]{0,300}intervalHours\s*:\s*24/.test(src),
-    'refreshSearchIndex default intervalHours must be 24 (mirrors the existing Owner task default)'
-  );
-  assert(
-    /updateAllScoresForOwner\s*:\s*\{/.test(src),
-    'DEFAULTS must still include updateAllScoresForOwner (no regression to the existing task — AC-11)'
-  );
+  const reg = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
+  assert(reg.tasks && reg.tasks.refreshSearchIndex,
+    'taskRegistry.json must contain refreshSearchIndex (registry is the schedulable-task source of truth post-ADR-0019).');
+  assert(reg.tasks && reg.tasks.updateAllScoresForOwner,
+    'taskRegistry.json must contain updateAllScoresForOwner (no regression — still schedulable).');
 });
 
 // ── ADR constraint: handlers route by taskId ─────────────────
@@ -57,22 +57,26 @@ test('scheduler handlers read taskId from req (query/body) — taskId-keyed rout
   );
 });
 
-// ── AC-3: 1h minimum still enforced after the refactor ───────
-test('handleUpdate still enforces the ≥1h minimum interval for any taskId', () => {
+// ── AC-3 — RE-BASELINED (inverted) for ADR 0019: the 1-hour floor is REMOVED ──
+// ADR 0019 supersedes ADR 0003 AC-3 — sub-hour cadence is required (reconcileRecent ~10 min),
+// so the old floor must be gone.
+test('handleUpdate no longer enforces a 1-hour minimum interval (ADR 0019 — sub-hour allowed)', () => {
   const src = fs.readFileSync(SCHEDULER_PATH, 'utf8');
   assert(
-    /Minimum interval is 1 hour/i.test(src) || /totalHours\s*<\s*1/.test(src),
-    'handleUpdate must enforce a ≥1h minimum interval (existing validation must survive the taskId refactor — AC-3)'
+    !/Minimum interval is 1 hour/i.test(src) && !/totalHours\s*<\s*1/.test(src),
+    'scheduled-tasks/index.js must NOT enforce the old 1-hour floor (ADR 0019 supersedes ADR 0003 AC-3).'
   );
 });
 
-// ── AC-6: cold-start restoration per task ────────────────────
-test('initScheduler iterates per-task IDs so each enabled task is restored after restart', () => {
+// ── AC-6 — RE-BASELINED for ADR 0019: boot reconcile replaces setInterval initScheduler ──
+// The cold-start-restoration intent survives: a boot reconcile upserts a durable BullMQ Job
+// Scheduler per enabled task (so each restores independently after restart) — now via Redis,
+// not an in-process setInterval.
+test('boot reconcile restores enabled schedules per task after restart (ADR 0019)', () => {
   const src = fs.readFileSync(SCHEDULER_PATH, 'utf8');
-  // The shape isn't prescribed; what matters is that we don't hardcode a single task on startup.
   assert(
-    /initScheduler[\s\S]{0,800}(Object\.keys\(DEFAULTS\)|for\s*\(\s*const\s+taskId|Object\.entries\(DEFAULTS\)|forEach[\s\S]{0,40}taskId)/.test(src),
-    'initScheduler must iterate per-task IDs (e.g. Object.keys(DEFAULTS) or for-of taskIds) so refreshSearchIndex restores independently of updateAllScoresForOwner — AC-6'
+    /reconcileSchedulesFromConfig/.test(src) && /readConfig\(\)/.test(src),
+    'scheduled-tasks/index.js must expose a boot reconcile (reconcileSchedulesFromConfig) that reads the per-task config and restores enabled schedules — replacing ADR 0003 initScheduler (AC-6 intent preserved).'
   );
 });
 
@@ -149,18 +153,19 @@ test('loadScoresIntoMeilisearch.sh still invokes the .js with no --povPubkey/--d
     `Owner-side loadScoresIntoMeilisearch.sh must NOT pass --povPubkey/--delegatedPubkey (would break the owner default path — AC-11 no regression). Current args after the .js path: "${argsPart}"`);
 });
 
-// ── AC-1, AC-2: new card in UI ───────────────────────────────
-test('RelaySettings.jsx renders a card titled "Refresh Meilisearch profiles & House PoV scores"', () => {
+// ── AC-1, AC-2 — RE-BASELINED for ADR 0019: panel is generalized over registered tasks ──
+// The panel now renders any registered task dynamically from /api/scheduled-tasks/list, so
+// card titles come from the registry `name` rather than hardcoded JSX literals. The
+// refreshSearchIndex title is preserved as its registry name (verified below).
+test('Scheduled Tasks panel is generalized over registered tasks; refreshSearchIndex title comes from the registry (ADR 0019)', () => {
   const src = fs.readFileSync(RELAY_SETTINGS_PATH, 'utf8');
-  assert(
-    /Refresh Meilisearch profiles\s*&(?:amp;|amp;|)?\s*House PoV scores/.test(src),
-    'RelaySettings.jsx must contain the literal title "Refresh Meilisearch profiles & House PoV scores" (AC-1)'
-  );
   assert(/ScheduledTasksPanel/.test(src),
-    'ScheduledTasksPanel must remain the host for both task cards (no parallel panel module)');
-  // Existing card title must remain (AC-11 no regression on the Owner card)
-  assert(/Update All Scores for Owner/.test(src),
-    'Existing "Update All Scores for Owner" card title must remain in RelaySettings.jsx (AC-11)');
+    'ScheduledTasksPanel must remain the host panel.');
+  assert(/scheduled-tasks\/list/.test(src),
+    'The panel must fetch /api/scheduled-tasks/list to render any registered task (ADR 0019 generalization).');
+  const reg = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
+  assert(reg.tasks.refreshSearchIndex && /Refresh Meilisearch profiles\s*&\s*House PoV scores/.test(reg.tasks.refreshSearchIndex.name || ''),
+    'taskRegistry.json refreshSearchIndex.name must carry the user-facing title (now the source of the card title).');
 });
 
 // ── AC-9: pre-run banner ─────────────────────────────────────

--- a/test/task-queue-bullmq.test.js
+++ b/test/task-queue-bullmq.test.js
@@ -320,16 +320,22 @@ test('R1: runTask.js still accepts the existing query parameters (taskName, pubk
   }
 });
 
-test('R2: scheduled-tasks/index.js still POSTs to /api/run-task (AC-7, AC-8, regression guard)', () => {
+test('R2: scheduled-tasks/index.js schedules via the BullMQ scheduler, not by POSTing /api/run-task (ADR 0019 phase-2 migration)', () => {
   const src = readSafe(SCHEDULED_TASKS);
   assert(src !== null, 'scheduled-tasks/index.js missing — re-baseline this sentinel.');
-  // AC-7: existing UIs work unchanged. The scheduler must continue to hit
-  // /api/run-task as today; the queue layer is invisible to it.
+  // RE-BASELINED for ADR 0019 (task-queue phase 2). The phase-1 R2 guarded the
+  // scheduler's fetch(/api/run-task) path and its own comment said "Migrating the
+  // scheduler off /api/run-task is a phase-2 story." This IS that story: recurring
+  // scheduling now runs through BullMQ Job Schedulers on the per-task queues.
   assert(
-    /\/api\/run-task/.test(src),
-    'R2: scheduled-tasks/index.js no longer references /api/run-task (AC-7/AC-8; regression). The phase-1 ' +
-      'design preserves the contract — scheduler hits /api/run-task; that endpoint enqueues; everything ' +
-      'downstream is invisible to the caller. Migrating the scheduler off /api/run-task is a phase-2 story.'
+    /queue\/scheduler|reconcileSchedulesFromConfig/.test(src),
+    'R2: scheduled-tasks/index.js must drive recurring scheduling through the BullMQ scheduler layer ' +
+      '(queue/scheduler.js, via reconcileSchedulesFromConfig) — ADR 0019 phase-2 migration.'
+  );
+  assert(
+    !/\/api\/run-task/.test(src),
+    'R2: scheduled-tasks/index.js should no longer POST to /api/run-task (ADR 0019). Scheduled fires are added ' +
+      'to the task queue by BullMQ Job Schedulers, not by the scheduler calling the HTTP endpoint.'
   );
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -40,6 +40,7 @@ const entrypointTemplateRendering = require('./entrypoint-template-rendering.tes
 const bullboardAdminAccess = require('./bullboard-admin-access.test.js');
 const adminToolsDashboardPanel = require('./admin-tools-dashboard-panel.test.js');
 const reconciliationIncrementalMode = require('./reconciliation-incremental-mode.test.js');
+const generalizedTaskScheduler = require('./generalized-task-scheduler.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -98,6 +99,9 @@ async function main() {
   console.log('\nreconciliation-incremental-mode suite:');
   const reconciliationIncrementalModeResult = await reconciliationIncrementalMode.run();
 
+  console.log('\ngeneralized-task-scheduler suite:');
+  const generalizedTaskSchedulerResult = await generalizedTaskScheduler.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -152,6 +156,9 @@ async function main() {
   console.log(
     `reconciliation-incremental-mode suite:           ${reconciliationIncrementalModeResult.fail === 0 ? 'PASS' : 'FAIL'} (${reconciliationIncrementalModeResult.pass} passed, ${reconciliationIncrementalModeResult.fail} failed)`
   );
+  console.log(
+    `generalized-task-scheduler suite:                ${generalizedTaskSchedulerResult.fail === 0 ? 'PASS' : 'FAIL'} (${generalizedTaskSchedulerResult.pass} passed, ${generalizedTaskSchedulerResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -171,7 +178,8 @@ async function main() {
     entrypointTemplateRenderingResult.fail === 0 &&
     bullboardAdminAccessResult.fail === 0 &&
     adminToolsDashboardPanelResult.fail === 0 &&
-    reconciliationIncrementalModeResult.fail === 0;
+    reconciliationIncrementalModeResult.fail === 0 &&
+    generalizedTaskSchedulerResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/ui/src/pages/settings/RelaySettings.jsx
+++ b/ui/src/pages/settings/RelaySettings.jsx
@@ -1397,6 +1397,8 @@ function ScheduledTaskCard({ taskId, title, hint, banner = null }) {
   const [enabled, setEnabled] = useState(false);
   const [days, setDays] = useState(0);
   const [hours, setHours] = useState(24);
+  const [minutes, setMinutes] = useState(0);
+  const [cron, setCron] = useState('');
 
   function flash(msg) { setMessage(msg); setTimeout(() => setMessage(null), 4000); }
   function flashError(msg) { setError(msg); setTimeout(() => setError(null), 5000); }
@@ -1408,8 +1410,10 @@ function ScheduledTaskCard({ taskId, title, hint, banner = null }) {
       if (data.success) {
         setStatus(data);
         setEnabled(data.schedule.enabled);
-        setDays(data.schedule.intervalDays);
-        setHours(data.schedule.intervalHours);
+        setDays(data.schedule.intervalDays || 0);
+        setHours(data.schedule.intervalHours || 0);
+        setMinutes(data.schedule.intervalMinutes || 0);
+        setCron(data.schedule.cron || '');
       }
     } catch (err) { flashError(err.message); }
   }, [taskId]);
@@ -1427,9 +1431,10 @@ function ScheduledTaskCard({ taskId, title, hint, banner = null }) {
   }, [fetchStatus, fetchHistory]);
 
   async function handleSave() {
-    const totalHours = (parseInt(days) || 0) * 24 + (parseInt(hours) || 0);
-    if (enabled && totalHours < 1) {
-      flashError('Minimum interval is 1 hour');
+    // No 1-hour floor (ADR 0019). An enabled schedule needs a cron OR a positive interval.
+    const totalMin = (parseInt(days) || 0) * 1440 + (parseInt(hours) || 0) * 60 + (parseInt(minutes) || 0);
+    if (enabled && !cron.trim() && totalMin <= 0) {
+      flashError('Enabled schedule needs a cron expression or a positive interval');
       return;
     }
     setSaving(true);
@@ -1437,7 +1442,7 @@ function ScheduledTaskCard({ taskId, title, hint, banner = null }) {
       const res = await fetch('/api/scheduled-tasks/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ taskId, enabled, intervalDays: parseInt(days) || 0, intervalHours: parseInt(hours) || 0 }),
+        body: JSON.stringify({ taskId, enabled, intervalDays: parseInt(days) || 0, intervalHours: parseInt(hours) || 0, intervalMinutes: parseInt(minutes) || 0, cron: cron.trim() }),
       });
       const data = await res.json();
       if (data.success) {
@@ -1514,10 +1519,27 @@ function ScheduledTaskCard({ taskId, title, hint, banner = null }) {
                 backgroundColor: 'rgba(0,0,0,0.3)', color: '#e0e0e0', fontSize: '0.85rem', textAlign: 'center' }} />
             <span style={{ fontSize: '0.85rem', color: '#aaa' }}>hours</span>
           </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.3rem' }}>
+            <input type="number" min="0" max="59" value={minutes}
+              onChange={e => setMinutes(e.target.value)}
+              style={{ width: '3.5rem', padding: '0.3rem 0.5rem', borderRadius: '4px', border: '1px solid rgba(255,255,255,0.15)',
+                backgroundColor: 'rgba(0,0,0,0.3)', color: '#e0e0e0', fontSize: '0.85rem', textAlign: 'center' }} />
+            <span style={{ fontSize: '0.85rem', color: '#aaa' }}>min</span>
+          </label>
           <button className="btn-small" onClick={handleSave} disabled={saving}
             style={{ padding: '0.3rem 0.75rem', fontSize: '0.85rem' }}>
             {saving ? 'Saving...' : 'Save'}
           </button>
+        </div>
+
+        {/* Cron (overrides the interval when set) */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.75rem', flexWrap: 'wrap' }}>
+          <span style={{ fontSize: '0.85rem', color: '#aaa' }}>or cron:</span>
+          <input type="text" value={cron} placeholder="e.g. 0 4 * * 0"
+            onChange={e => setCron(e.target.value)}
+            style={{ width: '12rem', padding: '0.3rem 0.5rem', borderRadius: '4px', border: '1px solid rgba(255,255,255,0.15)',
+              backgroundColor: 'rgba(0,0,0,0.3)', color: '#e0e0e0', fontSize: '0.85rem' }} />
+          <span style={{ fontSize: '0.75rem', color: '#777' }}>(cron overrides the interval)</span>
         </div>
 
         {/* Timer status */}
@@ -1586,26 +1608,70 @@ function ScheduledTaskCard({ taskId, title, hint, banner = null }) {
   );
 }
 
+// Generalized panel (story #22 / ADR 0019): any registered task is schedulable.
+// Lists currently-scheduled tasks as cards, plus a picker to add any other
+// registry task. Fed by GET /api/scheduled-tasks/list.
 function ScheduledTasksPanel() {
+  const [tasks, setTasks] = useState(null);
+  const [error, setError] = useState(null);
+  const [added, setAdded] = useState([]); // taskIds surfaced via the picker this session
+  const [pick, setPick] = useState('');
+
+  useEffect(() => {
+    fetch('/api/scheduled-tasks/list')
+      .then(r => r.json())
+      .then(d => { if (d.success) setTasks(d.tasks); else setError(d.error || 'Failed to load tasks'); })
+      .catch(e => setError(e.message));
+  }, []);
+
+  if (error) {
+    return <div className="settings-section"><h2>📅 Scheduled Tasks</h2>
+      <div style={{ color: '#ef4444', fontSize: '0.85rem' }}>{error}</div></div>;
+  }
+  if (tasks === null) {
+    return <div className="settings-section"><h2>📅 Scheduled Tasks</h2>
+      <div style={{ color: '#888', padding: '1rem' }}>Loading tasks…</div></div>;
+  }
+
+  const hasSchedule = (s) => s.enabled || s.cron || s.intervalDays || s.intervalHours || s.intervalMinutes;
+  const shown = tasks.filter(t => hasSchedule(t.schedule) || added.includes(t.taskId));
+  const shownIds = new Set(shown.map(t => t.taskId));
+
   return (
     <div className="settings-section">
       <h2>📅 Scheduled Tasks</h2>
       <p className="settings-hint">
-        Configure recurring background tasks. Each task below has its own enable toggle and schedule.
+        Any registered task can be scheduled by interval (down to minutes) or cron. Schedules are durable
+        (survive a restart) and run through the task queue.
       </p>
 
-      <ScheduledTaskCard
-        taskId="updateAllScoresForOwner"
-        title="Update All Scores for Owner"
-        hint={<>Run the full WoT score update pipeline (<code>updateAllScoresForOwner</code>) on a recurring schedule. Includes GrapeRank, PageRank, follower/muter/reporter counts, and kind 30382 event publishing.</>}
-      />
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', marginBottom: '1rem', flexWrap: 'wrap' }}>
+        <span style={{ fontSize: '0.85rem', color: '#aaa' }}>Add a task to schedule:</span>
+        <select value={pick} onChange={e => setPick(e.target.value)}
+          style={{ padding: '0.3rem 0.5rem', borderRadius: '4px', border: '1px solid rgba(255,255,255,0.15)',
+            backgroundColor: 'rgba(0,0,0,0.3)', color: '#e0e0e0', fontSize: '0.85rem' }}>
+          <option value="">— pick a task —</option>
+          {tasks.filter(t => !shownIds.has(t.taskId)).map(t => (
+            <option key={t.taskId} value={t.taskId}>{t.name || t.taskId}</option>
+          ))}
+        </select>
+        <button className="btn-small" disabled={!pick}
+          onClick={() => { setAdded(a => [...a, pick]); setPick(''); }}
+          style={{ padding: '0.3rem 0.75rem', fontSize: '0.85rem' }}>Add</button>
+      </div>
 
-      <ScheduledTaskCard
-        taskId="refreshSearchIndex"
-        title="Refresh Meilisearch profiles & House PoV scores"
-        hint={<>Refresh kind-0 profile data in Meilisearch and, when House PoV is configured, reload House's WoT scores from the latest kind 30382 Trusted Assertions.</>}
-        banner={<HousePovUnconfiguredBanner />}
-      />
+      {shown.length === 0 && (
+        <p style={{ color: '#888', fontSize: '0.85rem' }}>No tasks scheduled yet — use the picker above to add one.</p>
+      )}
+      {shown.map(t => (
+        <ScheduledTaskCard
+          key={t.taskId}
+          taskId={t.taskId}
+          title={t.name || t.taskId}
+          hint={t.resourceClass ? <>Resource class: <code>{t.resourceClass}</code>.</> : null}
+          banner={t.taskId === 'refreshSearchIndex' ? <HousePovUnconfiguredBanner /> : null}
+        />
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Task-queue **phase 2** (story #22 / ADR 0019): replace the in-process `setInterval` scheduler with **BullMQ Job Schedulers** attached to each task's existing per-task queue. Any registered task is now schedulable (not a hardcoded `DEFAULTS` set), by **interval (sub-hour allowed) or cron**, with schedules **persisted in Redis** so they survive a control-panel restart, and every fire **routed through the task queue** (so the `neo4j-heavy` semaphore, per-task concurrency, and BullBoard all apply). `scheduled-tasks.json` stays the source of truth, reconciled into Redis on boot and on each operator update. Unblocks story #21's prod usability (`reconcileRecent` sub-hour, `reconcileAll` weekly).

## Changes

- **`src/manage/taskQueue/queue/scheduler.js`** (new) — reconcile config → Job Schedulers (`upsertJobScheduler`/`removeJobScheduler`), orphan cleanup, kill-switch.
- **`src/api/scheduled-tasks/index.js`** — rewritten: registry-validated tasks, `intervalMinutes` + `cron` schema, boot reconcile, new `GET /api/scheduled-tasks/list`; `setInterval` machinery removed.
- **`bin/control-panel.js`** — boot reconcile (gated on `TASK_QUEUE_ENABLED`, after queue init) replaces `initScheduler`.
- **`src/api/index.js`** — register the `/list` route.
- **`ui/src/pages/settings/RelaySettings.jsx`** — Scheduled Tasks panel generalized over any registry task; minutes + cron inputs; no 1-hour client guard.
- **`OPERATIONS.md`** §13 — scheduler, durability + skip-no-backfill policy, kill-switch, seed-first runbook.
- **Tests** — new `generalized-task-scheduler` suite (12/12); `scheduled-search` + `task-queue-bullmq` sentinels re-baselined for ADR 0019.

## Test plan

- [ ] After merge: deploy-staging.yml runs.
- [ ] Tier 1/2: staging boots clean (proves the `setInterval`→Job-Scheduler boot-reconcile rewrite didn't break startup).
- [ ] Tier 3: `GET /api/scheduled-tasks/list` is registered; UI bundle carries the generalized panel.
- [ ] Tier 4: Scheduled Tasks panel renders (any-task picker, minutes/cron fields).
- [ ] **Operator behavioral gate before prod (needs droplet access):** S3 durability across `supervisorctl restart`, S4 `refreshSearchIndex` continuity, S5 `reconcileRecent`/`reconcileAll` serialize via `neo4j-heavy`, S6 kill-switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)