### PR TITLE
Add Assistant Profile editor for owner and customers

### DIFF
--- a/src/api/assistant/index.js
+++ b/src/api/assistant/index.js
@@ -1,17 +1,18 @@
 /**
  * Brainstorm Assistant API
  *
- * Publishes a kind 0 profile event for a customer's Brainstorm Assistant
- * (their relay identity that publishes kind 30382 Trust Assertions).
+ * Endpoints for managing an assistant's kind 0 nostr profile. The "assistant"
+ * is a server-side nostr identity:
+ *   - For the owner: the Tapestry Assistant (TA) key.
+ *   - For a customer: their Customer Relay Key.
  *
- * The profile includes:
- * - Name: "<CustomerName>'s Brainstorm Assistant"
- * - About: describes the assistant's NIP-85 role
- * - Website: https://brainstorm.nosfabrica.com
+ * The key is selected by getAssistantKeys(pubkey). The kind 0 event is signed
+ * server-side with that key and published to local strfry plus the external
+ * relays in EXTERNAL_RELAYS.
  *
- * Future enhancements: avatar image, banner image, NIP-05.
- *
- * The event is signed server-side with the assistant's private key.
+ * POST /api/assistant/publish-profile accepts an optional `content` object so
+ * the caller can pass user-edited fields; when omitted, instance-branded
+ * defaults are used (legacy behavior for older callers).
  */
 
 const { exec } = require('child_process');
@@ -66,12 +67,13 @@ function publishToRelay(relayUrl, signedEvent, timeoutMs = 10000) {
   });
 }
 
-const ABOUT_TEXT = 'I am the Brainstorm Assistant for my owner. My primary task is to publish kind 30382 Trusted Assertions so that my owner\'s personalized web of trust metrics are available to be utilized by any nostr client that supports NIP-85.';
+const PROFILE_FIELDS = ['name', 'display_name', 'about', 'picture', 'banner', 'website', 'nip05', 'lud16'];
 
 /**
- * Fetch a customer's kind 0 name from strfry.
+ * Fetch a nostr kind 0 display name for a pubkey from local strfry.
+ * Used to derive the customer name for an assistant's default profile.
  */
-function getCustomerName(pubkey) {
+function getKind0DisplayName(pubkey, fallback = 'My Owner') {
   return new Promise((resolve) => {
     const filter = JSON.stringify({ kinds: [0], authors: [pubkey], limit: 1 });
     exec(`strfry scan '${filter.replace(/'/g, "'\\''")}' 2>/dev/null`, {
@@ -79,27 +81,94 @@ function getCustomerName(pubkey) {
       timeout: 10000,
     }, (error, stdout) => {
       if (error || !stdout.trim()) {
-        resolve('My Owner');
+        resolve(fallback);
         return;
       }
       try {
         const event = JSON.parse(stdout.trim().split('\n')[0]);
         const content = JSON.parse(event.content);
-        resolve(content.display_name || content.name || 'My Owner');
+        resolve(content.display_name || content.name || fallback);
       } catch {
-        resolve('My Owner');
+        resolve(fallback);
       }
     });
   });
 }
 
 /**
+ * Derive the instance's https website URL from configured domain or relay URL.
+ * Returns e.g. "https://brainstorm.world" or empty string if unconfigured.
+ */
+function getInstanceWebsite() {
+  const domain = getConfigFromFile('STRFRY_DOMAIN', '');
+  if (domain && domain !== 'localhost') return `https://${domain}`;
+  const relayUrl = getConfigFromFile('BRAINSTORM_RELAY_URL', '');
+  if (relayUrl) {
+    const host = relayUrl.replace(/^wss?:\/\//, '').replace(/\/.*$/, '');
+    if (host && host !== 'localhost') return `https://${host}`;
+  }
+  return '';
+}
+
+/**
+ * Build instance-branded default kind 0 content for an assistant.
+ * Owner assistant defaults differ from customer assistant defaults.
+ */
+async function buildDefaultProfileContent(pubkey, isOwner) {
+  const website = getInstanceWebsite();
+  if (isOwner) {
+    const ownerName = await getKind0DisplayName(pubkey, 'the owner');
+    return {
+      name: 'Tapestry Assistant',
+      display_name: 'Tapestry Assistant',
+      about: `Server-side Tapestry Assistant for ${ownerName}. Signs firmware events, concept graph nodes, kind 30382 Trust Assertions, and other automated events on behalf of this Tapestry instance.`,
+      picture: '',
+      banner: '',
+      website,
+      nip05: '',
+      lud16: '',
+    };
+  }
+  const customerName = await getKind0DisplayName(pubkey, 'a customer');
+  return {
+    name: `${customerName}'s Brainstorm Assistant`,
+    display_name: `${customerName}'s Brainstorm Assistant`,
+    about: `I am the Brainstorm Assistant for ${customerName}. My primary task is to publish kind 30382 Trusted Assertions so that ${customerName}'s personalized web of trust metrics are available to be utilized by any nostr client that supports NIP-85.`,
+    picture: '',
+    banner: '',
+    website,
+    nip05: '',
+    lud16: '',
+  };
+}
+
+/**
+ * Strip any keys outside the allowed kind 0 fields and coerce values to strings.
+ */
+function sanitizeProfileContent(content) {
+  const clean = {};
+  for (const key of PROFILE_FIELDS) {
+    const value = content?.[key];
+    if (typeof value === 'string') {
+      clean[key] = value;
+    }
+  }
+  return clean;
+}
+
+/**
  * POST /api/assistant/publish-profile
- * Body: { customerPubkey: "hex" }
+ * Body: {
+ *   customerPubkey: "hex",          // pubkey whose assistant we're publishing for
+ *   content?: {                      // optional user-edited kind 0 fields
+ *     name, display_name, about, picture, banner, website, nip05, lud16
+ *   }
+ * }
+ * If `content` is omitted, instance-branded defaults are used (legacy behavior).
  */
 async function handlePublishProfile(req, res) {
   try {
-    const { customerPubkey } = req.body;
+    const { customerPubkey, content } = req.body;
     if (!customerPubkey || !/^[0-9a-f]{64}$/.test(customerPubkey)) {
       return res.status(400).json({ success: false, error: 'Valid customerPubkey is required' });
     }
@@ -131,17 +200,17 @@ async function handlePublishProfile(req, res) {
 
     const assistantPubkey = nostrTools.getPublicKey(privkeyBytes);
 
-    // 2. Get customer's name for the assistant's display name
-    const customerName = await getCustomerName(customerPubkey);
-    const assistantName = `${customerName}'s Brainstorm Assistant`;
+    // 2. Pick profile content: user-supplied if present, otherwise instance defaults
+    const profileContent = content && typeof content === 'object'
+      ? sanitizeProfileContent(content)
+      : await buildDefaultProfileContent(customerPubkey, isOwner);
 
-    // 3. Build kind 0 event
-    const profileContent = {
-      name: assistantName,
-      display_name: assistantName,
-      website: 'https://brainstorm.nosfabrica.com',
-      about: ABOUT_TEXT,
-    };
+    // Drop empty-string keys so we don't pollute kind 0 with blank fields
+    for (const k of Object.keys(profileContent)) {
+      if (profileContent[k] === '') delete profileContent[k];
+    }
+
+    const assistantName = profileContent.display_name || profileContent.name || 'Assistant';
 
     const event = {
       kind: 0,
@@ -195,7 +264,9 @@ async function handlePublishProfile(req, res) {
 /**
  * GET /api/assistant/status
  * Query: ?customerPubkey=hex
- * Returns whether the assistant has a kind 0 profile published.
+ * Returns the assistant's pubkey, the current published kind 0 (if any), and
+ * the instance-branded defaults the UI should prefill into the form for a
+ * fresh setup.
  */
 async function handleAssistantStatus(req, res) {
   try {
@@ -204,10 +275,15 @@ async function handleAssistantStatus(req, res) {
       return res.status(400).json({ success: false, error: 'customerPubkey is required' });
     }
 
+    const ownerPubkey = getConfigFromFile('BRAINSTORM_OWNER_PUBKEY');
+    const isOwner = customerPubkey === ownerPubkey;
+
     // Unified assistant key access (owner → TA key, customer → customer relay key)
     const relayKeys = await getAssistantKeys(customerPubkey);
+    const defaults = await buildDefaultProfileContent(customerPubkey, isOwner);
+
     if (!relayKeys || !relayKeys.pubkey) {
-      return res.json({ success: true, hasRelayKey: false, hasProfile: false });
+      return res.json({ success: true, hasRelayKey: false, hasProfile: false, defaults });
     }
 
     // Check if kind 0 exists for the assistant pubkey
@@ -243,6 +319,8 @@ async function handleAssistantStatus(req, res) {
       assistantNpub: relayKeys.npub,
       hasProfile: !!result,
       profile,
+      defaults,
+      isOwner,
     });
   } catch (err) {
     return res.status(500).json({ success: false, error: err.message });

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -265,6 +265,7 @@ const router = createBrowserRouter([
           { path: 'databases', handle: { crumb: 'Databases' } },
           { path: 'uuids', handle: { crumb: 'Concept UUIDs' } },
           { path: 'firmware', handle: { crumb: 'Firmware' } },
+          { path: 'assistant', handle: { crumb: 'Assistant Profile' } },
           { path: 'auditing', handle: { crumb: 'Auditing Tools' } },
           { path: '*', element: <Navigate to="/tapestry/settings/relays" replace /> },
         ],

--- a/ui/src/components/AssistantProfileEditor.jsx
+++ b/ui/src/components/AssistantProfileEditor.jsx
@@ -1,0 +1,214 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const PROFILE_FIELDS = [
+  { key: 'name', label: 'Name', placeholder: 'e.g. Alice\'s Brainstorm Assistant' },
+  { key: 'display_name', label: 'Display name', placeholder: 'Shown in nostr clients' },
+  { key: 'about', label: 'About', placeholder: 'Short description of what this assistant does', multiline: true },
+  { key: 'picture', label: 'Picture URL', placeholder: 'https://example.com/avatar.png' },
+  { key: 'banner', label: 'Banner URL', placeholder: 'https://example.com/banner.png' },
+  { key: 'website', label: 'Website', placeholder: 'https://example.com' },
+  { key: 'nip05', label: 'NIP-05', placeholder: 'name@example.com' },
+  { key: 'lud16', label: 'Lightning address', placeholder: 'name@example.com' },
+];
+
+const labelStyle = { fontSize: '0.75rem', fontWeight: 600, display: 'block', marginBottom: '0.25rem' };
+const inputStyle = {
+  padding: '0.4rem 0.6rem',
+  fontSize: '0.85rem',
+  backgroundColor: 'var(--bg-primary, #0f0f23)',
+  color: 'var(--text-primary, #e0e0e0)',
+  border: '1px solid var(--border, #444)',
+  borderRadius: '4px',
+  width: '100%',
+  boxSizing: 'border-box',
+};
+
+function emptyForm() {
+  return PROFILE_FIELDS.reduce((acc, f) => { acc[f.key] = ''; return acc; }, {});
+}
+
+function pickFields(source) {
+  if (!source || typeof source !== 'object') return emptyForm();
+  return PROFILE_FIELDS.reduce((acc, f) => {
+    acc[f.key] = typeof source[f.key] === 'string' ? source[f.key] : '';
+    return acc;
+  }, {});
+}
+
+export default function AssistantProfileEditor({ customerPubkey }) {
+  const [status, setStatus] = useState(null);
+  const [form, setForm] = useState(emptyForm);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [publishing, setPublishing] = useState(false);
+  const [publishResult, setPublishResult] = useState(null);
+
+  const loadStatus = useCallback(async () => {
+    if (!customerPubkey) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/assistant/status?customerPubkey=${customerPubkey}`);
+      const data = await res.json();
+      if (!data.success) throw new Error(data.error || 'Failed to load assistant status');
+      setStatus(data);
+      // Prefer existing published profile if present, else use server-provided defaults
+      const source = data.hasProfile ? data.profile : data.defaults;
+      setForm(pickFields(source));
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [customerPubkey]);
+
+  useEffect(() => { loadStatus(); }, [loadStatus]);
+
+  function updateField(key, value) {
+    setForm(prev => ({ ...prev, [key]: value }));
+    setPublishResult(null);
+  }
+
+  function resetToDefaults() {
+    if (!status?.defaults) return;
+    setForm(pickFields(status.defaults));
+    setPublishResult(null);
+  }
+
+  async function publish() {
+    if (!customerPubkey) return;
+    setPublishing(true);
+    setPublishResult(null);
+    try {
+      const res = await fetch('/api/assistant/publish-profile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ customerPubkey, content: form }),
+      });
+      const data = await res.json();
+      if (!data.success) throw new Error(data.error || 'Publish failed');
+      setPublishResult({ ok: true, message: data.message, relays: data.relays });
+      // Reload status so the "currently published" section refreshes
+      await loadStatus();
+    } catch (err) {
+      setPublishResult({ ok: false, message: err.message });
+    } finally {
+      setPublishing(false);
+    }
+  }
+
+  if (loading) {
+    return <div className="settings-group"><p>Loading assistant profile…</p></div>;
+  }
+
+  if (error) {
+    return (
+      <div className="settings-group">
+        <p style={{ color: '#ef4444' }}>Error: {error}</p>
+        <button className="settings-action-btn" onClick={loadStatus}>Retry</button>
+      </div>
+    );
+  }
+
+  if (!status?.hasRelayKey) {
+    return (
+      <div className="settings-group">
+        <h3 style={{ margin: '0 0 0.5rem' }}>
+          {status?.isOwner ? '🤖 Tapestry Assistant Profile' : '🤖 Your Brainstorm Assistant Profile'}
+        </h3>
+        <p style={{ opacity: 0.8 }}>
+          {status?.isOwner
+            ? 'The Tapestry Assistant key has not been created yet. Restart the container to provision it.'
+            : 'Your Customer Relay Key has not been created yet. Set up Trusted Assertions first.'}
+        </p>
+      </div>
+    );
+  }
+
+  const shortPk = status.assistantPubkey
+    ? `${status.assistantPubkey.slice(0, 12)}…${status.assistantPubkey.slice(-8)}`
+    : '';
+
+  return (
+    <div className="settings-group" style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <div>
+        <h3 style={{ margin: '0 0 0.25rem' }}>
+          {status.isOwner ? '🤖 Tapestry Assistant Profile' : '🤖 Your Brainstorm Assistant Profile'}
+        </h3>
+        <p style={{ margin: 0, fontSize: '0.85rem', opacity: 0.75 }}>
+          {status.isOwner
+            ? 'The kind 0 profile published by this instance\'s Tapestry Assistant — the server-side identity that signs automated events.'
+            : 'The kind 0 profile published by your server-side assistant — the identity that signs your kind 30382 Trust Assertions.'}
+        </p>
+      </div>
+
+      <div style={{ fontSize: '0.8rem', opacity: 0.8 }}>
+        <div><strong>Assistant pubkey:</strong> <code>{shortPk}</code></div>
+        <div>
+          <strong>Currently published:</strong>{' '}
+          {status.hasProfile
+            ? <span style={{ color: '#22c55e' }}>✅ Yes</span>
+            : <span style={{ color: '#f59e0b' }}>⚠️ Not yet</span>}
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        {PROFILE_FIELDS.map(field => (
+          <div key={field.key}>
+            <label style={labelStyle}>{field.label}</label>
+            {field.multiline ? (
+              <textarea
+                value={form[field.key]}
+                onChange={e => updateField(field.key, e.target.value)}
+                placeholder={field.placeholder}
+                rows={4}
+                style={{ ...inputStyle, fontFamily: 'inherit', resize: 'vertical' }}
+              />
+            ) : (
+              <input
+                type="text"
+                value={form[field.key]}
+                onChange={e => updateField(field.key, e.target.value)}
+                placeholder={field.placeholder}
+                style={inputStyle}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+        <button
+          className="settings-action-btn"
+          onClick={publish}
+          disabled={publishing}
+        >
+          {publishing ? 'Publishing…' : status.hasProfile ? 'Re-publish profile' : 'Publish profile'}
+        </button>
+        <button
+          className="settings-action-btn settings-action-btn-secondary"
+          onClick={resetToDefaults}
+          disabled={publishing}
+          type="button"
+        >
+          Reset to defaults
+        </button>
+      </div>
+
+      {publishResult && (
+        <div
+          className={`settings-message settings-message-${publishResult.ok ? 'success' : 'error'}`}
+          style={{ marginTop: 0 }}
+        >
+          {publishResult.ok ? '✅ ' : '❌ '}
+          {publishResult.message}
+          {publishResult.ok && publishResult.relays && (
+            <div style={{ fontSize: '0.75rem', opacity: 0.8, marginTop: '0.25rem' }}>
+              Pushed to local strfry + {publishResult.relays.success}/{publishResult.relays.total} external relays.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/BrainstormSettings.jsx
+++ b/ui/src/pages/BrainstormSettings.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { useConfig } from '../context/ConfigContext';
 import BrainstormUserMenu, { useHouseProfile } from '../components/BrainstormUserMenu';
+import AssistantProfileEditor from '../components/AssistantProfileEditor';
 
 /* ── Helpers ──────────────────────────────────────────── */
 
@@ -485,6 +486,11 @@ export default function BrainstormSettings() {
               <div className="bss-profile-pubkey">{user.pubkey.slice(0, 16)}…{user.pubkey.slice(-8)}</div>
             </div>
           </div>
+        </div>
+
+        {/* Assistant profile card */}
+        <div className="bss-card">
+          <AssistantProfileEditor customerPubkey={user.pubkey} />
         </div>
 
         {/* WoT Status */}

--- a/ui/src/pages/settings/Index.jsx
+++ b/ui/src/pages/settings/Index.jsx
@@ -7,12 +7,14 @@ import UuidSettings from './UuidSettings';
 import DatabaseSettings from './DatabaseSettings';
 import FirmwareExplorer from './FirmwareExplorer';
 import Audit from '../manage/Audit';
+import AssistantProfileEditor from '../../components/AssistantProfileEditor';
 
 const TABS = [
   { key: 'relays', path: 'relays', label: '📡 Relays' },
   { key: 'databases', path: 'databases', label: '🗄️ Databases' },
   { key: 'uuids', path: 'uuids', label: '🔑 Concept UUIDs' },
   { key: 'firmware', path: 'firmware', label: '🔧 Firmware' },
+  { key: 'assistant', path: 'assistant', label: '🤖 Assistant Profile' },
   { key: 'auditing', path: 'auditing', label: '🔍 Auditing Tools' },
 ];
 
@@ -205,6 +207,9 @@ export default function SettingsIndex() {
         )}
         {activeTab === 'firmware' && (
           <FirmwareExplorer />
+        )}
+        {activeTab === 'assistant' && (
+          <AssistantProfileEditor customerPubkey={user?.pubkey} />
         )}
         {activeTab === 'auditing' && (
           <Audit />


### PR DESCRIPTION
## Summary

Lets a logged-in owner or customer edit and publish the kind 0 nostr profile metadata for their server-side Assistant key — the Tapestry Assistant (TA) for the owner, the Customer Relay Key for a customer. Previously the only way to publish that kind 0 was via two legacy HTML pages that hardcoded the content (including a fixed `brainstorm.nosfabrica.com` website URL). This PR replaces the hardcoded content with an editable form, sourced from instance-branded defaults that differ between owner and customer flavors.

## Changes

- `src/api/assistant/index.js`
  - `POST /api/assistant/publish-profile` now accepts an optional `content` object so callers can pass user-edited fields. Legacy callers without `content` still get the default-fill behavior.
  - `GET /api/assistant/status` now also returns `defaults` and `isOwner` so the UI can prefill the form.
  - New `buildDefaultProfileContent(pubkey, isOwner)` produces owner vs customer-flavored defaults.
  - Hardcoded `brainstorm.nosfabrica.com` replaced with a website derived from `STRFRY_DOMAIN` / `BRAINSTORM_RELAY_URL`.
- `ui/src/components/AssistantProfileEditor.jsx` — new shared React component (8 fields: name, display_name, about, picture, banner, website, nip05, lud16; publish + reset-to-defaults).
- `ui/src/pages/settings/Index.jsx` — adds "🤖 Assistant Profile" tab to the owner settings.
- `ui/src/pages/BrainstormSettings.jsx` — adds a new card on the customer-facing `/settings` page.
- `ui/src/App.jsx` — registers `/tapestry/settings/assistant` route + breadcrumb.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs cleanly.
- [ ] `GET /api/assistant/status?customerPubkey=<owner-pubkey>` returns `isOwner:true` and a `defaults` block with the owner-flavored "Server-side Tapestry Assistant for {name}..." about text.
- [ ] `GET /api/assistant/status?customerPubkey=<customer-pubkey>` returns `isOwner:false` and a customer-flavored "{Name}'s Brainstorm Assistant" defaults block.
- [ ] `POST /api/assistant/publish-profile` without an authenticated session returns 403.
- [ ] Visiting `/tapestry/settings/assistant` as the owner shows the new tab, prefills the existing kind 0 (if any) or instance defaults, and the publish button publishes a new kind 0 from the TA pubkey.
- [ ] Visiting `/settings` as a customer shows the new "Your Brainstorm Assistant Profile" card with the same behavior, prefilling `"{customer name}'s Brainstorm Assistant"`.
- [ ] Legacy `POST /api/assistant/publish-profile` calls from `public/pages/customers/customer.html` and `public/pages/nip85.html` (no `content` body) still publish using defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)