### PR TITLE
fix: re-include reconcile* in Add Scheduled Entry dropdown

### DIFF
--- a/src/api/scheduled-tasks/index.js
+++ b/src/api/scheduled-tasks/index.js
@@ -228,26 +228,49 @@ async function handleList(req, res) {
   return res.json({ success: true, entries });
 }
 
-/** GET /api/scheduled-tasks/registry-tasks — parameterized-task subset
- *  (tasks with non-empty `arguments` AND frequency !== "continuous"),
- *  for the Add Entry modal's task picker. */
-function handleRegistryTasks(req, res) {
-  const reg = loadRegistry();
+/**
+ * Pure-function filter for the Add Entry modal's task dropdown. Exported
+ * for unit testability — handleRegistryTasks wraps it for the HTTP boundary.
+ *
+ * Rule: any non-continuous task in the registry. ADR 0019's panel already
+ * permitted scheduling any non-continuous task; ADR 0021's amendment
+ * preserves that surface — non-parameterized tasks (e.g., reconcileAll,
+ * reconcileRecent, reconcileAuthor, reconcileNetwork) MUST remain
+ * schedulable from the modal even though they don't take operator-supplied
+ * arguments. The modal handles a no-args task gracefully: argsSchema is
+ * empty so no arg form fields render, and Save is enabled immediately.
+ *
+ * "continuous" excludes the queue-internal daemons (taskQueueManager /
+ * taskScheduler / taskExecutor / systemStateGatherer) which are not
+ * scheduled tasks at all.
+ */
+function filterSchedulableTasks(registry) {
   const tasks = [];
-  for (const [taskId, task] of Object.entries(reg.tasks || {})) {
+  for (const [taskId, task] of Object.entries((registry && registry.tasks) || {})) {
+    if (!task || typeof task !== 'object') continue;
     if (task.frequency === 'continuous') continue;
-    if (!task.arguments || typeof task.arguments !== 'object' || Array.isArray(task.arguments)) continue;
-    if (Object.keys(task.arguments).length === 0) continue;
     tasks.push({
       taskId,
       name: task.name || taskId,
       description: task.description || '',
-      arguments: task.arguments,
+      // Normalize arguments to an object for the modal — `false` / missing
+      // collapses to `{}` so the modal's switch over `Object.entries(args)`
+      // is well-defined for non-parameterized tasks.
+      arguments: (task.arguments && typeof task.arguments === 'object' && !Array.isArray(task.arguments))
+        ? task.arguments
+        : {},
       categories: task.categories || [],
       frequency: task.frequency || 'periodic',
     });
   }
-  return res.json({ success: true, tasks });
+  return tasks;
+}
+
+/** GET /api/scheduled-tasks/registry-tasks — the dropdown source for the
+ *  Add Entry modal. Returns every non-continuous registered task; the modal
+ *  renders an arg form only for tasks whose arguments object is non-empty. */
+function handleRegistryTasks(req, res) {
+  return res.json({ success: true, tasks: filterSchedulableTasks(loadRegistry()) });
 }
 
 /** POST /api/scheduled-tasks/create — new entry. */
@@ -457,4 +480,5 @@ module.exports = {
   readConfig,
   isRegisteredTask,
   getRecentRuns,
+  filterSchedulableTasks,
 };

--- a/test/scheduled-tasks-with-arguments.test.js
+++ b/test/scheduled-tasks-with-arguments.test.js
@@ -563,6 +563,53 @@ test('R2: src/api/scheduled-tasks/index.js still exports reconcileSchedulesFromC
     'src/api/scheduled-tasks/index.js must continue to export reconcileSchedulesFromConfig — bin/control-panel.js invokes it once at startup to reconcile config → BullMQ Job Schedulers (story #22 / ADR 0019 cold-start hook; ADR 0021 keeps the function name and call site, only changes internals to iterate entries).');
 });
 
+test('R3: filterSchedulableTasks includes non-parameterized tasks like reconcile* (regression guard — ADR 0019 surface preserved)', () => {
+  // Background: when ADR 0021's "+ Add Scheduled Entry" modal first shipped,
+  // handleRegistryTasks had an overly strict filter that excluded any task
+  // whose `arguments` block was empty/false — silently dropping all four
+  // reconcile* tasks from the dropdown (story #22 / ADR 0019's motivating
+  // consumers). This test pins the corrected contract: every non-continuous
+  // task in the registry is schedulable, regardless of whether it takes args.
+  const r = safeRequire(SCHEDULER_API_PATH);
+  assert(r.ok, `scheduler API module unavailable: ${r.error}`);
+  assert(typeof r.module.filterSchedulableTasks === 'function',
+    'src/api/scheduled-tasks/index.js must export `filterSchedulableTasks(registry) → tasks[]` for direct testability of the dropdown-population rule.');
+
+  const registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
+  const tasks = r.module.filterSchedulableTasks(registry);
+  const taskIds = new Set(tasks.map(t => t.taskId));
+
+  // Must-include: the four reconcile* tasks (ADR 0019's motivating consumers
+  // — story #22 explicitly designed scheduling around them). All four have
+  // arguments: false in the registry, so any "non-empty arguments required"
+  // filter would silently exclude them — exactly the regression this guards.
+  for (const id of ['reconcileAll', 'reconcileRecent', 'reconcileAuthor', 'reconcileNetwork']) {
+    assert(taskIds.has(id),
+      `filterSchedulableTasks must include "${id}" — it has arguments:false but a real schedule via ADR 0019. Schedulable tasks the modal returned: ${[...taskIds].join(', ').slice(0, 200)}…`);
+  }
+
+  // Sanity-include: a parameterized task (must still work).
+  assert(taskIds.has('processCustomer'),
+    'filterSchedulableTasks must include parameterized tasks like processCustomer too.');
+
+  // Must-exclude: continuous-frequency queue-internal daemons. These are
+  // the queue runtime, not user-schedulable tasks; including them would
+  // let an operator accidentally start/stop daemon-like infrastructure.
+  for (const id of ['taskQueueManager', 'taskScheduler', 'taskExecutor', 'systemStateGatherer']) {
+    if (registry.tasks[id] && registry.tasks[id].frequency === 'continuous') {
+      assert(!taskIds.has(id),
+        `filterSchedulableTasks must EXCLUDE "${id}" (frequency: continuous — queue-internal daemon, not schedulable).`);
+    }
+  }
+
+  // The returned shape must normalize `arguments` to an object so the modal's
+  // `Object.entries(task.arguments || {})` iteration is well-defined for
+  // non-parameterized tasks (where the registry has arguments:false).
+  const reconcileAll = tasks.find(t => t.taskId === 'reconcileAll');
+  assert(reconcileAll && typeof reconcileAll.arguments === 'object' && !Array.isArray(reconcileAll.arguments),
+    'filterSchedulableTasks must normalize `arguments` to an object on the returned task — `false` collapses to `{}` so the modal\'s arg-form iteration is safe.');
+});
+
 // ─────────────────────────────────────────────────────────────────────────
 // Runner
 // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes a regression introduced by [#195](https://github.com/nous-clawds4/tapestry/pull/195) (story #24 / ADR 0021). The "+ Add Scheduled Entry" modal's dropdown was filtering out any task whose `arguments` block is empty/false — silently dropping the four reconcile* tasks (`reconcileAll`, `reconcileRecent`, `reconcileAuthor`, `reconcileNetwork`) that were the motivating consumers of ADR 0019's generalized scheduler. Operator reported they could no longer schedule `reconcileNetwork` from the panel.

Root cause: `handleRegistryTasks` interpreted story #24 AC-1 ("every parameterized task is schedulable") as a ceiling rather than a floor. Fixed by extracting `filterSchedulableTasks(registry)` as a pure function and dropping the non-empty-arguments filter — keeping only the `frequency !== "continuous"` rule that still correctly excludes the queue-internal daemons.

The modal already handles no-args tasks gracefully (no fields render, Save is enabled immediately), and the scheduler / entryResolver / processor all pack `{taskName, entryId, timeoutMs}` regardless of args, so non-parameterized tasks fire correctly through the per-entry path.

## Changes

- `src/api/scheduled-tasks/index.js` — extract `filterSchedulableTasks(registry)` as a pure function; drop the "must have non-empty arguments" filter; normalize the returned `arguments` to `{}` for non-parameterized tasks so the modal's `Object.entries` iteration is well-defined. Exported for testability.
- `test/scheduled-tasks-with-arguments.test.js` — add regression test R3 that calls `filterSchedulableTasks` against the live registry and asserts (a) all four reconcile* tasks appear, (b) `processCustomer` still appears, (c) the queue-internal daemons (`taskQueueManager` / `taskScheduler` / `taskExecutor` / `systemStateGatherer`) are excluded, (d) the returned `arguments` is always an object.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs cleanly.
- [ ] Smoke test on `staging.brainstorm.world`:
  - `GET /api/scheduled-tasks/registry-tasks` includes `reconcileAll`, `reconcileRecent`, `reconcileAuthor`, `reconcileNetwork` in `tasks[]`.
  - `GET /api/scheduled-tasks/registry-tasks` still includes the parameterized tasks (`processCustomer` and family).
  - `GET /api/scheduled-tasks/registry-tasks` still excludes `taskQueueManager` / `taskScheduler` / `taskExecutor` / `systemStateGatherer`.
- [ ] Operator can now open "+ Add Scheduled Entry" on `/tapestry/settings/relays` Scheduled Tasks tab and see `reconcileNetwork` (etc.) in the task dropdown.
- [ ] Tier 5 regression: scheduling a parameterized task (e.g., `processCustomer`) still works — modal renders the customer picker, Save still blocks on missing required arg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)