### PR TITLE
Promote staging → main: neo4j-heavy registry tag backfill (PR #201)

### DIFF
--- a/src/manage/taskQueue/taskRegistry.json
+++ b/src/manage/taskQueue/taskRegistry.json
@@ -185,6 +185,7 @@
     },
 
     "neo4jConstraintsAndIndexes": {
+      "resourceClass": "neo4j-heavy",
       "name": "Neo4j Constraints and Indexes",
       "categories": ["maintenance"],
       "description": "Sets up database constraints and indexes",
@@ -460,6 +461,7 @@
     },
 
     "processAllActiveCustomers": {
+      "resourceClass": "neo4j-heavy",
       "name": "Process All Active Customers",
       "categories": ["orchestrator", "customer"],
       "description": "Processes all active customers by calling processCustomer.sh for each",
@@ -491,6 +493,7 @@
     },
 
     "processCustomer": {
+      "resourceClass": "neo4j-heavy",
       "name": "Process Customer",
       "categories": ["customer"],
       "description": "Complete processing pipeline for a single customer",
@@ -525,6 +528,7 @@
     },
 
     "prepareNeo4jForCustomerData": {
+      "resourceClass": "neo4j-heavy",
       "name": "Prepare Neo4j For Customer Data",
       "categories": ["customer", "maintenance"],
       "description": "Preliminary steps for customer data processing, common to all customers",
@@ -547,6 +551,7 @@
     },
 
     "updateAllScoresForOwner": {
+      "resourceClass": "neo4j-heavy",
       "name": "Update All Scores For Owner",
       "categories": ["owner", "algorithms"],
       "description": "Updates all trust scores for the owner",
@@ -595,6 +600,7 @@
     },
 
     "updateAllScoresForSingleCustomer": {
+      "resourceClass": "neo4j-heavy",
       "name": "Update All Scores For Single Customer",
       "categories": ["customer", "algorithms"],
       "description": "Updates all trust scores for a single customer",
@@ -657,6 +663,7 @@
     },
 
     "calculateCustomerGrapeRank": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Customer GrapeRank",
       "categories": ["algorithms", "customer"],
       "description": "Calculates personalized GrapeRank scores for a specific customer",
@@ -708,6 +715,7 @@
     },
 
     "calculateCustomerPageRank": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Customer PageRank",
       "categories": ["algorithms", "customer"],
       "description": "Calculates personalized PageRank scores for a customer",
@@ -753,6 +761,7 @@
     },
 
     "calculateCustomerHops": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Customer Hops",
       "categories": ["algorithms", "customer"],
       "description": "Calculates hop distances for a specific customer",
@@ -775,6 +784,7 @@
     },
 
     "processCustomerFollowsMutesReports": {
+      "resourceClass": "neo4j-heavy",
       "name": "Process Customer Follows Mutes Reports",
       "categories": ["algorithms", "customer"],
       "description": "Processes follows, mutes, and reports data for a specific customer",
@@ -805,6 +815,7 @@
     },
 
     "calculateVerifiedFollowerCounts": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Verified Follower Counts",
       "categories": ["algorithms", "customer"],
       "description": "Calculates verified follower counts for a specific customer",
@@ -828,6 +839,7 @@
     },
 
     "calculateVerifiedMuterCounts": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Verified Muter Counts",
       "categories": ["algorithms", "customer"],
       "description": "Calculates verified muter counts for a specific customer",
@@ -851,6 +863,7 @@
     },
 
     "calculateVerifiedReporterCounts": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Verified Reporter Counts",
       "categories": ["algorithms", "customer"],
       "description": "Calculates verified reporter counts for a specific customer",
@@ -874,6 +887,7 @@
     },
 
     "calculateFollowerInputs": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Follower Inputs",
       "categories": ["algorithms", "customer"],
       "description": "Calculates follower inputs for a specific customer",
@@ -897,6 +911,7 @@
     },
 
     "calculateMuterInputs": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Muter Inputs",
       "categories": ["algorithms", "customer"],
       "description": "Calculates muter inputs for a specific customer",
@@ -920,6 +935,7 @@
     },
 
     "calculateReporterInputs": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Reporter Inputs",
       "categories": ["algorithms", "customer"],
       "description": "Calculates reporter inputs for a specific customer",
@@ -943,6 +959,7 @@
     },
 
     "processOwnerFollowsMutesReports": {
+      "resourceClass": "neo4j-heavy",
       "name": "Process Owner Follows Mutes Reports",
       "categories": ["algorithms", "owner"],
       "description": "Processes follows, mutes, and reports data for the instance owner",
@@ -963,6 +980,7 @@
     },
 
     "calculateReportScores": {
+      "resourceClass": "neo4j-heavy",
       "name": "Calculate Report Scores",
       "categories": ["algorithms", "owner"],
       "description": "Calculates report scores for the system",
@@ -1106,6 +1124,7 @@
     },
 
     "npubManager": {
+      "resourceClass": "neo4j-heavy",
       "name": "Npub Manager",
       "categories": ["maintenance"],
       "description": "Ensures all NostrUser nodes have npub properties",
@@ -1167,6 +1186,7 @@
     },
 
     "updateNpubsInNeo4j": {
+      "resourceClass": "neo4j-heavy",
       "name": "Update Npubs In Neo4j",
       "categories": ["maintenance"],
       "description": "Updates Neo4j nodes with generated npubs",

--- a/test/task-queue-neo4j-resource-class.test.js
+++ b/test/task-queue-neo4j-resource-class.test.js
@@ -332,6 +332,77 @@ test('R4: BullBoard mount module still exists and references /admin/queues + som
   );
 });
 
+test('R5: the full neo4j-heavy allowlist is tagged in taskRegistry.json (operator-approved backfill, post-story-#24)', () => {
+  // Background: operator observed on staging that scheduling
+  // updateAllScoresForOwner + reconcileAll on aligned 6h cadences caused
+  // them to fire concurrently — both hit Neo4j hard, no semaphore
+  // serialization. Root cause: updateAllScoresForOwner (and many siblings)
+  // were never tagged with `resourceClass: "neo4j-heavy"` even though the
+  // already-tagged calculateOwner* trio (T9 above) implied the convention.
+  //
+  // This sentinel pins the full operator-approved allowlist. If a future
+  // edit drops a tag, R5 fails and names the specific task. If a new task
+  // belongs in the heavy set, extend the allowlist below.
+  //
+  // The allowlist was finalized in conversation with the operator (per the
+  // discussion that produced this commit). It deliberately EXCLUDES:
+  //   - reconcileAuthor (lightweight; UI-triggered, needs fast turnaround)
+  //   - queryMissingNpubs (single read-only Cypher query — much lighter
+  //     than write-heavy multi-query tasks)
+  //   - generateNpubs (pure JS + filesystem write; no Neo4j touch — the
+  //     Neo4j write in the chain is in updateNpubsInNeo4j, which IS tagged)
+  // If you're considering adding any of these, re-read the rationale above
+  // and the parent/child semaphore-dormancy discussion (parent-tag holds
+  // semaphore for the whole subshell chain; child-tag is dormant under
+  // parent-driven invocations).
+  const r = readJsonSafe(TASK_REGISTRY);
+  assert(r !== null && r.tasks, 'taskRegistry.json missing or malformed — re-baseline this sentinel.');
+
+  const HEAVY_ALLOWLIST = [
+    // Pre-existing (story #15 / ADR 0013 — the initial trio + reconcile-family
+    // additions from story #21):
+    'calculateOwnerHops', 'calculateOwnerPageRank', 'calculateOwnerGrapeRank',
+    'reconcileRecent', 'reconcileAll', 'reconcileNetwork',
+    // Backfill (post-story-#24, operator-approved):
+    'updateAllScoresForOwner', 'updateAllScoresForSingleCustomer',
+    'processCustomer', 'processAllActiveCustomers',
+    'calculateCustomerGrapeRank', 'calculateCustomerPageRank', 'calculateCustomerHops',
+    'processCustomerFollowsMutesReports', 'processOwnerFollowsMutesReports',
+    'calculateVerifiedFollowerCounts', 'calculateVerifiedMuterCounts', 'calculateVerifiedReporterCounts',
+    'calculateFollowerInputs', 'calculateMuterInputs', 'calculateReporterInputs',
+    'calculateReportScores', 'prepareNeo4jForCustomerData',
+    'updateNpubsInNeo4j', 'neo4jConstraintsAndIndexes', 'npubManager',
+  ];
+
+  const missing = [];
+  for (const taskName of HEAVY_ALLOWLIST) {
+    const entry = r.tasks[taskName];
+    if (!entry) {
+      missing.push(`${taskName} (NOT IN REGISTRY)`);
+      continue;
+    }
+    if (entry.resourceClass !== 'neo4j-heavy') {
+      missing.push(`${taskName} (resourceClass=${JSON.stringify(entry.resourceClass)})`);
+    }
+  }
+  assert(
+    missing.length === 0,
+    'R5: the following tasks must carry `"resourceClass": "neo4j-heavy"` per the operator-approved backfill ' +
+      '(post-story-#24 fix; otherwise concurrent fires don\'t serialize on the semaphore): ' + missing.join(', ') +
+      '. If a task was intentionally removed from the heavy set, also remove it from R5\'s allowlist and ' +
+      'document the rationale alongside the existing exclusions (reconcileAuthor / queryMissingNpubs / generateNpubs).'
+  );
+
+  // Bonus check: the count should be exactly the allowlist length. If a
+  // NEW task in the registry got the tag without being added to R5, R5
+  // doesn't fail — but if the count drift is large, future operators may
+  // want to know.
+  const actuallyTagged = Object.entries(r.tasks).filter(([_, t]) => t.resourceClass === 'neo4j-heavy').map(([n]) => n);
+  if (actuallyTagged.length !== HEAVY_ALLOWLIST.length) {
+    console.log(`      [R5 note] registry has ${actuallyTagged.length} neo4j-heavy tasks; allowlist has ${HEAVY_ALLOWLIST.length}. Extra in registry: ${actuallyTagged.filter(n => !HEAVY_ALLOWLIST.includes(n)).join(', ') || '(none)'}.`);
+  }
+});
+
 async function run() {
   let pass = 0, fail = 0;
   for (const t of tests) {


### PR DESCRIPTION
## Summary

Promotes the operator-approved neo4j-heavy tag backfill from PR #201 to production. Closes the concurrency gap where `updateAllScoresForOwner` and `reconcileAll` (and many siblings) ran simultaneously on Neo4j without semaphore serialization, because they were never tagged `resourceClass: "neo4j-heavy"` in the registry.

## Bundled

- **#201** — `fix: backfill 20 missing neo4j-heavy registry tags`. Adds `"resourceClass": "neo4j-heavy"` to 20 tasks in `taskRegistry.json`; brings total tagged set from 6 → 26. Surgical 20-line edits, no reformat. Plus R5 regression test in `task-queue-neo4j-resource-class` suite with the full operator-approved allowlist + rationale for the 3 explicit exclusions.

## Net production impact

After this lands, any two of the 26 tagged tasks running on overlapping cadences will **serialize** at the Redis-backed semaphore (cap=1) instead of fighting for Neo4j resources concurrently. User-visible effect on the panel: heavy tasks scheduled to align will show staggered `lastRunAt` timestamps (one waiting for the other to complete) rather than identical. No data migration, no UI change.

Each tagged task running solo behaves unchanged — semaphore acquire is fast when nothing else holds it.

## Verification trail

- **Staging deploy:** [#26367448651](https://github.com/nous-clawds4/tapestry/actions/runs/26367448651) — ✓ success in 1m24s.
- **Stability poll on staging:** stable after 3×2s polls; 5s settle clean.
- **Tier 2/5 sanity on staging:** all pages 200, all public APIs 200, regression sweep clean.
- **Structural verification:** brainstorm process restarted as part of the deploy, BullMQ Worker init re-reads `taskRegistry.json` and constructs the conditional semaphore wrap per-task at that moment — the 20 newly-tagged tasks now have the wrap active on staging.
- **R5 allowlist regression test** passing (15/15 in the neo4j-resource-class suite). Pins the 26-task heavy set; if a future edit drops a tag, R5 fails and names the specific task.
- **Behavioral verification of the serialize-at-tick path:** explicitly deferred to next 19:08:20Z tick on staging (~2 hours after this PR opens). Operator accepted the risk in promoting before that tick — the fix is small and additive (resourceClass tags + the existing semaphore mechanism), worst case is no-op.

## Test plan

- [ ] After merge: `deploy-brainstorm.yml` runs to completion.
- [ ] Stability poll on `brainstorm.world` reaches streak 3.
- [ ] Tier 2 sanity: standard pages + APIs 200; jack 504 holds (known gotcha).
- [ ] Tier 5 regression: `/api/scheduled-tasks/list` + `/registry-tasks` + `/api/get-customers` 200.
- [ ] When two prod-enabled tagged tasks next overlap on a cadence, observe staggered `lastRunAt` in the panel (instead of identical) — confirms the semaphore is engaged in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)