### PR TITLE
fix: per-task timeouts for long-running neo4j-heavy tasks (Track A)

### DIFF
--- a/src/manage/taskQueue/taskRegistry.json
+++ b/src/manage/taskQueue/taskRegistry.json
@@ -523,7 +523,16 @@
       "status": "active",
       "estimatedDuration": "20-60 minutes",
       "structuredLogging": true,
-      "options":{},
+      "options": {
+        "completion": {
+          "failure": {
+            "timeout": {
+              "comments": "5400000 = 90 minutes. Covers the 20-60 min estimatedDuration with headroom. Empirical staging+prod evidence post story #27 (2026-05-25): held_seconds=1805 confirmed this task exceeds the 30-min options_default ceiling on prod-scale graphs.",
+              "duration": 5400000
+            }
+          }
+        }
+      },
       "notes": "Phase 1 structured events implemented"
     },
 
@@ -577,7 +586,16 @@
       "timeout": "4 hours",
       "retries": 3,
       "structuredLogging": true,
-      "options":{},
+      "options": {
+        "completion": {
+          "failure": {
+            "timeout": {
+              "comments": "14400000 = 4 hours. Honors the legacy `timeout: \"4 hours\"` decorative field above (the string form was never actually parsed by resolveTaskTimeout). Task orchestrates 8 children including syncWoT-class work; 4h is the long-standing operator expectation.",
+              "duration": 14400000
+            }
+          }
+        }
+      },
       "notes":"Phase 2 structured events implemented - emits TASK_START/END, CHILD_TASK_START/END/ERROR for all 5 child tasks"
     },
 
@@ -634,7 +652,16 @@
       "timeout": "4 hours",
       "retries": 3,
       "structuredLogging": true,
-      "options":{},
+      "options": {
+        "completion": {
+          "failure": {
+            "timeout": {
+              "comments": "14400000 = 4 hours. Matches updateAllScoresForOwner's override; honors the legacy `timeout: \"4 hours\"` decorative field above (never actually parsed pre-fix). Per-customer scope means it can run frequently — per-fire timeout protection is load-bearing.",
+              "duration": 14400000
+            }
+          }
+        }
+      },
       "notes":"Phase 2 structured events implemented - emits TASK_START/END, CHILD_TASK_START/END/ERROR for all 5 child tasks"
     },
 


### PR DESCRIPTION
## Summary

Track A follow-up to story #27 / ADR 0024 — intake `eb2df679`. Adds explicit `options.completion.failure.timeout.duration` to three `neo4j-heavy` tagged tasks whose actual work duration exceeds the 30-min `options_default` ceiling on prod-scale graphs. The override mechanism is already supported by `resolveTaskTimeout` Priority 1 (verified by story #27 test U2 in `test/scheduled-task-timeout-propagation.test.js`); this is a pure data change.

## Why now

The story #27 fix that landed earlier today correctly propagates the `options_default.completion.failure.timeout.duration: 1800000` (30 min) value to the wrapper script. Empirical evidence from staging + prod after that fix landed showed `processCustomer` consistently hits the 30-min ceiling — `held_seconds: 1805/1806` on every fire — because the actual `processCustomer.sh` work runtime exceeds 30 min on the prod-scale graph. Without per-task overrides, the wrapper now fires a spurious `CHILD_TASK_ERROR error_type=timeout elapsed_time=1800000` event every time these long tasks complete. The work itself continues (`forceKill: false` is preserved per story #27 scope-out), but the noise clutters `events.jsonl` and gives operators a false signal.

## Changes

`src/manage/taskQueue/taskRegistry.json`, three task entries:

| Task | New `duration` (ms) | Equivalent | Rationale |
|---|---|---|---|
| `processCustomer` | 5400000 | 90 min | Empirical `held_seconds: 1805` on staging + prod. Registry hint `estimatedDuration: "20-60 minutes"` undercounts on prod-scale. 1.5× the upper hint. |
| `updateAllScoresForOwner` | 14400000 | 4 hr | Honors the legacy `timeout: "4 hours"` decorative field (never actually parsed pre-fix). Task orchestrates 8 children. |
| `updateAllScoresForSingleCustomer` | 14400000 | 4 hr | Matches updateAllScoresForOwner; per-customer scope. |

The other 20 tagged tasks with `"options": {}` are intentionally left at the 30-min default. If empirical evidence shows any of them exceeding 30 min on prod, add overrides iteratively.

## Pre-flight (local)

- `npm test`: 23 suites PASS (233 tests). No regressions.
- `resolveTaskTimeout` verification: each of the three tasks returns the new value, sourced from `"task-specific registry config"`. Untouched tasks (`reconcileAll`, `calculateOwnerGrapeRank`) still resolve correctly.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs cleanly (~80s warm cache).
- [ ] Tier 1 stability poll on `staging.brainstorm.world`.
- [ ] Tier 2 sanity reachability.
- [ ] Tier 3 (PR-specific, passive `docker exec` reads):
  - `docker exec tapestry grep "Starting monitoring loop" /var/log/brainstorm/launchChildTask.log | tail -5` — post-deploy `processCustomer` fires should show `(timeout: 5400s)` instead of `(timeout: 1800s)`. `updateAllScoresFor*` fires (less frequent) may not capture in the smoke window — not blocking.
  - `docker exec tapestry sh -c 'tail -200 /var/log/brainstorm/taskQueue/events.jsonl | grep CHILD_TASK_ERROR | grep "\"elapsed_time\":1800000" | tail -5'` — no new entries for the three overridden tasks after the merge timestamp.
- [ ] Tier 4 Chrome visual: skip — no UI changes.
- [ ] Tier 5 regression: adjacent endpoints still 200.

Check 3 (the killer — verify post-deploy `processCustomer` fires now release with `held_seconds` matching actual duration, not 1805) requires waiting ~35 min for the next processCustomer fire to complete; not blocking the staging smoke.

## Out of scope

- The other 20 tagged tasks (will add overrides if they show up in `events.jsonl` with `elapsed_time=1800000`).
- Removing the legacy decorative `"timeout": "4 hours"` string fields (harmless metadata; pure cleanup that doesn't affect behavior).
- `forceKill: false` reconsideration (still preserved per story #27 scope; processor.js still hardcodes false; per-task `forceKill` overrides wouldn't take effect today).
- Track B auto-tune feature (separate, larger story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)