### PR TITLE
Promote staging → main: Recent Runs session dedup (PR #199)

### DIFF
--- a/src/api/scheduled-tasks/index.js
+++ b/src/api/scheduled-tasks/index.js
@@ -99,39 +99,69 @@ async function reconcileSchedulesFromConfig() {
 //    entries that share a taskId share this surface, per ADR 0021's
 //    documented constraint) ──
 
+/**
+ * Group raw events.jsonl lines into one logical "run" per session, where a
+ * session is `<pid>_<YYYY-MM-DD>`. Pure function — exported for testability.
+ *
+ * Why session-dedup is necessary: the structured-logging utility writes
+ * TASK_START + TASK_END events from MULTIPLE layers per fire — the
+ * launchChildTask.sh wrapper AND the task script's own emit each write a
+ * record. Both share the same PID. Without dedup, `getRecentRuns` returns
+ * 2× rows per fire — exactly the bug operator reported (panel showing
+ * `processCustomer` ran twice at each scheduled tick when it only ran once).
+ *
+ * Matches the legacy task explorer's contract
+ * (src/api/taskExplorer/getTaskExplorerSingleTaskData), which groups by
+ * sessionId = `<pid>_<YYYY-MM-DD>` and reports one row per session.
+ *
+ * Returns an array of `{ startedAt, endedAt, durationMs, status, exitCode }`
+ * sorted by startedAt descending. Each session uses the earliest TASK_START
+ * timestamp and the latest TASK_END timestamp.
+ */
+function groupEventsIntoSessions(taskName, lines) {
+  const sessions = new Map(); // sessionKey → { startedAt, endedAt, durationMs, status, exitCode }
+  for (const line of lines) {
+    let rec;
+    try { rec = JSON.parse(line); } catch { continue; }
+    if (!rec || rec.taskName !== taskName) continue;
+    if (rec.eventType !== 'TASK_START' && rec.eventType !== 'TASK_END') continue;
+
+    const pid = (rec.pid !== undefined && rec.pid !== null) ? String(rec.pid) : 'unknown';
+    const date = (rec.timestamp || '').slice(0, 10); // YYYY-MM-DD
+    const key = `${pid}_${date}`;
+
+    let s = sessions.get(key);
+    if (!s) {
+      s = { startedAt: null, endedAt: null, durationMs: null, status: 'running', exitCode: null };
+      sessions.set(key, s);
+    }
+
+    if (rec.eventType === 'TASK_START') {
+      // Earliest TASK_START within the session.
+      if (!s.startedAt || (rec.timestamp && rec.timestamp < s.startedAt)) s.startedAt = rec.timestamp;
+    } else {
+      // Latest TASK_END within the session.
+      if (!s.endedAt || (rec.timestamp && rec.timestamp > s.endedAt)) s.endedAt = rec.timestamp;
+      s.status = rec.failure ? 'failed' : 'success';
+      if (rec.exitCode !== undefined) s.exitCode = rec.exitCode;
+      if (rec.duration !== undefined) s.durationMs = rec.duration;
+    }
+  }
+
+  return Array.from(sessions.values())
+    .filter(s => s.startedAt) // drop sessions that only saw TASK_END (orphan / pre-process)
+    .sort((a, b) => (b.startedAt || '').localeCompare(a.startedAt || ''));
+}
+
 function getRecentRuns(taskName, maxRuns = 5) {
-  const runs = [];
   try {
-    if (!fs.existsSync(EVENTS_PATH)) return runs;
+    if (!fs.existsSync(EVENTS_PATH)) return [];
     const lines = fs.readFileSync(EVENTS_PATH, 'utf8').trim().split('\n').filter(Boolean);
-    const starts = [];
-    const ends = [];
-    for (const line of lines) {
-      try {
-        const rec = JSON.parse(line);
-        if (rec.taskName !== taskName) continue;
-        if (rec.eventType === 'TASK_START') starts.push(rec);
-        else if (rec.eventType === 'TASK_END') ends.push(rec);
-      } catch { /* skip bad lines */ }
-    }
-    for (let i = starts.length - 1; i >= 0 && runs.length < maxRuns; i--) {
-      const start = starts[i];
-      let matchedEnd = null;
-      for (const end of ends) {
-        if (new Date(end.timestamp) > new Date(start.timestamp)) { matchedEnd = end; break; }
-      }
-      runs.push({
-        startedAt: start.timestamp,
-        endedAt: matchedEnd ? matchedEnd.timestamp : null,
-        durationMs: matchedEnd ? matchedEnd.duration : null,
-        status: matchedEnd ? (matchedEnd.failure ? 'failed' : 'success') : 'running',
-        exitCode: matchedEnd ? matchedEnd.exitCode : null,
-      });
-    }
+    return groupEventsIntoSessions(taskName, lines).slice(0, maxRuns);
   } catch (e) {
     console.error('[scheduled-tasks] Error reading history:', e.message);
+    return [];
   }
-  return runs;
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -480,5 +510,6 @@ module.exports = {
   readConfig,
   isRegisteredTask,
   getRecentRuns,
+  groupEventsIntoSessions,
   filterSchedulableTasks,
 };

--- a/test/scheduled-tasks-with-arguments.test.js
+++ b/test/scheduled-tasks-with-arguments.test.js
@@ -563,6 +563,80 @@ test('R2: src/api/scheduled-tasks/index.js still exports reconcileSchedulesFromC
     'src/api/scheduled-tasks/index.js must continue to export reconcileSchedulesFromConfig — bin/control-panel.js invokes it once at startup to reconcile config → BullMQ Job Schedulers (story #22 / ADR 0019 cold-start hook; ADR 0021 keeps the function name and call site, only changes internals to iterate entries).');
 });
 
+test('R4: groupEventsIntoSessions deduplicates multi-emit TASK_START/TASK_END records by <pid>_<date> (regression — Recent Runs was showing 2 rows per fire)', () => {
+  // Background: structured-logging utility writes TASK_START + TASK_END from
+  // BOTH layers per fire — the launchChildTask.sh wrapper AND the task
+  // script's own emit each write a record. Both share the same PID. The naive
+  // initial getRecentRuns counted raw records and showed 2× rows per fire on
+  // the panel's Recent Runs table while the legacy explorer (which groups by
+  // <pid>_<date> sessions) correctly showed 1.
+  //
+  // This test pins the corrected contract: each (pid, date) pair is one
+  // logical run regardless of how many wrapper layers emitted events for it.
+  const r = safeRequire(SCHEDULER_API_PATH);
+  assert(r.ok, `scheduler API module unavailable: ${r.error}`);
+  assert(typeof r.module.groupEventsIntoSessions === 'function',
+    'src/api/scheduled-tasks/index.js must export `groupEventsIntoSessions(taskName, lines) → runs[]` for direct unit testing of the dedup rule.');
+
+  // Fixture: two simultaneous fires (pid 35608 at 11:12, pid 26031 at 08:12),
+  // each emitting the launchChildTask wrapper's TASK_START + TASK_END AND the
+  // script's TASK_START + TASK_END. That's 4 lines per fire → 8 raw records.
+  // Expected result: 2 logical sessions (one per pid).
+  const lines = [
+    // pid 35608 session — wrapper emit
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_START', pid: 35608, timestamp: '2026-05-24T11:12:58+00:00', target: '' }),
+    // pid 35608 session — script emit (same pid, same fire)
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_START', pid: 35608, timestamp: '2026-05-24T11:12:58+00:00', target: '<pubkey>' }),
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_END',   pid: 35608, timestamp: '2026-05-24T12:28:05+00:00', target: '<pubkey>', exitCode: 0, duration: 4507000 }),
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_END',   pid: 35608, timestamp: '2026-05-24T12:28:05+00:00', target: '', exitCode: 0 }),
+    // pid 26031 session — separate fire
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_START', pid: 26031, timestamp: '2026-05-24T08:12:58+00:00' }),
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_START', pid: 26031, timestamp: '2026-05-24T08:12:58+00:00' }),
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_END',   pid: 26031, timestamp: '2026-05-24T09:33:03+00:00', exitCode: 0 }),
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_END',   pid: 26031, timestamp: '2026-05-24T09:33:03+00:00', exitCode: 0 }),
+    // unrelated task on same pid — must NOT bleed into our results
+    JSON.stringify({ taskName: 'someOtherTask', eventType: 'TASK_START', pid: 35608, timestamp: '2026-05-24T13:00:00+00:00' }),
+    // malformed line — must be skipped, not throw
+    'this is not json',
+  ];
+
+  const sessions = r.module.groupEventsIntoSessions('processCustomer', lines);
+
+  assert(Array.isArray(sessions),
+    'groupEventsIntoSessions must return an array.');
+  assert(sessions.length === 2,
+    `Expected 2 deduped sessions (one per pid), got ${sessions.length}. Multi-emit TASK_START/TASK_END records were NOT collapsed into sessions — getRecentRuns will return doubled rows on the panel.`);
+
+  // Most recent first.
+  assert(sessions[0].startedAt === '2026-05-24T11:12:58+00:00',
+    `Sessions must be sorted by startedAt descending; got first session startedAt: ${sessions[0].startedAt}`);
+  assert(sessions[0].endedAt === '2026-05-24T12:28:05+00:00',
+    `Latest TASK_END must be picked as endedAt; got: ${sessions[0].endedAt}`);
+  assert(sessions[0].status === 'success',
+    `Session status must reflect the TASK_END outcome (failure flag); got: ${sessions[0].status}`);
+  assert(sessions[0].durationMs === 4507000,
+    `Session durationMs must be picked from the TASK_END record; got: ${sessions[0].durationMs}`);
+  assert(sessions[1].startedAt === '2026-05-24T08:12:58+00:00',
+    `Second session startedAt mismatch; got: ${sessions[1].startedAt}`);
+
+  // Sanity: failure flag honored.
+  const failureLines = [
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_START', pid: 99999, timestamp: '2026-05-24T15:00:00+00:00' }),
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_END',   pid: 99999, timestamp: '2026-05-24T15:01:00+00:00', failure: true, exitCode: 1 }),
+  ];
+  const failureSessions = r.module.groupEventsIntoSessions('processCustomer', failureLines);
+  assert(failureSessions.length === 1 && failureSessions[0].status === 'failed' && failureSessions[0].exitCode === 1,
+    `TASK_END with failure:true must produce status:'failed' + exitCode preserved; got: ${JSON.stringify(failureSessions)}`);
+
+  // Sanity: still-running session (TASK_START only) keeps status:'running'.
+  const runningLines = [
+    JSON.stringify({ taskName: 'processCustomer', eventType: 'TASK_START', pid: 77777, timestamp: '2026-05-24T16:00:00+00:00' }),
+  ];
+  const runningSessions = r.module.groupEventsIntoSessions('processCustomer', runningLines);
+  assert(runningSessions.length === 1 && runningSessions[0].status === 'running' && runningSessions[0].endedAt === null,
+    `TASK_START without a paired TASK_END must produce status:'running' + endedAt:null; got: ${JSON.stringify(runningSessions)}`);
+});
+
 test('R3: filterSchedulableTasks includes non-parameterized tasks like reconcile* (regression guard — ADR 0019 surface preserved)', () => {
   // Background: when ADR 0021's "+ Add Scheduled Entry" modal first shipped,
   // handleRegistryTasks had an overly strict filter that excluded any task


### PR DESCRIPTION
## Summary

Promotes a Recent-Runs display fix from PR #199 to production. Operator reported on staging that scheduling `processCustomer` every 3h showed each fire **twice** in the new panel's Recent Runs table (1:12, 4:12, 7:12 each appearing as two rows), while the legacy task explorer correctly showed one fire per tick.

## Bundled

- **#199** — `fix: Recent Runs deduped to one row per fire (was 2× per fire)`. Extracts `groupEventsIntoSessions(taskName, lines)` as a pure helper that groups raw events.jsonl records by `<pid>_<YYYY-MM-DD>` session — matching the legacy `getTaskExplorerSingleTaskData` contract. `getRecentRuns` now wraps the helper; same return shape, no caller changes. Regression test R4 added with a fixture events.jsonl that simulates the 2-emitter pattern.

## Net production impact

**Display-only fix.** No data migration. No semantic behavior change in the scheduler or queue layers. The panel's Recent Runs table will now show one row per fire instead of two — bringing it into agreement with the legacy task explorer's view of the same data. Other entries (`legacy:updateAllScoresForOwner`, `legacy:refreshSearchIndex`, `legacy:reconcileAll`) get the same fix applied since they all consume the same helper.

## Root cause (for the record)

`events.jsonl` actually contains 2 TASK_START + 2 TASK_END records per fire — the structured-logging utility emits from BOTH `launchChildTask.sh`'s wrapper AND the task script's own emit. Both share the same PID. The legacy task explorer groups events into sessions by `<pid>_<date>` and reports one row per session; my naive `getRecentRuns` counted raw records and surfaced every duplicate.

## Verification trail

- **Staging deploy:** [#26362964066](https://github.com/nous-clawds4/tapestry/actions/runs/26362964066) — ✓ success in 1m23s.
- **Stability poll on staging:** stable after 3×2s polls; 5s settle clean.
- **Tier 3 PR-specific verification on staging:**
  - Before fix: `GET /api/scheduled-tasks/history` for the `processCustomer` entry returned 5 runs with two duplicated `startedAt` timestamps (11:12 ×2, 8:12 ×2, 5:12 ×1).
  - After fix: returns **4 runs, 0 duplicate startedAt values** — `2026-05-24T{02,05,08,11}:12:* + 00:00`. Each pairs with the latest TASK_END in the session.
  - Legacy explorer ground truth on staging: `totalRuns: 4`, `successfulRuns: 4`, `executionSessions: 4` → my endpoint now matches exactly.
- **Test gate:** 37/37 in scheduled-tasks-with-arguments suite (R4 added); all 20 sibling suites still pass (194 total tests).

## Test plan

- [ ] After merge: `deploy-brainstorm.yml` runs to completion.
- [ ] Stability poll on `brainstorm.world` reaches streak 3.
- [ ] `GET /api/scheduled-tasks/history?entryId=<any prod entryId>` returns one row per fire (no duplicate `startedAt` timestamps).
- [ ] `GET /api/scheduled-tasks/history` `runs.length` matches the legacy explorer's `executionSessions.length` for the same taskName.
- [ ] Tier 5 regression: `/api/scheduled-tasks/list` + `/api/scheduled-tasks/registry-tasks` + `/api/get-customers` still 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)