### PR TITLE
Promote staging → main: per-task timeouts for long-running neo4j-heavy tasks (Track A)

### DIFF
--- a/src/manage/taskQueue/taskRegistry.json
+++ b/src/manage/taskQueue/taskRegistry.json
@@ -523,7 +523,16 @@
       "status": "active",
       "estimatedDuration": "20-60 minutes",
       "structuredLogging": true,
-      "options":{},
+      "options": {
+        "completion": {
+          "failure": {
+            "timeout": {
+              "comments": "5400000 = 90 minutes. Covers the 20-60 min estimatedDuration with headroom. Empirical staging+prod evidence post story #27 (2026-05-25): held_seconds=1805 confirmed this task exceeds the 30-min options_default ceiling on prod-scale graphs.",
+              "duration": 5400000
+            }
+          }
+        }
+      },
       "notes": "Phase 1 structured events implemented"
     },
 
@@ -577,7 +586,16 @@
       "timeout": "4 hours",
       "retries": 3,
       "structuredLogging": true,
-      "options":{},
+      "options": {
+        "completion": {
+          "failure": {
+            "timeout": {
+              "comments": "14400000 = 4 hours. Honors the legacy `timeout: \"4 hours\"` decorative field above (the string form was never actually parsed by resolveTaskTimeout). Task orchestrates 8 children including syncWoT-class work; 4h is the long-standing operator expectation.",
+              "duration": 14400000
+            }
+          }
+        }
+      },
       "notes":"Phase 2 structured events implemented - emits TASK_START/END, CHILD_TASK_START/END/ERROR for all 5 child tasks"
     },
 
@@ -634,7 +652,16 @@
       "timeout": "4 hours",
       "retries": 3,
       "structuredLogging": true,
-      "options":{},
+      "options": {
+        "completion": {
+          "failure": {
+            "timeout": {
+              "comments": "14400000 = 4 hours. Matches updateAllScoresForOwner's override; honors the legacy `timeout: \"4 hours\"` decorative field above (never actually parsed pre-fix). Per-customer scope means it can run frequently — per-fire timeout protection is load-bearing.",
+              "duration": 14400000
+            }
+          }
+        }
+      },
       "notes":"Phase 2 structured events implemented - emits TASK_START/END, CHILD_TASK_START/END/ERROR for all 5 child tasks"
     },
 


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`. Track A follow-up to story #27 / ADR 0024 (which shipped to prod earlier today as PR #215) — adds explicit per-task timeout overrides to three long-running `neo4j-heavy` tasks whose actual work duration exceeds the 30-min `options_default` ceiling on prod-scale graphs.

## Bundled

- **#216** — `fix: per-task timeouts for long-running neo4j-heavy tasks (Track A)` — pure JSON registry edit, adding `options.completion.failure.timeout.duration` to three task entries. [PR](https://github.com/nous-clawds4/tapestry/pull/216) | merged `2026-05-25T15:38:31Z`.

## Net production impact

For three `neo4j-heavy` tagged tasks (`processCustomer`, `updateAllScoresForOwner`, `updateAllScoresForSingleCustomer`):

- **Before this PR (current prod state since PR #215 landed at 14:13Z today):** the wrapper script correctly fired a `CHILD_TASK_ERROR error_type=timeout elapsed_time=1800000` event on every fire's 30-min mark — the semaphore was held for the full 30 min, then released; the underlying task work continued orphaned past that (`forceKill: false`, per ADR 0024 scope).
- **After this PR:** the wrapper uses per-task overrides — `processCustomer` runs to its natural conclusion or hits the new 90-min ceiling; `updateAllScoresForOwner` / `updateAllScoresForSingleCustomer` run to natural conclusion or hit the new 4-hour ceiling. The `CHILD_TASK_ERROR error_type=timeout elapsed_time=1800000` noise events stop accumulating for these three tasks.
- **No data migration, no Redis state to clear, no operator action.** taskRegistry.json is loaded at boot from disk; new values take effect on container restart.

The mechanism (`resolveTaskTimeout` Priority 1) was already shipped with story #27 / ADR 0024 and is regression-tested by `test/scheduled-task-timeout-propagation.test.js` U2. This PR is data-only — no code change.

The other 20 `neo4j-heavy` tasks with `"options": {}` are intentionally left at the 30-min default. If empirical evidence shows any of them exceeding 30 min on prod, add overrides iteratively.

## Verification trail (staging)

- **PR #216 staging deploy:** merged `2026-05-25T15:38:31Z`, deploy-staging.yml ran cleanly in 1m21s.
- **Pre-flight (local):** `npm test` 23/23 PASS, no regressions. `resolveTaskTimeout` verified locally for all three tasks (returns 5400000, 14400000, 14400000 — source: "task-specific registry config").
- **Staging smoke (passive, `docker exec` reads):**
  - **Tier 1:** stability poll stable on first 3 attempts (no flicker).
  - **Tier 2:** 7/7 pages 200; 4/4 public APIs 200; search returns 2 hits.
  - **Tier 3 (killer signal):** post-deploy `processCustomer` fire at 17:12:58Z showed `(timeout: 5400s)` in launchChildTask.log — the override engaged. Non-overridden `refreshSearchIndex` at 16:08:20Z still correctly shows `(timeout: 1800s)`.
  - **Bonus pre-deploy evidence:** both `updateAllScoresForOwner` (13:38:25Z) AND `processCustomer` (14:43:03Z) had fired the noise event Track A eliminates — confirming both task overrides were correctly motivated.

## Test plan (prod smoke — same passive evidence shape)

- [ ] After merge: `deploy-brainstorm.yml` runs to completion.
- [ ] Tier 1 stability poll: 3 consecutive 200s from `https://brainstorm.world`.
- [ ] Tier 2 sanity reachability.
- [ ] Tier 3 (PR-specific, passive `docker exec` reads on the prod droplet):
  - `docker exec tapestry grep "(timeout: 5400s)" /var/log/brainstorm/launchChildTask.log | tail -3` — expect at least one entry with timestamp > prod merge timestamp after the first post-deploy `processCustomer` fire (~60 min wall-clock max, hourly `:12:58` cadence).
  - `docker exec tapestry grep "(timeout: 14400s)" /var/log/brainstorm/launchChildTask.log | tail -3` — may be empty in the smoke window; updateAllScores* fires less frequently. Not blocking.
  - `docker exec tapestry grep "Starting monitoring loop" /var/log/brainstorm/launchChildTask.log | tail -5` — non-overridden tasks still show `(timeout: 1800s)` confirming targeted scope.
- [ ] Tier 4 (Chrome visual): skip — no UI changes in this bundle.
- [ ] Tier 5 regression sweep on `brainstorm.world`.

## Out of scope (deferred per intake `eb2df679` + ADR 0024)

- Other 20 `neo4j-heavy` tasks still using the 30-min default — add overrides iteratively if `elapsed_time:1800000` events accumulate for them.
- Held branch `fix/launch-child-task-protection-audit` (story #26's parent-task tag-additions) — re-evaluate now that the semaphore works.
- JS-exec API endpoints intake (MEDIUM-HIGH).
- Track B auto-tune feature based on observed average durations.
- `forceKill: false` reconsideration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)