### PR TITLE
fix: backfill 20 missing neo4j-heavy registry tags

### DIFF
--- a/src/manage/taskQueue/taskRegistry.json
+++ b/src/manage/taskQueue/taskRegistry.json
@@ -185,6 +185,7 @@
     },
 
     "neo4jConstraintsAndIndexes": {
+      "resourceClass": "neo4j-heavy",
       "name": "Neo4j Constraints and Indexes",
       "categories": ["maintenance"],
       "description": "Sets up database constraints and indexes",
@@ -460,6 +461,7 @@
     },
 
     "processAllActiveCustomers": {
+      "resourceClass": "neo4j-heavy",
       "name": "Process All Active Customers",
       "categories": ["orchestrator", "customer"],
       "description": "Processes all active customers by calling processCustomer.sh for each",
@@ -491,6 +493,7 @@
     },
 
     "processCustomer": {
+      "resourceClass": "neo4j-heavy",
       "name": "Process Customer",
       "categories": ["customer"],
       "description": "Complete processing pipeline for a single customer",
@@ -525,6 +528,7 @@
     },
 
     "prepareNeo4jForCustomerData": {
+      "resourceClass": "neo4j-heavy",
       "name": "Prepare Neo4j For Customer Data",
       "categories": ["customer", "maintenance"],
       "description": "Preliminary steps for customer data processing, common to all customers",
@@ -547,6 +551,7 @@
     },
 
     "updateAllScoresForOwner": {
+      "resourceClass": "neo4j-heavy",
       "name": "Update All Scores For Owner",
       "categories": ["owner", "algorithms"],
       "description": "Updates all trust scores for the owner",
@@ -595,6 +600,7 @@
     },
 
     "updateAllScoresForSingleCustomer": {
+      "resourceClass": "neo4j-heavy",
       "name": "Update All Scores For Single Customer",
       "categories": ["customer", "algorithms"],
       "description": "Updates all trust scores for a single customer",
@@ -657,6 +663,7 @@
     },
 
     "calculateCustomerGrapeRank": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Customer GrapeRank",
       "categories": ["algorithms", "customer"],
       "description": "Calculates personalized GrapeRank scores for a specific customer",
@@ -708,6 +715,7 @@
     },
 
     "calculateCustomerPageRank": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Customer PageRank",
       "categories": ["algorithms", "customer"],
       "description": "Calculates personalized PageRank scores for a customer",
@@ -753,6 +761,7 @@
     },
 
     "calculateCustomerHops": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Customer Hops",
       "categories": ["algorithms", "customer"],
       "description": "Calculates hop distances for a specific customer",
@@ -775,6 +784,7 @@
     },
 
     "processCustomerFollowsMutesReports": {
+      "resourceClass": "neo4j-heavy",
       "name": "Process Customer Follows Mutes Reports",
       "categories": ["algorithms", "customer"],
       "description": "Processes follows, mutes, and reports data for a specific customer",
@@ -805,6 +815,7 @@
     },
 
     "calculateVerifiedFollowerCounts": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Verified Follower Counts",
       "categories": ["algorithms", "customer"],
       "description": "Calculates verified follower counts for a specific customer",
@@ -828,6 +839,7 @@
     },
 
     "calculateVerifiedMuterCounts": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Verified Muter Counts",
       "categories": ["algorithms", "customer"],
       "description": "Calculates verified muter counts for a specific customer",
@@ -851,6 +863,7 @@
     },
 
     "calculateVerifiedReporterCounts": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Verified Reporter Counts",
       "categories": ["algorithms", "customer"],
       "description": "Calculates verified reporter counts for a specific customer",
@@ -874,6 +887,7 @@
     },
 
     "calculateFollowerInputs": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Follower Inputs",
       "categories": ["algorithms", "customer"],
       "description": "Calculates follower inputs for a specific customer",
@@ -897,6 +911,7 @@
     },
 
     "calculateMuterInputs": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Muter Inputs",
       "categories": ["algorithms", "customer"],
       "description": "Calculates muter inputs for a specific customer",
@@ -920,6 +935,7 @@
     },
 
     "calculateReporterInputs": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Reporter Inputs",
       "categories": ["algorithms", "customer"],
       "description": "Calculates reporter inputs for a specific customer",
@@ -943,6 +959,7 @@
     },
 
     "processOwnerFollowsMutesReports": {
+      "resourceClass": "neo4j-heavy",
       "name": "Process Owner Follows Mutes Reports",
       "categories": ["algorithms", "owner"],
       "description": "Processes follows, mutes, and reports data for the instance owner",
@@ -963,6 +980,7 @@
     },
 
     "calculateReportScores": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Report Scores",
       "categories": ["algorithms", "owner"],
       "description": "Calculates report scores for the system",
@@ -1106,6 +1124,7 @@
     },
 
     "npubManager": {
+      "resourceClass": "neo4j-heavy",
       "name": "Npub Manager",
       "categories": ["maintenance"],
       "description": "Ensures all NostrUser nodes have npub properties",
@@ -1167,6 +1186,7 @@
     },
 
     "updateNpubsInNeo4j": {
+      "resourceClass": "neo4j-heavy",
       "name": "Update Npubs In Neo4j",
       "categories": ["maintenance"],
       "description": "Updates Neo4j nodes with generated npubs",

--- a/test/task-queue-neo4j-resource-class.test.js
+++ b/test/task-queue-neo4j-resource-class.test.js
@@ -332,6 +332,77 @@ test('R4: BullBoard mount module still exists and references /admin/queues + som
   );
 });
 
+test('R5: the full neo4j-heavy allowlist is tagged in taskRegistry.json (operator-approved backfill, post-story-#24)', () => {
+  // Background: operator observed on staging that scheduling
+  // updateAllScoresForOwner + reconcileAll on aligned 6h cadences caused
+  // them to fire concurrently — both hit Neo4j hard, no semaphore
+  // serialization. Root cause: updateAllScoresForOwner (and many siblings)
+  // were never tagged with `resourceClass: "neo4j-heavy"` even though the
+  // already-tagged calculateOwner* trio (T9 above) implied the convention.
+  //
+  // This sentinel pins the full operator-approved allowlist. If a future
+  // edit drops a tag, R5 fails and names the specific task. If a new task
+  // belongs in the heavy set, extend the allowlist below.
+  //
+  // The allowlist was finalized in conversation with the operator (per the
+  // discussion that produced this commit). It deliberately EXCLUDES:
+  //   - reconcileAuthor (lightweight; UI-triggered, needs fast turnaround)
+  //   - queryMissingNpubs (single read-only Cypher query — much lighter
+  //     than write-heavy multi-query tasks)
+  //   - generateNpubs (pure JS + filesystem write; no Neo4j touch — the
+  //     Neo4j write in the chain is in updateNpubsInNeo4j, which IS tagged)
+  // If you're considering adding any of these, re-read the rationale above
+  // and the parent/child semaphore-dormancy discussion (parent-tag holds
+  // semaphore for the whole subshell chain; child-tag is dormant under
+  // parent-driven invocations).
+  const r = readJsonSafe(TASK_REGISTRY);
+  assert(r !== null && r.tasks, 'taskRegistry.json missing or malformed — re-baseline this sentinel.');
+
+  const HEAVY_ALLOWLIST = [
+    // Pre-existing (story #15 / ADR 0013 — the initial trio + reconcile-family
+    // additions from story #21):
+    'calculateOwnerHops', 'calculateOwnerPageRank', 'calculateOwnerGrapeRank',
+    'reconcileRecent', 'reconcileAll', 'reconcileNetwork',
+    // Backfill (post-story-#24, operator-approved):
+    'updateAllScoresForOwner', 'updateAllScoresForSingleCustomer',
+    'processCustomer', 'processAllActiveCustomers',
+    'calculateCustomerGrapeRank', 'calculateCustomerPageRank', 'calculateCustomerHops',
+    'processCustomerFollowsMutesReports', 'processOwnerFollowsMutesReports',
+    'calculateVerifiedFollowerCounts', 'calculateVerifiedMuterCounts', 'calculateVerifiedReporterCounts',
+    'calculateFollowerInputs', 'calculateMuterInputs', 'calculateReporterInputs',
+    'calculateReportScores', 'prepareNeo4jForCustomerData',
+    'updateNpubsInNeo4j', 'neo4jConstraintsAndIndexes', 'npubManager',
+  ];
+
+  const missing = [];
+  for (const taskName of HEAVY_ALLOWLIST) {
+    const entry = r.tasks[taskName];
+    if (!entry) {
+      missing.push(`${taskName} (NOT IN REGISTRY)`);
+      continue;
+    }
+    if (entry.resourceClass !== 'neo4j-heavy') {
+      missing.push(`${taskName} (resourceClass=${JSON.stringify(entry.resourceClass)})`);
+    }
+  }
+  assert(
+    missing.length === 0,
+    'R5: the following tasks must carry `"resourceClass": "neo4j-heavy"` per the operator-approved backfill ' +
+      '(post-story-#24 fix; otherwise concurrent fires don\'t serialize on the semaphore): ' + missing.join(', ') +
+      '. If a task was intentionally removed from the heavy set, also remove it from R5\'s allowlist and ' +
+      'document the rationale alongside the existing exclusions (reconcileAuthor / queryMissingNpubs / generateNpubs).'
+  );
+
+  // Bonus check: the count should be exactly the allowlist length. If a
+  // NEW task in the registry got the tag without being added to R5, R5
+  // doesn't fail — but if the count drift is large, future operators may
+  // want to know.
+  const actuallyTagged = Object.entries(r.tasks).filter(([_, t]) => t.resourceClass === 'neo4j-heavy').map(([n]) => n);
+  if (actuallyTagged.length !== HEAVY_ALLOWLIST.length) {
+    console.log(`      [R5 note] registry has ${actuallyTagged.length} neo4j-heavy tasks; allowlist has ${HEAVY_ALLOWLIST.length}. Extra in registry: ${actuallyTagged.filter(n => !HEAVY_ALLOWLIST.includes(n)).join(', ') || '(none)'}.`);
+  }
+});
+
 async function run() {
   let pass = 0, fail = 0;
   for (const t of tests) {


### PR DESCRIPTION
## Summary

Operator reported on staging: scheduling `updateAllScoresForOwner` (every 6h) alongside `reconcileAll` (every 6h) caused both to fire concurrently at the same timestamp (13:08:20) and hit Neo4j hard simultaneously. Per ADR 0013, `neo4j-heavy` tasks should serialize via the Redis-backed counted semaphore (cap=1), but `updateAllScoresForOwner` had `resourceClass: undefined` in the registry — so its Worker callback ran without the semaphore wrap and the two heavy tasks raced.

Latent gap dating to ADR 0013 (only the 3 owner-score-calc tasks got tagged at first) and ADR 0018 (3 of the 4 reconcile* tasks got tagged, but the operator-side family was never backfilled). Exposed now because the operator is actively using per-entry scheduling from story #24.

## Changes

- **`src/manage/taskQueue/taskRegistry.json`** — add `"resourceClass": "neo4j-heavy"` to **20 tasks**. Surgical 20-line text-level inserts; no reformat / no blank-line drift. Brings the total `neo4j-heavy` set from 6 → 26.
- **`test/task-queue-neo4j-resource-class.test.js`** — new regression test **R5** with the full operator-approved allowlist + rationale for the 3 explicit exclusions (`reconcileAuthor`, `queryMissingNpubs`, `generateNpubs`). If a future edit drops a tag, R5 fails and names the specific task. R5 also notes (non-blocking) when a NEW registry task is tagged but missing from R5's allowlist.

## Tagged in this PR (20 tasks)

| Why | Tasks |
|---|---|
| **Reported bug** | `updateAllScoresForOwner` |
| **Parent-tags** (load-bearing — hold semaphore across subshell chain) | `processCustomer`, `processAllActiveCustomers`, `updateAllScoresForSingleCustomer`, `npubManager`, `neo4jConstraintsAndIndexes` |
| **Customer-side score calc family** (mirrors of already-tagged `calculateOwner*`) | `calculateCustomerGrapeRank`, `calculateCustomerPageRank`, `calculateCustomerHops` |
| **Counts + inputs** (graph queries/writes) | `processCustomerFollowsMutesReports`, `processOwnerFollowsMutesReports`, `calculateVerifiedFollowerCounts`, `calculateVerifiedMuterCounts`, `calculateVerifiedReporterCounts`, `calculateFollowerInputs`, `calculateMuterInputs`, `calculateReporterInputs`, `calculateReportScores`, `prepareNeo4jForCustomerData` |
| **Bulk Neo4j writes** | `updateNpubsInNeo4j` |

## Explicitly NOT tagged (with rationale)

- **`reconcileAuthor`** — lightweight; UI-triggered, needs fast turnaround
- **`queryMissingNpubs`** — single read-only Cypher query (per script inspection); much lighter than write-heavy multi-query tasks
- **`generateNpubs`** — pure JS + filesystem (nip19.npubEncode → JSON file); no Neo4j touch. The chain's actual Neo4j write is in `updateNpubsInNeo4j`, which IS tagged.

## Net production impact

After this lands, scheduling any two of the 26 tagged tasks on overlapping cadences serializes them — the second one's Worker waits at the semaphore until the first completes. The user-visible effect on the panel's Recent Runs: aligned `lastRunAt` timestamps between heavy tasks will now show staggered (one waiting for the other to finish) instead of identical.

Each `neo4j-heavy` task running solo behaves unchanged (semaphore acquire is fast when nothing else holds it).

## Test plan

- [ ] After merge: `deploy-staging.yml` runs cleanly.
- [ ] On staging: trigger the regression test condition by waiting for the next 19:08:20 tick (both `legacy:updateAllScoresForOwner` and `legacy:reconcileAll` are enabled every 6h). Verify they now serialize:
  - Whichever fires first holds the semaphore. The second waits.
  - In `events.jsonl`: the second task's structured-logging entries include a `resource_class_wait_acquired` phase token (per ADR 0013's observability).
  - In the panel: the two entries' `lastRunAt` timestamps are no longer aligned (one ran later).
- [ ] Tier 5 regression: the other entries still show their Recent Runs / next/last-run correctly; `/api/scheduled-tasks/list` + `/registry-tasks` still 200.
- [ ] `processCustomer` (which the operator is actively scheduling) continues to fire on schedule; if it overlaps with `reconcileAll` or any other newly-tagged task, it now serializes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)