### PR TITLE
Promote staging → main: docs handoff + assistant-profile bundle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,11 @@ Before starting work, read all four:
 - [BIBLE.md](./BIBLE.md) — architecture, protocol, data model, API, design decisions (universal, fork-agnostic)
 - [OPERATIONS.md](./OPERATIONS.md) — brainstorm.world deployment: branches, CI/CD, droplets, gotchas
 
+**Also check at session start:**
+
+- [`docs/*HANDOFF*.md`](./docs/) — session continuity notes. Each handoff doc starts with a `**Status:**` line: `🔴 OPEN` = work hasn't been picked up; `✅ ADDRESSED / SUPERSEDED` = the follow-on work has shipped (the body is preserved for historical context, no action needed). Always scan for `OPEN` handoffs before starting fresh work — a previous session may have left specific instructions for the new one.
+- [`engineering-team/stories/_intake.md`](./engineering-team/stories/_intake.md) — queued-but-unplanned work catalog. See [engineering-team/README.md](./engineering-team/README.md) for the format. Scan before opening a fresh feature request — there's often a relevant entry already triaged.
+
 ## Engineering Team Mode
 
 This project runs every change through a **Product Owner → Architect → Tester → Implementer → Reviewer** harness with explicit human approval gates between phases. Pattern adapted from Rob Conery's *Eliminate Crappy Slop Code* (https://bigmachine.io/articles/video/eliminate-crappy-slop-code/).

--- a/docs/SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md
+++ b/docs/SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md
@@ -1,0 +1,145 @@
+# neo4j-heavy Semaphore Investigation — Session Handoff (2026-05-24)
+
+**Status:** 🔴 **OPEN** — investigation work not yet started; awaiting fresh session.
+**Audience:** the operator / next-session reader who is picking up the task-queue semaphore investigation.
+**Source session:** the multi-phase work on 2026-05-24 that (a) shipped story #25 (manual task re-trigger dedup fix) to prod, and (b) discovered during story #26's review that the `neo4j-heavy` semaphore is functionally broken — it releases ~5-6 seconds after acquire while tagged work runs unprotected for hours.
+
+---
+
+## TL;DR for the new session
+
+1. **The investigation target is the new HIGH-priority intake at [`engineering-team/stories/_intake.md`](../engineering-team/stories/_intake.md)** — the entry titled "**2026-05-24 — Bug: `neo4j-heavy` semaphore released ~5s after acquire while tagged work runs unprotected for hours**" (last entry in the file). It has the probe steps, fix-shape options, and impact analysis.
+2. **The full evidence + architectural context is in [`engineering-team/decisions/0023-task-queue-semaphore-protection-audit.md`](../engineering-team/decisions/0023-task-queue-semaphore-protection-audit.md)** — specifically the section titled "**2026-05-24 amendment (later) — chosen mechanism is functionally moot; story #26 paused pending root-cause investigation**". Read this for the empirical PID-by-PID evidence table, candidate hypotheses, and impact on past work (PR #201 + story #26).
+3. **There's a held branch** [`fix/launch-child-task-protection-audit`](https://github.com/nous-clawds4/tapestry/tree/fix/launch-child-task-protection-audit) on origin (pushed for preservation; NOT merged). It contains story #26's tag-additions + ADR amendments. After the investigation completes, the new session decides whether to revert, carry forward, or ship as no-op-with-honest-docs.
+4. **Don't trust ADR 0013's documented contract** (cap concurrent neo4j-heavy at 1) until the investigation completes. The contract is not actually enforced. See operational caveats below.
+
+---
+
+## What shipped to production today (story #25 only)
+
+| PR | Merge commit | Summary |
+|---|---|---|
+| [#205](https://github.com/nous-clawds4/tapestry/pull/205) | `cfa25e23` | Story #25 / ADR 0022 — manual task re-trigger dedup fix (closes Intake B) |
+| [#206](https://github.com/nous-clawds4/tapestry/pull/206) | `f94d3458` | Promotion of #205 to main |
+
+Story #25 added `removeOnComplete: true, removeOnFail: true` to the `queue.add` call at `src/manage/taskQueue/queue/index.js:185`. Manual `/api/run-task` re-triggers now correctly create fresh executions after the previous attempt finishes (completed or failed). Cycle-staging + cycle-prod both clean; current docs at brainstorm.world reflect the fix.
+
+## What's PAUSED (story #26)
+
+Story #26 ("Close `neo4j-heavy` semaphore coverage gaps for subshell-invoked task chains") went through Planning → Architecture → Test Design → Implementation → **paused at Review** when the operator surfaced the held_seconds=6 discovery.
+
+The paused work lives on `fix/launch-child-task-protection-audit` (6 commits ahead of `origin/staging` at the time of handoff). It contains:
+- `processAllTasks` and `processNpubsUpToMaxNumBlocks` tagged `resourceClass: "neo4j-heavy"` in `taskRegistry.json`
+- ADR 0013 amended in place with a "Protection model" section + audit-results table
+- BIBLE.md §24 updated with the parent-tag convention paragraph
+- ADR 0023 written + amended twice (JS-exec scope-out, then premise-undermined)
+- Reviewer report committed WITH withdrawal addendum (preserved audit trail)
+- 6 structural sentinels in `test/task-queue-semaphore-protection-audit.test.js`
+
+**The work is structurally correct against the AC list it was written against.** It just doesn't actually protect anything in production because the semaphore is released within ~6 seconds regardless. Decision on what to do with these commits is part of the investigation outcome.
+
+---
+
+## The discovery
+
+Operator noticed on staging Scheduled Tasks panel: `Process Brainstorm` (taskId: processCustomer) had a TASK_START at 7:12 PM EDT with no matching TASK_END for 1.5 hours. BullBoard active view: empty. Task explorer: TASK_START without TASK_END.
+
+Pulling `resource_class_*` events from `events.jsonl` revealed (all UTC):
+
+| Timestamp | Event | PID | Detail |
+|---|---|---|---|
+| 23:12:57.975 | `resource_class_wait_end` | 188 (Node Worker) | semaphore **acquired**, wait_seconds: 0 |
+| 23:12:58 | `TASK_START` (×2) | 1723 (processCustomer.sh) | task begins |
+| **23:13:03.973** | **`resource_class_released`** | **188** | semaphore released, **`held_seconds: 6`** |
+| (77-min gap — processCustomer.sh PID 1723 still running) | | | |
+| 00:29:37 (2026-05-25) | `TASK_END` (×2) | 1723 | task finishes |
+
+**Confirmed against another tagged task:** `updateAllScoresForOwner`'s most recent run (19:08:19 UTC) — same `held_seconds: 6` shape. Pattern is likely universal across all tagged tasks that go through the scheduler.
+
+**Mechanism (not yet root-caused):** The BullMQ Worker callback in `src/manage/taskQueue/queue/index.js:118-131` is `await processor.processJob(...)` then `await release()` in `finally`. processor.processJob spawns `bash launchChildTask.sh ...` and resolves on `child.on('close')`. Empirically that close fires within 5-6 seconds even when the backgrounded task script is clearly still running. **Why** the close fires is the open investigation question. Hypotheses (all unverified) in the intake entry.
+
+---
+
+## What to do first in the new session
+
+1. **Read the intake entry** (last entry in `engineering-team/stories/_intake.md`) for the probe shape + fix-shape options + impact analysis.
+2. **Read ADR 0023's amendment** for the full evidence + candidate root-cause hypotheses.
+3. **Write the reproduction probe** described in the intake (Method section: deterministic, runs inside the container, instruments every event in the chain). The probe identifies which event at T+~5s causes the close to fire while the work continues. Without the probe, fix design is guesswork.
+4. **Then design the fix** — the intake lists 5 fix shapes (fix launchChildTask PID tracking, fix processor.js spawn, refactor semaphore wrap into bash, lease/poll model, refactor parents to /api/run-task). Architect picks one after the probe results land.
+5. **Then re-evaluate story #26's held branch** — revert / carry forward / ship as no-op-with-honest-docs.
+
+Workflow: `/discuss` first (align on investigation scope + interpret the probe outcome), then Planning + Architecture + Test + Implementation + Review.
+
+---
+
+## Operational caveats while the investigation is open
+
+**Do NOT** rely on the `neo4j-heavy` semaphore for cross-task serialization until this is fixed. Specifically:
+
+- **Avoid the JS-exec API endpoints** (they bypass BullMQ AND the semaphore — separate intake also filed, see "JS-driven `child_process.exec`" entry in `_intake.md`):
+  - `POST /api/process-all-active-customers`
+  - `POST /api/generate-pagerank`
+  - `POST /api/generate-reports`
+  - `POST /api/generate-verified-followers`
+  - `GET /api/calculate-hops`-ish
+- **Don't manually trigger `/api/run-task` for heavy tasks** while another heavy task is scheduled to fire — the semaphore won't actually serialize them.
+- **Don't add new tagged scheduled entries** that overlap in cadence with existing ones.
+
+**But leave automated tasks running.** The broken-protection state has been live since story #15 shipped (~2026-05-20) without a Neo4j crash. Current scheduled fires are stable. Halting them would cost more (no GrapeRank recalcs, no Meili refresh, no NPub sync, no reconciliation, no customer processing) than the marginal risk reduction is worth. Whatever's been keeping Neo4j stable will continue.
+
+---
+
+## Other open intakes (so the new session doesn't lose track)
+
+All in [`engineering-team/stories/_intake.md`](../engineering-team/stories/_intake.md) — sorted by priority:
+
+### HIGH
+
+- **[2026-05-24] `neo4j-heavy` semaphore released ~5s after acquire** — THIS investigation (the one this handoff is about).
+
+### MEDIUM-HIGH
+
+- **[2026-05-24] Legacy API handlers `child_process.exec` tagged-task scripts directly, bypassing BullMQ + semaphore** — 5 endpoints listed; same root concern as this investigation but via different URLs.
+
+### MEDIUM
+
+- **[2026-05-24] `launch_child_task` subshell pattern bypasses BullMQ + `neo4j-heavy` semaphore** (the original Intake A — story #26's premise; superseded by this handoff's investigation but the architectural framing is still useful).
+
+### MEDIUM-LOW
+
+- **[2026-05-24] Unified all-tasks timeline UI (cross-queue past + present + future)** — operator-experience Feature surfaced during `/discuss` of Intake B. Independent from the semaphore work.
+- **[2026-05-21] `/relay` public HTTP landing page is unhelpful plain-text (+ NIP-11 merge silently incomplete)** — UX + Bug, public-facing.
+- **[2026-05-21] `reconcileAuthor` trigger surfaces (profile button + API + per-customer scheduling)** — Feature; engine works, UI/API surfaces deferred.
+- **[2026-05-21] Deprecate legacy `reconciliation` task + `reconcile.timer`** — Cleanup; superseded by story #21.
+
+### LOW
+
+- **[2026-05-24] Scheduled-fire job retention (`upsertJobScheduler` opts)** — Redis-memory hygiene; deferred from story #25.
+- **[2026-05-21] Per-request `/etc/brainstorm.conf` re-read spam in `brainstorm.log`** — log-hygiene.
+- **[2026-05-24] Origin-sync check at PO + Architect phases** — meta-tooling for the engineering-team harness; prevents stale-branch bugs at session start.
+
+Already-shipped older intakes from May 13–21 (`Scheduled task: refresh Meilisearch…`, `strfry-router FATAL on first boot`, `NIP-05 SSRF`, `graperank shared CSV race`, `generalized Task Scheduler`) are still in the log for historical context but no longer need action. A future cleanup pass could prune them.
+
+---
+
+## State of the world
+
+| Item | Status |
+|---|---|
+| `main` (prod) | `f94d3458` — story #25 live, behaves correctly within the now-known semaphore limitations |
+| `origin/staging` | `6aa92c08` — = main + PR #207 (`feat/assistant-profile` — unrelated, merged during this session by user) |
+| `fix/launch-child-task-protection-audit` | Pushed to origin, NOT merged. 6 commits of paused story #26 work + investigation evidence. |
+| `docs/semaphore-investigation-handoff-2026-05-24` | THIS doc + intake updates + README + CLAUDE.md updates. Ready for cycle-staging. |
+| Empirical probe | NOT YET WRITTEN. New session's first concrete work. |
+| Chrome MCP | Confirmed working at end of source session. Sign-in cookies shared with the user's main Chrome profile. |
+
+---
+
+## Where to start the next session
+
+1. Read this doc. Read the new-intake entry. Read ADR 0023's amendment.
+2. `/discuss` the investigation scope. Confirm: probe first, then fix design.
+3. `/plan-feature` the investigation as its own story.
+4. `/design-architecture` once the probe identifies the root cause.
+5. `/design-tests` + `/implement-feature` + `/review-changes` per the standard chain.
+6. After the fix lands and verifies on staging+prod, return to the held branch (`fix/launch-child-task-protection-audit`) and decide its fate.

--- a/docs/TASK_SCHEDULING_HANDOFF_2026-05-24.md
+++ b/docs/TASK_SCHEDULING_HANDOFF_2026-05-24.md
@@ -1,5 +1,15 @@
 # Task Scheduling — Session Handoff (2026-05-24)
 
+**Status:** ✅ **ADDRESSED / SUPERSEDED** by [`SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md`](SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md).
+
+The follow-on session this handoff was written for took place on 2026-05-24. During it: story #25 (Intake B — manual task re-trigger dedup fix) shipped to prod; story #26 (Intake A — close subshell-chain semaphore coverage gaps) ran through Planning → Architecture → Test Design → Implementation → Review and was then PAUSED when an operator-surfaced discrepancy revealed that the `neo4j-heavy` semaphore is functionally broken (released ~5-6 seconds after acquire while tagged work runs unprotected for hours). That discovery is now the primary investigation target. **New work continues from the superseding handoff doc above, not from this one.**
+
+The testing checklist (T1–T28) below was largely overtaken by events — story #25 implicitly verified many of the items by shipping cleanly, and the semaphore discovery makes T11/T27's behavioral claims about cross-task serialization moot until the investigation lands.
+
+The original content of this handoff is preserved below for historical context.
+
+---
+
 > **Audience:** the operator / next-session reader who wants to know what shipped today, what's been verified, what hasn't, and where to start testing.
 > **Source session:** the multi-PR cycle on 2026-05-24 that closed story #24 (per-entry scheduled tasks with arguments) plus three operator-discovered follow-up fixes.
 

--- a/engineering-team/README.md
+++ b/engineering-team/README.md
@@ -14,8 +14,11 @@ engineering-team/
 ├── templates/          document templates (user story, ADR, test plan, review)
 ├── decisions/          ADRs accumulate here as <NNNN>-<slug>.md
 ├── stories/            user stories accumulate here as <n>-<slug>.md
+│   └── _intake.md      queued-but-unplanned work catalog (see below)
 └── reviews/            review reports accumulate here as <n>-<slug>.md
 ```
+
+**`stories/_intake.md`** is the append-only queue of incoming requests that haven't been formalized as stories yet. Anything a session surfaces that's worth doing but isn't ready for `/plan-feature` lands here first with classification + priority + a sketch of the work. When picking up new work, scan `_intake.md` for queued items before opening a fresh feature request — there's often a relevant entry already triaged. Entries are roughly chronological and dated `## YYYY-MM-DD — <Type>: <slug>`. Filed entries are not auto-pruned when shipped; older entries may be historical.
 
 The Claude Code wiring lives elsewhere:
 

--- a/engineering-team/stories/_intake.md
+++ b/engineering-team/stories/_intake.md
@@ -360,3 +360,99 @@ await queue.upsertJobScheduler(
 **Strictness:** Standard.
 **Phase path:** Architecture (brief — same Option A pattern as ADR 0022 applied to a sibling code path) → Test Design (one sentinel + one probe extension) → Implementation → Review. Architecture could potentially fast-track since the design rationale is verbatim ADR 0022.
 **Priority:** Low. Slow-growing Redis bloat; no operator workflow blocked today. Worth doing for hygiene before the next major task-queue work or if Redis memory becomes a concern.
+
+---
+
+## 2026-05-24 — Architecture: legacy API handlers `child_process.exec` tagged-task scripts directly, bypassing BullMQ + semaphore
+
+**Surfaced during:** the Implementer's audit pass for story #26 / ADR 0023 on 2026-05-24. Halted implementation per ADR 0023's Outcome contract ("stop and re-open ADR 0023 if the audit surfaces a new spawn pattern not enumerated... or any other novelty"). ADR 0023's amendment scopes the JS-exec pattern OUT and files this intake.
+
+**Mechanism:** five registered API endpoints in `src/api/index.js` route to JS handlers that use `child_process.exec` to spawn bash scripts directly. The spawned scripts map to neo4j-heavy tagged tasks in the registry, but the exec path completely bypasses BullMQ — no Worker callback runs, no semaphore acquire happens. Parent-tag inheritance (the mechanism story #26 ships for the subshell pattern) does not apply because there's no parent in a BullMQ Worker callback chain; the handler IS the entry point.
+
+**Confirmed handler-to-tagged-task mappings:**
+
+| Endpoint | Handler | Tagged task |
+|---|---|---|
+| `POST /api/process-all-active-customers` | `process-all-active-customers.js:21` | processAllActiveCustomers |
+| `POST /api/generate-pagerank` | `algos/pagerank/commands/generate.js:21` | calculateOwnerPageRank |
+| `POST /api/generate-reports` | `algos/reports/commands/generate.js:21` | calculateReportScores |
+| `POST /api/generate-verified-followers` | `algos/verifiedFollowers/commands/generate.js:21` | calculateVerifiedFollowerCounts |
+| `GET /api/calculate-hops`-ish | `algos/hops/commands/calculate.js:31` | calculateCustomerHops |
+
+Also flagged: `algos/graperank/commands/generate.js` spawns `calculatePersonalizedGrapeRank.sh` (not in registry — possibly superseded by `/api/run-task?taskName=calculateOwnerGrapeRank`), `pipeline/reconcile/commands/execute.js` spawns `reconciliation.sh` (deprecated path per OPERATIONS.md). These two probably want deprecation rather than refactor.
+
+**Three remediation options (Architect to triage):**
+
+1. **Refactor JS handlers to enqueue via BullMQ.** Replace the `exec` call with a call to `taskQueue.enqueueTask` (or an internal `/api/run-task` HTTP call). Job goes through Worker callback, semaphore engages, BullBoard sees it. Closest to ADR 0012's intent. Trade-off: ~5 handler files to touch + behavioral migration (sync vs async semantics, response shape).
+2. **Deprecate the legacy endpoints.** These handlers predate `/api/run-task` (story #13 / ADR 0012, 2026-05-20). Confirm no live consumers (UI, scripts, cron); if clear, remove the endpoint + handler; document `/api/run-task?taskName=<task>` as the replacement. Smallest diff if no consumers; can't ship if consumers exist.
+3. **Accept + document.** Add a warning to each handler comment + OPERATIONS.md noting these bypass the semaphore. Punts the gap. Probably unacceptable for the live `/api/generate-pagerank` and `/api/process-all-active-customers` endpoints — they run heavy Neo4j work.
+
+**Classification:** Bug — public API endpoints bypass the documented ADR 0013 protection model. Same neo4j-heavy serialization concern as Intake A but via different URLs.
+**Strictness:** Standard.
+**Phase path:** `/discuss` first to triage the three options (especially: which endpoints have live consumers? which to refactor vs deprecate?), then Planning → Architecture → Test Design → Implementation → Review.
+**Priority:** Medium-high. Operator-triggerable, currently unprotected on prod. Same severity as Intake B was before story #25 closed it.
+
+---
+
+## 2026-05-24 — Bug: `neo4j-heavy` semaphore released ~5s after acquire while tagged work runs unprotected for hours
+
+**Surfaced during:** Review-phase operator triage on story #26 / ADR 0023. Operator noticed a "Running" task in the Scheduled Tasks panel with no matching TASK_END for 1.5 hours; investigation revealed `held_seconds: 6` on `resource_class_released` events across MULTIPLE tagged tasks (`processCustomer`, `updateAllScoresForOwner` confirmed; pattern likely universal). See ADR 0023's 2026-05-24 (later) amendment for the full evidence table.
+
+**The bug:** The BullMQ Worker callback at `src/manage/taskQueue/queue/index.js:118-131` is `await processor.processJob(...)` then `await release()`. processor.processJob spawns `bash launchChildTask.sh ...` and resolves on `child.on('close')`. Empirically, that close event fires ~5-6 seconds after spawn EVEN WHEN the underlying task script (e.g., processCustomer.sh) is still running and will continue running for hours. As a result, the semaphore releases ~5-6s after acquire, and the actual heavy Neo4j work runs concurrently with any other heavy work — defeating ADR 0013's cap=1 serialization contract.
+
+**Investigation required:** what causes `child.on('close')` on the launchChildTask.sh bash process to fire within 5-6 seconds when the backgrounded child it spawned is still running? Candidate hypotheses (unverified):
+1. `launchChildTask.sh:380-390`'s `while ps -p $child_pid` monitor loop exits prematurely — possibly the captured PID from `bash $child_script &` corresponds to a short-lived intermediate.
+2. BullMQ stalled-job recovery (default 30s `stalledInterval` × `maxStalledCount`=1) fires and moves the job, triggering the `finally` block.
+3. Bash subshell semantics with `&` + `set -e`/`set -o pipefail` cause the wrapper to exit unexpectedly.
+4. Something else.
+
+**Method:** write a deterministic reproduction probe (similar in shape to story #25's `probe-bullmq-removeOnComplete-immediate.js`). Steps:
+1. Create a synthetic tagged task whose script sleeps for N=120 seconds.
+2. Wire it through the actual `initTaskQueue` machinery (real BullMQ Worker, real semaphore wrap, real processor.js → launchChildTask.sh path).
+3. Trigger via `enqueueTask` or scheduler.
+4. Observe and log: Worker callback entry time, semaphore acquire time, bash subprocess spawn time, every `ps -p $child_pid` check result in launchChildTask.sh, `child.on('close')` fire time, semaphore release time, bash subprocess actual end time.
+5. Identify exactly which event fires at T+~5s that causes the close to fire while the work continues.
+
+**Once root cause identified, design the fix.** Possible fix shapes (architect chooses after the probe finishes):
+- **Fix launchChildTask.sh's PID tracking** so the monitor loop waits for the actual long-running process, not an intermediate.
+- **Fix the spawn pattern in processor.js** to use `child_process.spawn` with options that don't background-detach the subprocess.
+- **Refactor the semaphore wrap location** to be inside launchChildTask.sh itself (using Redis directly) so it covers the full subprocess lifetime regardless of Node-side timing.
+- **Refactor to a poll/lease model** where the Worker periodically checks if the bash subprocess is still running and re-acquires/renews the semaphore lease.
+- **Bigger refactor:** Option B from `/discuss` (refactor parents to enqueue children via /api/run-task) — children flow through their own BullMQ Workers, semaphore engages on each.
+
+**Impact on story #26:** That story's tag-additions are functionally moot pending this fix. They can be: (a) reverted, (b) kept as "no-op-but-documented" with the BIBLE.md / ADR amendments updated to reflect the actual broken state, or (c) carried forward into the investigation story and shipped together with the real fix. Architect/PO call.
+
+**Impact on PR #201's tagging:** Same. PR #201's value was always "defense-in-depth on the BullMQ-direct path" — that part still works (when a tagged task is fired via `/api/run-task` directly, the Worker callback wraps the few seconds of setup with the semaphore). But the "protect the subshell chain" intent is empty.
+
+**Classification:** Bug — high severity (load-bearing assumption violated, ADR 0013's documented contract not enforced, multiple shipped stories built on this assumption).
+**Strictness:** Standard.
+**Phase path:** `/discuss` first to align on the investigation scope, then Planning (probe + investigation story), then Architecture (fix design after probe results), then Test Design / Implementation / Review.
+**Priority:** **HIGH.** Architecture's stated contract has been functionally absent for the entire life of the resource-class semaphore (story #15, 2026-05-20 onward). Each new Neo4j-heavy task added since then has been relying on a protection that doesn't actually engage. Investigation deserves immediate attention.
+
+---
+
+## 2026-05-24 — Meta: origin-sync check at PO + Architect phase entry
+
+**Surfaced during:** the 2026-05-24 session start. A chip was spawned proposing this same idea (a pre-flight check that verifies the local branch is in sync with origin before any PO or Architect work begins). The chip was never picked up. Filed here as a proper intake so the work doesn't depend on the chip persisting.
+
+**Background:** during the work-up to story #25, the session started on a branch (`main`) that was *behind* `origin/staging`. The drift wasn't caught until pushing time, costing a small but real debugging cycle. This is a recurring class of bug at session boundaries when the operator switches between machines / branches across sessions.
+
+**Goal:** Make this drift impossible (or at least loud) at the *start* of a session. Specifically, the Product Owner and Architect phases of `engineering-team/` should refuse to proceed (or warn aggressively) if `git fetch` would reveal divergence from the configured base branch.
+
+**Where to look:**
+- `engineering-team/roles/product-owner.md`
+- `engineering-team/roles/architect.md`
+- `engineering-team/workflows/1-planning.md`
+- `engineering-team/workflows/2-architecture.md`
+- Any pre-flight check pattern already in `.claude/agents/*.md` or `.claude/commands/*.md`
+
+**Decision points to triage:**
+1. Should this be a hard fail (refuse to plan/design) or just a loud warning?
+2. Should the check fetch automatically, or just compare `HEAD` vs the cached `origin/<base>`?
+3. Which base branch? Likely `origin/staging` for this project per `OPERATIONS.md`, but the check should probably read from a config rather than hardcode.
+4. Should this apply to all five phases or just the two upstream ones (PO + Architect)?
+
+**Classification:** Meta-tooling (engineering-team harness improvement; no production code impact).
+**Strictness:** Standard.
+**Phase path:** `/discuss` first to settle the four decision points; then likely Implementation + Review (Architecture and Test Design probably skippable — small mechanical change with no ADR-worthy design choice).
+**Priority:** Low. Quality-of-life improvement for the harness. No correctness issue today.

--- a/src/api/assistant/index.js
+++ b/src/api/assistant/index.js
@@ -1,17 +1,18 @@
 /**
  * Brainstorm Assistant API
  *
- * Publishes a kind 0 profile event for a customer's Brainstorm Assistant
- * (their relay identity that publishes kind 30382 Trust Assertions).
+ * Endpoints for managing an assistant's kind 0 nostr profile. The "assistant"
+ * is a server-side nostr identity:
+ *   - For the owner: the Tapestry Assistant (TA) key.
+ *   - For a customer: their Customer Relay Key.
  *
- * The profile includes:
- * - Name: "<CustomerName>'s Brainstorm Assistant"
- * - About: describes the assistant's NIP-85 role
- * - Website: https://brainstorm.nosfabrica.com
+ * The key is selected by getAssistantKeys(pubkey). The kind 0 event is signed
+ * server-side with that key and published to local strfry plus the external
+ * relays in EXTERNAL_RELAYS.
  *
- * Future enhancements: avatar image, banner image, NIP-05.
- *
- * The event is signed server-side with the assistant's private key.
+ * POST /api/assistant/publish-profile accepts an optional `content` object so
+ * the caller can pass user-edited fields; when omitted, instance-branded
+ * defaults are used (legacy behavior for older callers).
  */
 
 const { exec } = require('child_process');
@@ -66,12 +67,13 @@ function publishToRelay(relayUrl, signedEvent, timeoutMs = 10000) {
   });
 }
 
-const ABOUT_TEXT = 'I am the Brainstorm Assistant for my owner. My primary task is to publish kind 30382 Trusted Assertions so that my owner\'s personalized web of trust metrics are available to be utilized by any nostr client that supports NIP-85.';
+const PROFILE_FIELDS = ['name', 'display_name', 'about', 'picture', 'banner', 'website', 'nip05', 'lud16'];
 
 /**
- * Fetch a customer's kind 0 name from strfry.
+ * Fetch a nostr kind 0 display name for a pubkey from local strfry.
+ * Used to derive the customer name for an assistant's default profile.
  */
-function getCustomerName(pubkey) {
+function getKind0DisplayName(pubkey, fallback = 'My Owner') {
   return new Promise((resolve) => {
     const filter = JSON.stringify({ kinds: [0], authors: [pubkey], limit: 1 });
     exec(`strfry scan '${filter.replace(/'/g, "'\\''")}' 2>/dev/null`, {
@@ -79,27 +81,94 @@ function getCustomerName(pubkey) {
       timeout: 10000,
     }, (error, stdout) => {
       if (error || !stdout.trim()) {
-        resolve('My Owner');
+        resolve(fallback);
         return;
       }
       try {
         const event = JSON.parse(stdout.trim().split('\n')[0]);
         const content = JSON.parse(event.content);
-        resolve(content.display_name || content.name || 'My Owner');
+        resolve(content.display_name || content.name || fallback);
       } catch {
-        resolve('My Owner');
+        resolve(fallback);
       }
     });
   });
 }
 
 /**
+ * Derive the instance's https website URL from configured domain or relay URL.
+ * Returns e.g. "https://brainstorm.world" or empty string if unconfigured.
+ */
+function getInstanceWebsite() {
+  const domain = getConfigFromFile('STRFRY_DOMAIN', '');
+  if (domain && domain !== 'localhost') return `https://${domain}`;
+  const relayUrl = getConfigFromFile('BRAINSTORM_RELAY_URL', '');
+  if (relayUrl) {
+    const host = relayUrl.replace(/^wss?:\/\//, '').replace(/\/.*$/, '');
+    if (host && host !== 'localhost') return `https://${host}`;
+  }
+  return '';
+}
+
+/**
+ * Build instance-branded default kind 0 content for an assistant.
+ * Owner assistant defaults differ from customer assistant defaults.
+ */
+async function buildDefaultProfileContent(pubkey, isOwner) {
+  const website = getInstanceWebsite();
+  if (isOwner) {
+    const ownerName = await getKind0DisplayName(pubkey, 'the owner');
+    return {
+      name: 'Tapestry Assistant',
+      display_name: 'Tapestry Assistant',
+      about: `Server-side Tapestry Assistant for ${ownerName}. Signs firmware events, concept graph nodes, kind 30382 Trust Assertions, and other automated events on behalf of this Tapestry instance.`,
+      picture: '',
+      banner: '',
+      website,
+      nip05: '',
+      lud16: '',
+    };
+  }
+  const customerName = await getKind0DisplayName(pubkey, 'a customer');
+  return {
+    name: `${customerName}'s Brainstorm Assistant`,
+    display_name: `${customerName}'s Brainstorm Assistant`,
+    about: `I am the Brainstorm Assistant for ${customerName}. My primary task is to publish kind 30382 Trusted Assertions so that ${customerName}'s personalized web of trust metrics are available to be utilized by any nostr client that supports NIP-85.`,
+    picture: '',
+    banner: '',
+    website,
+    nip05: '',
+    lud16: '',
+  };
+}
+
+/**
+ * Strip any keys outside the allowed kind 0 fields and coerce values to strings.
+ */
+function sanitizeProfileContent(content) {
+  const clean = {};
+  for (const key of PROFILE_FIELDS) {
+    const value = content?.[key];
+    if (typeof value === 'string') {
+      clean[key] = value;
+    }
+  }
+  return clean;
+}
+
+/**
  * POST /api/assistant/publish-profile
- * Body: { customerPubkey: "hex" }
+ * Body: {
+ *   customerPubkey: "hex",          // pubkey whose assistant we're publishing for
+ *   content?: {                      // optional user-edited kind 0 fields
+ *     name, display_name, about, picture, banner, website, nip05, lud16
+ *   }
+ * }
+ * If `content` is omitted, instance-branded defaults are used (legacy behavior).
  */
 async function handlePublishProfile(req, res) {
   try {
-    const { customerPubkey } = req.body;
+    const { customerPubkey, content } = req.body;
     if (!customerPubkey || !/^[0-9a-f]{64}$/.test(customerPubkey)) {
       return res.status(400).json({ success: false, error: 'Valid customerPubkey is required' });
     }
@@ -131,17 +200,17 @@ async function handlePublishProfile(req, res) {
 
     const assistantPubkey = nostrTools.getPublicKey(privkeyBytes);
 
-    // 2. Get customer's name for the assistant's display name
-    const customerName = await getCustomerName(customerPubkey);
-    const assistantName = `${customerName}'s Brainstorm Assistant`;
+    // 2. Pick profile content: user-supplied if present, otherwise instance defaults
+    const profileContent = content && typeof content === 'object'
+      ? sanitizeProfileContent(content)
+      : await buildDefaultProfileContent(customerPubkey, isOwner);
 
-    // 3. Build kind 0 event
-    const profileContent = {
-      name: assistantName,
-      display_name: assistantName,
-      website: 'https://brainstorm.nosfabrica.com',
-      about: ABOUT_TEXT,
-    };
+    // Drop empty-string keys so we don't pollute kind 0 with blank fields
+    for (const k of Object.keys(profileContent)) {
+      if (profileContent[k] === '') delete profileContent[k];
+    }
+
+    const assistantName = profileContent.display_name || profileContent.name || 'Assistant';
 
     const event = {
       kind: 0,
@@ -195,7 +264,9 @@ async function handlePublishProfile(req, res) {
 /**
  * GET /api/assistant/status
  * Query: ?customerPubkey=hex
- * Returns whether the assistant has a kind 0 profile published.
+ * Returns the assistant's pubkey, the current published kind 0 (if any), and
+ * the instance-branded defaults the UI should prefill into the form for a
+ * fresh setup.
  */
 async function handleAssistantStatus(req, res) {
   try {
@@ -204,10 +275,15 @@ async function handleAssistantStatus(req, res) {
       return res.status(400).json({ success: false, error: 'customerPubkey is required' });
     }
 
+    const ownerPubkey = getConfigFromFile('BRAINSTORM_OWNER_PUBKEY');
+    const isOwner = customerPubkey === ownerPubkey;
+
     // Unified assistant key access (owner → TA key, customer → customer relay key)
     const relayKeys = await getAssistantKeys(customerPubkey);
+    const defaults = await buildDefaultProfileContent(customerPubkey, isOwner);
+
     if (!relayKeys || !relayKeys.pubkey) {
-      return res.json({ success: true, hasRelayKey: false, hasProfile: false });
+      return res.json({ success: true, hasRelayKey: false, hasProfile: false, defaults });
     }
 
     // Check if kind 0 exists for the assistant pubkey
@@ -243,6 +319,8 @@ async function handleAssistantStatus(req, res) {
       assistantNpub: relayKeys.npub,
       hasProfile: !!result,
       profile,
+      defaults,
+      isOwner,
     });
   } catch (err) {
     return res.status(500).json({ success: false, error: err.message });

--- a/src/api/assistant/index.js
+++ b/src/api/assistant/index.js
@@ -18,7 +18,8 @@
 const { exec } = require('child_process');
 const nostrTools = require('nostr-tools');
 const { getAssistantKeys } = require('../../utils/assistantKeys');
-const { getConfigFromFile } = require('../../utils/config');
+const { getConfigFromFile, getAdminPubkeys } = require('../../utils/config');
+const { SecureKeyStorage } = require('../../utils/secureKeyStorage');
 const WebSocket = require('ws');
 
 const EXTERNAL_RELAYS = [
@@ -131,9 +132,9 @@ async function buildDefaultProfileContent(pubkey, isOwner) {
   }
   const customerName = await getKind0DisplayName(pubkey, 'a customer');
   return {
-    name: `${customerName}'s Brainstorm Assistant`,
-    display_name: `${customerName}'s Brainstorm Assistant`,
-    about: `I am the Brainstorm Assistant for ${customerName}. My primary task is to publish kind 30382 Trusted Assertions so that ${customerName}'s personalized web of trust metrics are available to be utilized by any nostr client that supports NIP-85.`,
+    name: `${customerName}'s Tapestry Assistant`,
+    display_name: `${customerName}'s Tapestry Assistant`,
+    about: `I am the Tapestry Assistant for ${customerName}. My primary task is to publish kind 30382 Trusted Assertions so that ${customerName}'s personalized web of trust metrics are available to be utilized by any nostr client that supports NIP-85.`,
     picture: '',
     banner: '',
     website,
@@ -340,4 +341,75 @@ function handleGetTAPubkey(req, res) {
   return res.json({ success: true, pubkey });
 }
 
-module.exports = { handlePublishProfile, handleAssistantStatus, handleGetTAPubkey };
+/**
+ * POST /api/assistant/provision-key
+ * Generates and stores a new server-side Assistant keypair for the caller's
+ * session pubkey, if one doesn't already exist. Used by admins (who don't
+ * get one at signup the way customers do) and as a fallback in any case
+ * where a recognised user is missing their Assistant key.
+ *
+ * Auth: any authenticated session whose pubkey is the owner, an admin, or
+ * an active customer. Storage scheme matches customer relay keys (slot is
+ * the caller's pubkey), so getAssistantKeys(pubkey) will find it without
+ * any extra routing.
+ */
+async function handleProvisionAssistantKey(req, res) {
+  try {
+    if (!req.session || !req.session.authenticated || !req.session.pubkey) {
+      return res.status(401).json({ success: false, error: 'Authentication required' });
+    }
+    const sessionPubkey = req.session.pubkey;
+
+    // Only known roles can provision: owner, admin, or active customer.
+    const ownerPubkey = getConfigFromFile('BRAINSTORM_OWNER_PUBKEY');
+    const isOwner = sessionPubkey === ownerPubkey;
+    const isAdmin = !isOwner && getAdminPubkeys().includes(sessionPubkey);
+    let isCustomer = false;
+    if (!isOwner && !isAdmin) {
+      try {
+        const CustomerManager = require('../../utils/customerManager');
+        const cm = new CustomerManager();
+        await cm.initialize();
+        const customer = await cm.getCustomer(sessionPubkey);
+        isCustomer = customer && customer.status === 'active';
+      } catch {}
+    }
+    if (!isOwner && !isAdmin && !isCustomer) {
+      return res.status(403).json({ success: false, error: 'Only the owner, an admin, or an active customer can provision an Assistant key' });
+    }
+
+    // If a key already exists, refuse — re-provisioning would lose the
+    // signing identity of every event already signed by the old key.
+    const existing = await getAssistantKeys(sessionPubkey);
+    if (existing && existing.pubkey) {
+      return res.status(409).json({
+        success: false,
+        error: 'Assistant key already exists for this user',
+        pubkey: existing.pubkey,
+        npub: existing.npub,
+      });
+    }
+
+    const { generateRelayKeys } = require('../../utils/customerRelayKeys');
+    const keys = generateRelayKeys();
+
+    // Store under the caller's pubkey — same slot scheme as customer keys.
+    // Owner is handled above (existing check would have returned the TA key
+    // stored under 'tapestry-assistant'), so we never write the owner here.
+    const storage = new SecureKeyStorage();
+    await storage.storeRelayKeys(sessionPubkey, keys);
+
+    console.log(`[assistant] Provisioned new Assistant key for ${sessionPubkey.slice(0, 8)} (role: ${isAdmin ? 'admin' : isCustomer ? 'customer' : 'owner'})`);
+
+    return res.json({
+      success: true,
+      pubkey: keys.pubkey,
+      npub: keys.npub,
+    });
+  } catch (err) {
+    console.error('[assistant] provision-key error:', err);
+    return res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+module.exports = { handlePublishProfile, handleAssistantStatus, handleGetTAPubkey, handleProvisionAssistantKey };

--- a/src/api/auth/getUserClassification.js
+++ b/src/api/auth/getUserClassification.js
@@ -1,9 +1,26 @@
 const { getConfigFromFile, getAdminPubkeys } = require('../../utils/config');
 const CustomerManager = require('../../utils/customerManager');
+const { getAssistantKeys } = require('../../utils/assistantKeys');
+
+/**
+ * Resolve the caller's Assistant pubkey, if one exists.
+ * Returns null for users who don't have a key provisioned yet (e.g. admins
+ * who haven't run provision-key, or unauthenticated callers).
+ */
+async function resolveAssistantPubkey(userPubkey) {
+    if (!userPubkey) return null;
+    try {
+        const keys = await getAssistantKeys(userPubkey);
+        return keys && keys.pubkey ? keys.pubkey : null;
+    } catch {
+        return null;
+    }
+}
 
 /**
  * Get user classification (owner/customer/regular user)
- * Returns the classification of the authenticated user
+ * Returns the classification of the authenticated user, plus the caller's
+ * server-side Assistant pubkey if one is provisioned.
  * to call: api/auth/user-classification
  */
 async function handleGetUserClassification(req, res) {
@@ -13,11 +30,13 @@ async function handleGetUserClassification(req, res) {
             return res.json({
                 success: true,
                 classification: 'unauthenticated',
-                pubkey: null
+                pubkey: null,
+                assistantPubkey: null,
             });
         }
 
         const userPubkey = req.session.pubkey;
+        const assistantPubkey = await resolveAssistantPubkey(userPubkey);
 
         // Get owner pubkey from brainstorm.conf
         let ownerPubkey = getConfigFromFile('BRAINSTORM_OWNER_PUBKEY');
@@ -28,6 +47,7 @@ async function handleGetUserClassification(req, res) {
                 success: true,
                 classification: 'owner',
                 pubkey: userPubkey,
+                assistantPubkey,
             });
         }
 
@@ -38,6 +58,7 @@ async function handleGetUserClassification(req, res) {
                 success: true,
                 classification: 'admin',
                 pubkey: userPubkey,
+                assistantPubkey,
             });
         }
 
@@ -45,17 +66,18 @@ async function handleGetUserClassification(req, res) {
         try {
             const customerManager = new CustomerManager();
             await customerManager.initialize();
-            
+
             // Get customer by pubkey
             const customer = await customerManager.getCustomer(userPubkey);
-            
+
             if (customer && customer.status === 'active') {
                 return res.json({
                     success: true,
                     classification: 'customer',
                     pubkey: userPubkey,
                     customerName: customer.name,
-                    customerId: customer.id
+                    customerId: customer.id,
+                    assistantPubkey,
                 });
             }
         } catch (error) {
@@ -66,7 +88,8 @@ async function handleGetUserClassification(req, res) {
         return res.json({
             success: true,
             classification: 'guest',
-            pubkey: userPubkey
+            pubkey: userPubkey,
+            assistantPubkey,
         });
 
     } catch (error) {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -485,6 +485,7 @@ async function register(app) {
     // ── Brainstorm Assistant API ──
     const assistantApi = require('./assistant');
     app.post('/api/assistant/publish-profile', assistantApi.handlePublishProfile);
+    app.post('/api/assistant/provision-key', assistantApi.handleProvisionAssistantKey);
     app.get('/api/assistant/status', assistantApi.handleAssistantStatus);
     app.get('/api/assistant/pubkey', assistantApi.handleGetTAPubkey);
 

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -265,6 +265,7 @@ const router = createBrowserRouter([
           { path: 'databases', handle: { crumb: 'Databases' } },
           { path: 'uuids', handle: { crumb: 'Concept UUIDs' } },
           { path: 'firmware', handle: { crumb: 'Firmware' } },
+          { path: 'assistant', handle: { crumb: 'Assistant Profile' } },
           { path: 'auditing', handle: { crumb: 'Auditing Tools' } },
           { path: '*', element: <Navigate to="/tapestry/settings/relays" replace /> },
         ],

--- a/ui/src/components/AssistantProfileEditor.jsx
+++ b/ui/src/components/AssistantProfileEditor.jsx
@@ -1,0 +1,214 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const PROFILE_FIELDS = [
+  { key: 'name', label: 'Name', placeholder: 'e.g. Alice\'s Brainstorm Assistant' },
+  { key: 'display_name', label: 'Display name', placeholder: 'Shown in nostr clients' },
+  { key: 'about', label: 'About', placeholder: 'Short description of what this assistant does', multiline: true },
+  { key: 'picture', label: 'Picture URL', placeholder: 'https://example.com/avatar.png' },
+  { key: 'banner', label: 'Banner URL', placeholder: 'https://example.com/banner.png' },
+  { key: 'website', label: 'Website', placeholder: 'https://example.com' },
+  { key: 'nip05', label: 'NIP-05', placeholder: 'name@example.com' },
+  { key: 'lud16', label: 'Lightning address', placeholder: 'name@example.com' },
+];
+
+const labelStyle = { fontSize: '0.75rem', fontWeight: 600, display: 'block', marginBottom: '0.25rem' };
+const inputStyle = {
+  padding: '0.4rem 0.6rem',
+  fontSize: '0.85rem',
+  backgroundColor: 'var(--bg-primary, #0f0f23)',
+  color: 'var(--text-primary, #e0e0e0)',
+  border: '1px solid var(--border, #444)',
+  borderRadius: '4px',
+  width: '100%',
+  boxSizing: 'border-box',
+};
+
+function emptyForm() {
+  return PROFILE_FIELDS.reduce((acc, f) => { acc[f.key] = ''; return acc; }, {});
+}
+
+function pickFields(source) {
+  if (!source || typeof source !== 'object') return emptyForm();
+  return PROFILE_FIELDS.reduce((acc, f) => {
+    acc[f.key] = typeof source[f.key] === 'string' ? source[f.key] : '';
+    return acc;
+  }, {});
+}
+
+export default function AssistantProfileEditor({ customerPubkey }) {
+  const [status, setStatus] = useState(null);
+  const [form, setForm] = useState(emptyForm);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [publishing, setPublishing] = useState(false);
+  const [publishResult, setPublishResult] = useState(null);
+
+  const loadStatus = useCallback(async () => {
+    if (!customerPubkey) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/assistant/status?customerPubkey=${customerPubkey}`);
+      const data = await res.json();
+      if (!data.success) throw new Error(data.error || 'Failed to load assistant status');
+      setStatus(data);
+      // Prefer existing published profile if present, else use server-provided defaults
+      const source = data.hasProfile ? data.profile : data.defaults;
+      setForm(pickFields(source));
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [customerPubkey]);
+
+  useEffect(() => { loadStatus(); }, [loadStatus]);
+
+  function updateField(key, value) {
+    setForm(prev => ({ ...prev, [key]: value }));
+    setPublishResult(null);
+  }
+
+  function resetToDefaults() {
+    if (!status?.defaults) return;
+    setForm(pickFields(status.defaults));
+    setPublishResult(null);
+  }
+
+  async function publish() {
+    if (!customerPubkey) return;
+    setPublishing(true);
+    setPublishResult(null);
+    try {
+      const res = await fetch('/api/assistant/publish-profile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ customerPubkey, content: form }),
+      });
+      const data = await res.json();
+      if (!data.success) throw new Error(data.error || 'Publish failed');
+      setPublishResult({ ok: true, message: data.message, relays: data.relays });
+      // Reload status so the "currently published" section refreshes
+      await loadStatus();
+    } catch (err) {
+      setPublishResult({ ok: false, message: err.message });
+    } finally {
+      setPublishing(false);
+    }
+  }
+
+  if (loading) {
+    return <div className="settings-group"><p>Loading assistant profile…</p></div>;
+  }
+
+  if (error) {
+    return (
+      <div className="settings-group">
+        <p style={{ color: '#ef4444' }}>Error: {error}</p>
+        <button className="settings-action-btn" onClick={loadStatus}>Retry</button>
+      </div>
+    );
+  }
+
+  if (!status?.hasRelayKey) {
+    return (
+      <div className="settings-group">
+        <h3 style={{ margin: '0 0 0.5rem' }}>
+          {status?.isOwner ? '🤖 Tapestry Assistant Profile' : '🤖 Your Brainstorm Assistant Profile'}
+        </h3>
+        <p style={{ opacity: 0.8 }}>
+          {status?.isOwner
+            ? 'The Tapestry Assistant key has not been created yet. Restart the container to provision it.'
+            : 'Your Customer Relay Key has not been created yet. Set up Trusted Assertions first.'}
+        </p>
+      </div>
+    );
+  }
+
+  const shortPk = status.assistantPubkey
+    ? `${status.assistantPubkey.slice(0, 12)}…${status.assistantPubkey.slice(-8)}`
+    : '';
+
+  return (
+    <div className="settings-group" style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <div>
+        <h3 style={{ margin: '0 0 0.25rem' }}>
+          {status.isOwner ? '🤖 Tapestry Assistant Profile' : '🤖 Your Brainstorm Assistant Profile'}
+        </h3>
+        <p style={{ margin: 0, fontSize: '0.85rem', opacity: 0.75 }}>
+          {status.isOwner
+            ? 'The kind 0 profile published by this instance\'s Tapestry Assistant — the server-side identity that signs automated events.'
+            : 'The kind 0 profile published by your server-side assistant — the identity that signs your kind 30382 Trust Assertions.'}
+        </p>
+      </div>
+
+      <div style={{ fontSize: '0.8rem', opacity: 0.8 }}>
+        <div><strong>Assistant pubkey:</strong> <code>{shortPk}</code></div>
+        <div>
+          <strong>Currently published:</strong>{' '}
+          {status.hasProfile
+            ? <span style={{ color: '#22c55e' }}>✅ Yes</span>
+            : <span style={{ color: '#f59e0b' }}>⚠️ Not yet</span>}
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        {PROFILE_FIELDS.map(field => (
+          <div key={field.key}>
+            <label style={labelStyle}>{field.label}</label>
+            {field.multiline ? (
+              <textarea
+                value={form[field.key]}
+                onChange={e => updateField(field.key, e.target.value)}
+                placeholder={field.placeholder}
+                rows={4}
+                style={{ ...inputStyle, fontFamily: 'inherit', resize: 'vertical' }}
+              />
+            ) : (
+              <input
+                type="text"
+                value={form[field.key]}
+                onChange={e => updateField(field.key, e.target.value)}
+                placeholder={field.placeholder}
+                style={inputStyle}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+        <button
+          className="settings-action-btn"
+          onClick={publish}
+          disabled={publishing}
+        >
+          {publishing ? 'Publishing…' : status.hasProfile ? 'Re-publish profile' : 'Publish profile'}
+        </button>
+        <button
+          className="settings-action-btn settings-action-btn-secondary"
+          onClick={resetToDefaults}
+          disabled={publishing}
+          type="button"
+        >
+          Reset to defaults
+        </button>
+      </div>
+
+      {publishResult && (
+        <div
+          className={`settings-message settings-message-${publishResult.ok ? 'success' : 'error'}`}
+          style={{ marginTop: 0 }}
+        >
+          {publishResult.ok ? '✅ ' : '❌ '}
+          {publishResult.message}
+          {publishResult.ok && publishResult.relays && (
+            <div style={{ fontSize: '0.75rem', opacity: 0.8, marginTop: '0.25rem' }}>
+              Pushed to local strfry + {publishResult.relays.success}/{publishResult.relays.total} external relays.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/AssistantProfileEditor.jsx
+++ b/ui/src/components/AssistantProfileEditor.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 
 const PROFILE_FIELDS = [
-  { key: 'name', label: 'Name', placeholder: 'e.g. Alice\'s Brainstorm Assistant' },
+  { key: 'name', label: 'Name', placeholder: 'e.g. Alice\'s Tapestry Assistant' },
   { key: 'display_name', label: 'Display name', placeholder: 'Shown in nostr clients' },
   { key: 'about', label: 'About', placeholder: 'Short description of what this assistant does', multiline: true },
   { key: 'picture', label: 'Picture URL', placeholder: 'https://example.com/avatar.png' },
@@ -42,6 +42,8 @@ export default function AssistantProfileEditor({ customerPubkey }) {
   const [error, setError] = useState(null);
   const [publishing, setPublishing] = useState(false);
   const [publishResult, setPublishResult] = useState(null);
+  const [provisioning, setProvisioning] = useState(false);
+  const [provisionError, setProvisionError] = useState(null);
 
   const loadStatus = useCallback(async () => {
     if (!customerPubkey) return;
@@ -73,6 +75,22 @@ export default function AssistantProfileEditor({ customerPubkey }) {
     if (!status?.defaults) return;
     setForm(pickFields(status.defaults));
     setPublishResult(null);
+  }
+
+  async function provisionKey() {
+    setProvisioning(true);
+    setProvisionError(null);
+    try {
+      const res = await fetch('/api/assistant/provision-key', { method: 'POST' });
+      const data = await res.json();
+      if (!data.success) throw new Error(data.error || 'Provisioning failed');
+      // Key created; reload status so the editor flips into the form view.
+      await loadStatus();
+    } catch (err) {
+      setProvisionError(err.message);
+    } finally {
+      setProvisioning(false);
+    }
   }
 
   async function publish() {
@@ -112,15 +130,28 @@ export default function AssistantProfileEditor({ customerPubkey }) {
 
   if (!status?.hasRelayKey) {
     return (
-      <div className="settings-group">
-        <h3 style={{ margin: '0 0 0.5rem' }}>
-          {status?.isOwner ? '🤖 Tapestry Assistant Profile' : '🤖 Your Brainstorm Assistant Profile'}
+      <div className="settings-group" style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        <h3 style={{ margin: '0 0 0.25rem' }}>
+          {status?.isOwner ? '🤖 Tapestry Assistant Profile' : '🤖 Your Tapestry Assistant Profile'}
         </h3>
-        <p style={{ opacity: 0.8 }}>
-          {status?.isOwner
-            ? 'The Tapestry Assistant key has not been created yet. Restart the container to provision it.'
-            : 'Your Customer Relay Key has not been created yet. Set up Trusted Assertions first.'}
+        <p style={{ margin: 0, opacity: 0.8 }}>
+          You don't have a server-side Tapestry Assistant key yet. Create one to start publishing
+          {status?.isOwner ? ' automated events' : ' a kind 0 profile and kind 30382 Trust Assertions'} from your Assistant.
         </p>
+        <div>
+          <button
+            className="settings-action-btn"
+            onClick={provisionKey}
+            disabled={provisioning}
+          >
+            {provisioning ? 'Creating…' : 'Create my Tapestry Assistant key'}
+          </button>
+        </div>
+        {provisionError && (
+          <div className="settings-message settings-message-error" style={{ marginTop: 0 }}>
+            ❌ {provisionError}
+          </div>
+        )}
       </div>
     );
   }
@@ -133,12 +164,12 @@ export default function AssistantProfileEditor({ customerPubkey }) {
     <div className="settings-group" style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
       <div>
         <h3 style={{ margin: '0 0 0.25rem' }}>
-          {status.isOwner ? '🤖 Tapestry Assistant Profile' : '🤖 Your Brainstorm Assistant Profile'}
+          {status.isOwner ? '🤖 Tapestry Assistant Profile' : '🤖 Your Tapestry Assistant Profile'}
         </h3>
         <p style={{ margin: 0, fontSize: '0.85rem', opacity: 0.75 }}>
           {status.isOwner
             ? 'The kind 0 profile published by this instance\'s Tapestry Assistant — the server-side identity that signs automated events.'
-            : 'The kind 0 profile published by your server-side assistant — the identity that signs your kind 30382 Trust Assertions.'}
+            : 'The kind 0 profile published by your server-side Tapestry Assistant — the identity that signs your kind 30382 Trust Assertions.'}
         </p>
       </div>
 

--- a/ui/src/components/Header.jsx
+++ b/ui/src/components/Header.jsx
@@ -104,9 +104,11 @@ export default function Header({ onToggleSidebar }) {
                 <button className="dropdown-item" onClick={() => { setMenuOpen(false); navigate(`/tapestry/users/${user.pubkey}`); }}>
                   👤 My Profile
                 </button>
-                <button className="dropdown-item" onClick={() => { setMenuOpen(false); navigate(`/tapestry/users/${TA_PUBKEY}`); }}>
-                  🤖 My Assistant's Profile
-                </button>
+                {user.assistantPubkey && (
+                  <button className="dropdown-item" onClick={() => { setMenuOpen(false); navigate(`/tapestry/users/${user.assistantPubkey}`); }}>
+                    🤖 My Assistant's Profile
+                  </button>
+                )}
                 {(user.classification === 'owner' || user.classification === 'admin') && (
                   <button className="dropdown-item" onClick={() => { setMenuOpen(false); navigate('/tapestry/settings'); }}>
                     ⚙️ Settings

--- a/ui/src/context/AuthContext.jsx
+++ b/ui/src/context/AuthContext.jsx
@@ -41,6 +41,7 @@ export function AuthProvider({ children }) {
         setUser({
           pubkey: data.pubkey,
           classification: classData.classification || 'guest',
+          assistantPubkey: classData.assistantPubkey || null,
           profile,
         });
       } else {

--- a/ui/src/pages/BrainstormSettings.jsx
+++ b/ui/src/pages/BrainstormSettings.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { useConfig } from '../context/ConfigContext';
 import BrainstormUserMenu, { useHouseProfile } from '../components/BrainstormUserMenu';
+import AssistantProfileEditor from '../components/AssistantProfileEditor';
 
 /* ── Helpers ──────────────────────────────────────────── */
 
@@ -485,6 +486,11 @@ export default function BrainstormSettings() {
               <div className="bss-profile-pubkey">{user.pubkey.slice(0, 16)}…{user.pubkey.slice(-8)}</div>
             </div>
           </div>
+        </div>
+
+        {/* Assistant profile card */}
+        <div className="bss-card">
+          <AssistantProfileEditor customerPubkey={user.pubkey} />
         </div>
 
         {/* WoT Status */}

--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -42,7 +42,7 @@ function WelcomeCard({ taProfile, onSetupProfile, onSurpriseMe }) {
           </p>
           <div style={{ display: 'flex', gap: '0.75rem' }}>
             <button className="btn btn-primary" onClick={onSetupProfile}>
-              🎨 Set up my profile
+              🎨 Set up my Assistant's profile
             </button>
             <button className="btn" onClick={onSurpriseMe}>
               🎲 Surprise me
@@ -736,7 +736,7 @@ export default function Dashboard() {
   function handleOnboardingAction(key) {
     switch (key) {
       case 'ta-profile':
-        navigate(`/tapestry/users/${TA_PUBKEY}`);
+        navigate('/tapestry/settings/assistant');
         break;
       case 'bios':
         navigate('/tapestry/settings/firmware');
@@ -782,7 +782,7 @@ export default function Dashboard() {
         <>
           <WelcomeCard
             taProfile={taProfile}
-            onSetupProfile={() => navigate(`/tapestry/users/${TA_PUBKEY}`)}
+            onSetupProfile={() => navigate('/tapestry/settings/assistant')}
             onSurpriseMe={handleSurpriseMe}
           />
           <OnboardingChecklist

--- a/ui/src/pages/settings/Index.jsx
+++ b/ui/src/pages/settings/Index.jsx
@@ -7,12 +7,14 @@ import UuidSettings from './UuidSettings';
 import DatabaseSettings from './DatabaseSettings';
 import FirmwareExplorer from './FirmwareExplorer';
 import Audit from '../manage/Audit';
+import AssistantProfileEditor from '../../components/AssistantProfileEditor';
 
 const TABS = [
   { key: 'relays', path: 'relays', label: '📡 Relays' },
   { key: 'databases', path: 'databases', label: '🗄️ Databases' },
   { key: 'uuids', path: 'uuids', label: '🔑 Concept UUIDs' },
   { key: 'firmware', path: 'firmware', label: '🔧 Firmware' },
+  { key: 'assistant', path: 'assistant', label: '🤖 Assistant Profile' },
   { key: 'auditing', path: 'auditing', label: '🔍 Auditing Tools' },
 ];
 
@@ -205,6 +207,9 @@ export default function SettingsIndex() {
         )}
         {activeTab === 'firmware' && (
           <FirmwareExplorer />
+        )}
+        {activeTab === 'assistant' && (
+          <AssistantProfileEditor customerPubkey={user?.pubkey} />
         )}
         {activeTab === 'auditing' && (
           <Audit />

--- a/ui/src/pages/users/UserDetail.jsx
+++ b/ui/src/pages/users/UserDetail.jsx
@@ -6,6 +6,7 @@ import useProfiles from '../../hooks/useProfiles';
 import useNip05Verification from '../../hooks/useNip05Verification';
 import { useTrust } from '../../context/TrustContext';
 import { useConfig } from '../../context/ConfigContext';
+import { useAuth } from '../../context/AuthContext';
 import { useCypher } from '../../hooks/useCypher';
 import { queryRelay } from '../../api/relay';
 import AuthorCell from '../../components/AuthorCell';
@@ -49,7 +50,9 @@ export default function UserDetail() {
   const navigate = useNavigate();
   const { povPubkey, setPovPubkey } = useTrust();
   const { aRelays } = useConfig();
+  const { user } = useAuth();
   const isCurrentPov = povPubkey === pubkey;
+  const isMyAssistant = !!user?.assistantPubkey && user.assistantPubkey === pubkey;
   const pubkeys = useMemo(() => [pubkey], [pubkey]);
   const profiles = useProfiles(pubkeys);
   const profile = profiles?.[pubkey];
@@ -73,6 +76,33 @@ export default function UserDetail() {
   return (
     <div className="page">
       <Breadcrumbs />
+      {isMyAssistant && (
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.75rem',
+          padding: '0.75rem 1rem',
+          marginBottom: '1rem',
+          backgroundColor: 'rgba(99, 102, 241, 0.12)',
+          border: '1px solid rgba(99, 102, 241, 0.5)',
+          borderRadius: '8px',
+        }}>
+          <span style={{ fontSize: '1.4rem' }}>🤖</span>
+          <div style={{ flex: 1, fontSize: '0.9rem' }}>
+            <strong>This is your Tapestry Assistant.</strong>{' '}
+            <span style={{ opacity: 0.8 }}>
+              The server-side identity that signs automated events on your behalf.
+            </span>
+          </div>
+          <Link
+            to="/tapestry/settings/assistant"
+            className="btn btn-primary"
+            style={{ fontSize: '0.85rem', whiteSpace: 'nowrap', textDecoration: 'none' }}
+          >
+            ✏️ Edit Assistant profile →
+          </Link>
+        </div>
+      )}
       <div className="user-detail-header">
         {profile?.picture ? (
           <img src={profile.picture} alt="" className="user-detail-avatar" />


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`. Bundle contains three PRs that landed on staging today.

## Bundled

- **[#207](https://github.com/nous-clawds4/tapestry/pull/207)** — Add Assistant Profile editor for owner and customers (merged 2026-05-24 by user; not part of the docs work).
- **[#208](https://github.com/nous-clawds4/tapestry/pull/208)** — Per-user Assistant routing + admin key provisioning + naming pass (merged today by user; not part of the docs work).
- **[#209](https://github.com/nous-clawds4/tapestry/pull/209)** — Session wrap-up docs: new `SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md`, supersede note on prior handoff, three new intakes, `engineering-team/README.md` `_intake.md` mention, `CLAUDE.md` handoff-Status convention. Pure docs + harness-config.

## Net production impact

- **From #207/#208:** Assistant Profile editor + per-user routing become available to owner and customers; admin key provisioning surfaced. Whatever operator-facing behavior change those PRs ship.
- **From #209:** Zero runtime impact — pure docs. Documents three new queued-work items, formalizes a handoff doc Status convention, and closes a discoverability gap for `_intake.md`.

## Verification trail

- **#209 staging deploy:** run [26379841490](https://github.com/nous-clawds4/tapestry/actions/runs/26379841490), 2m12s, clean. Tier 1 stability immediate (3 polls × 2s). Tier 2 sanity (pages 200). No code paths touched.
- **#207 + #208 staging deploys:** ran earlier in the session by the user; no smoke-test data captured here (user verified independently).

## Test plan

- [ ] After merge: `deploy-brainstorm.yml` runs to completion.
- [ ] Tier 1 stability on `brainstorm.world` (3 × 2s polls + 5s settle).
- [ ] Tier 2 sanity (`/`, `/tapestry`, `/tapestry/settings`, public API endpoints → 200; expected 504 for Jack's `/api/get-user-data`).
- [ ] Tier 3 PR-specific: confirm the new handoff doc + intake additions are present on the deployed `main` (via `docs/SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md` raw URL or browser).
- [ ] Tier 3 PR-specific: spot-check the Assistant Profile editor UI surface (#207 / #208) — confirm it renders for owner without console errors.
- [ ] Tier 5 regression: Scheduled Tasks panel still loads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)