### PR TITLE
fix: Recent Runs deduped to one row per fire (was 2× per fire)

### DIFF
--- a/src/api/scheduled-tasks/index.js
+++ b/src/api/scheduled-tasks/index.js
@@ -99,39 +99,69 @@ async function reconcileSchedulesFromConfig() {
 //    entries that share a taskId share this surface, per ADR 0021's
 //    documented constraint) ──
 
+/**
+ * Group raw events.jsonl lines into one logical "run" per session, where a
+ * session is `<pid>_<YYYY-MM-DD>`. Pure function — exported for testability.
+ *
+ * Why session-dedup is necessary: the structured-logging utility writes
+ * TASK_START + TASK_END events from MULTIPLE layers per fire — the
+ * launchChildTask.sh wrapper AND the task script's own emit each write a
+ * record. Both share the same PID. Without dedup, `getRecentRuns` returns
+ * 2× rows per fire — exactly the bug operator reported (panel showing
+ * `processCustomer` ran twice at each scheduled tick when it only ran once).
+ *
+ * Matches the legacy task explorer's contract
+ * (src/api/taskExplorer/getTaskExplorerSingleTaskData), which groups by
+ * sessionId = `<pid>_<YYYY-MM-DD>` and reports one row per session.
+ *
+ * Returns an array of `{ startedAt, endedAt, durationMs, status, exitCode }`
+ * sorted by startedAt descending. Each session uses the earliest TASK_START
+ * timestamp and the latest TASK_END timestamp.
+ */
+function groupEventsIntoSessions(taskName, lines) {
+  const sessions = new Map(); // sessionKey → { startedAt, endedAt, durationMs, status, exitCode }
+  for (const line of lines) {
+    let rec;
+    try { rec = JSON.parse(line); } catch { continue; }
+    if (!rec || rec.taskName !== taskName) continue;
+    if (rec.eventType !== 'TASK_START' && rec.eventType !== 'TASK_END') continue;
+
+    const pid = (rec.pid !== undefined && rec.pid !== null) ? String(rec.pid) : 'unknown';
+    const date = (rec.timestamp || '').slice(0, 10); // YYYY-MM-DD
+    const key = `${pid}_${date}`;
+
+    let s = sessions.get(key);
+    if (!s) {
+      s = { startedAt: null, endedAt: null, durationMs: null, status: 'running', exitCode: null };
+      sessions.set(key, s);
+    }
+
+    if (rec.eventType === 'TASK_START') {
+      // Earliest TASK_START within the session.
+      if (!s.startedAt || (rec.timestamp && rec.timestamp < s.startedAt)) s.startedAt = rec.timestamp;
+    } else {
+      // Latest TASK_END within the session.
+      if (!s.endedAt || (rec.timestamp && rec.timestamp > s.endedAt)) s.endedAt = rec.timestamp;
+      s.status = rec.failure ? 'failed' : 'success';
+      if (rec.exitCode !== undefined) s.exitCode = rec.exitCode;
+      if (rec.duration !== undefined) s.durationMs = rec.duration;
+    }
+  }
+
+  return Array.from(sessions.values())
+    .filter(s => s.startedAt) // drop sessions that only saw TASK_END (orphan / pre-process)
+    .sort((a, b) => (b.startedAt || '').localeCompare(a.startedAt || ''));
+}
+
 function getRecentRuns(taskName, maxRuns = 5) {
-  const runs = [];
   try {
-    if (!fs.existsSync(EVENTS_PATH)) return runs;
+    if (!fs.existsSync(EVENTS_PATH)) return [];
     const lines = fs.readFileSync(EVENTS_PATH, 'utf8').trim().split('\n').filter(Boolean);
-    const starts = [];
-    const ends = [];
-    for (const line of lines) {
-      try {
-        const rec = JSON.parse(line);
-        if (rec.taskName !== taskName) continue;
-        if (rec.eventType === 'TASK_START') starts.push(rec);
-        else if (rec.eventType === 'TASK_END') ends.push(rec);
-      } catch { /* skip bad lines */ }
-    }
-    for (let i = starts.length - 1; i >= 0 && runs.length < maxRuns; i--) {
-      const start = starts[i];
-      let matchedEnd = null;
-      for (const end of ends) {
-        if (new Date(end.timestamp) > new Date(start.timestamp)) { matchedEnd = end; break; }
-      }
-      runs.push({
-        startedAt: start.timestamp,
-        endedAt: matchedEnd ? matchedEnd.timestamp : null,
-        durationMs: matchedEnd ? matchedEnd.duration : null,
-        status: matchedEnd ? (matchedEnd.failure ? 'failed' : 'success') : 'running',
-        exitCode: matchedEnd ? matchedEnd.exitCode : null,
-      });
-    }
+    return groupEventsIntoSessions(taskName, lines).slice(0, maxRuns);
   } catch (e) {
     console.error('[scheduled-tasks] Error reading history:', e.message);
+    return [];
   }
-  return runs;
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -480,5 +510,6 @@ module.exports = {
   readConfig,
   isRegisteredTask,
   getRecentRuns,
+  groupEventsIntoSessions,
   filterSchedulableTasks,
 };

--- a/test/scheduled-tasks-with-arguments.test.js
+++ b/test/scheduled-tasks-with-arguments.test.js
@@ -563,6 +563,80 @@ test('R2: src/api/scheduled-tasks/index.js still exports reconcileSchedulesFromC
     'src/api/scheduled-tasks/index.js must continue to export reconcileSchedulesFromConfig — bin/control-panel.js invokes it once at startup to reconcile config → BullMQ Job Schedulers (story #22 / ADR 0019 cold-start hook; ADR 0021 keeps the function name and call site, only changes internals to iterate entries).');
 });
 
+test('R4: groupEventsIntoSessions deduplicates multi-emit TASK_START/TASK_END records by <pid>_<date> (regression — Recent Runs was showing 2 rows per fire)', () => {
+  // Background: structured-logging utility writes TASK_START + TASK_END from
+  // BOTH layers per fire — the launchChildTask.sh wrapper AND the task
+  // script's own emit each write a record. Both share the same PID. The naive
+  // initial getRecentRuns counted raw records and showed 2× rows per fire on
+  // the panel's Recent Runs table while the legacy explorer (which groups by
+  // <pid>_<date> sessions) correctly showed 1.
+  //
+  // This test pins the corrected contract: each (pid, date) pair is one
+  // logical run regardless of how many wrapper layers emitted events for it.
+  const r = safeRequire(SCHEDULER_API_PATH);
+  assert(r.ok, `scheduler API module unavailable: ${r.error}`);
+  assert(typeof r.module.groupEventsIntoSessions === 'function',
+    'src/api/scheduled-tasks/index.js must export `groupEventsIntoSessions(taskName, lines) → runs[]` for direct unit testing of the dedup rule.');
+
+  // Fixture: two simultaneous fires (pid 35608 at 11:12, pid 26031 at 08:12),
+  // each emitting the launchChildTask wrapper's TASK_START + TASK_END AND the
+  // script's TASK_START + TASK_END. That's 4 lines per fire → 8 raw records.
+  // Expected result: 2 logical sessions (one per pid).
+  const lines = [
+    // pid 35608 session — wrapper emit
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_START', pid: 35608, timestamp: '2026-05-24T11:12:58+00:00', target: '' }),
+    // pid 35608 session — script emit (same pid, same fire)
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_START', pid: 35608, timestamp: '2026-05-24T11:12:58+00:00', target: '<pubkey>' }),
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_END',   pid: 35608, timestamp: '2026-05-24T12:28:05+00:00', target: '<pubkey>', exitCode: 0, duration: 4507000 }),
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_END',   pid: 35608, timestamp: '2026-05-24T12:28:05+00:00', target: '', exitCode: 0 }),
+    // pid 26031 session — separate fire
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_START', pid: 26031, timestamp: '2026-05-24T08:12:58+00:00' }),
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_START', pid: 26031, timestamp: '2026-05-24T08:12:58+00:00' }),
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_END',   pid: 26031, timestamp: '2026-05-24T09:33:03+00:00', exitCode: 0 }),
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_END',   pid: 26031, timestamp: '2026-05-24T09:33:03+00:00', exitCode: 0 }),
+    // unrelated task on same pid — must NOT bleed into our results
+    JSON.stringify({ taskName: 'someOtherTask', eventType: 'TASK_START', pid: 35608, timestamp: '2026-05-24T13:00:00+00:00' }),
+    // malformed line — must be skipped, not throw
+    'this is not json',
+  ];
+
+  const sessions = r.module.groupEventsIntoSessions('processCustomer', lines);
+
+  assert(Array.isArray(sessions),
+    'groupEventsIntoSessions must return an array.');
+  assert(sessions.length === 2,
+    `Expected 2 deduped sessions (one per pid), got ${sessions.length}. Multi-emit TASK_START/TASK_END records were NOT collapsed into sessions — getRecentRuns will return doubled rows on the panel.`);
+
+  // Most recent first.
+  assert(sessions[0].startedAt === '2026-05-24T11:12:58+00:00',
+    `Sessions must be sorted by startedAt descending; got first session startedAt: ${sessions[0].startedAt}`);
+  assert(sessions[0].endedAt === '2026-05-24T12:28:05+00:00',
+    `Latest TASK_END must be picked as endedAt; got: ${sessions[0].endedAt}`);
+  assert(sessions[0].status === 'success',
+    `Session status must reflect the TASK_END outcome (failure flag); got: ${sessions[0].status}`);
+  assert(sessions[0].durationMs === 4507000,
+    `Session durationMs must be picked from the TASK_END record; got: ${sessions[0].durationMs}`);
+  assert(sessions[1].startedAt === '2026-05-24T08:12:58+00:00',
+    `Second session startedAt mismatch; got: ${sessions[1].startedAt}`);
+
+  // Sanity: failure flag honored.
+  const failureLines = [
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_START', pid: 99999, timestamp: '2026-05-24T15:00:00+00:00' }),
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_END',   pid: 99999, timestamp: '2026-05-24T15:01:00+00:00', failure: true, exitCode: 1 }),
+  ];
+  const failureSessions = r.module.groupEventsIntoSessions('processCustomer', failureLines);
+  assert(failureSessions.length === 1 && failureSessions[0].status === 'failed' && failureSessions[0].exitCode === 1,
+    `TASK_END with failure:true must produce status:'failed' + exitCode preserved; got: ${JSON.stringify(failureSessions)}`);
+
+  // Sanity: still-running session (TASK_START only) keeps status:'running'.
+  const runningLines = [
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_START', pid: 77777, timestamp: '2026-05-24T16:00:00+00:00' }),
+  ];
+  const runningSessions = r.module.groupEventsIntoSessions('processCustomer', runningLines);
+  assert(runningSessions.length === 1 && runningSessions[0].status === 'running' && runningSessions[0].endedAt === null,
+    `TASK_START without a paired TASK_END must produce status:'running' + endedAt:null; got: ${JSON.stringify(runningSessions)}`);
+});
+
 test('R3: filterSchedulableTasks includes non-parameterized tasks like reconcile* (regression guard — ADR 0019 surface preserved)', () => {
   // Background: when ADR 0021's "+ Add Scheduled Entry" modal first shipped,
   // handleRegistryTasks had an overly strict filter that excluded any task


### PR DESCRIPTION
## Summary

Fixes a Recent Runs display bug operator reported on staging. Scheduling `processCustomer` every 3h showed the task fired TWICE at each scheduled tick (1:12 AM, 4:12 AM, 7:12 AM) in the new panel's history table, while the legacy task explorer page correctly showed one fire per tick.

Root cause: `events.jsonl` actually contains 2 TASK_START + 2 TASK_END records per fire — the structured-logging utility emits from BOTH `launchChildTask.sh`'s wrapper (target='', snake_case metadata) AND the task script's own emit (target=<pubkey>, camelCase metadata). Both share the same PID. The legacy task-explorer (`src/api/taskExplorer/getTaskExplorerSingleTaskData`) groups events into sessions by `<pid>_<date>` and correctly reports one logical run per session; my naive `getRecentRuns` counted raw records and surfaced every duplicate as a separate Recent Runs row.

Direct cause verified on staging: probing `/api/scheduled-tasks/history?entryId=...` for the `processCustomer` entry returned the most-recent fires duplicated; counting raw TASK_START events in the legacy explorer's executionSessions confirmed 2 TASK_STARTs per session, 4 sessions, all with the same PID. Fixed `getRecentRuns` matches the legacy explorer's session-grouping contract.

## Changes

- `src/api/scheduled-tasks/index.js` — extract `groupEventsIntoSessions(taskName, lines)` as a pure function. Groups events into one logical session per `<pid>_<YYYY-MM-DD>`, earliest TASK_START + latest TASK_END within each session. Returns sessions sorted by startedAt descending. Same `{startedAt, endedAt, durationMs, status, exitCode}` row shape as before — no caller changes needed. `getRecentRuns(taskName, maxRuns)` now wraps the helper and slices to `maxRuns`. Empty file / read errors still return `[]`.
- `test/scheduled-tasks-with-arguments.test.js` — regression test R4 added against a fixture `events.jsonl` (8 raw records = 4 per fire × 2 fires from the two wrapper layers + an unrelated task on the same PID + a malformed line). Asserts exactly 2 deduped sessions, sorted descending, with the right status/duration/exitCode flowing through. Also covers failure-flag honoring and still-running (TASK_START-only) status.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs cleanly.
- [ ] Smoke test on `staging.brainstorm.world`:
  - `GET /api/scheduled-tasks/history?entryId=entry-b0bf379a-1ae2-4691-8830-8e5eb3dd6686` returns the processCustomer fires with **one row per fire** (was: two rows per fire).
  - Number of `runs[]` returned should equal the legacy explorer's `executionSessions.length` for the same task.
- [ ] Operator can refresh the panel at `https://staging.brainstorm.world/tapestry/settings/relays` → Scheduled Tasks tab → the processCustomer entry's Recent Runs table now shows one row per scheduled fire (1:12, 4:12, 7:12 in operator's local timezone — not duplicated).
- [ ] Tier 5 regression: the other entries (`legacy:updateAllScoresForOwner`, `legacy:refreshSearchIndex`, `legacy:reconcileAll`) still show their Recent Runs correctly (one row per fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)