### PR TITLE
fix: reconcileNetwork author-filter ignored = arg form (story #23)

### DIFF
--- a/src/pipeline/reconciliation/kind10000EventsToMutes.js
+++ b/src/pipeline/reconciliation/kind10000EventsToMutes.js
@@ -13,13 +13,19 @@ const outputPath = path.join(__dirname, 'currentMutesFromStrfry.json');
 // stays bounded to the network instead of every strfry author.
 let filterAuthors = null;
 {
-  const fIdx = process.argv.indexOf('--filterAuthorsFile');
-  if (fIdx !== -1 && process.argv[fIdx + 1]) {
+  // Accept both `--filterAuthorsFile <path>` and `--filterAuthorsFile=<path>`.
+  let filterPath = null;
+  for (let k = 0; k < process.argv.length; k++) {
+    const a = process.argv[k];
+    if (a === '--filterAuthorsFile') { filterPath = process.argv[k + 1]; }
+    else if (a.startsWith('--filterAuthorsFile=')) { filterPath = a.slice('--filterAuthorsFile='.length); }
+  }
+  if (filterPath) {
     filterAuthors = new Set(
-      fs.readFileSync(process.argv[fIdx + 1], 'utf8')
+      fs.readFileSync(filterPath, 'utf8')
         .split('\n').map((s) => s.trim().toLowerCase()).filter(Boolean)
     );
-    console.log(`Filtering output to ${filterAuthors.size} covered authors from ${process.argv[fIdx + 1]}`);
+    console.log(`Filtering output to ${filterAuthors.size} covered authors from ${filterPath}`);
   }
 }
 

--- a/src/pipeline/reconciliation/kind1984EventsToReports.js
+++ b/src/pipeline/reconciliation/kind1984EventsToReports.js
@@ -9,13 +9,19 @@ const readline = require('readline');
 // stays bounded to the network instead of every strfry author.
 let filterAuthors = null;
 {
-  const fIdx = process.argv.indexOf('--filterAuthorsFile');
-  if (fIdx !== -1 && process.argv[fIdx + 1]) {
+  // Accept both `--filterAuthorsFile <path>` and `--filterAuthorsFile=<path>`.
+  let filterPath = null;
+  for (let k = 0; k < process.argv.length; k++) {
+    const a = process.argv[k];
+    if (a === '--filterAuthorsFile') { filterPath = process.argv[k + 1]; }
+    else if (a.startsWith('--filterAuthorsFile=')) { filterPath = a.slice('--filterAuthorsFile='.length); }
+  }
+  if (filterPath) {
     filterAuthors = new Set(
-      fs.readFileSync(process.argv[fIdx + 1], 'utf8')
+      fs.readFileSync(filterPath, 'utf8')
         .split('\n').map((s) => s.trim().toLowerCase()).filter(Boolean)
     );
-    console.log(`Filtering output to ${filterAuthors.size} covered authors from ${process.argv[fIdx + 1]}`);
+    console.log(`Filtering output to ${filterAuthors.size} covered authors from ${filterPath}`);
   }
 }
 

--- a/src/pipeline/reconciliation/kind3EventsToFollows.js
+++ b/src/pipeline/reconciliation/kind3EventsToFollows.js
@@ -13,13 +13,19 @@ const inputPath = path.join(__dirname, 'allKind3EventsStripped.json');
 // fanout bounded to the network instead of every strfry author.
 let filterAuthors = null;
 {
-  const fIdx = process.argv.indexOf('--filterAuthorsFile');
-  if (fIdx !== -1 && process.argv[fIdx + 1]) {
+  // Accept both `--filterAuthorsFile <path>` and `--filterAuthorsFile=<path>`.
+  let filterPath = null;
+  for (let k = 0; k < process.argv.length; k++) {
+    const a = process.argv[k];
+    if (a === '--filterAuthorsFile') { filterPath = process.argv[k + 1]; }
+    else if (a.startsWith('--filterAuthorsFile=')) { filterPath = a.slice('--filterAuthorsFile='.length); }
+  }
+  if (filterPath) {
     filterAuthors = new Set(
-      fs.readFileSync(process.argv[fIdx + 1], 'utf8')
+      fs.readFileSync(filterPath, 'utf8')
         .split('\n').map((s) => s.trim().toLowerCase()).filter(Boolean)
     );
-    console.log(`Filtering output to ${filterAuthors.size} covered authors from ${process.argv[fIdx + 1]}`);
+    console.log(`Filtering output to ${filterAuthors.size} covered authors from ${filterPath}`);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the reconcileNetwork bug caught on staging: the converter `--filterAuthorsFile` was parsed only in the space-separated form, but `reconcileNetwork.sh` passes the `=` form — so the filter was **silently skipped** and `reconcileNetwork` ran as a full `reconcileAll` (extractor streamed ~2.24M raters instead of the verified set). Converters now parse both forms.

## Test plan

- [ ] After merge + deploy: re-trigger `reconcileNetwork` (no args → verified network).
- [ ] Log shows `Network author set: N users` (N << 2.24M, ~verified) and `Filtering output to N covered authors`; extractor `Streamed batch X of M` is over the small set; completes within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)