### PR TITLE
Assistant Profile: per-user routing, admin key provisioning, naming pass

### DIFF
--- a/src/api/assistant/index.js
+++ b/src/api/assistant/index.js
@@ -18,7 +18,8 @@
 const { exec } = require('child_process');
 const nostrTools = require('nostr-tools');
 const { getAssistantKeys } = require('../../utils/assistantKeys');
-const { getConfigFromFile } = require('../../utils/config');
+const { getConfigFromFile, getAdminPubkeys } = require('../../utils/config');
+const { SecureKeyStorage } = require('../../utils/secureKeyStorage');
 const WebSocket = require('ws');
 
 const EXTERNAL_RELAYS = [
@@ -131,9 +132,9 @@ async function buildDefaultProfileContent(pubkey, isOwner) {
   }
   const customerName = await getKind0DisplayName(pubkey, 'a customer');
   return {
-    name: `${customerName}'s Brainstorm Assistant`,
-    display_name: `${customerName}'s Brainstorm Assistant`,
-    about: `I am the Brainstorm Assistant for ${customerName}. My primary task is to publish kind 30382 Trusted Assertions so that ${customerName}'s personalized web of trust metrics are available to be utilized by any nostr client that supports NIP-85.`,
+    name: `${customerName}'s Tapestry Assistant`,
+    display_name: `${customerName}'s Tapestry Assistant`,
+    about: `I am the Tapestry Assistant for ${customerName}. My primary task is to publish kind 30382 Trusted Assertions so that ${customerName}'s personalized web of trust metrics are available to be utilized by any nostr client that supports NIP-85.`,
     picture: '',
     banner: '',
     website,
@@ -340,4 +341,75 @@ function handleGetTAPubkey(req, res) {
   return res.json({ success: true, pubkey });
 }
 
-module.exports = { handlePublishProfile, handleAssistantStatus, handleGetTAPubkey };
+/**
+ * POST /api/assistant/provision-key
+ * Generates and stores a new server-side Assistant keypair for the caller's
+ * session pubkey, if one doesn't already exist. Used by admins (who don't
+ * get one at signup the way customers do) and as a fallback in any case
+ * where a recognised user is missing their Assistant key.
+ *
+ * Auth: any authenticated session whose pubkey is the owner, an admin, or
+ * an active customer. Storage scheme matches customer relay keys (slot is
+ * the caller's pubkey), so getAssistantKeys(pubkey) will find it without
+ * any extra routing.
+ */
+async function handleProvisionAssistantKey(req, res) {
+  try {
+    if (!req.session || !req.session.authenticated || !req.session.pubkey) {
+      return res.status(401).json({ success: false, error: 'Authentication required' });
+    }
+    const sessionPubkey = req.session.pubkey;
+
+    // Only known roles can provision: owner, admin, or active customer.
+    const ownerPubkey = getConfigFromFile('BRAINSTORM_OWNER_PUBKEY');
+    const isOwner = sessionPubkey === ownerPubkey;
+    const isAdmin = !isOwner && getAdminPubkeys().includes(sessionPubkey);
+    let isCustomer = false;
+    if (!isOwner && !isAdmin) {
+      try {
+        const CustomerManager = require('../../utils/customerManager');
+        const cm = new CustomerManager();
+        await cm.initialize();
+        const customer = await cm.getCustomer(sessionPubkey);
+        isCustomer = customer && customer.status === 'active';
+      } catch {}
+    }
+    if (!isOwner && !isAdmin && !isCustomer) {
+      return res.status(403).json({ success: false, error: 'Only the owner, an admin, or an active customer can provision an Assistant key' });
+    }
+
+    // If a key already exists, refuse — re-provisioning would lose the
+    // signing identity of every event already signed by the old key.
+    const existing = await getAssistantKeys(sessionPubkey);
+    if (existing && existing.pubkey) {
+      return res.status(409).json({
+        success: false,
+        error: 'Assistant key already exists for this user',
+        pubkey: existing.pubkey,
+        npub: existing.npub,
+      });
+    }
+
+    const { generateRelayKeys } = require('../../utils/customerRelayKeys');
+    const keys = generateRelayKeys();
+
+    // Store under the caller's pubkey — same slot scheme as customer keys.
+    // Owner is handled above (existing check would have returned the TA key
+    // stored under 'tapestry-assistant'), so we never write the owner here.
+    const storage = new SecureKeyStorage();
+    await storage.storeRelayKeys(sessionPubkey, keys);
+
+    console.log(`[assistant] Provisioned new Assistant key for ${sessionPubkey.slice(0, 8)} (role: ${isAdmin ? 'admin' : isCustomer ? 'customer' : 'owner'})`);
+
+    return res.json({
+      success: true,
+      pubkey: keys.pubkey,
+      npub: keys.npub,
+    });
+  } catch (err) {
+    console.error('[assistant] provision-key error:', err);
+    return res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+module.exports = { handlePublishProfile, handleAssistantStatus, handleGetTAPubkey, handleProvisionAssistantKey };

--- a/src/api/auth/getUserClassification.js
+++ b/src/api/auth/getUserClassification.js
@@ -1,9 +1,26 @@
 const { getConfigFromFile, getAdminPubkeys } = require('../../utils/config');
 const CustomerManager = require('../../utils/customerManager');
+const { getAssistantKeys } = require('../../utils/assistantKeys');
+
+/**
+ * Resolve the caller's Assistant pubkey, if one exists.
+ * Returns null for users who don't have a key provisioned yet (e.g. admins
+ * who haven't run provision-key, or unauthenticated callers).
+ */
+async function resolveAssistantPubkey(userPubkey) {
+    if (!userPubkey) return null;
+    try {
+        const keys = await getAssistantKeys(userPubkey);
+        return keys && keys.pubkey ? keys.pubkey : null;
+    } catch {
+        return null;
+    }
+}
 
 /**
  * Get user classification (owner/customer/regular user)
- * Returns the classification of the authenticated user
+ * Returns the classification of the authenticated user, plus the caller's
+ * server-side Assistant pubkey if one is provisioned.
  * to call: api/auth/user-classification
  */
 async function handleGetUserClassification(req, res) {
@@ -13,11 +30,13 @@ async function handleGetUserClassification(req, res) {
             return res.json({
                 success: true,
                 classification: 'unauthenticated',
-                pubkey: null
+                pubkey: null,
+                assistantPubkey: null,
             });
         }
 
         const userPubkey = req.session.pubkey;
+        const assistantPubkey = await resolveAssistantPubkey(userPubkey);
 
         // Get owner pubkey from brainstorm.conf
         let ownerPubkey = getConfigFromFile('BRAINSTORM_OWNER_PUBKEY');
@@ -28,6 +47,7 @@ async function handleGetUserClassification(req, res) {
                 success: true,
                 classification: 'owner',
                 pubkey: userPubkey,
+                assistantPubkey,
             });
         }
 
@@ -38,6 +58,7 @@ async function handleGetUserClassification(req, res) {
                 success: true,
                 classification: 'admin',
                 pubkey: userPubkey,
+                assistantPubkey,
             });
         }
 
@@ -45,17 +66,18 @@ async function handleGetUserClassification(req, res) {
         try {
             const customerManager = new CustomerManager();
             await customerManager.initialize();
-            
+
             // Get customer by pubkey
             const customer = await customerManager.getCustomer(userPubkey);
-            
+
             if (customer && customer.status === 'active') {
                 return res.json({
                     success: true,
                     classification: 'customer',
                     pubkey: userPubkey,
                     customerName: customer.name,
-                    customerId: customer.id
+                    customerId: customer.id,
+                    assistantPubkey,
                 });
             }
         } catch (error) {
@@ -66,7 +88,8 @@ async function handleGetUserClassification(req, res) {
         return res.json({
             success: true,
             classification: 'guest',
-            pubkey: userPubkey
+            pubkey: userPubkey,
+            assistantPubkey,
         });
 
     } catch (error) {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -485,6 +485,7 @@ async function register(app) {
     // ── Brainstorm Assistant API ──
     const assistantApi = require('./assistant');
     app.post('/api/assistant/publish-profile', assistantApi.handlePublishProfile);
+    app.post('/api/assistant/provision-key', assistantApi.handleProvisionAssistantKey);
     app.get('/api/assistant/status', assistantApi.handleAssistantStatus);
     app.get('/api/assistant/pubkey', assistantApi.handleGetTAPubkey);
 

--- a/ui/src/components/AssistantProfileEditor.jsx
+++ b/ui/src/components/AssistantProfileEditor.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 
 const PROFILE_FIELDS = [
-  { key: 'name', label: 'Name', placeholder: 'e.g. Alice\'s Brainstorm Assistant' },
+  { key: 'name', label: 'Name', placeholder: 'e.g. Alice\'s Tapestry Assistant' },
   { key: 'display_name', label: 'Display name', placeholder: 'Shown in nostr clients' },
   { key: 'about', label: 'About', placeholder: 'Short description of what this assistant does', multiline: true },
   { key: 'picture', label: 'Picture URL', placeholder: 'https://example.com/avatar.png' },
@@ -42,6 +42,8 @@ export default function AssistantProfileEditor({ customerPubkey }) {
   const [error, setError] = useState(null);
   const [publishing, setPublishing] = useState(false);
   const [publishResult, setPublishResult] = useState(null);
+  const [provisioning, setProvisioning] = useState(false);
+  const [provisionError, setProvisionError] = useState(null);
 
   const loadStatus = useCallback(async () => {
     if (!customerPubkey) return;
@@ -73,6 +75,22 @@ export default function AssistantProfileEditor({ customerPubkey }) {
     if (!status?.defaults) return;
     setForm(pickFields(status.defaults));
     setPublishResult(null);
+  }
+
+  async function provisionKey() {
+    setProvisioning(true);
+    setProvisionError(null);
+    try {
+      const res = await fetch('/api/assistant/provision-key', { method: 'POST' });
+      const data = await res.json();
+      if (!data.success) throw new Error(data.error || 'Provisioning failed');
+      // Key created; reload status so the editor flips into the form view.
+      await loadStatus();
+    } catch (err) {
+      setProvisionError(err.message);
+    } finally {
+      setProvisioning(false);
+    }
   }
 
   async function publish() {
@@ -112,15 +130,28 @@ export default function AssistantProfileEditor({ customerPubkey }) {
 
   if (!status?.hasRelayKey) {
     return (
-      <div className="settings-group">
-        <h3 style={{ margin: '0 0 0.5rem' }}>
-          {status?.isOwner ? '🤖 Tapestry Assistant Profile' : '🤖 Your Brainstorm Assistant Profile'}
+      <div className="settings-group" style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        <h3 style={{ margin: '0 0 0.25rem' }}>
+          {status?.isOwner ? '🤖 Tapestry Assistant Profile' : '🤖 Your Tapestry Assistant Profile'}
         </h3>
-        <p style={{ opacity: 0.8 }}>
-          {status?.isOwner
-            ? 'The Tapestry Assistant key has not been created yet. Restart the container to provision it.'
-            : 'Your Customer Relay Key has not been created yet. Set up Trusted Assertions first.'}
+        <p style={{ margin: 0, opacity: 0.8 }}>
+          You don't have a server-side Tapestry Assistant key yet. Create one to start publishing
+          {status?.isOwner ? ' automated events' : ' a kind 0 profile and kind 30382 Trust Assertions'} from your Assistant.
         </p>
+        <div>
+          <button
+            className="settings-action-btn"
+            onClick={provisionKey}
+            disabled={provisioning}
+          >
+            {provisioning ? 'Creating…' : 'Create my Tapestry Assistant key'}
+          </button>
+        </div>
+        {provisionError && (
+          <div className="settings-message settings-message-error" style={{ marginTop: 0 }}>
+            ❌ {provisionError}
+          </div>
+        )}
       </div>
     );
   }
@@ -133,12 +164,12 @@ export default function AssistantProfileEditor({ customerPubkey }) {
     <div className="settings-group" style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
       <div>
         <h3 style={{ margin: '0 0 0.25rem' }}>
-          {status.isOwner ? '🤖 Tapestry Assistant Profile' : '🤖 Your Brainstorm Assistant Profile'}
+          {status.isOwner ? '🤖 Tapestry Assistant Profile' : '🤖 Your Tapestry Assistant Profile'}
         </h3>
         <p style={{ margin: 0, fontSize: '0.85rem', opacity: 0.75 }}>
           {status.isOwner
             ? 'The kind 0 profile published by this instance\'s Tapestry Assistant — the server-side identity that signs automated events.'
-            : 'The kind 0 profile published by your server-side assistant — the identity that signs your kind 30382 Trust Assertions.'}
+            : 'The kind 0 profile published by your server-side Tapestry Assistant — the identity that signs your kind 30382 Trust Assertions.'}
         </p>
       </div>
 

--- a/ui/src/components/Header.jsx
+++ b/ui/src/components/Header.jsx
@@ -104,9 +104,11 @@ export default function Header({ onToggleSidebar }) {
                 <button className="dropdown-item" onClick={() => { setMenuOpen(false); navigate(`/tapestry/users/${user.pubkey}`); }}>
                   👤 My Profile
                 </button>
-                <button className="dropdown-item" onClick={() => { setMenuOpen(false); navigate(`/tapestry/users/${TA_PUBKEY}`); }}>
-                  🤖 My Assistant's Profile
-                </button>
+                {user.assistantPubkey && (
+                  <button className="dropdown-item" onClick={() => { setMenuOpen(false); navigate(`/tapestry/users/${user.assistantPubkey}`); }}>
+                    🤖 My Assistant's Profile
+                  </button>
+                )}
                 {(user.classification === 'owner' || user.classification === 'admin') && (
                   <button className="dropdown-item" onClick={() => { setMenuOpen(false); navigate('/tapestry/settings'); }}>
                     ⚙️ Settings

--- a/ui/src/context/AuthContext.jsx
+++ b/ui/src/context/AuthContext.jsx
@@ -41,6 +41,7 @@ export function AuthProvider({ children }) {
         setUser({
           pubkey: data.pubkey,
           classification: classData.classification || 'guest',
+          assistantPubkey: classData.assistantPubkey || null,
           profile,
         });
       } else {

--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -42,7 +42,7 @@ function WelcomeCard({ taProfile, onSetupProfile, onSurpriseMe }) {
           </p>
           <div style={{ display: 'flex', gap: '0.75rem' }}>
             <button className="btn btn-primary" onClick={onSetupProfile}>
-              🎨 Set up my profile
+              🎨 Set up my Assistant's profile
             </button>
             <button className="btn" onClick={onSurpriseMe}>
               🎲 Surprise me
@@ -736,7 +736,7 @@ export default function Dashboard() {
   function handleOnboardingAction(key) {
     switch (key) {
       case 'ta-profile':
-        navigate(`/tapestry/users/${TA_PUBKEY}`);
+        navigate('/tapestry/settings/assistant');
         break;
       case 'bios':
         navigate('/tapestry/settings/firmware');
@@ -782,7 +782,7 @@ export default function Dashboard() {
         <>
           <WelcomeCard
             taProfile={taProfile}
-            onSetupProfile={() => navigate(`/tapestry/users/${TA_PUBKEY}`)}
+            onSetupProfile={() => navigate('/tapestry/settings/assistant')}
             onSurpriseMe={handleSurpriseMe}
           />
           <OnboardingChecklist


### PR DESCRIPTION
## Summary

Three follow-ups to PR #207 surfaced after eye-testing on staging:

1. **The Dashboard "Set up my profile" button and the user-menu "My Assistant's Profile" link always pointed at the owner's Tapestry Assistant**, even when an admin was signed in. The user-classification endpoint now resolves the caller's own Assistant pubkey via `getAssistantKeys` and returns it as `assistantPubkey`; AuthContext exposes it; the Header dropdown uses it (and hides the link when absent); the Dashboard buttons now route to `/tapestry/settings/assistant` (the editor) so the page itself figures out which key belongs to the caller.

2. **An admin who isn't also a customer had no Assistant key**, so the editor's no-key state showed a dead-end "Set up Trusted Assertions first" message. New `POST /api/assistant/provision-key` generates a keypair and stores it under the caller's pubkey via SecureKeyStorage (same scheme as customer relay keys, so `getAssistantKeys` picks it up). Owner, admin, or active customer only. Refuses with 409 if a key already exists. The editor's no-key state now shows a "Create my Tapestry Assistant key" button calling this endpoint.

3. **Naming consistency** — the customer-side copy was "Brainstorm Assistant" while the owner-side said "Tapestry Assistant". Renamed throughout the editor and the customer default profile content.

The multi-role question (admin who later becomes customer, etc.) is filed in agent memory as a future concern; the current key storage scheme already enforces one Assistant per pubkey, so role transitions don't duplicate identities.

## Changes

- `src/api/assistant/index.js` — new `handleProvisionAssistantKey`; customer defaults renamed to "Tapestry Assistant".
- `src/api/auth/getUserClassification.js` — also resolves and returns `assistantPubkey`.
- `src/api/index.js` — registers `POST /api/assistant/provision-key`.
- `ui/src/components/AssistantProfileEditor.jsx` — "Brainstorm" → "Tapestry" rename; new "Create my Tapestry Assistant key" button + provision flow in the no-key state.
- `ui/src/components/Header.jsx` — "My Assistant's Profile" uses `user.assistantPubkey`, hidden if absent.
- `ui/src/context/AuthContext.jsx` — exposes `assistantPubkey` on the user object.
- `ui/src/pages/Dashboard.jsx` — `WelcomeCard` button + onboarding checklist action route to `/tapestry/settings/assistant`; button label clarified to "Set up my Assistant's profile".

## Test plan

- [ ] After merge: `deploy-staging.yml` runs cleanly.
- [ ] `GET /api/auth/user-classification` (unauth) returns `assistantPubkey: null`.
- [ ] `GET /api/auth/user-classification` while signed in as the owner returns the owner's TA pubkey as `assistantPubkey`.
- [ ] `POST /api/assistant/provision-key` without a session returns 401.
- [ ] `POST /api/assistant/provision-key` while signed in as the owner returns 409 (key already exists).
- [ ] Signed in as Nous (admin) with no existing key: editor's no-key state shows "Create my Tapestry Assistant key" button; clicking it provisions a key; editor flips to the form view with admin-flavored defaults; publish succeeds.
- [ ] Header dropdown "🤖 My Assistant's Profile" link routes to the signed-in user's own Assistant pubkey, not the owner's TA pubkey.
- [ ] Dashboard "🎨 Set up my Assistant's profile" button routes to `/tapestry/settings/assistant`.
- [ ] No "Brainstorm Assistant" copy remains anywhere in the editor — all references say "Tapestry Assistant".

🤖 Generated with [Claude Code](https://claude.com/claude-code)