### PR TITLE
docs: semaphore investigation handoff + intake hygiene + session-start discoverability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,11 @@ Before starting work, read all four:
 - [BIBLE.md](./BIBLE.md) — architecture, protocol, data model, API, design decisions (universal, fork-agnostic)
 - [OPERATIONS.md](./OPERATIONS.md) — brainstorm.world deployment: branches, CI/CD, droplets, gotchas
 
+**Also check at session start:**
+
+- [`docs/*HANDOFF*.md`](./docs/) — session continuity notes. Each handoff doc starts with a `**Status:**` line: `🔴 OPEN` = work hasn't been picked up; `✅ ADDRESSED / SUPERSEDED` = the follow-on work has shipped (the body is preserved for historical context, no action needed). Always scan for `OPEN` handoffs before starting fresh work — a previous session may have left specific instructions for the new one.
+- [`engineering-team/stories/_intake.md`](./engineering-team/stories/_intake.md) — queued-but-unplanned work catalog. See [engineering-team/README.md](./engineering-team/README.md) for the format. Scan before opening a fresh feature request — there's often a relevant entry already triaged.
+
 ## Engineering Team Mode
 
 This project runs every change through a **Product Owner → Architect → Tester → Implementer → Reviewer** harness with explicit human approval gates between phases. Pattern adapted from Rob Conery's *Eliminate Crappy Slop Code* (https://bigmachine.io/articles/video/eliminate-crappy-slop-code/).

--- a/docs/SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md
+++ b/docs/SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md
@@ -1,0 +1,145 @@
+# neo4j-heavy Semaphore Investigation — Session Handoff (2026-05-24)
+
+**Status:** 🔴 **OPEN** — investigation work not yet started; awaiting fresh session.
+**Audience:** the operator / next-session reader who is picking up the task-queue semaphore investigation.
+**Source session:** the multi-phase work on 2026-05-24 that (a) shipped story #25 (manual task re-trigger dedup fix) to prod, and (b) discovered during story #26's review that the `neo4j-heavy` semaphore is functionally broken — it releases ~5-6 seconds after acquire while tagged work runs unprotected for hours.
+
+---
+
+## TL;DR for the new session
+
+1. **The investigation target is the new HIGH-priority intake at [`engineering-team/stories/_intake.md`](../engineering-team/stories/_intake.md)** — the entry titled "**2026-05-24 — Bug: `neo4j-heavy` semaphore released ~5s after acquire while tagged work runs unprotected for hours**" (last entry in the file). It has the probe steps, fix-shape options, and impact analysis.
+2. **The full evidence + architectural context is in [`engineering-team/decisions/0023-task-queue-semaphore-protection-audit.md`](../engineering-team/decisions/0023-task-queue-semaphore-protection-audit.md)** — specifically the section titled "**2026-05-24 amendment (later) — chosen mechanism is functionally moot; story #26 paused pending root-cause investigation**". Read this for the empirical PID-by-PID evidence table, candidate hypotheses, and impact on past work (PR #201 + story #26).
+3. **There's a held branch** [`fix/launch-child-task-protection-audit`](https://github.com/nous-clawds4/tapestry/tree/fix/launch-child-task-protection-audit) on origin (pushed for preservation; NOT merged). It contains story #26's tag-additions + ADR amendments. After the investigation completes, the new session decides whether to revert, carry forward, or ship as no-op-with-honest-docs.
+4. **Don't trust ADR 0013's documented contract** (cap concurrent neo4j-heavy at 1) until the investigation completes. The contract is not actually enforced. See operational caveats below.
+
+---
+
+## What shipped to production today (story #25 only)
+
+| PR | Merge commit | Summary |
+|---|---|---|
+| [#205](https://github.com/nous-clawds4/tapestry/pull/205) | `cfa25e23` | Story #25 / ADR 0022 — manual task re-trigger dedup fix (closes Intake B) |
+| [#206](https://github.com/nous-clawds4/tapestry/pull/206) | `f94d3458` | Promotion of #205 to main |
+
+Story #25 added `removeOnComplete: true, removeOnFail: true` to the `queue.add` call at `src/manage/taskQueue/queue/index.js:185`. Manual `/api/run-task` re-triggers now correctly create fresh executions after the previous attempt finishes (completed or failed). Cycle-staging + cycle-prod both clean; current docs at brainstorm.world reflect the fix.
+
+## What's PAUSED (story #26)
+
+Story #26 ("Close `neo4j-heavy` semaphore coverage gaps for subshell-invoked task chains") went through Planning → Architecture → Test Design → Implementation → **paused at Review** when the operator surfaced the held_seconds=6 discovery.
+
+The paused work lives on `fix/launch-child-task-protection-audit` (6 commits ahead of `origin/staging` at the time of handoff). It contains:
+- `processAllTasks` and `processNpubsUpToMaxNumBlocks` tagged `resourceClass: "neo4j-heavy"` in `taskRegistry.json`
+- ADR 0013 amended in place with a "Protection model" section + audit-results table
+- BIBLE.md §24 updated with the parent-tag convention paragraph
+- ADR 0023 written + amended twice (JS-exec scope-out, then premise-undermined)
+- Reviewer report committed WITH withdrawal addendum (preserved audit trail)
+- 6 structural sentinels in `test/task-queue-semaphore-protection-audit.test.js`
+
+**The work is structurally correct against the AC list it was written against.** It just doesn't actually protect anything in production because the semaphore is released within ~6 seconds regardless. Decision on what to do with these commits is part of the investigation outcome.
+
+---
+
+## The discovery
+
+Operator noticed on staging Scheduled Tasks panel: `Process Brainstorm` (taskId: processCustomer) had a TASK_START at 7:12 PM EDT with no matching TASK_END for 1.5 hours. BullBoard active view: empty. Task explorer: TASK_START without TASK_END.
+
+Pulling `resource_class_*` events from `events.jsonl` revealed (all UTC):
+
+| Timestamp | Event | PID | Detail |
+|---|---|---|---|
+| 23:12:57.975 | `resource_class_wait_end` | 188 (Node Worker) | semaphore **acquired**, wait_seconds: 0 |
+| 23:12:58 | `TASK_START` (×2) | 1723 (processCustomer.sh) | task begins |
+| **23:13:03.973** | **`resource_class_released`** | **188** | semaphore released, **`held_seconds: 6`** |
+| (77-min gap — processCustomer.sh PID 1723 still running) | | | |
+| 00:29:37 (2026-05-25) | `TASK_END` (×2) | 1723 | task finishes |
+
+**Confirmed against another tagged task:** `updateAllScoresForOwner`'s most recent run (19:08:19 UTC) — same `held_seconds: 6` shape. Pattern is likely universal across all tagged tasks that go through the scheduler.
+
+**Mechanism (not yet root-caused):** The BullMQ Worker callback in `src/manage/taskQueue/queue/index.js:118-131` is `await processor.processJob(...)` then `await release()` in `finally`. processor.processJob spawns `bash launchChildTask.sh ...` and resolves on `child.on('close')`. Empirically that close fires within 5-6 seconds even when the backgrounded task script is clearly still running. **Why** the close fires is the open investigation question. Hypotheses (all unverified) in the intake entry.
+
+---
+
+## What to do first in the new session
+
+1. **Read the intake entry** (last entry in `engineering-team/stories/_intake.md`) for the probe shape + fix-shape options + impact analysis.
+2. **Read ADR 0023's amendment** for the full evidence + candidate root-cause hypotheses.
+3. **Write the reproduction probe** described in the intake (Method section: deterministic, runs inside the container, instruments every event in the chain). The probe identifies which event at T+~5s causes the close to fire while the work continues. Without the probe, fix design is guesswork.
+4. **Then design the fix** — the intake lists 5 fix shapes (fix launchChildTask PID tracking, fix processor.js spawn, refactor semaphore wrap into bash, lease/poll model, refactor parents to /api/run-task). Architect picks one after the probe results land.
+5. **Then re-evaluate story #26's held branch** — revert / carry forward / ship as no-op-with-honest-docs.
+
+Workflow: `/discuss` first (align on investigation scope + interpret the probe outcome), then Planning + Architecture + Test + Implementation + Review.
+
+---
+
+## Operational caveats while the investigation is open
+
+**Do NOT** rely on the `neo4j-heavy` semaphore for cross-task serialization until this is fixed. Specifically:
+
+- **Avoid the JS-exec API endpoints** (they bypass BullMQ AND the semaphore — separate intake also filed, see "JS-driven `child_process.exec`" entry in `_intake.md`):
+  - `POST /api/process-all-active-customers`
+  - `POST /api/generate-pagerank`
+  - `POST /api/generate-reports`
+  - `POST /api/generate-verified-followers`
+  - `GET /api/calculate-hops`-ish
+- **Don't manually trigger `/api/run-task` for heavy tasks** while another heavy task is scheduled to fire — the semaphore won't actually serialize them.
+- **Don't add new tagged scheduled entries** that overlap in cadence with existing ones.
+
+**But leave automated tasks running.** The broken-protection state has been live since story #15 shipped (~2026-05-20) without a Neo4j crash. Current scheduled fires are stable. Halting them would cost more (no GrapeRank recalcs, no Meili refresh, no NPub sync, no reconciliation, no customer processing) than the marginal risk reduction is worth. Whatever's been keeping Neo4j stable will continue.
+
+---
+
+## Other open intakes (so the new session doesn't lose track)
+
+All in [`engineering-team/stories/_intake.md`](../engineering-team/stories/_intake.md) — sorted by priority:
+
+### HIGH
+
+- **[2026-05-24] `neo4j-heavy` semaphore released ~5s after acquire** — THIS investigation (the one this handoff is about).
+
+### MEDIUM-HIGH
+
+- **[2026-05-24] Legacy API handlers `child_process.exec` tagged-task scripts directly, bypassing BullMQ + semaphore** — 5 endpoints listed; same root concern as this investigation but via different URLs.
+
+### MEDIUM
+
+- **[2026-05-24] `launch_child_task` subshell pattern bypasses BullMQ + `neo4j-heavy` semaphore** (the original Intake A — story #26's premise; superseded by this handoff's investigation but the architectural framing is still useful).
+
+### MEDIUM-LOW
+
+- **[2026-05-24] Unified all-tasks timeline UI (cross-queue past + present + future)** — operator-experience Feature surfaced during `/discuss` of Intake B. Independent from the semaphore work.
+- **[2026-05-21] `/relay` public HTTP landing page is unhelpful plain-text (+ NIP-11 merge silently incomplete)** — UX + Bug, public-facing.
+- **[2026-05-21] `reconcileAuthor` trigger surfaces (profile button + API + per-customer scheduling)** — Feature; engine works, UI/API surfaces deferred.
+- **[2026-05-21] Deprecate legacy `reconciliation` task + `reconcile.timer`** — Cleanup; superseded by story #21.
+
+### LOW
+
+- **[2026-05-24] Scheduled-fire job retention (`upsertJobScheduler` opts)** — Redis-memory hygiene; deferred from story #25.
+- **[2026-05-21] Per-request `/etc/brainstorm.conf` re-read spam in `brainstorm.log`** — log-hygiene.
+- **[2026-05-24] Origin-sync check at PO + Architect phases** — meta-tooling for the engineering-team harness; prevents stale-branch bugs at session start.
+
+Already-shipped older intakes from May 13–21 (`Scheduled task: refresh Meilisearch…`, `strfry-router FATAL on first boot`, `NIP-05 SSRF`, `graperank shared CSV race`, `generalized Task Scheduler`) are still in the log for historical context but no longer need action. A future cleanup pass could prune them.
+
+---
+
+## State of the world
+
+| Item | Status |
+|---|---|
+| `main` (prod) | `f94d3458` — story #25 live, behaves correctly within the now-known semaphore limitations |
+| `origin/staging` | `6aa92c08` — = main + PR #207 (`feat/assistant-profile` — unrelated, merged during this session by user) |
+| `fix/launch-child-task-protection-audit` | Pushed to origin, NOT merged. 6 commits of paused story #26 work + investigation evidence. |
+| `docs/semaphore-investigation-handoff-2026-05-24` | THIS doc + intake updates + README + CLAUDE.md updates. Ready for cycle-staging. |
+| Empirical probe | NOT YET WRITTEN. New session's first concrete work. |
+| Chrome MCP | Confirmed working at end of source session. Sign-in cookies shared with the user's main Chrome profile. |
+
+---
+
+## Where to start the next session
+
+1. Read this doc. Read the new-intake entry. Read ADR 0023's amendment.
+2. `/discuss` the investigation scope. Confirm: probe first, then fix design.
+3. `/plan-feature` the investigation as its own story.
+4. `/design-architecture` once the probe identifies the root cause.
+5. `/design-tests` + `/implement-feature` + `/review-changes` per the standard chain.
+6. After the fix lands and verifies on staging+prod, return to the held branch (`fix/launch-child-task-protection-audit`) and decide its fate.

--- a/docs/TASK_SCHEDULING_HANDOFF_2026-05-24.md
+++ b/docs/TASK_SCHEDULING_HANDOFF_2026-05-24.md
@@ -1,5 +1,15 @@
 # Task Scheduling — Session Handoff (2026-05-24)
 
+**Status:** ✅ **ADDRESSED / SUPERSEDED** by [`SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md`](SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md).
+
+The follow-on session this handoff was written for took place on 2026-05-24. During it: story #25 (Intake B — manual task re-trigger dedup fix) shipped to prod; story #26 (Intake A — close subshell-chain semaphore coverage gaps) ran through Planning → Architecture → Test Design → Implementation → Review and was then PAUSED when an operator-surfaced discrepancy revealed that the `neo4j-heavy` semaphore is functionally broken (released ~5-6 seconds after acquire while tagged work runs unprotected for hours). That discovery is now the primary investigation target. **New work continues from the superseding handoff doc above, not from this one.**
+
+The testing checklist (T1–T28) below was largely overtaken by events — story #25 implicitly verified many of the items by shipping cleanly, and the semaphore discovery makes T11/T27's behavioral claims about cross-task serialization moot until the investigation lands.
+
+The original content of this handoff is preserved below for historical context.
+
+---
+
 > **Audience:** the operator / next-session reader who wants to know what shipped today, what's been verified, what hasn't, and where to start testing.
 > **Source session:** the multi-PR cycle on 2026-05-24 that closed story #24 (per-entry scheduled tasks with arguments) plus three operator-discovered follow-up fixes.
 

--- a/engineering-team/README.md
+++ b/engineering-team/README.md
@@ -14,8 +14,11 @@ engineering-team/
 ├── templates/          document templates (user story, ADR, test plan, review)
 ├── decisions/          ADRs accumulate here as <NNNN>-<slug>.md
 ├── stories/            user stories accumulate here as <n>-<slug>.md
+│   └── _intake.md      queued-but-unplanned work catalog (see below)
 └── reviews/            review reports accumulate here as <n>-<slug>.md
 ```
+
+**`stories/_intake.md`** is the append-only queue of incoming requests that haven't been formalized as stories yet. Anything a session surfaces that's worth doing but isn't ready for `/plan-feature` lands here first with classification + priority + a sketch of the work. When picking up new work, scan `_intake.md` for queued items before opening a fresh feature request — there's often a relevant entry already triaged. Entries are roughly chronological and dated `## YYYY-MM-DD — <Type>: <slug>`. Filed entries are not auto-pruned when shipped; older entries may be historical.
 
 The Claude Code wiring lives elsewhere:
 

--- a/engineering-team/stories/_intake.md
+++ b/engineering-team/stories/_intake.md
@@ -360,3 +360,99 @@ await queue.upsertJobScheduler(
 **Strictness:** Standard.
 **Phase path:** Architecture (brief — same Option A pattern as ADR 0022 applied to a sibling code path) → Test Design (one sentinel + one probe extension) → Implementation → Review. Architecture could potentially fast-track since the design rationale is verbatim ADR 0022.
 **Priority:** Low. Slow-growing Redis bloat; no operator workflow blocked today. Worth doing for hygiene before the next major task-queue work or if Redis memory becomes a concern.
+
+---
+
+## 2026-05-24 — Architecture: legacy API handlers `child_process.exec` tagged-task scripts directly, bypassing BullMQ + semaphore
+
+**Surfaced during:** the Implementer's audit pass for story #26 / ADR 0023 on 2026-05-24. Halted implementation per ADR 0023's Outcome contract ("stop and re-open ADR 0023 if the audit surfaces a new spawn pattern not enumerated... or any other novelty"). ADR 0023's amendment scopes the JS-exec pattern OUT and files this intake.
+
+**Mechanism:** five registered API endpoints in `src/api/index.js` route to JS handlers that use `child_process.exec` to spawn bash scripts directly. The spawned scripts map to neo4j-heavy tagged tasks in the registry, but the exec path completely bypasses BullMQ — no Worker callback runs, no semaphore acquire happens. Parent-tag inheritance (the mechanism story #26 ships for the subshell pattern) does not apply because there's no parent in a BullMQ Worker callback chain; the handler IS the entry point.
+
+**Confirmed handler-to-tagged-task mappings:**
+
+| Endpoint | Handler | Tagged task |
+|---|---|---|
+| `POST /api/process-all-active-customers` | `process-all-active-customers.js:21` | processAllActiveCustomers |
+| `POST /api/generate-pagerank` | `algos/pagerank/commands/generate.js:21` | calculateOwnerPageRank |
+| `POST /api/generate-reports` | `algos/reports/commands/generate.js:21` | calculateReportScores |
+| `POST /api/generate-verified-followers` | `algos/verifiedFollowers/commands/generate.js:21` | calculateVerifiedFollowerCounts |
+| `GET /api/calculate-hops`-ish | `algos/hops/commands/calculate.js:31` | calculateCustomerHops |
+
+Also flagged: `algos/graperank/commands/generate.js` spawns `calculatePersonalizedGrapeRank.sh` (not in registry — possibly superseded by `/api/run-task?taskName=calculateOwnerGrapeRank`), `pipeline/reconcile/commands/execute.js` spawns `reconciliation.sh` (deprecated path per OPERATIONS.md). These two probably want deprecation rather than refactor.
+
+**Three remediation options (Architect to triage):**
+
+1. **Refactor JS handlers to enqueue via BullMQ.** Replace the `exec` call with a call to `taskQueue.enqueueTask` (or an internal `/api/run-task` HTTP call). Job goes through Worker callback, semaphore engages, BullBoard sees it. Closest to ADR 0012's intent. Trade-off: ~5 handler files to touch + behavioral migration (sync vs async semantics, response shape).
+2. **Deprecate the legacy endpoints.** These handlers predate `/api/run-task` (story #13 / ADR 0012, 2026-05-20). Confirm no live consumers (UI, scripts, cron); if clear, remove the endpoint + handler; document `/api/run-task?taskName=<task>` as the replacement. Smallest diff if no consumers; can't ship if consumers exist.
+3. **Accept + document.** Add a warning to each handler comment + OPERATIONS.md noting these bypass the semaphore. Punts the gap. Probably unacceptable for the live `/api/generate-pagerank` and `/api/process-all-active-customers` endpoints — they run heavy Neo4j work.
+
+**Classification:** Bug — public API endpoints bypass the documented ADR 0013 protection model. Same neo4j-heavy serialization concern as Intake A but via different URLs.
+**Strictness:** Standard.
+**Phase path:** `/discuss` first to triage the three options (especially: which endpoints have live consumers? which to refactor vs deprecate?), then Planning → Architecture → Test Design → Implementation → Review.
+**Priority:** Medium-high. Operator-triggerable, currently unprotected on prod. Same severity as Intake B was before story #25 closed it.
+
+---
+
+## 2026-05-24 — Bug: `neo4j-heavy` semaphore released ~5s after acquire while tagged work runs unprotected for hours
+
+**Surfaced during:** Review-phase operator triage on story #26 / ADR 0023. Operator noticed a "Running" task in the Scheduled Tasks panel with no matching TASK_END for 1.5 hours; investigation revealed `held_seconds: 6` on `resource_class_released` events across MULTIPLE tagged tasks (`processCustomer`, `updateAllScoresForOwner` confirmed; pattern likely universal). See ADR 0023's 2026-05-24 (later) amendment for the full evidence table.
+
+**The bug:** The BullMQ Worker callback at `src/manage/taskQueue/queue/index.js:118-131` is `await processor.processJob(...)` then `await release()`. processor.processJob spawns `bash launchChildTask.sh ...` and resolves on `child.on('close')`. Empirically, that close event fires ~5-6 seconds after spawn EVEN WHEN the underlying task script (e.g., processCustomer.sh) is still running and will continue running for hours. As a result, the semaphore releases ~5-6s after acquire, and the actual heavy Neo4j work runs concurrently with any other heavy work — defeating ADR 0013's cap=1 serialization contract.
+
+**Investigation required:** what causes `child.on('close')` on the launchChildTask.sh bash process to fire within 5-6 seconds when the backgrounded child it spawned is still running? Candidate hypotheses (unverified):
+1. `launchChildTask.sh:380-390`'s `while ps -p $child_pid` monitor loop exits prematurely — possibly the captured PID from `bash $child_script &` corresponds to a short-lived intermediate.
+2. BullMQ stalled-job recovery (default 30s `stalledInterval` × `maxStalledCount`=1) fires and moves the job, triggering the `finally` block.
+3. Bash subshell semantics with `&` + `set -e`/`set -o pipefail` cause the wrapper to exit unexpectedly.
+4. Something else.
+
+**Method:** write a deterministic reproduction probe (similar in shape to story #25's `probe-bullmq-removeOnComplete-immediate.js`). Steps:
+1. Create a synthetic tagged task whose script sleeps for N=120 seconds.
+2. Wire it through the actual `initTaskQueue` machinery (real BullMQ Worker, real semaphore wrap, real processor.js → launchChildTask.sh path).
+3. Trigger via `enqueueTask` or scheduler.
+4. Observe and log: Worker callback entry time, semaphore acquire time, bash subprocess spawn time, every `ps -p $child_pid` check result in launchChildTask.sh, `child.on('close')` fire time, semaphore release time, bash subprocess actual end time.
+5. Identify exactly which event fires at T+~5s that causes the close to fire while the work continues.
+
+**Once root cause identified, design the fix.** Possible fix shapes (architect chooses after the probe finishes):
+- **Fix launchChildTask.sh's PID tracking** so the monitor loop waits for the actual long-running process, not an intermediate.
+- **Fix the spawn pattern in processor.js** to use `child_process.spawn` with options that don't background-detach the subprocess.
+- **Refactor the semaphore wrap location** to be inside launchChildTask.sh itself (using Redis directly) so it covers the full subprocess lifetime regardless of Node-side timing.
+- **Refactor to a poll/lease model** where the Worker periodically checks if the bash subprocess is still running and re-acquires/renews the semaphore lease.
+- **Bigger refactor:** Option B from `/discuss` (refactor parents to enqueue children via /api/run-task) — children flow through their own BullMQ Workers, semaphore engages on each.
+
+**Impact on story #26:** That story's tag-additions are functionally moot pending this fix. They can be: (a) reverted, (b) kept as "no-op-but-documented" with the BIBLE.md / ADR amendments updated to reflect the actual broken state, or (c) carried forward into the investigation story and shipped together with the real fix. Architect/PO call.
+
+**Impact on PR #201's tagging:** Same. PR #201's value was always "defense-in-depth on the BullMQ-direct path" — that part still works (when a tagged task is fired via `/api/run-task` directly, the Worker callback wraps the few seconds of setup with the semaphore). But the "protect the subshell chain" intent is empty.
+
+**Classification:** Bug — high severity (load-bearing assumption violated, ADR 0013's documented contract not enforced, multiple shipped stories built on this assumption).
+**Strictness:** Standard.
+**Phase path:** `/discuss` first to align on the investigation scope, then Planning (probe + investigation story), then Architecture (fix design after probe results), then Test Design / Implementation / Review.
+**Priority:** **HIGH.** Architecture's stated contract has been functionally absent for the entire life of the resource-class semaphore (story #15, 2026-05-20 onward). Each new Neo4j-heavy task added since then has been relying on a protection that doesn't actually engage. Investigation deserves immediate attention.
+
+---
+
+## 2026-05-24 — Meta: origin-sync check at PO + Architect phase entry
+
+**Surfaced during:** the 2026-05-24 session start. A chip was spawned proposing this same idea (a pre-flight check that verifies the local branch is in sync with origin before any PO or Architect work begins). The chip was never picked up. Filed here as a proper intake so the work doesn't depend on the chip persisting.
+
+**Background:** during the work-up to story #25, the session started on a branch (`main`) that was *behind* `origin/staging`. The drift wasn't caught until pushing time, costing a small but real debugging cycle. This is a recurring class of bug at session boundaries when the operator switches between machines / branches across sessions.
+
+**Goal:** Make this drift impossible (or at least loud) at the *start* of a session. Specifically, the Product Owner and Architect phases of `engineering-team/` should refuse to proceed (or warn aggressively) if `git fetch` would reveal divergence from the configured base branch.
+
+**Where to look:**
+- `engineering-team/roles/product-owner.md`
+- `engineering-team/roles/architect.md`
+- `engineering-team/workflows/1-planning.md`
+- `engineering-team/workflows/2-architecture.md`
+- Any pre-flight check pattern already in `.claude/agents/*.md` or `.claude/commands/*.md`
+
+**Decision points to triage:**
+1. Should this be a hard fail (refuse to plan/design) or just a loud warning?
+2. Should the check fetch automatically, or just compare `HEAD` vs the cached `origin/<base>`?
+3. Which base branch? Likely `origin/staging` for this project per `OPERATIONS.md`, but the check should probably read from a config rather than hardcode.
+4. Should this apply to all five phases or just the two upstream ones (PO + Architect)?
+
+**Classification:** Meta-tooling (engineering-team harness improvement; no production code impact).
+**Strictness:** Standard.
+**Phase path:** `/discuss` first to settle the four decision points; then likely Implementation + Review (Architecture and Test Design probably skippable — small mechanical change with no ADR-worthy design choice).
+**Priority:** Low. Quality-of-life improvement for the harness. No correctness issue today.


### PR DESCRIPTION
## Summary

End-of-session wrap-up for the 2026-05-24 multi-phase work. Pure docs + harness-config change — no source code, no registry edits, no behavior change. Closes a documentation gap (`_intake.md` wasn't discoverable from `engineering-team/README.md` or `CLAUDE.md`), formalizes a handoff-doc Status convention, and ensures the next session can pick up the in-flight investigation work without dropping context.

The held investigation branch [`fix/launch-child-task-protection-audit`](https://github.com/nous-clawds4/tapestry/tree/fix/launch-child-task-protection-audit) is preserved on origin (also pushed today) but explicitly NOT merged — the new session decides its fate after the root-cause investigation completes.

## Changes

- **`docs/SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md`** (new) — 🔴 OPEN handoff. Points the next session at the HIGH-priority `_intake.md` entry for the `neo4j-heavy` semaphore root-cause investigation, the held branch, and ADR 0023's evidence amendment. Also lists other open intakes and operational caveats for working while the bug is live.
- **`docs/TASK_SCHEDULING_HANDOFF_2026-05-24.md`** — added ✅ ADDRESSED / SUPERSEDED Status header pointing to the new handoff. Original body preserved for historical context.
- **`engineering-team/stories/_intake.md`** — three new entries:
  - **HIGH:** `neo4j-heavy` semaphore released ~5s after acquire while tagged work runs unprotected for hours (the investigation target).
  - **Medium-high:** Legacy API handlers `child_process.exec` tagged-task scripts directly, bypassing BullMQ + semaphore.
  - **Low:** Meta — origin-sync check at PO + Architect phase entry (filed from the parked chip).
- **`engineering-team/README.md`** — Layout section now lists `_intake.md` + a paragraph explaining what it's for.
- **`CLAUDE.md`** — new "Also check at session start" subsection: handoff Status convention (🔴 OPEN / ✅ ADDRESSED) + scan list (`docs/*HANDOFF*.md` + `_intake.md`).

## Test plan

- [ ] After merge: `deploy-staging.yml` runs.
- [ ] Stability poll on `staging.brainstorm.world` (Tier 1).
- [ ] Verify the new handoff doc is fetchable on staging: `curl https://staging.brainstorm.world/...` (or via the deployed file tree).
- [ ] Grep `engineering-team/README.md` on the running container to confirm the `_intake.md` mention is present post-deploy.
- [ ] No regression to existing pages or APIs (docs change shouldn't affect runtime — Tier 2 sanity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)