### PR TITLE
Promote staging → main: kill timeout-orphans by default (story #28)

### DIFF
--- a/docs/POST_TIMEOUT_FIX_HANDOFF_2026-05-25.md
+++ b/docs/POST_TIMEOUT_FIX_HANDOFF_2026-05-25.md
@@ -1,0 +1,162 @@
+# Post-Timeout-Fix Session Handoff (2026-05-25)
+
+**Status:** 🔴 **OPEN** — follow-up intakes filed; no immediate-action work in flight, but several medium-to-high priority items are queued for the next session's pick.
+**Audience:** the operator / next-session reader picking up after today's `neo4j-heavy` timeout-propagation fix shipped to production.
+**Source session:** the work on 2026-05-25 that (a) addressed the open `SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md`, (b) shipped story #27 / ADR 0024 (scheduled-task timeout propagation fix) to prod, (c) shipped the Track A follow-up (per-task timeout overrides) to prod, and (d) surfaced two new high-signal intakes during cycle-prod verification.
+
+---
+
+## TL;DR for the new session
+
+1. **The semaphore investigation from `SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md` is COMPLETE.** That handoff's recommended path (`/discuss` → probe → fix design → ship) was followed end-to-end. The fix landed via **PR #215** (story #27 / ADR 0024 — `8968b384` on main, `2026-05-25 14:13Z`) and was further refined via **PR #217** (Track A — `9d9fb98a` on main, `2026-05-25 17:36Z`).
+2. **Production state:** ADR 0013's documented `cap=1 neo4j-heavy` semaphore contract is now actually enforced for the first time since story #15 shipped on 2026-05-20. `processCustomer`'s post-fix `held_seconds` jumped from `6` (pre-fix bug shape) to `1805` (post-story-#27) to **`5400`-bounded** (post-Track-A). Verified empirically.
+3. **Two NEW intakes filed today** in `engineering-team/stories/_intake.md` — both surfaced during Track A's cycle-prod verification:
+   - **`forceKill: false` orphans suppress subsequent scheduled fires via `check_task_already_running`** (medium-high priority). Production was silently skipping scheduled fires since story #15 whenever wrapper-script timeouts fired. Track A reduces the frequency of timeouts but doesn't fix the mechanism. **Strong argument for `forceKill: true` as the new default.**
+   - **BullMQ Job Scheduler stalled-recovered ticks use pre-deploy `job.data`** (low priority). Cutover-only artifact at deploy boundary; clears within a few ticks. Documented for future debug clarity.
+4. **Held branch `fix/launch-child-task-protection-audit` (story #26 / ADR 0023)** is now **architecturally enabled to ship**. Its parent-task tag-additions for `processAllTasks` and `processNpubsUpToMaxNumBlocks` would correctly extend semaphore protection across the parent's full subshell chain (which is no longer 5 seconds — it's the configured timeout duration). Decision deferred to the next session.
+
+---
+
+## What shipped to production today (2026-05-25)
+
+| PR | mergeCommit | Time (UTC) | Summary |
+|---|---|---|---|
+| [#214](https://github.com/nous-clawds4/tapestry/pull/214) | `8d11198a` | 05:51Z | Story #27 / ADR 0024 → staging — three-layer defense-in-depth fix for scheduled-task timeout propagation |
+| [#215](https://github.com/nous-clawds4/tapestry/pull/215) | `8968b384` | 14:13Z | Promotion of story #27 to main → live on `brainstorm.world` at 14:14:30Z |
+| [#216](https://github.com/nous-clawds4/tapestry/pull/216) | `14338901` | 15:38Z | Track A → staging — per-task timeout overrides for `processCustomer` (90 min), `updateAllScoresForOwner` (4 hr), `updateAllScoresForSingleCustomer` (4 hr) |
+| [#217](https://github.com/nous-clawds4/tapestry/pull/217) | `9d9fb98a` | 17:36Z | Promotion of Track A to main → live on `brainstorm.world` at 17:38Z |
+| direct push | `2764f79f` | (post-Track-A) | Two new intake entries filed (forceKill orphan + stalled-tick recovery) — currently on staging, awaiting next prod promotion |
+
+All five 5-phase engineering-team artifacts for story #27 live in the repo:
+- Story: `engineering-team/stories/27-scheduled-task-timeout-propagation.md`
+- ADR: `engineering-team/decisions/0024-scheduled-task-timeout-propagation.md`
+- Test plan: `engineering-team/stories/27-scheduled-task-timeout-propagation.test-plan.md`
+- Tests + probe: `test/scheduled-task-timeout-propagation.test.js` + `test/probe-scheduled-task-timeout-propagation.js`
+- Review: `engineering-team/reviews/27-scheduled-task-timeout-propagation.md` (verdict PASS)
+
+Track A shipped fast-track (Implementer + Reviewer only, per intake guidance) — no story / ADR / test-plan files. The PR description (`#216`) carries the rationale.
+
+---
+
+## Key empirical findings from prod verification
+
+### The fix works end-to-end
+
+Three layers verified independently:
+
+1. **scheduler.js → resolveTaskTimeout adoption** (story #27 layer 1): verified by U1 unit test + the fact that the master Job Scheduler in Redis (`bull:processCustomer:repeat:sched:entry-...`) now stores `data.timeoutMs: 5400000` post-Track-A.
+2. **processor.js → conditional optionsJson** (story #27 layer 2): verified by S3 sentinel test + the wrapper script's `resolved_options` JSON now correctly carries `duration: 5400000`.
+3. **launchChildTask.sh → monitor-loop guard** (story #27 layer 3): verified by S4 sentinel + by Path 1 of the in-container probe (`test/probe-scheduled-task-timeout-propagation.js` — runs cleanly via `docker exec`).
+
+### Production timeline (`brainstorm.world` `held_seconds` evolution)
+
+```
+Pre-story-#27 (~10 days):   held_seconds:    6   ← bug (semaphore released 6s after acquire)
+Post-story-#27, pre-Track-A: held_seconds: 1805   ← 30-min options_default ceiling hit
+Post-Track-A:                held_seconds: 5400   ← 90-min processCustomer override (or actual duration, whichever shorter)
+```
+
+The 22:06:32Z post-Track-A processCustomer fire was the conclusive evidence — `resolved_options.failure.timeout.duration: 5400000` computed correctly. (That specific fire didn't actually run because of the forceKill orphan-suppression interaction documented in intake #1 below — but the wrapper-level evidence is unambiguous.)
+
+### Surprise discovery: `forceKill: false` orphans silently suppress subsequent scheduled fires
+
+During cycle-prod verification, the 20:23:04Z scheduled processCustomer tick (post-Track-A, fresh data) hit `check_task_already_running` at 22:06:32 and found the orphan from the previous stale-recovered 17:23 tick still running (PID 195788). The default `processAlreadyRunning.withoutError.launchNew: false` policy prevented the new launch — the scheduled fire was effectively SKIPPED, silently.
+
+This means: **production has been silently skipping scheduled fires since story #15 shipped**, whenever a wrapper-script timeout created an orphan that outlived the next scheduled tick's start. The cumulative impact wasn't visible because the `TASK_LAUNCH_PREVENTED` event looks like success from BullMQ's perspective.
+
+Track A reduces the frequency of orphan-creating timeouts (90 min vs 30 min for `processCustomer`), but doesn't fix the underlying mechanism. **The next session should triage the `forceKill: false` reconsideration with this evidence in hand.** See intake entry below.
+
+---
+
+## Operational caveats while next session is pending
+
+**Production is stable.** No on-call urgency from today's work. The semaphore now correctly serializes neo4j-heavy work; the only operator-visible change is a new class of `CHILD_TASK_ERROR error_type=timeout elapsed_time=1800000` (or `5400000` post-Track-A) events for tasks that genuinely exceed their configured timeout. Those are honest signals, not noise.
+
+**Watch for** these specific signals over the next 24-48 hours (a regular `events.jsonl` grep is the cleanest check):
+
+```bash
+# 1. Track A's 90-min override holding for processCustomer
+docker exec tapestry grep '"phase":"resource_class_released"' /var/log/brainstorm/taskQueue/events.jsonl | grep processCustomer | tail -5
+# Expect: held_seconds in [1800, 5400] range. If consistently 5400+ → bump the 90-min override.
+
+# 2. forceKill orphan suppression rate
+docker exec tapestry grep 'TASK_LAUNCH_PREVENTED' /var/log/brainstorm/taskQueue/events.jsonl | tail -20
+# Expect: dramatically lower than pre-Track-A, but non-zero. Higher than expected → escalates the
+# forceKill intake's priority.
+
+# 3. Other tasks hitting the 30-min options_default ceiling
+docker exec tapestry sh -c 'grep CHILD_TASK_ERROR /var/log/brainstorm/taskQueue/events.jsonl | grep "\"elapsed_time\":1800000" | tail -20'
+# Each task that hits this ceiling is a candidate for adding to the Track A override list.
+# Current overrides: processCustomer (90 min), updateAllScoresForOwner (4 hr),
+# updateAllScoresForSingleCustomer (4 hr). Other 20 neo4j-heavy tasks still at 30-min default.
+```
+
+---
+
+## What to do first in the next session
+
+1. **Read this handoff.** Read the two new 2026-05-25 intakes in `engineering-team/stories/_intake.md`.
+2. **Decide priority for next work** (operator's call). The natural order:
+   - **Held branch `fix/launch-child-task-protection-audit`** — re-evaluate. Now that the semaphore actually works for the configured timeout duration (90 min for `processCustomer`, etc.), the held branch's parent-task tagging would correctly extend semaphore coverage across subshell chains. Original story #26 framing was wrong-shape (assumed the semaphore released at 6s); the new shape is correct. Probably `/discuss` → small decision → either revert the branch, carry-forward into a fresh small story, or ship with light updates to ADR 0023's amendments.
+   - **`forceKill: false` orphan-suppression intake (2026-05-25)** — medium-high. `/discuss` first to triage the 5 remediation options outlined in the intake. Likely a small story to flip the default + per-task overrides for tasks that legitimately need long-running timeouts.
+   - **JS-exec API endpoints intake (2026-05-24)** — medium-high. Separate from the timeout work but same architectural class (load-bearing protection silently absent on a different invocation path). 5 endpoints to triage; `/discuss` to settle the three remediation options (refactor handlers, deprecate, accept+document).
+   - **Track B auto-tune feature (intake `eb2df679` 2026-05-25)** — low-medium. Larger feature with 6 design questions outlined. Multi-session work.
+   - **Other older intakes** — operator priority.
+
+---
+
+## State of the world
+
+| Item | Status |
+|---|---|
+| `main` (prod) | `9d9fb98a` — story #27 + Track A live; smoke-verified |
+| `origin/staging` | `2764f79f` — main + 2 new intakes (forceKill orphan + stalled-tick) — awaiting next prod promotion |
+| `fix/launch-child-task-protection-audit` (held branch) | Unchanged from prior handoff. 6 commits of story #26's tag-additions + ADR 0023 amendments + reviewer report. Architecturally enabled to ship now that the semaphore works. Decision pending. |
+| `docs/POST_TIMEOUT_FIX_HANDOFF_2026-05-25.md` (this doc) | Pending direct push to staging alongside the prior handoff's status update. |
+| `docs/SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md` (prior handoff) | Status updated to ✅ ADDRESSED by today's work. Body preserved. |
+| Working tree | Clean. Local `staging` matches `origin/staging`. |
+| Chrome MCP | Not used in this session. Should still work for the next session per prior-session notes. |
+
+---
+
+## Open intakes (priority-ordered)
+
+All in [`engineering-team/stories/_intake.md`](../engineering-team/stories/_intake.md). Picked-up intakes from this session marked `PICKED UP 2026-05-25`.
+
+### HIGH
+
+_(none open — story #27 closed the prior HIGH)_
+
+### MEDIUM-HIGH
+
+- **[2026-05-25] `forceKill: false` orphans suppress subsequent scheduled fires** — NEW today. Strong empirical evidence; production-impacting (silent fire suppression). Strong argument for flipping `forceKill: true` as default.
+- **[2026-05-24] Legacy API handlers `child_process.exec` tagged-task scripts directly, bypassing BullMQ + semaphore** — 5 endpoints listed; same architectural concern class as story #27.
+
+### MEDIUM
+
+- **Held branch fate**: `fix/launch-child-task-protection-audit` (story #26 paused work). Now architecturally enabled. NOT a formal intake but tracked here.
+- **[2026-05-24] Unified all-tasks timeline UI** (cross-queue past + present + future) — operator-experience feature.
+
+### MEDIUM-LOW
+
+- **[2026-05-25] Track B: auto-tune timeouts from observed average runtimes** (intake `eb2df679`, Track B portion). 6 design questions; multi-session.
+- **[2026-05-21] `/relay` public HTTP landing page is unhelpful plain-text (+ NIP-11 merge silently incomplete)** — UX + bug, public-facing.
+- **[2026-05-21] `reconcileAuthor` trigger surfaces** (profile button + API + per-customer scheduling).
+- **[2026-05-21] Deprecate legacy `reconciliation` task + `reconcile.timer`** — cleanup; superseded by story #21.
+
+### LOW
+
+- **[2026-05-25] BullMQ Job Scheduler stalled-recovered ticks use pre-deploy `job.data`** — NEW today. Cutover-only impact; clears within a few ticks. Worth fixing or documenting but not load-bearing.
+- **[2026-05-24] Scheduled-fire job retention** (`upsertJobScheduler` opts) — Redis-memory hygiene.
+- **[2026-05-21] Per-request `/etc/brainstorm.conf` re-read spam in `brainstorm.log`** — log-hygiene.
+- **[2026-05-24] Origin-sync check at PO + Architect phases** — meta-tooling for the engineering-team harness.
+
+---
+
+## Where to start the next session
+
+1. Read this handoff. Read the two 2026-05-25 intakes (newest entries in `_intake.md`).
+2. `/discuss` whichever next-work the operator chooses.
+3. Standard 5-phase flow from there (or fast-track Implementer + Reviewer for data-only changes per the strictness table).
+
+The first prod-promotion of the next session should bundle the 2 follow-up intakes already on staging (`2764f79f`) with whatever code change ships. Pure docs; no functional impact; no smoke complexity.

--- a/docs/SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md
+++ b/docs/SEMAPHORE_INVESTIGATION_HANDOFF_2026-05-24.md
@@ -1,6 +1,10 @@
 # neo4j-heavy Semaphore Investigation — Session Handoff (2026-05-24)
 
-**Status:** 🔴 **OPEN** — investigation work not yet started; awaiting fresh session.
+**Status:** ✅ **ADDRESSED 2026-05-25** — the investigation completed and shipped end-to-end. Root cause was a three-bug timeout-propagation chain (NOT any of the candidate hypotheses listed below — see ADR 0024 for the actual mechanism). Fix shipped via story #27 / ADR 0024 (`8968b384` on main) + Track A per-task overrides (`9d9fb98a` on main). See [`POST_TIMEOUT_FIX_HANDOFF_2026-05-25.md`](POST_TIMEOUT_FIX_HANDOFF_2026-05-25.md) for what's next. Body below preserved as historical context for the original investigation framing.
+
+---
+
+**Original status (preserved):** 🔴 **OPEN** — investigation work not yet started; awaiting fresh session.
 **Audience:** the operator / next-session reader who is picking up the task-queue semaphore investigation.
 **Source session:** the multi-phase work on 2026-05-24 that (a) shipped story #25 (manual task re-trigger dedup fix) to prod, and (b) discovered during story #26's review that the `neo4j-heavy` semaphore is functionally broken — it releases ~5-6 seconds after acquire while tagged work runs unprotected for hours.
 

--- a/engineering-team/decisions/0025-kill-timeout-orphans-by-default.md
+++ b/engineering-team/decisions/0025-kill-timeout-orphans-by-default.md
@@ -1,0 +1,286 @@
+# ADR 0025: Flip `forceKill: true` as the default in both the registry and processor.js so timeouts actually terminate work
+
+**Status:** Proposed
+**Date:** 2026-05-25
+**Story:** `engineering-team/stories/28-kill-timeout-orphans-by-default.md`
+**Builds on:** ADR 0013 (story #15 — `neo4j-heavy` cap=1 semaphore — this ADR closes a separate timeout-shaped escape from its contract), ADR 0024 (story #27 — scheduled-task timeout propagation fix — which restored the no-timeout case; this ADR completes the picture for the timeout case).
+**Does NOT supersede ADR 0013 or ADR 0024.** ADR 0013's contract is correct; ADR 0024's fix is correct. This ADR closes the third hole: when a timeout actually fires, the work should terminate cleanly.
+
+## Context
+
+### The bug, restated from story #28 + grounded in code
+
+When a task hits the wrapper-script timeout in `src/manage/taskQueue/launchChildTask.sh:374-413`, the monitor loop's `force_kill` check at `:403` reads `resolved_options.failure.timeout.forceKill // false`. With the current default `false`, the wrapper declares timeout, emits `CHILD_TASK_ERROR`, and **exits without killing the backgrounded child** (`bash $script &`). The child process keeps running orphaned.
+
+The Node Worker callback at `src/manage/taskQueue/queue/index.js:118-131` receives `child.on('close')`, executes `finally { await release() }`, and releases the `neo4j-heavy` semaphore. The orphan continues doing Neo4j-heavy work without semaphore protection — already a violation of ADR 0013's cap=1 contract.
+
+The compounding bug: the next scheduled fire of the same task lands. Its wrapper runs `check_task_already_running` at `launchChildTask.sh:25-67`, which `pgrep -f`-finds the orphan PID. Under the default `processAlreadyRunning.withoutError.launchNew = false` policy at `taskRegistry.json:22-26`, the wrapper emits `TASK_LAUNCH_PREVENTED` and exits success — BullMQ records job completion. **The scheduled fire was silently dropped.**
+
+Concrete empirical evidence from prod 2026-05-25 (Track A verification): the post-deploy `processCustomer` tick at 20:23:04Z had its launch prevented at 22:06:32Z because the prior stale-recovered tick's orphan (PID 195788) was still running. Story #27 + Track A fixed the no-timeout case (semaphore now holds for configured duration); this ADR closes the timeout case.
+
+### The fix needs to land in TWO places, not one
+
+The story's user-facing description says "flip the global default." A naive read suggests a one-line change to `src/manage/taskQueue/taskRegistry.json:41`. **That alone would not work.**
+
+The wrapper script's hierarchical-options merge gives per-invocation JSON HIGHEST precedence (it overrides per-task overrides which override `options_default`). The Node-side processor at `src/manage/taskQueue/queue/processor.js:117-127` currently hardcodes `forceKill: false` into the per-invocation JSON:
+
+```js
+const optionsJson = (timeoutMs && timeoutMs > 0)
+  ? JSON.stringify({
+      completion: {
+        failure: {
+          timeout: { duration: timeoutMs, forceKill: false }
+        }
+      }
+    })
+  : '{}';
+```
+
+For every BullMQ-invoked task (which is essentially every scheduled fire and every `/api/run-task` call — the bulk of the system), this per-invocation `forceKill: false` would WIN at the wrapper's merge, defeating any registry-default change. The fix must land in both layers.
+
+### Per-task `forceKill: false` overrides — surveyed during this Architect session
+
+The 11 per-task overrides break into two classes (confirmed by reading each task's full registry entry):
+
+| Line | Task | Duration | Class | Risk if global forceKill flips to true while this override stays |
+|---|---|---|---|---|
+| 110 | `processAllTasks` | 6h | Reasonable | None — 6h is generous for the orchestrator |
+| **231** | **`syncWoT`** | **60s** | **WRONG** | Would kill every sync run that exceeds 60s; `estimatedDuration: "30-60 minutes"`, `averageDuration: 44500` — many runs exceed |
+| **262** | **`syncProfiles`** | **60s** | **WRONG** | Same as syncWoT |
+| 291 | `callBatchTransfer` | 1h | Reasonable | None |
+| 342 | `reconcileRecent` | 30min | Reasonable | None |
+| 373 | `reconcileAll` | 8h | Reasonable | None |
+| 403 | `reconcileAuthor` | 10min | Reasonable | None |
+| 435 | `reconcileNetwork` | 60min | Reasonable | None |
+| 1431 | `applicationHealthMonitor` | 10min | Reasonable | None |
+| 1460 | `neo4jPerformanceMonitor` | 10min | Reasonable | None |
+| 1489 | `externalNetworkConnectivityMonitor` | 10min | Reasonable | None |
+
+The 9 "reasonable" overrides have `forceKill: false` that looks like copy-paste artifacts from the registry's early scaffolding — none have a `comments` field justifying the choice (only duration justifications). The 2 "wrong" overrides (`syncWoT`, `syncProfiles`) carry a 60-second duration that's clearly mis-sized for their actual workload — but that mis-sizing is a separate bug; story #28 is about kill-on-timeout, not about timeout durations.
+
+### Neo4j cleanliness on `kill -9` — Open Question 1 resolved
+
+The wrapper's kill is `kill -9 "$child_pid"` at `launchChildTask.sh:407` — the `$child_pid` is the bash subprocess spawned with `bash "$child_script" &`. That bash process is the parent of any `cypher-shell` (or equivalent Bolt-protocol client) it spawned to do Neo4j work.
+
+Killing the bash process:
+1. Bash dies immediately (no cleanup chance).
+2. Bash's children become orphaned; in the tapestry container, supervisord (PID 1) reaps them.
+3. The TCP connection from cypher-shell to Neo4j drops (either from cypher-shell itself catching SIGHUP or from kernel-level socket cleanup at process death).
+4. **Neo4j observes a dropped connection and rolls back any in-flight transaction on that connection.** This is standard Bolt server semantics — atomic at the transaction boundary; partial-write half-applied state is not exposed.
+
+Partial-work risk does exist: a script that splits its work into many small transactions and commits each will lose any work not yet committed. But this risk is **identical to today's BullMQ stalled-recovery risk** — when a Worker is recycled mid-task (default `stalledInterval: 30000` × `maxStalledCount: 1`), the task gets re-tried, and any partially-committed work is the same shape. Script idempotence is already a requirement (which is why tasks already get retried via `restart: true, maxRetries: 3` in `options_default`). This ADR doesn't introduce new requirements on script idempotence; it makes use of one that already exists.
+
+### Constraints from the story
+
+- AC #1: timeout produces a kill (no orphan). Layer 1 + Layer 2 both must change.
+- AC #2: next scheduled fire runs. Consequence of AC #1 — no orphan means no `check_task_already_running` match means launch proceeds.
+- AC #3: operator visibility via existing `CHILD_TASK_ERROR` events — no new event types. Already satisfied by the wrapper's existing emit at `launchChildTask.sh:416-435`; this ADR doesn't change emit behavior, only kill behavior.
+- AC #4: uniform across invocation paths. Layer 1's registry-default change reaches all paths through the wrapper; Layer 2's processor.js change reaches the BullMQ Worker path specifically. Together they cover all invocation paths that reach `launchChildTask.sh`.
+- AC #5: no manual cleanup of in-flight tasks. Pre-existing orphans on prod continue until natural completion or operator kill. The change affects new wrapper invocations post-deploy.
+
+### Concept-graph impact
+
+Concept Graph API not reachable from this Architect session (curl to `http://localhost:8877/api/concept-graph/summaries` returned connection refused). Same circumstance as ADR 0023 and ADR 0024 today. The task-queue + wrapper-script subsystem has no concept-graph footprint — ADR 0013 explicitly confirmed, ADR 0021 reconfirmed, ADR 0024 reconfirmed. Story #28 explicitly notes "Concepts touched: None." **Firmware reinstall: no.**
+
+## Options considered
+
+### Option A — Flip both layers; preserve per-task overrides; file follow-up intake (chosen)
+
+Two-file change:
+
+1. **`src/manage/taskQueue/taskRegistry.json:41`** — flip `options_default.completion.failure.timeout.forceKill: false → true`.
+2. **`src/manage/taskQueue/queue/processor.js:117-127`** — remove the hardcoded `forceKill: false` from the per-invocation JSON. The merged options block ships only `{ duration: timeoutMs }`; the wrapper's hierarchical merge then resolves `forceKill` from per-task override (if present) or global default (now `true`).
+
+Preserve all 11 per-task `forceKill: false` overrides as-is. The 9 reasonable ones retain pre-fix behavior — story #28's bug is fixed for the 27 tasks without overrides (the bulk of the scheduled-tasks surface). The 2 problematic ones (syncWoT, syncProfiles) keep pre-fix behavior, which is what we want until their duration mis-sizing is separately triaged. File a follow-up intake to clean up the 9-of-11 redundant overrides + investigate the 2-of-11 duration mis-sizing.
+
+Illustrative sketches:
+
+```json
+// taskRegistry.json — at the global default block (around line 39):
+"failure": {
+  "timeout": {
+    "duration": 1800000,
+    "forceKill": true,
+    "restart": true,
+    "maxRetries": 3,
+    "parentNextStep": "nextTaskInQueue"
+  }
+}
+```
+
+```js
+// processor.js — replacing the current optionsJson literal:
+const optionsJson = (timeoutMs && timeoutMs > 0)
+  ? JSON.stringify({
+      completion: {
+        failure: {
+          timeout: { duration: timeoutMs }
+        }
+      }
+    })
+  : '{}';
+```
+
+**Pros**
+- **Satisfies all 5 ACs.** Layer 1 reaches non-BullMQ invocation paths (`launch_child_task` recursive calls, manual `bash launchChildTask.sh`); Layer 2 reaches BullMQ-invoked paths. Together they cover AC #4.
+- **Minimal blast radius.** Two files, ~3 lines of net change. Compare to Option D's 9 additional registry edits.
+- **Avoids the hidden regression** on syncWoT/syncProfiles. Those tasks' wrong 60s timeout stays paired with `forceKill: false` until separately fixed — no surprise kills.
+- **Architecturally cleaner per-invocation contract.** processor.js no longer asserts opinions about `forceKill` that have nothing to do with per-invocation context. The wrapper's hierarchical merge becomes the single source of truth for resolved `forceKill`.
+- **Defense-in-depth at the wrapper.** The wrapper already supports any value of `forceKill` correctly (kill -9 vs no-op). No wrapper edit required for the fix.
+
+**Cons**
+- **9 redundant per-task `forceKill: false` overrides remain.** Reading the registry, a future maintainer sees these explicit `false` values and may interpret them as deliberate — they're not, they're copy-paste artifacts. Mitigated: follow-up intake captures the cleanup as a properly-scoped task.
+- **2 known-wrong duration values remain unfixed** (syncWoT, syncProfiles). The story-scope-correct call is to preserve them with their explicit override; the follow-up intake flags the bug separately. Operator-visible impact today: noisy spurious 60s timeout events that are no-ops (orphan continues until natural completion).
+
+### Option B — Flip Layer 1 only (registry default)
+
+Single-line change to `taskRegistry.json:41`. Don't touch processor.js.
+
+**Pros**
+- Smallest possible diff (1 line).
+
+**Cons**
+- **Does not satisfy any AC.** Layer 2's hardcoded `forceKill: false` in processor.js wins at runtime via per-invocation precedence in the wrapper's hierarchical merge. For BullMQ-invoked tasks (essentially everything that fires today), nothing changes. Operator would see no behavior change.
+- **Documentation lie.** Registry says `true`; runtime says `false`. Anyone reading the registry to predict behavior would be wrong.
+
+**Rejected.** Doesn't actually fix the bug.
+
+### Option C — Flip Layer 2 only (processor.js hardcode)
+
+Change processor.js's hardcoded `forceKill: false → true` (or omit it). Don't touch the registry default.
+
+**Pros**
+- Single-file change.
+- Closes the BullMQ-invoked path correctly.
+
+**Cons**
+- **Doesn't satisfy AC #4 (uniform across invocation paths).** Non-BullMQ paths through the wrapper (`launch_child_task` recursive calls from parent scripts, manual `bash launchChildTask.sh` for testing/operator use) don't go through processor.js. They consult the registry global default at the wrapper's hierarchical merge. With Layer 1 unchanged, those paths retain `forceKill: false`.
+- **The registry default remains misleading documentation.** Same problem as Option B's documentation lie, in the other direction.
+- **More fragile.** Future code paths that bypass processor.js (e.g., a CLI debug tool that invokes the wrapper directly) silently fall off the fix.
+
+**Rejected.** Doesn't satisfy AC #4.
+
+### Option D — Option A + delete the 9 redundant per-task overrides
+
+Same as Option A, plus surgical removal of the `forceKill: false` line from the 9 reasonable per-task overrides (lines 110, 291, 342, 373, 403, 435, 1431, 1460, 1489). Keep the 2 unsafe ones (231, 262) with an added `comments` field justifying why.
+
+**Pros**
+- **More uniform behavior post-fix** — all 25 reasonable-duration tasks gain `forceKill: true` consistently.
+- **Cleaner registry** — fewer copy-paste artifacts left around for future readers.
+
+**Cons**
+- **Mixes two concerns.** Story #28 is "flip the default"; deleting per-task overrides is a different change. Tester needs separate coverage for the cleanup; Reviewer needs to verify each deletion is safe.
+- **Larger diff** — 9 additional edits, each requiring JSON trailing-comma care.
+- **The follow-up intake from Option A captures this cleanly** as a properly-scoped story. The 60s-mis-sizing investigation belongs in the same follow-up, where it can get its own ADR.
+
+**Rejected.** Right architectural direction but wrong story to bundle it into. Story #28 stays narrowly-scoped; follow-up intake carries the cleanup.
+
+## Decision
+
+**We chose Option A** — flip both layers (registry default + processor.js hardcode), preserve all 11 per-task overrides as-is for this story, file a follow-up intake for the per-task override cleanup.
+
+This is the minimal-correct-change that satisfies all 5 story ACs without expanding scope into the per-task override surface or the orthogonal 60s-mis-sizing bug.
+
+What we trade away:
+- The 9 redundant per-task `forceKill: false` overrides remain in the registry as noise (and as functional carve-outs that retain pre-fix behavior on those 9 tasks). The bulk of the system — the 27 tasks without overrides — gets the new behavior, including the 3 highest-impact tasks (`processCustomer`, `updateAllScoresForOwner`, `updateAllScoresForSingleCustomer`) that Track A just sized to 90 min / 4 hr / 4 hr and have NO explicit forceKill override.
+- The 2 problematic per-task overrides (syncWoT, syncProfiles) remain with their 60s mis-sizing — which is unchanged from today's state. No regression, no improvement, deferred.
+- ~30 minutes of mechanical follow-up work to author the intake + later triage.
+
+## Consequences
+
+**Enabled**
+- Story #28's 5 ACs all pass for the 27 tasks without per-task `forceKill: false` overrides — including the 3 biggest neo4j-heavy orchestrators that Track A just sized.
+- ADR 0013's cap=1 contract holds across timeout boundaries — when a task times out, the bash subprocess dies, the semaphore release matches the actual end of work, the next scheduled fire runs cleanly.
+- `processor.js`'s per-invocation JSON becomes minimal and intent-aligned (`{ duration: timeoutMs }` only) — it stops asserting opinions about `forceKill` that have no per-invocation justification.
+- Future operator-debug invocations via manual `bash launchChildTask.sh` get the same kill-on-timeout behavior as BullMQ-invoked fires.
+
+**Constrained / made harder**
+- Tasks that previously relied on "wrapper times out at N, but bash keeps running past N" as an implicit semantic now get their work killed at N. Operators who set N too tight will see work cut short. Mitigation: per-task timeout sizing is now load-bearing; Track A established the pattern; Track B will automate it.
+- The 11 per-task `forceKill: false` overrides become functionally meaningful (they were always functionally meaningful — they're just no longer redundant copies of the global default). A future reader of the registry must understand that those 11 tasks opt OUT of the new default.
+
+**Follow-up debt (filed at commit time)**
+- **Per-task `forceKill: false` override cleanup.** Intake entry to be appended to `engineering-team/stories/_intake.md` (Implementer copy-to-file at commit time, similar pattern to ADR 0023's amendment block). The intake breaks the work into two halves:
+  - **9-of-11 redundant overrides** (`processAllTasks`, `callBatchTransfer`, `reconcileRecent`, `reconcileAll`, `reconcileAuthor`, `reconcileNetwork`, `applicationHealthMonitor`, `neo4jPerformanceMonitor`, `externalNetworkConnectivityMonitor`) — likely safe to delete; durations look reasonable; deletion makes them inherit the new global default. Standard 5-phase fits.
+  - **2-of-11 duration mis-sizing** (`syncWoT`, `syncProfiles`) — 60s timeout is wrong for tasks with `estimatedDuration: "30-60 minutes"`, `averageDuration: 44500`. Bug fix: investigate correct timeout duration (probably ~30-60 min matching estimatedDuration with headroom), then drop the `forceKill: false` override. Could ride as part of the same intake's story or a separate one.
+
+**Firmware reinstall required?** No. No concept-graph changes.
+
+## Implementation notes
+
+The Implementer reads this section verbatim.
+
+### Files to edit
+
+1. **`src/manage/taskQueue/taskRegistry.json`** (1 line)
+   - Change `options_default.completion.failure.timeout.forceKill: false → true` (at line ~41 today, around the global default block lines 35-47). Preserve adjacent fields (`duration`, `restart`, `maxRetries`, `parentNextStep`).
+   - **Do NOT touch** the 11 per-task overrides at lines 110, 231, 262, 291, 342, 373, 403, 435, 1431, 1460, 1489. Those stay as-is for this story.
+
+2. **`src/manage/taskQueue/queue/processor.js`** (1 line + JSON shape)
+   - In the `runWithResolvedArgs` function (around line 110-130), modify the `optionsJson` builder: remove `forceKill: false` from the per-invocation JSON. The resulting shape is `{ completion: { failure: { timeout: { duration: timeoutMs } } } }` when `timeoutMs > 0`, else `'{}'` (unchanged for the empty case).
+   - The wrapper's hierarchical merge at `launchChildTask.sh:208-211` will resolve `forceKill` from per-task override (if any) or global default (now `true`).
+
+### Files NOT to edit
+
+- `src/manage/taskQueue/launchChildTask.sh` — already supports `forceKill: true` correctly at `:402-412`. No change needed.
+- `src/manage/taskQueue/queue/scheduler.js` — doesn't touch forceKill. No change needed.
+- `src/manage/taskQueue/queue/resourceSemaphore.js` — unchanged.
+- `src/manage/taskQueue/queue/index.js` — Worker-callback semaphore wrap unchanged.
+- `src/utils/taskTimeout.js` — resolveTaskTimeout is duration-only; doesn't touch forceKill. Unchanged.
+
+### Intake to file at commit time
+
+Append the following block verbatim to `engineering-team/stories/_intake.md` (end of file). This intake filing is a deliverable of story #28; it doesn't need re-Architect review.
+
+> **## 2026-05-25 — Cleanup + Bug: per-task `forceKill: false` overrides after story #28's default-flip**
+>
+> **Surfaced during:** Architect-phase audit for story #28 / ADR 0025 (2026-05-25). The audit of all 11 per-task `forceKill: false` overrides in `taskRegistry.json` found two distinct concerns that story #28's narrow scope (flip the global default) deliberately did not address.
+>
+> **Part A — Cleanup: 9 redundant overrides.** The following 9 entries have a `forceKill: false` override that appears to be a copy-paste artifact rather than a deliberate choice (no `comments` field justifying the choice; durations are reasonable for the work):
+>
+> | Line | Task | Duration |
+> |---|---|---|
+> | 110 | processAllTasks | 6h |
+> | 291 | callBatchTransfer | 1h |
+> | 342 | reconcileRecent | 30min |
+> | 373 | reconcileAll | 8h |
+> | 403 | reconcileAuthor | 10min |
+> | 435 | reconcileNetwork | 60min |
+> | 1431 | applicationHealthMonitor | 10min |
+> | 1460 | neo4jPerformanceMonitor | 10min |
+> | 1489 | externalNetworkConnectivityMonitor | 10min |
+>
+> Deleting just the `"forceKill": false` line from each (preserving `duration`/`comments` if present) would let these tasks inherit the new `forceKill: true` global default. Each is independently low-risk (durations are generous; if the kill bites, it bites for a real reason).
+>
+> **Part B — Bug: 2 mis-sized timeout durations.** The following 2 entries carry a 60-second timeout that's clearly wrong for tasks with `estimatedDuration: "30-60 minutes"` and `averageDuration: 44500` (44.5s average — many runs exceed):
+>
+> | Line | Task | Duration | Comment |
+> |---|---|---|---|
+> | 231 | syncWoT | 60s | `estimatedDuration: "30-60 minutes"`, `averageDuration: 44500` |
+> | 262 | syncProfiles | 60s | same |
+>
+> Today the `forceKill: false` override masks the impact (wrapper declares timeout, bash continues unprotected, work eventually completes). If we drop the override without fixing the duration, work gets killed at 60s every time a sync runs slow. The right sequence is: investigate the correct duration value (probably 30-60 min matching the estimatedDuration with headroom) FIRST, then drop the override.
+>
+> **Suggested phase path:**
+> - Part A (cleanup): one fast-track story or part of a story. Standard 5-phase if bundled with Part B.
+> - Part B (bug): properly-scoped story + ADR (the right duration value is an architectural choice that affects operator expectations + may have a follow-on on auto-tune Track B).
+>
+> **Classification:** Mixed (cleanup + bug). **Priority:** Medium — incomplete coverage of story #28's intended fix; cosmetic + 2 latent bugs.
+
+### Deployment dry-run
+
+Identical no-downtime profile to ADR 0024's:
+- Pure registry-data change + tiny JS change. No Redis schema change, no migration code, no scheduler pause, no manual operator step.
+- In-flight wrapper invocations at deploy time finish with their pre-deploy `resolved_options` — i.e., whatever forceKill they resolved at wrapper entry. New invocations post-deploy resolve forceKill from the new defaults.
+- Pre-existing orphans on prod (from past timeouts) continue running until natural completion or operator action. The deploy itself doesn't kill them. Operator may choose to clean them up pre-deploy for tidiness; not required.
+- Worst-case interaction: a long-running task already in its wrapper monitor loop at deploy time. It will use its pre-deploy resolved forceKill (likely false). The next invocation post-deploy gets the new default.
+
+## Out of scope
+
+- **Per-task `forceKill: false` override cleanup** — captured in the follow-up intake above.
+- **Investigation of the 60s timeout on syncWoT / syncProfiles** — captured in Part B of the follow-up intake.
+- **SIGTERM-then-SIGKILL graceful-kill ladder.** The current wrapper uses `kill -9` directly. A more graceful pattern (SIGTERM, wait N seconds, then SIGKILL) would give scripts a chance to clean up if they trap SIGTERM. Existing scripts don't trap SIGTERM, so the change is non-trivial; deferred.
+- **Auto-tune of timeout durations** (Track B from 2026-05-25 intake `eb2df679`). Separate multi-session feature.
+- **Held branch `fix/launch-child-task-protection-audit`** — separate work proceeding in parallel.
+- **JS-exec API handlers intake** — those handlers bypass the wrapper entirely; story #28's fix doesn't reach them.
+- **Changes to the `processAlreadyRunning.withoutError.launchNew` default** — explicitly rejected during /discuss (intake Option 3).
+- **Smarter `check_task_already_running` PID-attribute detection** — explicitly rejected during /discuss (intake Option 2).

--- a/engineering-team/reviews/28-kill-timeout-orphans-by-default.md
+++ b/engineering-team/reviews/28-kill-timeout-orphans-by-default.md
@@ -1,0 +1,96 @@
+# Review: Story 28 — Kill timeout-orphans by default so they stop suppressing subsequent scheduled fires
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-25
+**Diff:** `git diff 872303d6...HEAD` (commit `5f8134c5`)
+**Branch:** `fix/kill-timeout-orphans-by-default`
+**Story:** [`engineering-team/stories/28-kill-timeout-orphans-by-default.md`](../stories/28-kill-timeout-orphans-by-default.md)
+**ADR:** [`engineering-team/decisions/0025-kill-timeout-orphans-by-default.md`](../decisions/0025-kill-timeout-orphans-by-default.md)
+**Test plan:** [`engineering-team/stories/28-kill-timeout-orphans-by-default.test-plan.md`](../stories/28-kill-timeout-orphans-by-default.test-plan.md)
+
+## Quality gates (run independently by reviewer, not trusted)
+
+- [x] `npm test` — **PASS** (23 suites, 240 individual tests; `kill-timeout-orphans-by-default suite: PASS (9 passed, 0 failed)`; all 22 prior suites also PASS; Overall: PASS).
+- [x] **Cycle-local empirical probe** (`test/probe-kill-timeout-orphans.js`) — **not run** in Review. Deferred to cycle-local at deploy time per story #27 precedent. Probe ships correctly per P0/P1 sentinels; the Implementer or operator runs it via `docker exec tapestry node /usr/local/lib/node_modules/brainstorm/test/probe-kill-timeout-orphans.js`. Reasoning: the structural sentinels + regression guards cover the implementation surface comprehensively, and the probe's role is empirical end-to-end against the installed wrapper script + jq — not a Review-gating concern given the diff is 2 small data/code changes that the sentinels exhaustively pin.
+- [x] _Lint not configured — skipped._
+- [x] _Typecheck not configured — skipped._
+- [x] _Build not configured — skipped._
+
+## Spec adherence (story #28's 5 acceptance criteria)
+
+| AC | Coverage | Verified |
+|---|---|---|
+| **AC #1** Timeout produces a kill (no surviving orphan PID) | S1 (registry default = true) + S2 (processor.js omits per-invocation forceKill) + R1 (wrapper kill machinery preserved). Behavioral: probe Path 1's `kill -0 $childPid` post-wrapper-exit assertion. | ✅ structurally; probe deferred to cycle-local |
+| **AC #2** Next scheduled fire runs (no `TASK_LAUNCH_PREVENTED`) | Consequence of AC #1 — no orphan means no `check_task_already_running` match. Behavioral: probe Path 2 verifies absence of `TASK_LAUNCH_PREVENTED` + presence of `CHILD_TASK_START` for the re-invocation. | ✅ structurally; probe deferred to cycle-local |
+| **AC #3** Operator visibility via existing `CHILD_TASK_ERROR` events | R2 (regression guard: `launchChildTask.sh` still emits `CHILD_TASK_ERROR` with `error_type="timeout"`). Behavioral: probe Path 1 transitively confirms the event lands. | ✅ |
+| **AC #4** Uniform across all wrapper invocation paths | S1's registry-default change reaches all paths through the wrapper's hierarchical merge (`launchChildTask.sh:200-211`). S2's processor.js change covers the BullMQ-mediated path specifically by stopping per-invocation `forceKill` assertion. R3 (queue/index.js wrap preserved) + R1 (wrapper kill machinery preserved) together hold the invariant. | ✅ |
+| **AC #5** No-downtime deploy / no manual cleanup | Process-level invariant. Pure registry-data + tiny JS literal change — no Redis migration, no scheduler pause, no schema change. In-flight wrapper invocations at deploy time use their pre-deploy resolved_options. Verified at cycle-staging / cycle-prod time. | ✅ structurally; cycle-local pending |
+
+- [x] Every acceptance criterion has a passing test or documented behavioral verification.
+- [x] No criterion silently dropped.
+- [x] No behavior added that isn't in the story.
+
+## ADR adherence (ADR 0025)
+
+- [x] **Files changed match ADR 0025 §"Implementation notes / Files to edit" exactly.** Two source files: `src/manage/taskQueue/taskRegistry.json` (one-line value flip at line 41) + `src/manage/taskQueue/queue/processor.js` (forceKill removed from per-invocation JSON at line 122). Plus the intake append. Diff size matches the ADR's "minimal blast radius" claim: 3 files, +39/-2 net.
+- [x] **Layering matches Architect's Option A.** Both layers flipped, not Option B (registry only — would be a no-op) or Option C (processor only — would miss non-BullMQ paths).
+- [x] **Implementer chose `omit` over `flip-to-true`** for processor.js. Correct — the ADR's Option A explicitly says "remove the hardcoded forceKill: false from the per-invocation JSON" and the Cons of the alternative (pinning per-invocation true) are flagged in S2's failure message. Implementer respected this.
+- [x] **The 11 per-task `forceKill: false` overrides are preserved as-is.** R4 sentinel guards this. Verified at all 11 specified line locations (110, 231, 262, 291, 342, 373, 403, 435, 1431, 1460, 1489) via JSON-parse + property check. Architect's Option A vs D decision honored cleanly.
+- [x] **No edits to "Files NOT to edit" list** — `launchChildTask.sh`, `scheduler.js`, `resourceSemaphore.js`, `queue/index.js`, `taskTimeout.js` all unchanged. Confirmed via diff stat (those paths are not in the diff).
+- [x] **Intake filed verbatim** per the ADR's "Implementer copy-to-file at commit time" instruction. The blockquote `> ` prefixes from the ADR are correctly stripped (intake file convention is unindented markdown). Header matches the I1 sentinel exactly.
+- [x] **No new dependencies, no new infrastructure.** No `package.json` change; no new env vars; no new config files.
+- [x] **No firmware reinstall** — story explicitly notes no concept-graph footprint; ADR reconfirms.
+
+## Concept-graph integrity
+
+- [x] **No concept handles touched.** Story #28 + ADR 0025 + ADR 0013 / 0021 / 0024 all confirm the task-queue / wrapper-script subsystem has no concept-graph footprint. **Firmware reinstall: not required.**
+
+## Things tests can't catch
+
+- [x] **No secrets in committed files.** Diff is data + Markdown + a 2-line JS edit. Clean.
+- [x] **No leftover debug logging.** None added.
+- [x] **No commented-out code.** None.
+- [x] **Error paths.** Registry-loading code unchanged. processor.js's optionsJson still goes through `JSON.stringify` — output shape is now `{"completion":{"failure":{"timeout":{"duration":N}}}}` which is a strict subset of the pre-fix shape, so any downstream consumer that handled the old shape will handle the new one. The wrapper's force_kill block is unchanged and already handled `force_kill="true"` via `kill -9 "$child_pid"` correctly.
+- [x] **Concurrency.** No new shared state; no new race conditions. The semaphore primitive (`resourceSemaphore.js`) is unchanged. The Worker callback wrap (`queue/index.js`) is unchanged. ADR 0013's cap=1 contract holds across timeout boundaries post-fix because the kill makes the semaphore release match the actual end of work (when the bash subprocess dies).
+- [x] **Security.** No new endpoints, no new input validation surface, no new auth surface. The change is internal to the task-queue subsystem.
+- [x] **Deploy hazards.** Pure registry data + 2-line JS change. In-flight wrapper invocations at deploy time finish with their pre-deploy resolved_options (which carry the old forceKill: false). New invocations post-deploy resolve forceKill from the new defaults. Pre-existing orphans from past timeouts (if any) continue running until natural completion or operator action — the deploy itself doesn't kill them. Matches ADR 0025 §"Deployment dry-run" exactly.
+- [x] **Probe ships but isn't run.** The empirical probe at [`test/probe-kill-timeout-orphans.js`](../../test/probe-kill-timeout-orphans.js) is shipped + correctly shaped per P0/P1 sentinels but not yet executed against the installed container. This is the expected pattern from story #27 (probe runs at cycle-local, not at Review). Cycle-local must run the probe before cycle-staging signs off.
+
+## House rules check
+
+- [x] **Concept Graph API authority respected.** No graph reads/writes (correctly — none needed).
+- [x] **No new lint/typecheck/build tooling.** Zero infrastructure added.
+- [x] **JS-without-build preserved.** Diff is pure JSON + Markdown + JS literal edit.
+
+## Process integrity (this story specifically)
+
+- The five-phase flow ran cleanly: story → ADR → test plan + failing tests → impl. Each phase produced its expected commit on the same feature branch. No re-opens, no phase escalations.
+- The Architect's audit of the 11 per-task overrides during Phase 2 (which surfaced the 9-safe / 2-unsafe split and the syncWoT/syncProfiles 60s mis-sizing bug) is exactly the kind of upstream audit that turns a "flip a default" task into a properly-scoped story. The follow-up intake captures the deferred work cleanly — same pattern ADR 0023 / ADR 0024 used for their Implementer-copy-to-file intakes.
+- The Tester shipped the probe alongside the sentinels (P0/P1 PASS pre-impl) — de-risked the Implementer's commit by establishing the probe file before it was needed. Same pattern story #27 used.
+- The Implementer's diff is exactly the ADR's Implementation notes, no scope creep. R4's "preserve 11 per-task overrides" sentinel was not just decorative — it actively constrained the Implementer's hand.
+
+## Findings
+
+### Blocking
+
+_None._
+
+### Non-blocking
+
+1. **[`src/manage/taskQueue/launchChildTask.sh:403`](../../src/manage/taskQueue/launchChildTask.sh:403)** — `local force_kill=$(echo "$resolved_options" | jq -r '.failure.timeout.forceKill // false')`. The `// false` jq fallback at the bash level is now misaligned with the new global default (`true`). In practice this fallback only engages if the entire `options_default.completion` block is missing from the registry — which would be a much deeper corruption issue — but a future cleanup intake could flip `// false` → `// true` for consistency. ADR 0025 §"Files NOT to edit" explicitly excludes this file from story #28's scope, so the Implementer correctly did not touch it. Worth filing a separate hygiene intake; not blocking this story.
+
+2. **Probe runtime deferred to cycle-local.** AC #1 and AC #2's behavioral claims have structural coverage (S1, S2, R1, R3) but the empirical end-to-end check via `test/probe-kill-timeout-orphans.js` has not been run in Review. This matches story #27's precedent (probe runs at cycle-local, not at Review) and the structural coverage is comprehensive for a 2-file fix. The probe MUST be run during the next `cycle-local` step before staging signs off — that's the empirical confirmation that the wrapper actually kills the orphan when the resolved forceKill is true. If the probe FAILs at cycle-local, re-open ADR 0025 with the probe output attached. Not blocking the Review verdict because the deployment chain's own gates (cycle-local → cycle-staging → cycle-prod) cover this empirically.
+
+3. **Cycle-staging is the AC #5 final gate.** No-downtime deploy + no-manual-cleanup is a process-level invariant that's only verifiable at deploy time. The structural diff supports the claim (pure data + tiny JS edit; no in-flight-state migration needed); cycle-staging will confirm operationally.
+
+## Verdict
+
+**PASS.**
+
+Implementation matches ADR 0025 exactly. Both layers (registry default + processor.js literal) are flipped per Architect's Option A; the 11 per-task `forceKill: false` overrides are preserved unchanged per the Architect's explicit non-change decision; the follow-up intake is filed verbatim from the ADR's "Implementer copy-to-file at commit time" block. All 9 new sentinels pass; no regressions across the other 22 suites (240 individual tests total).
+
+The fix's mechanism — flip the registry global default + remove processor.js's per-invocation hardcode — correctly addresses both layers ADR 0025 §Context identified as necessary. Without Layer 2, Layer 1 would be a no-op for the BullMQ-mediated path (which is most scheduled fires); the Implementer correctly fixed both.
+
+Three non-blocking observations recorded above (wrapper jq fallback misalignment, probe runtime deferred, cycle-staging is AC #5's final gate). None affect correctness or deploy safety.
+
+Ready for the standard deploy chain: `cycle-local` first (runs the probe + verifies the wrapper behavior end-to-end), then `cycle-staging`, then `cycle-prod` on user approval. AC #1, #2, #4 (full kill behavior across paths) and AC #5 (no-downtime deploy) get their final behavioral verification during those cycles.

--- a/engineering-team/stories/28-kill-timeout-orphans-by-default.md
+++ b/engineering-team/stories/28-kill-timeout-orphans-by-default.md
@@ -1,0 +1,59 @@
+# Story 28: Kill timeout-orphans by default so they stop suppressing subsequent scheduled fires
+
+**Status:** Draft
+**Created:** 2026-05-25
+**Type:** Bug
+
+## Background
+
+ADR 0013 (story #15, 2026-05-20) introduced a Redis-backed `neo4j-heavy` semaphore (cap=1) to serialize concurrent Neo4j-heavy work and prevent crashes. Story #27 / ADR 0024 (2026-05-25) plus its Track A follow-up (PR #217) restored the contract that the semaphore actually be held for the configured task duration rather than releasing at ~6 seconds — the no-timeout case is now correct on prod.
+
+A second failure mode remains. When a tagged task hits its configured timeout (either genuine — the task really did run too long — or operator-misjudged — the configured timeout was too tight), the wrapper script's monitor loop declares timeout and exits. The current default `forceKill: false` (registry global default + a hardcoded fallback in `processor.js`) means the backgrounded child process is **not** killed. The Node Worker callback's `finally { release() }` releases the semaphore. The orphaned bash subprocess keeps running.
+
+When the next scheduled fire of the same task occurs, the wrapper script's `check_task_already_running` (`launchChildTask.sh:25-67`) finds the orphan PID via `pgrep -f`. Under the default `processAlreadyRunning.withoutError.launchNew = false` policy, it emits `TASK_LAUNCH_PREVENTED` and exits success — BullMQ records job completion. The scheduled fire was silently dropped.
+
+This was concretely observed on prod 2026-05-25 during Track A verification: the post-deploy `processCustomer` tick at 20:23:04Z had its launch prevented at 22:06:32Z because the prior stale-recovered tick's orphan (PID 195788) was still running. The fresh tick's actual neo4j-heavy work did not run at all. Cumulatively, since story #15 shipped on 2026-05-20, the system has likely dropped a meaningful fraction of scheduled fires for tasks whose work routinely exceeded their pre-Track-A 30-min timeouts.
+
+The current posture is architecturally incoherent. `forceKill: false` carries the semantic "let the work finish past its timeout"; the orphan-detection carries the semantic "if a prior fire is still running, skip the new one." Together they violate both ADR 0013's cap=1 contract (the orphan runs unprotected after semaphore release) AND the scheduling contract (fires silently dropped). Track A reduced timeout frequency for the three biggest offenders but did not change the kill-on-timeout decision. Story #27 explicitly scoped this out (its ADR 0024 §"Constraints from the story" notes "this ADR preserves the current `forceKill: false` behavior").
+
+The fix ships into a live prod task queue. The deploy must not require operator cleanup of in-flight tasks or pre-existing orphans.
+
+## User-facing description
+
+As an operator of a Brainstorm deployment who relies on scheduled task fires to actually execute,
+I want a task that hits its configured timeout to be killed rather than left running as an orphan,
+so that the next scheduled fire of the same task runs at its scheduled time instead of being silently dropped by the wrapper's already-running detection.
+
+## Acceptance criteria
+
+- [ ] Given a task whose script exceeds its configured timeout, when the wrapper script's monitor loop fires timeout, then the backgrounded child process is killed (no surviving orphan PID after wrapper exit).
+- [ ] Given a tagged task whose prior fire was killed at timeout, when the next scheduled fire occurs, then `check_task_already_running` finds no orphan and the new fire's script runs (a `TASK_START` event lands in `events.jsonl`; no `TASK_LAUNCH_PREVENTED` event).
+- [ ] Given a timeout-triggered kill, when an operator queries `events.jsonl`, then the timeout is observable via the existing `CHILD_TASK_ERROR` / timeout token — no new event type is required (operator can distinguish "killed via timeout" from other failure modes through existing fields).
+- [ ] Given any invocation path that reaches `launchChildTask.sh` (BullMQ Worker, parent script's `launch_child_task` recursive call, manual `bash launchChildTask.sh ...`), when timeout fires, the kill behavior applies uniformly — controlled by the wrapper's `resolved_options`, which honors the registry global default regardless of caller.
+- [ ] Given the deploy of this change, when prod restarts, no manual cleanup of in-flight tasks or pre-existing orphans is required. Pre-existing orphans run to natural completion or operator action; new timeouts post-deploy kill cleanly.
+
+## Concepts touched
+
+None. Per ADR 0013, the task-queue + wrapper-script subsystem has no concept-graph footprint. The Architect should re-confirm by querying `/api/concept-graph/summaries` once the local control panel is up (per AGENTS.md §1–§3).
+
+## Out of scope
+
+- **Track B — auto-tune timeouts from observed average runtimes** (2026-05-25 intake at `_intake.md`, "Follow-up: per-task timeout overrides ... and auto-tune"). Separate multi-session feature with 6 design questions.
+- **Cleanup of the 11 existing per-task `forceKill: false` overrides** in `taskRegistry.json` (lines 110, 231, 262, 291, 342, 373, 403, 435, 1431, 1460, 1489). The Architect decides whether to delete them so the global default applies uniformly, keep them with documented justification, or preserve as-is. This story specifies the global default change, not the per-task cleanup.
+- **Smarter `check_task_already_running` PID-attribute detection** (intake Option 2 — distinguish "expected concurrent run" from "orphan-from-timeout"). Rejected during `/discuss` 2026-05-25 — significant complexity, doesn't address the semaphore-contract issue, and treats a symptom rather than the cause.
+- **Flipping `processAlreadyRunning.withoutError.launchNew = true`** (intake Option 3 — let the new fire run alongside the orphan). Rejected during `/discuss` 2026-05-25 — would violate ADR 0013's cap=1 contract during the overlap window.
+- **New operator-facing surfaces for kill visibility** — no new event types, no new dashboard fields, no new BullBoard columns. Existing `CHILD_TASK_ERROR` tokens carry the information.
+- **The held branch `fix/launch-child-task-protection-audit`** (story #26 / ADR 0023). Separate work, separate Implementer pickup. Independent from this story.
+- **The 2026-05-24 JS-exec API handlers intake** (legacy handlers that `child_process.exec` task scripts directly, bypassing the wrapper). Those paths do not go through `launchChildTask.sh` so this story's fix does not reach them. Separate triage.
+- **Changes to the `forceKill` field's location or shape** in the registry schema. The change is a single value flip + (optionally, per Architect) cleanup of overrides. No schema redesign.
+
+## Open questions
+
+- **Neo4j cleanliness on `kill -9` of a bash subprocess running an in-flight Cypher transaction.** Architect to research/affirm: does killing the bash wrapper around a `cypher-shell` invocation (or equivalent) leave Neo4j in a half-applied transactional state? Working hypothesis: no — Neo4j transactions are atomic at the query level, and any in-flight transaction at process death is rolled back by the server. But this is the highest-risk operator-visible aspect of the change and deserves explicit confirmation in the ADR rather than implicit acceptance.
+- **Per-task override policy.** The 11 explicit `forceKill: false` overrides in `taskRegistry.json` need an Architect decision: delete (uniform), keep (documented per-task reason), or preserve (those tasks retain pre-fix behavior). Resolve in Phase 2.
+
+## Linked artifacts
+
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/28-kill-timeout-orphans-by-default.md
+++ b/engineering-team/stories/28-kill-timeout-orphans-by-default.md
@@ -56,4 +56,4 @@ None. Per ADR 0013, the task-queue + wrapper-script subsystem has no concept-gra
 
 - ADR: [`engineering-team/decisions/0025-kill-timeout-orphans-by-default.md`](../decisions/0025-kill-timeout-orphans-by-default.md)
 - Test plan: [`engineering-team/stories/28-kill-timeout-orphans-by-default.test-plan.md`](28-kill-timeout-orphans-by-default.test-plan.md) (9 sentinels at `test/kill-timeout-orphans-by-default.test.js` + empirical probe at `test/probe-kill-timeout-orphans.js`)
-- Review: (filled in after Review phase)
+- Review: [`engineering-team/reviews/28-kill-timeout-orphans-by-default.md`](../reviews/28-kill-timeout-orphans-by-default.md) — verdict **PASS** (2026-05-25)

--- a/engineering-team/stories/28-kill-timeout-orphans-by-default.md
+++ b/engineering-team/stories/28-kill-timeout-orphans-by-default.md
@@ -54,6 +54,6 @@ None. Per ADR 0013, the task-queue + wrapper-script subsystem has no concept-gra
 
 ## Linked artifacts
 
-- ADR: (filled in after Architecture phase)
+- ADR: [`engineering-team/decisions/0025-kill-timeout-orphans-by-default.md`](../decisions/0025-kill-timeout-orphans-by-default.md)
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/28-kill-timeout-orphans-by-default.md
+++ b/engineering-team/stories/28-kill-timeout-orphans-by-default.md
@@ -55,5 +55,5 @@ None. Per ADR 0013, the task-queue + wrapper-script subsystem has no concept-gra
 ## Linked artifacts
 
 - ADR: [`engineering-team/decisions/0025-kill-timeout-orphans-by-default.md`](../decisions/0025-kill-timeout-orphans-by-default.md)
-- Test plan: (filled in after Test Design phase)
+- Test plan: [`engineering-team/stories/28-kill-timeout-orphans-by-default.test-plan.md`](28-kill-timeout-orphans-by-default.test-plan.md) (9 sentinels at `test/kill-timeout-orphans-by-default.test.js` + empirical probe at `test/probe-kill-timeout-orphans.js`)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/28-kill-timeout-orphans-by-default.test-plan.md
+++ b/engineering-team/stories/28-kill-timeout-orphans-by-default.test-plan.md
@@ -1,0 +1,116 @@
+# Test Plan: Story 28 — Kill timeout-orphans by default so they stop suppressing subsequent scheduled fires
+
+**Story:** `engineering-team/stories/28-kill-timeout-orphans-by-default.md`
+**ADR:** `engineering-team/decisions/0025-kill-timeout-orphans-by-default.md`
+**Date:** 2026-05-25
+
+## Approach
+
+ADR 0025's chosen fix is a two-layer change across `taskRegistry.json` (flip global default `forceKill: true`) + `queue/processor.js` (omit the hardcoded per-invocation `forceKill: false`). The mechanically-changed surface is tiny — under 5 lines of code — but the bug shape is operational (orphan persists past wrapper exit; next fire is silently suppressed by `check_task_already_running`), so behavioral verification needs to actually exercise the wrapper script's resolved kill behavior.
+
+Three test tiers — matching the precedent set by stories #15 (resource-class semaphore tests), #24 (scheduler tests), #25 (manual re-trigger tests), and #27 (timeout-propagation tests):
+
+1. **Structural sentinels + intake sentinel** in `test/kill-timeout-orphans-by-default.test.js` — pin the two source-level fix points (registry default + processor.js literal) and the ADR-mandated follow-up intake. Pure file-read + JSON-parse + regex. Run on the host via `npm test`; no Redis, no BullMQ, no Docker stack required.
+
+2. **Regression guards** in the same file — verify the wrapper script's existing `force_kill` block + CHILD_TASK_ERROR emit + queue/index.js's semaphore wrap + the 11 per-task `forceKill: false` overrides ALL remain unchanged. ADR 0025 §Decision specifies the 11 overrides as explicit non-changes (Architect chose Option A over D); this guard prevents accidental scope creep into Option D territory.
+
+3. **Empirical probe** at `test/probe-kill-timeout-orphans.js` — one-shot Node script that exercises the **actual** `launchChildTask.sh` against a temporary probe task. Confirms two behavioral claims: (Path 1) after wrapper-script timeout, the child PID is dead (kill happened); (Path 2) the immediately-next invocation of the same task is allowed to launch (no `TASK_LAUNCH_PREVENTED`). Runs inside the `tapestry` container; not registered in `test/test.js` (one-shot empirical check, not a regression test). The P0/P1 sentinels in tier 1 protect the probe's existence + shape.
+
+This split matches the precedent of stories #15, #22, #24, #25, #27 — the project deliberately keeps BullMQ semantics out of the host unit suite (no host BullMQ installation), and Docker-stack tests are run as probes + cycle-local smoke rather than CI.
+
+The cycle-local smoke at deploy time (AC #5) verifies the no-downtime deploy profile end-to-end — same evidence pattern that surfaced the original bug (operator-observed orphans via `pgrep -f`; `TASK_LAUNCH_PREVENTED` events in `events.jsonl`).
+
+## Coverage map
+
+| Criterion | Test name | Test file | Level |
+|---|---|---|---|
+| **AC #1** Timeout produces a kill (no surviving orphan PID) | S1: `taskRegistry.json's options_default.completion.failure.timeout.forceKill === true` | `test/kill-timeout-orphans-by-default.test.js` | structural sentinel |
+| **AC #1** | S2: `processor.js's optionsJson literal omits the forceKill field entirely (lets hierarchical merge resolve it)` | `test/kill-timeout-orphans-by-default.test.js` | structural sentinel |
+| **AC #1** (behavioral confirmation) | probe Path 1 — invoke wrapper with `timeoutMs: 5000` against a 15-second sleep script (NO per-invocation forceKill); assert `ps -p $childPid` returns dead after wrapper exit AND events.jsonl contains a `CHILD_TASK_ERROR error_type="timeout"` for this run | `test/probe-kill-timeout-orphans.js` | empirical probe (Implementer-run inside container) |
+| **AC #2** Next scheduled fire runs (no `TASK_LAUNCH_PREVENTED`) | probe Path 2 — immediately after Path 1, re-invoke wrapper with same task name; assert events.jsonl contains a `CHILD_TASK_START` for the second run AND does NOT contain a `TASK_LAUNCH_PREVENTED` between Path 1's `CHILD_TASK_ERROR` and the second run's `CHILD_TASK_START` | `test/probe-kill-timeout-orphans.js` | empirical probe |
+| **AC #3** Operator visibility via existing `CHILD_TASK_ERROR` events | R2: `launchChildTask.sh still emits CHILD_TASK_ERROR event with error_type="timeout"` (regression guard — fix must not change the emit shape) | `test/kill-timeout-orphans-by-default.test.js` | regression guard |
+| **AC #3** (transitive) | probe Path 1 (same) — the kill assertion is paired with verifying the `CHILD_TASK_ERROR error_type="timeout"` event lands, which proves the existing observability surface still carries the timeout signal | `test/probe-kill-timeout-orphans.js` | empirical probe |
+| **AC #4** Uniform across all wrapper invocation paths | S1 (registry default reaches all paths) + S2 (processor.js stops asserting per-invocation forceKill, so per-task and global default win for the BullMQ-mediated path) | `test/kill-timeout-orphans-by-default.test.js` | structural sentinel (combined) |
+| **AC #4** (regression guard on the wrapper-side kill mechanism) | R1: `launchChildTask.sh's force_kill block at :402-412 still reads from resolved_options and conditionally executes kill -9` (the wrapper's kill machinery must be preserved — the fix only flips the resolved default, the kill path must still work) | `test/kill-timeout-orphans-by-default.test.js` | regression guard |
+| **AC #4** (regression guard on ADR 0013 wrap) | R3: `queue/index.js still wraps tagged-task Worker callback with semaphore.acquire / release in try-finally` (ADR 0013 wrap preserved — story #28 must not regress story #15's contract) | `test/kill-timeout-orphans-by-default.test.js` | regression guard |
+| **AC #5** No-downtime deploy / no manual cleanup | cycle-staging smoke: deploy to staging; verify brainstorm container restarts cleanly; verify no pre-existing in-flight tasks are killed/disrupted by the deploy itself; on user approval, cycle-prod with the same check | cycle-local smoke | manual |
+| **ADR 0025 Decision: 11 per-task overrides preserved** | R4: `the 11 per-task forceKill: false overrides remain unchanged in taskRegistry.json` (Architect chose Option A over Option D — the cleanup of these overrides is explicitly deferred to a follow-up intake; this guard prevents scope creep) | `test/kill-timeout-orphans-by-default.test.js` | regression guard |
+| **ADR 0025 §"Intake to file at commit time"** | I1: `_intake.md contains the "## 2026-05-25 — Cleanup + Bug: per-task forceKill: false overrides after story #28's default-flip" section header at end of file` (the Implementer copies the intake block verbatim from ADR 0025 at commit time — same pattern as ADR 0023's amendment block) | `test/kill-timeout-orphans-by-default.test.js` | structural sentinel |
+| **ADR 0025 §"Implementer self-check"** (implied) | P0: `empirical probe exists at test/probe-kill-timeout-orphans.js` | `test/kill-timeout-orphans-by-default.test.js` | structural sentinel |
+| **ADR 0025 §"Implementer self-check"** | P1: `probe script exercises both Path 1 (kill verification) and Path 2 (next-fire-runs verification) and asserts against events.jsonl + ps` | `test/kill-timeout-orphans-by-default.test.js` | structural sentinel |
+
+## Edge cases
+
+Beyond the AC-driven coverage above, the following edges are surfaced — some deliberately deferred:
+
+- [ ] **Bash subprocess vs. its grandchildren.** `kill -9 $child_pid` kills the bash subprocess that the wrapper spawned via `bash "$child_script" &`. It does NOT cascade to the bash's own children (e.g., `sleep 15`). Those grandchildren become orphaned to init/supervisord and continue running until natural completion. The probe's Path 2 verifies that check_task_already_running's `pgrep -f $script_relative_path` does not match those grandchildren (whose cmdline doesn't carry the script path), so the next fire isn't blocked. This is the precise reason AC #1 says "no surviving orphan PID" (singular, referring to the script-path-bearing process) rather than "all descendant processes killed."
+
+- [ ] **The 11 per-task `forceKill: false` overrides retain pre-fix behavior.** Architect's Option A explicitly preserves these. After the fix, tasks like `processAllTasks`, `syncWoT`, `syncProfiles`, `callBatchTransfer`, etc. (full list in ADR 0025 §"Per-task overrides") still get `forceKill: false` at the wrapper's merge — meaning their timeout behavior is UNCHANGED. R4 guards against accidental removal. The follow-up intake (filed by Implementer at commit time per the ADR's "Intake to file at commit time" block) captures the proper triage for these.
+
+- [ ] **`syncWoT` and `syncProfiles` 60-second timeout mis-sizing** is a separate bug surfaced during ADR 0025's audit. Story #28 explicitly preserves the override on these (Architect Option A vs Option D) precisely BECAUSE flipping them would cause a hidden regression. The follow-up intake's Part B captures the bug investigation. Not exercised by these tests; covered transitively by R4.
+
+- [ ] **Neo4j atomicity on `kill -9` mid-Cypher.** ADR 0025 §Context resolved this as a non-issue (TCP drops → Neo4j rolls back in-flight transactions; partial-work risk identical to today's stalled-recovery risk). Not directly testable from the host test suite — would require a live Neo4j + cypher-shell + an in-flight transaction state. The cycle-staging smoke against real prod-shape work provides the operational evidence; no host-level assertion possible.
+
+- [ ] **Pre-existing orphans at deploy time** (AC #5) — the deploy doesn't kill them; they run to natural completion or operator action. Operationally verifiable via `pgrep -f $script_path` before/after deploy; not a code-level assertion.
+
+- [ ] **Story #27's existing test suite (`scheduled-task-timeout-propagation`)** must continue to PASS. Story #28 builds on story #27's fix; the regression guards in story #27 (S1-S4 in that suite + R1, R2 in that suite) cover the timeout-propagation correctness this story relies on. We don't re-duplicate them here; the overall `npm test` run is the regression guard.
+
+- [ ] **JS-exec API handlers** (2026-05-24 intake) — those handlers bypass `launchChildTask.sh` entirely; story #28's fix does not reach them. Out of scope, covered by the separate intake's eventual story.
+
+## Test infrastructure
+
+- **Test framework:** Node built-in runner via `npm test` (entry: `test/test.js`). No new dependencies.
+- **Concept Graph API:** not used. Story #28 has no concept-graph impact (confirmed by ADR 0025 §"Concept-graph impact").
+- **Firmware state:** no precondition.
+- **Fixtures:** the structural sentinels read source files directly (no fixtures). The probe creates a temporary probe-only entry in `taskRegistry.json` (backup → modify → run → restore) and a temporary script in `/tmp` (identical pattern to story #27's `test/probe-scheduled-task-timeout-propagation.js`).
+- **Local-vs-container split:**
+  - The 9 sentinels + regression guards in `test/kill-timeout-orphans-by-default.test.js` are pure file-read + JSON-parse + regex — they run on the host with no runtime dependencies.
+  - The probe at `test/probe-kill-timeout-orphans.js` requires `bash`, `jq`, the wrapper script's source dependencies, and a writable `events.jsonl` — all inside the `tapestry` container. Run via:
+    ```
+    docker exec tapestry node /usr/local/lib/node_modules/brainstorm/test/probe-kill-timeout-orphans.js
+    ```
+    Expected output: 4 ASSERT-PASS blocks across Path 1 (3 asserts: wrapper-exit-shape, child-pid-dead, CHILD_TASK_ERROR present) and Path 2 (1 assert: CHILD_TASK_START present, no TASK_LAUNCH_PREVENTED). If anything FAILs, the Implementer re-opens ADR 0025 with the probe output attached.
+
+## How to run
+
+```
+npm test
+```
+
+For the empirical probe (after the Implementer has run the host suite and committed the fix):
+```
+docker exec tapestry node /usr/local/lib/node_modules/brainstorm/test/probe-kill-timeout-orphans.js
+```
+
+For AC #5 (cycle-staging then cycle-prod): use the `cycle-staging` skill, verify the brainstorm container restarts cleanly + no in-flight tasks are disrupted. Then on user approval, `cycle-prod` with the same observation.
+
+## Verification
+
+The 9 sentinels + regression guards were committed against the pre-implementation tree on 2026-05-25. Pre-implementation state: **3 FAIL (S1, S2, I1) + 6 PASS (R1, R2, R3, R4, P0, P1)**. The three failing sentinels are the two fix-surface guards (one per file the Implementer touches) plus the intake sentinel. The six passing tests are:
+
+- **R1, R2, R3** — regression guards on the wrapper-script kill mechanism, the CHILD_TASK_ERROR emit, and the ADR 0013 semaphore wrap. These must remain green; the fix flips a default value, it must not remove the kill machinery, the timeout-emit surface, or the semaphore wrap.
+- **R4** — regression guard on Architect's explicit non-change decision (preserve the 11 per-task overrides). Must remain green; story #28 deliberately doesn't touch these.
+- **P0, P1** — probe-file existence + shape guards. The Tester ships the probe alongside the sentinels (de-risks the Implementer's self-check step). After implementation these still pass; they're regression guards against accidental probe-file deletion.
+
+Confirmed on 2026-05-25 (pre-implementation tree, commit `7d2c9355`'s tree updated with the test files):
+
+```
+kill-timeout-orphans-by-default suite:
+  ✗ S1: taskRegistry.json's options_default.completion.failure.timeout.forceKill === true (AC #1, AC #4; ADR 0025 §Implementation 1)
+      Pre-fix the global default is `false`. The Implementer must flip this to `true`. (AC #1, AC #4; ADR 0025 §Implementation 1)
+  ✗ S2: processor.js's optionsJson literal omits the forceKill field entirely (AC #1, AC #4; ADR 0025 §Implementation 2)
+      Pre-fix processor.js hardcodes `forceKill: false` at line 122. The fix removes the field entirely so the wrapper's hierarchical merge resolves forceKill from per-task override (if any) or global default (now true). (AC #1, AC #4; ADR 0025 §Implementation 2)
+  ✗ I1: _intake.md contains the new follow-up section header from ADR 0025's "Intake to file at commit time" block (ADR 0025 §"Intake to file at commit time")
+      Pre-fix the intake has not been appended. The Implementer copies the full block verbatim from ADR 0025 at commit time. (ADR 0025 §"Intake to file at commit time")
+  ✓ R1: launchChildTask.sh's force_kill block at :402-412 still reads from resolved_options and conditionally executes kill -9 (AC #1, AC #4 — wrapper kill machinery preserved)
+  ✓ R2: launchChildTask.sh still emits CHILD_TASK_ERROR event with error_type="timeout" (AC #3 — observability surface preserved)
+  ✓ R3: queue/index.js still wraps tagged-task Worker callback with semaphore.acquire / release in try-finally (AC #4 — ADR 0013 wrap preserved)
+  ✓ R4: the 11 per-task forceKill: false overrides remain unchanged in taskRegistry.json (ADR 0025 §Decision — explicit non-change)
+  ✓ P0: empirical probe exists at test/probe-kill-timeout-orphans.js (ADR 0025 §"Implementer self-check")
+  ✓ P1: probe script exercises both Path 1 (kill verification) and Path 2 (next-fire-runs verification) and asserts against events.jsonl + ps (ADR 0025 §"Implementer self-check")
+
+kill-timeout-orphans-by-default suite:           FAIL (6 passed, 3 failed)
+Overall:                                         FAIL
+```
+
+All 3 failures fail for the right reason — they reference the absent fix in each of the two files the Implementer must touch (S1 covers `taskRegistry.json`, S2 covers `processor.js`) plus the absent intake (I1). The Implementer's success criterion: all 9 PASS after the two-layer fix lands + the intake is appended; the probe runs cleanly inside the container with all 4 ASSERTs PASSing.

--- a/engineering-team/stories/_intake.md
+++ b/engineering-team/stories/_intake.md
@@ -581,3 +581,40 @@ reconcileAll    2026-05-25 07:51:43Z → held_seconds:  798  (baseline — alrea
 **Strictness:** Standard.
 **Phase path:** `/discuss` to settle the design choice (especially `forceKill: true` vs the smarter `check_task_already_running` logic). Then Planning → Architecture → Test Design → Implementation → Review.
 **Priority:** **Medium-high.** Production has been silently skipping scheduled fires since story #15 shipped (~2026-05-20) whenever timeouts fired. Track A reduces the frequency but doesn't fix the mechanism. Worth surfacing before the operator builds operational habits around the current behavior.
+
+---
+
+## 2026-05-25 — Cleanup + Bug: per-task `forceKill: false` overrides after story #28's default-flip
+
+**Surfaced during:** Architect-phase audit for story #28 / ADR 0025 (2026-05-25). The audit of all 11 per-task `forceKill: false` overrides in `taskRegistry.json` found two distinct concerns that story #28's narrow scope (flip the global default) deliberately did not address.
+
+**Part A — Cleanup: 9 redundant overrides.** The following 9 entries have a `forceKill: false` override that appears to be a copy-paste artifact rather than a deliberate choice (no `comments` field justifying the choice; durations are reasonable for the work):
+
+| Line | Task | Duration |
+|---|---|---|
+| 110 | processAllTasks | 6h |
+| 291 | callBatchTransfer | 1h |
+| 342 | reconcileRecent | 30min |
+| 373 | reconcileAll | 8h |
+| 403 | reconcileAuthor | 10min |
+| 435 | reconcileNetwork | 60min |
+| 1431 | applicationHealthMonitor | 10min |
+| 1460 | neo4jPerformanceMonitor | 10min |
+| 1489 | externalNetworkConnectivityMonitor | 10min |
+
+Deleting just the `"forceKill": false` line from each (preserving `duration`/`comments` if present) would let these tasks inherit the new `forceKill: true` global default. Each is independently low-risk (durations are generous; if the kill bites, it bites for a real reason).
+
+**Part B — Bug: 2 mis-sized timeout durations.** The following 2 entries carry a 60-second timeout that's clearly wrong for tasks with `estimatedDuration: "30-60 minutes"` and `averageDuration: 44500` (44.5s average — many runs exceed):
+
+| Line | Task | Duration | Comment |
+|---|---|---|---|
+| 231 | syncWoT | 60s | `estimatedDuration: "30-60 minutes"`, `averageDuration: 44500` |
+| 262 | syncProfiles | 60s | same |
+
+Today the `forceKill: false` override masks the impact (wrapper declares timeout, bash continues unprotected, work eventually completes). If we drop the override without fixing the duration, work gets killed at 60s every time a sync runs slow. The right sequence is: investigate the correct duration value (probably 30-60 min matching the estimatedDuration with headroom) FIRST, then drop the override.
+
+**Suggested phase path:**
+- Part A (cleanup): one fast-track story or part of a story. Standard 5-phase if bundled with Part B.
+- Part B (bug): properly-scoped story + ADR (the right duration value is an architectural choice that affects operator expectations + may have a follow-on on auto-tune Track B).
+
+**Classification:** Mixed (cleanup + bug). **Priority:** Medium — incomplete coverage of story #28's intended fix; cosmetic + 2 latent bugs.

--- a/engineering-team/stories/_intake.md
+++ b/engineering-team/stories/_intake.md
@@ -510,3 +510,74 @@ processCustomer 2026-05-25 08:43:03Z → held_seconds: 1805
 processCustomer 2026-05-25 11:43:04Z → held_seconds: 1806
 reconcileAll    2026-05-25 07:51:43Z → held_seconds:  798  (baseline — already had explicit timeout)
 ```
+
+**PICKED UP 2026-05-25** — Track A shipped as PR #216 (staging) + PR #217 (prod). Explicit per-task overrides added for `processCustomer` (90 min), `updateAllScoresForOwner` (4 hr), `updateAllScoresForSingleCustomer` (4 hr). Verified end-to-end on prod via the post-deploy fresh tick at 20:23:04Z showing `resolved_options.failure.timeout.duration: 5400000`. Track B (auto-tune) remains open — captured separately as the long-term feature, not yet started.
+
+---
+
+## 2026-05-25 — Bug: BullMQ Job Scheduler stalled-recovered ticks use pre-deploy `job.data`
+
+**Surfaced during:** prod verification of Track A (PR #217). Investigation thread documented inline in the Track A cycle-prod conversation; the conclusive evidence came from `HGETALL bull:processCustomer:repeat:sched:entry-...:1779729784143` showing `data:{...,"timeoutMs":1800000}` on a tick whose master scheduler template had been updated to `timeoutMs:5400000` post-deploy.
+
+**Mechanism:** BullMQ Job Schedulers snapshot the master `data` template into each per-tick job at JOB-GENERATION time (typically at previous-tick completion). When the container restarts mid-fire (deploy), any in-flight job is killed; BullMQ's stalled-job recovery moves it from `active` back to `wait` for re-pickup by the next Worker — **with its original `data` payload intact**. The recovered job runs to completion with whatever data was current when the tick was generated, not what's current at execution time. So a `taskRegistry.json` or scheduler-config change shipped in a deploy does NOT retroactively apply to any pre-deploy tick that gets recovered after the deploy. The downstream code path (`processor.js → launchChildTask.sh`) sees the stale `timeoutMs` in `job.data` and propagates it.
+
+**Concrete impact observed (2026-05-25 prod):**
+| Event | Timestamp | Source data |
+|---|---|---|
+| Track A deploy | 17:36:38Z | (no impact on tick data — only updates registry + master template) |
+| Pre-deploy tick generated | 14:23:04Z | `timeoutMs: 1800000` (correct for that era) |
+| Pre-deploy tick became active | 17:23:04Z | (running normally) |
+| Container restart kills active job | ~17:38:00Z | (BullMQ Worker reconnects, sees the active job, marks stalled) |
+| Stalled job recovered to wait | ~17:38:39Z | (data intact: `timeoutMs: 1800000` — stale) |
+| Worker picks up recovered job | 17:38:39Z | (semaphore wait, ran for 3h 45min waiting on semaphore held by ANOTHER stalled-recovered job) |
+| Wrapper spawned + ran 30-min timeout | 21:23:04Z | logged `(timeout: 1800s)` — stale data propagated end-to-end |
+| Worker callback completes | 21:53:09Z | emitted `CHILD_TASK_ERROR error_type=timeout elapsed_time=1800000` |
+
+**Why this isn't a Track A regression:** Track A (and story #27 before it) deliberately scoped only the propagation chain for NEW ticks. The fact that stalled-recovered ticks bypass `resolveTaskTimeout` is a BullMQ property + our deploy pattern interaction; nothing in story #27 or Track A pretends to address it. Future readers of the prod evidence will need to distinguish "still-broken Track A" from "stalled-recovered cutover artifact" — this intake makes that distinction crisp.
+
+**Cutover window:** typically clears within a few ticks (one or two scheduler periods). For `processCustomer` (3h cadence), within ~6 hours of deploy. After that, all live ticks have fresh data.
+
+**Possible fixes (Architect to triage when picked up):**
+1. **Re-derive `data` from current master template at job-pickup time.** Modify the BullMQ Worker callback (in `src/manage/taskQueue/queue/index.js:118-131`) to re-read the Job Scheduler's master template and merge fresh values into `job.data` before passing to `processor.processJob`. Low-impact change; recovers cleanly from any pre-deploy data drift.
+2. **Force-drain BullMQ active jobs before deploy.** Add a pre-deploy hook that waits for active jobs to complete (or fails them explicitly) so no stalled recovery is needed. Higher operational impact; would lengthen deploy windows during a heavy `processCustomer` run.
+3. **Accept and document.** This is a known BullMQ behavior with bounded cutover impact. The diagnostic pattern (HGETALL the master template + per-tick keys) is now established. Just document the operator playbook for distinguishing cutover noise from real regressions in `OPERATIONS.md`.
+
+**Classification:** Bug (subtle data-staleness on deploy boundary). Not user-facing under normal operation.
+**Strictness:** Standard.
+**Phase path:** `/discuss` to triage the three fix shapes (the trade-offs are real), then Planning if a fix is chosen. Option 3 (just document) might be the right call — needs operator input.
+**Priority:** **Low.** Only manifests at deploy moments, only affects in-flight jobs at that moment, only causes a few stale-data ticks before the system stabilizes. The bigger concern is the *combination* of this + the orphan-prevention issue below — together they can suppress a meaningful number of scheduled fires across a cutover.
+
+---
+
+## 2026-05-25 — Bug: `forceKill: false` timeout orphans suppress subsequent scheduled fires via `check_task_already_running`
+
+**Surfaced during:** prod verification of Track A (PR #217), specifically the post-deploy 20:23:04Z processCustomer tick at 22:06:32Z which logged `LAUNCHCHILDTASK_RESULT: {"launch_action":"prevented","existing_pid":195788,"launch_new":false}`. The 195788 PID came from the PREVIOUS fire (the stalled-recovered 17:23:04Z tick) whose wrapper had declared timeout at 21:53:09Z but — per the `forceKill: false` hardcode in `processor.js` — did NOT kill the backgrounded `processCustomer.sh`. The orphan was still running when the next scheduled tick fired, and the wrapper's standard `check_task_already_running` logic (`src/manage/taskQueue/launchChildTask.sh:25-67`) found it and prevented the new launch under the default `launchNew: false` policy.
+
+**Mechanism (full chain):**
+1. A wrapper-script timeout fires (genuine or spurious). `forceKill: false` (hardcoded in `processor.js:117-127`; deliberately preserved per story #27 §"Out of scope") means the script declares timeout and exits without killing the backgrounded child.
+2. The Node `child.on('close')` fires, Worker callback's `finally { await release() }` releases the semaphore.
+3. The backgrounded `processCustomer.sh` (or other tagged-task script) keeps running orphaned — could be minutes to hours of additional runtime depending on actual workload.
+4. The next scheduled fire of the same task fires its tick → Worker → processor → wrapper.
+5. Wrapper's `check_task_already_running` calls `pgrep -f "$script_relative_path"`, finds the orphan PID.
+6. Wrapper consults `options_default.launch.processAlreadyRunning.withoutError = { killPreexisting: false, launchNew: false }`. **Decides NOT to launch the new fire**, emits `TASK_LAUNCH_PREVENTED`, returns success (LAUNCHCHILDTASK_RESULT.launch_action="prevented").
+7. From BullMQ's perspective, the job completed successfully. The scheduled fire was effectively SKIPPED.
+
+**Concrete impact observed (2026-05-25 prod):** the post-deploy fresh tick at 20:23:04Z had its launch prevented at 22:06:32 because the prior stale tick's orphan (PID 195788) was still running. **The fresh tick's actual neo4j-heavy work did not run at all** — silently skipped.
+
+**Severity of skipping:** previously hidden. A single timeout firing on a long-running task could cascade-skip multiple subsequent scheduled fires for as long as the orphan persists. Pre-Track-A on prod (post-story-#27), every `processCustomer` fire was hitting the 30-min ceiling and orphaning — meaning the system was probably skipping a meaningful fraction of `processCustomer` runs cumulatively. Track A reduces the frequency of timeouts (90 min vs 30 min for `processCustomer`), but doesn't fix the underlying interaction.
+
+**Why story #27 / Track A didn't address it:** story #27 explicitly scoped out `forceKill` reconsideration. Track A only changes timeout VALUES; it doesn't change the orphan-prevention interaction. Both were correct scopes for their stories; this intake captures the next layer of the onion now that we have empirical evidence.
+
+**Strong argument for `forceKill: true` as the default:** with `forceKill: false`, a timed-out task creates an orphan that blocks subsequent fires. With `forceKill: true`, the orphan is killed at timeout, the next scheduled fire runs cleanly. The cost of `forceKill: true` is "an actually-still-doing-useful-work task gets killed at its timeout" — but with appropriately-sized per-task timeouts (which Track A + the auto-tune Track B trend toward), legitimate work shouldn't be hitting the timeout in the first place.
+
+**Possible fixes (Architect to triage):**
+1. **Flip `forceKill: false` → `true`** as the global default in `taskRegistry.json:options_default.completion.failure.timeout.forceKill`. Per-task overrides remain available. Easiest fix.
+2. **Smarter `check_task_already_running` policy:** detect that an "existing" PID is the orphan from a prior timed-out run (e.g., compare PID's parent process or runtime) and treat as "kill orphan + launch new." More logic, more accurate.
+3. **Change `processAlreadyRunning.withoutError.launchNew` default to `true`:** lets the next fire run concurrently with the orphan, accepting the doubled neo4j-heavy load for that window. Probably wrong — defeats the dedup purpose for legitimately-overlapping tasks.
+4. **Auto-tune timeouts** (Track B from intake `eb2df679`) so timeouts almost never fire. Doesn't solve the issue when they DO fire.
+5. **Combine #1 + #4:** `forceKill: true` as a backstop, but tune timeouts high enough that the backstop rarely engages.
+
+**Classification:** Bug — silent suppression of scheduled fires under post-timeout conditions. Production-impacting (cumulative work loss).
+**Strictness:** Standard.
+**Phase path:** `/discuss` to settle the design choice (especially `forceKill: true` vs the smarter `check_task_already_running` logic). Then Planning → Architecture → Test Design → Implementation → Review.
+**Priority:** **Medium-high.** Production has been silently skipping scheduled fires since story #15 shipped (~2026-05-20) whenever timeouts fired. Track A reduces the frequency but doesn't fix the mechanism. Worth surfacing before the operator builds operational habits around the current behavior.

--- a/src/manage/taskQueue/queue/processor.js
+++ b/src/manage/taskQueue/queue/processor.js
@@ -119,7 +119,7 @@ function runWithResolvedArgs({ job, taskDef, taskName, customerArgs, queryParams
       ? JSON.stringify({
           completion: {
             failure: {
-              timeout: { duration: timeoutMs, forceKill: false }
+              timeout: { duration: timeoutMs }
             }
           }
         })

--- a/src/manage/taskQueue/taskRegistry.json
+++ b/src/manage/taskQueue/taskRegistry.json
@@ -38,7 +38,7 @@
       "failure": {
         "timeout": {
           "duration": 1800000,
-          "forceKill": false,
+          "forceKill": true,
           "restart": true,
           "maxRetries": 3,
           "parentNextStep": "nextTaskInQueue"

--- a/test/kill-timeout-orphans-by-default.test.js
+++ b/test/kill-timeout-orphans-by-default.test.js
@@ -1,0 +1,343 @@
+/**
+ * Story #28 / ADR 0025 — Kill timeout-orphans by default so they stop suppressing
+ * subsequent scheduled fires.
+ *
+ * The fix is a two-layer change (per ADR 0025 §Decision Option A):
+ *   1. taskRegistry.json — flip global default
+ *      `options_default.completion.failure.timeout.forceKill: false → true`.
+ *   2. processor.js — remove the hardcoded `forceKill: false` from the per-invocation
+ *      JSON. The merged optionsJson now ships only `{ completion: { failure: { timeout:
+ *      { duration: timeoutMs } } } }` when timeoutMs > 0; the wrapper's hierarchical
+ *      merge resolves forceKill from per-task override (if any) or global default
+ *      (now true).
+ *
+ * Architect's Option A also explicitly preserves the 11 per-task `forceKill: false`
+ * overrides — R4 guards against accidental scope creep into Option D (delete the
+ * overrides). The follow-up intake (I1) captures the proper triage.
+ *
+ * Source/structural sentinels (S1, S2) pin the two-layer fix surface. Regression
+ * guards (R1-R4) protect the wrapper kill machinery, the timeout-emit shape, the
+ * ADR 0013 semaphore wrap, and the explicit non-change to per-task overrides.
+ * Probe-file sentinels (P0, P1) protect the empirical probe's existence + shape.
+ * The intake sentinel (I1) verifies the Implementer appended the ADR-mandated
+ * follow-up intake at commit time.
+ *
+ * Expected pre-implementation state:
+ *   - S1, S2, I1 FAIL — registry default still false, processor.js still hardcodes
+ *     false, _intake.md doesn't yet contain the Architect-mandated section.
+ *   - R1, R2, R3, R4, P0, P1 PASS — regression guards on existing-correct behavior
+ *     that the fix must preserve, plus the probe file the Tester ships alongside.
+ *
+ * Post-implementation: all 9 PASS.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const TASK_REGISTRY_PATH   = path.join(ROOT, 'src/manage/taskQueue/taskRegistry.json');
+const PROCESSOR_MODULE     = path.join(ROOT, 'src/manage/taskQueue/queue/processor.js');
+const WRAPPER_SCRIPT       = path.join(ROOT, 'src/manage/taskQueue/launchChildTask.sh');
+const QUEUE_INDEX_MODULE   = path.join(ROOT, 'src/manage/taskQueue/queue/index.js');
+const INTAKE_FILE          = path.join(ROOT, 'engineering-team/stories/_intake.md');
+const PROBE_SCRIPT         = path.join(ROOT, 'test/probe-kill-timeout-orphans.js');
+
+// The 11 per-task forceKill: false overrides ADR 0025 §Decision specifies
+// must remain unchanged for this story. (Architect chose Option A over Option D;
+// cleanup is deferred to the follow-up intake.)
+const PER_TASK_OVERRIDES_PRESERVED = [
+  'processAllTasks',
+  'syncWoT',
+  'syncProfiles',
+  'callBatchTransfer',
+  'reconcileRecent',
+  'reconcileAll',
+  'reconcileAuthor',
+  'reconcileNetwork',
+  'applicationHealthMonitor',
+  'neo4jPerformanceMonitor',
+  'externalNetworkConnectivityMonitor'
+];
+
+function readSafe(p) {
+  try { return fs.readFileSync(p, 'utf8'); }
+  catch (_e) { return null; }
+}
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+
+// ---------------------------------------------------------------------------
+// Source sentinels — FAIL pre-implementation, PASS post-implementation.
+// ---------------------------------------------------------------------------
+
+test('S1: taskRegistry.json\'s options_default.completion.failure.timeout.forceKill === true (AC #1, AC #4; ADR 0025 §Implementation 1)', () => {
+  const raw = readSafe(TASK_REGISTRY_PATH);
+  assert(raw !== null, 'taskRegistry.json missing at ' + TASK_REGISTRY_PATH);
+  let registry;
+  try {
+    registry = JSON.parse(raw);
+  } catch (e) {
+    throw new Error('taskRegistry.json failed to parse as JSON: ' + e.message);
+  }
+  const forceKill = registry &&
+    registry.options_default &&
+    registry.options_default.completion &&
+    registry.options_default.completion.failure &&
+    registry.options_default.completion.failure.timeout &&
+    registry.options_default.completion.failure.timeout.forceKill;
+
+  assert(
+    forceKill === true,
+    "taskRegistry.json's `options_default.completion.failure.timeout.forceKill` must be `true` " +
+    `(got ${JSON.stringify(forceKill)}). This is the central architectural change of story #28 — when ` +
+    "a tagged task hits its configured timeout, the wrapper script should kill the backgrounded child " +
+    "process rather than leave it as an orphan that suppresses subsequent scheduled fires via " +
+    "`check_task_already_running`. Layer 1 of the two-layer fix. (AC #1, AC #4; ADR 0025 §Implementation 1)"
+  );
+});
+
+test('S2: processor.js\'s optionsJson literal omits the forceKill field entirely (AC #1, AC #4; ADR 0025 §Implementation 2)', () => {
+  const src = readSafe(PROCESSOR_MODULE);
+  assert(src !== null, 'Processor module missing at ' + PROCESSOR_MODULE);
+  // The fix's intent: processor.js stops asserting opinions about forceKill at
+  // per-invocation precedence. The wrapper's hierarchical merge resolves it from
+  // per-task override (if present) or the (now true) registry global default.
+  //
+  // Pre-fix: line 122 reads `timeout: { duration: timeoutMs, forceKill: false }`.
+  // Post-fix: that literal becomes `timeout: { duration: timeoutMs }`.
+  //
+  // We assert the substring `forceKill` does NOT appear ANYWHERE in processor.js.
+  // Today it appears exactly once (line 122); removing it should drop the count to
+  // zero. If a future legitimate use re-adds it, this test will need to be revisited
+  // — but such a re-addition would itself be a meaningful semantic change worth
+  // re-thinking via the harness.
+  assert(
+    !/forceKill/.test(src),
+    "processor.js must NOT contain the literal `forceKill` anywhere. Pre-fix line 122 ships " +
+    "`forceKill: false` at per-invocation precedence, which would override per-task overrides AND " +
+    "the new (true) global default. The fix removes the field entirely so the wrapper's hierarchical " +
+    "merge resolves forceKill correctly. NOTE: if your intent was to change `false` → `true`, that's " +
+    "also wrong — it would pin per-invocation to true and rob per-task overrides of their precedence. " +
+    "Omit the field. Layer 2 of the two-layer fix. (AC #1, AC #4; ADR 0025 §Implementation 2)"
+  );
+});
+
+test('I1: _intake.md contains the Architect-mandated follow-up section header for the per-task override cleanup (ADR 0025 §"Intake to file at commit time")', () => {
+  const src = readSafe(INTAKE_FILE);
+  assert(src !== null, '_intake.md missing at ' + INTAKE_FILE);
+  // ADR 0025's "Intake to file at commit time" block specifies the exact section
+  // header the Implementer must copy verbatim. We pin the header (not the full
+  // body — that would be too brittle if minor wording changes happen) and the
+  // distinguishing phrase "after story #28's default-flip" which prevents this
+  // sentinel from being accidentally satisfied by a similarly-titled prior intake.
+  const expectedHeader = "## 2026-05-25 — Cleanup + Bug: per-task `forceKill: false` overrides after story #28's default-flip";
+  assert(
+    src.includes(expectedHeader),
+    "_intake.md must contain the section header `" + expectedHeader + "` exactly (per ADR 0025 " +
+    "§\"Intake to file at commit time\"). The Implementer copies the full intake block verbatim " +
+    "from ADR 0025 at commit time. Same pattern as ADR 0023's amendment-block intake filing in " +
+    "story #26. The intake captures the proper triage for the 9 redundant per-task overrides + the " +
+    "2 mis-sized timeout durations on syncWoT / syncProfiles — both deliberately deferred from " +
+    "story #28's scope per ADR 0025 §Decision."
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Regression guards — PASS pre AND post.
+// These protect the kill machinery, the timeout-emit shape, the ADR 0013
+// semaphore wrap, and the explicit non-change to per-task overrides.
+// ---------------------------------------------------------------------------
+
+test('R1: launchChildTask.sh\'s force_kill block at :402-412 still reads from resolved_options and conditionally executes kill -9 (AC #1, AC #4 — wrapper kill machinery preserved)', () => {
+  const src = readSafe(WRAPPER_SCRIPT);
+  assert(src !== null, 'Wrapper script missing at ' + WRAPPER_SCRIPT);
+  // The kill block has three structural requirements:
+  //   (a) reads force_kill from resolved_options via jq lookup at .failure.timeout.forceKill
+  //   (b) conditionally enters the kill branch when force_kill == "true"
+  //   (c) executes `kill -9 "$child_pid"`
+  // The fix does NOT touch this file; it only flips the *resolved value* that
+  // the merge will produce. The kill machinery itself must remain intact.
+  assert(
+    /force_kill=\$\(\s*echo\s+["']?\$resolved_options["']?\s*\|\s*jq\s+-r\s+['"]\.failure\.timeout\.forceKill\s*\/\/\s*false['"]/.test(src),
+    "launchChildTask.sh must still read `force_kill` from `resolved_options` via jq lookup at " +
+    "`.failure.timeout.forceKill // false`. The fix flips the resolved value upstream, but the " +
+    "wrapper's read path must remain. (AC #1, AC #4)"
+  );
+  assert(
+    /if\s*\[\[\s*["']?\$force_kill["']?\s*==\s*["']true["']\s*\]\]/.test(src),
+    "launchChildTask.sh must still conditionally enter the kill branch when `$force_kill == \"true\"`. " +
+    "(AC #1, AC #4)"
+  );
+  assert(
+    /kill\s+-9\s+["']?\$child_pid["']?/.test(src),
+    "launchChildTask.sh must still execute `kill -9 \"$child_pid\"` inside the force-kill branch. " +
+    "This is the actual kill that satisfies AC #1's no-surviving-orphan claim. (AC #1, AC #4)"
+  );
+});
+
+test('R2: launchChildTask.sh still emits CHILD_TASK_ERROR event with error_type="timeout" on timeout (AC #3 — observability surface preserved)', () => {
+  const src = readSafe(WRAPPER_SCRIPT);
+  assert(src !== null, 'Wrapper script missing — R1 must pass first.');
+  // AC #3 says: "no new event type is required (operator can distinguish 'killed
+  // via timeout' from other failure modes through existing fields)." This holds
+  // iff the existing CHILD_TASK_ERROR emit with `error_type: "timeout"` still
+  // fires. The fix does NOT change this; we guard against accidental removal.
+  assert(
+    /error_type="timeout"/.test(src),
+    "launchChildTask.sh must still set `error_type=\"timeout\"` inside the timeout branch. The fix " +
+    "flips the kill behavior but does NOT change the error-event shape. Operators continue to use the " +
+    "existing CHILD_TASK_ERROR + error_type=timeout signal to detect timed-out tasks. (AC #3)"
+  );
+  assert(
+    /emit_task_event\s+["']CHILD_TASK_ERROR["']/.test(src),
+    "launchChildTask.sh must still emit `CHILD_TASK_ERROR` via `emit_task_event`. (AC #3)"
+  );
+});
+
+test('R3: queue/index.js still wraps tagged-task Worker callback with semaphore.acquire / release in try-finally (AC #4 — ADR 0013 wrap preserved)', () => {
+  const src = readSafe(QUEUE_INDEX_MODULE);
+  assert(src !== null, 'queue/index.js missing at ' + QUEUE_INDEX_MODULE);
+  // Story #28's fix flips a value in the timeout path. It must not regress the
+  // ADR 0013 cross-task serialization mechanism that story #15 introduced and
+  // story #27 / Track A restored. Same regression guard as story #27's R1.
+  assert(
+    /resourceClass/.test(src),
+    "queue/index.js must still reference `resourceClass` — ADR 0013's wrap pattern conditionally " +
+    "wraps the Worker callback based on `taskDef.resourceClass`. (AC #4)"
+  );
+  assert(
+    /semaphore\.acquire\s*\(/.test(src),
+    "queue/index.js must still call `semaphore.acquire(...)` in the tagged-task Worker callback " +
+    "branch. (AC #4; ADR 0013)"
+  );
+  assert(
+    /\bfinally\b\s*\{[\s\S]*?\brelease\s*\(\s*\)/.test(src),
+    "queue/index.js must still release the semaphore in a `finally` block — ADR 0013's crash-safety " +
+    "property. (AC #4; ADR 0013)"
+  );
+});
+
+test('R4: the 11 per-task forceKill: false overrides remain unchanged in taskRegistry.json (ADR 0025 §Decision — explicit non-change)', () => {
+  const raw = readSafe(TASK_REGISTRY_PATH);
+  assert(raw !== null, 'taskRegistry.json missing — S1 must pass first.');
+  let registry;
+  try { registry = JSON.parse(raw); }
+  catch (e) { throw new Error('taskRegistry.json failed to parse: ' + e.message); }
+
+  // ADR 0025 §Decision chose Option A: preserve all 11 per-task `forceKill: false`
+  // overrides as-is for this story. The follow-up intake (I1) carries the proper
+  // triage for these. Touching them in this story = scope creep into Option D.
+  //
+  // Each preserved task must have its per-task override at
+  //   tasks.<name>.options.completion.failure.timeout.forceKill === false
+  for (const taskName of PER_TASK_OVERRIDES_PRESERVED) {
+    const task = registry.tasks && registry.tasks[taskName];
+    assert(
+      task !== undefined,
+      `Task \`${taskName}\` must exist in taskRegistry.json. ADR 0025 §Decision specifies this task's ` +
+      "explicit per-task `forceKill: false` override as a preserved non-change for story #28."
+    );
+    const fk = task &&
+      task.options &&
+      task.options.completion &&
+      task.options.completion.failure &&
+      task.options.completion.failure.timeout &&
+      task.options.completion.failure.timeout.forceKill;
+    assert(
+      fk === false,
+      `Task \`${taskName}\` must retain its explicit per-task \`forceKill: false\` override ` +
+      `(got ${JSON.stringify(fk)}). ADR 0025 §Decision chose Option A — preserve all 11 per-task ` +
+      "overrides; the cleanup is captured in the follow-up intake (Part A: 9 redundant overrides, " +
+      "Part B: 2 mis-sized durations on syncWoT/syncProfiles). Removing this override in story #28 " +
+      "is scope creep into Option D, which the Architect explicitly rejected."
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Probe-file sentinels — PASS pre AND post (Tester ships the probe alongside).
+// ---------------------------------------------------------------------------
+
+test('P0: empirical probe exists at test/probe-kill-timeout-orphans.js (ADR 0025 §"Implementer self-check")', () => {
+  const src = readSafe(PROBE_SCRIPT);
+  assert(
+    src !== null,
+    `Probe script must exist at ${PROBE_SCRIPT}. The Tester ships this alongside the sentinels (same ` +
+    "pattern as story #27's probe — de-risks the Implementer's self-check step). The Implementer runs " +
+    "it inside the container via `docker exec tapestry node /usr/local/lib/node_modules/brainstorm/" +
+    "test/probe-kill-timeout-orphans.js` to confirm the wrapper-script kill behavior works end-to-end " +
+    "against the actual installed bash + jq + structured-logging machinery. If the probe ASSERTs FAIL, " +
+    "re-open ADR 0025 with the probe output attached."
+  );
+});
+
+test('P1: probe script exercises both Path 1 (kill verification) and Path 2 (next-fire-runs verification) and asserts against events.jsonl + ps (ADR 0025 §"Implementer self-check")', () => {
+  const src = readSafe(PROBE_SCRIPT);
+  assert(src !== null, 'Probe script missing — P0 must pass first.');
+  // (a) The probe must spawn the wrapper script.
+  assert(
+    /launchChildTask\.sh/.test(src),
+    "Probe script must invoke launchChildTask.sh (the wrapper script under test). " +
+    "Loose check: the literal `launchChildTask.sh` must appear in the probe."
+  );
+  // (b) The probe must require child_process to spawn the wrapper.
+  assert(
+    /require\s*\(\s*['"]child_process['"]\s*\)/.test(src),
+    "Probe script must `require('child_process')` to spawn the wrapper script."
+  );
+  // (c) The probe must observe events.jsonl.
+  assert(
+    /events\.jsonl/.test(src),
+    "Probe script must read or grep events.jsonl to confirm CHILD_TASK_ERROR / CHILD_TASK_START / " +
+    "TASK_LAUNCH_PREVENTED event presence/absence."
+  );
+  // (d) Path 1: verify the child PID is dead after wrapper exit.
+  // Loose check: a `ps -p` invocation or equivalent (`ps -o`, `kill -0`).
+  assert(
+    /ps\s+-[op]\b|kill\s+-0\b/.test(src),
+    "Probe script's Path 1 must verify the bash subprocess PID (captured from CHILD_TASK_ERROR's " +
+    "child_pid metadata) is dead after the wrapper exits. Use `ps -p <pid>` (expecting non-zero exit) " +
+    "or `kill -0 <pid>` (expecting non-zero exit). This is the empirical proof that AC #1's " +
+    "no-surviving-orphan claim holds end-to-end."
+  );
+  // (e) Path 1: assert CHILD_TASK_ERROR with error_type=timeout.
+  assert(
+    /CHILD_TASK_ERROR/.test(src) && /error_type/.test(src),
+    "Probe script's Path 1 must verify that the wrapper emitted a CHILD_TASK_ERROR event with " +
+    "error_type=\"timeout\" (AC #3's existing observability surface)."
+  );
+  // (f) Path 2: assert TASK_LAUNCH_PREVENTED is NOT present.
+  assert(
+    /TASK_LAUNCH_PREVENTED/.test(src),
+    "Probe script's Path 2 must verify that the immediately-next invocation of the same task does NOT " +
+    "produce a TASK_LAUNCH_PREVENTED event (AC #2's no-silent-suppression claim)."
+  );
+  // (g) Path 2: assert CHILD_TASK_START is present for the second run.
+  assert(
+    /CHILD_TASK_START/.test(src),
+    "Probe script's Path 2 must verify that the immediately-next invocation emits CHILD_TASK_START " +
+    "(the launch proceeded). (AC #2)"
+  );
+});
+
+async function run() {
+  let pass = 0;
+  let fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/probe-kill-timeout-orphans.js
+++ b/test/probe-kill-timeout-orphans.js
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+/**
+ * Empirical probe — ADR 0025 §"Implementer self-check" (implied).
+ *
+ * Verifies, against the actually-installed launchChildTask.sh + bash + jq +
+ * structured-logging machinery in the tapestry container, that the two-layer
+ * fix from ADR 0025 works end-to-end:
+ *
+ *   - Path 1 (the kill verification, AC #1): per-invocation `{ timeout: { duration:
+ *     5000 } }` (NO per-invocation forceKill — let the wrapper's hierarchical merge
+ *     resolve it from the registry global default, which post-fix is `true`)
+ *     against a 15-second sleep script. The wrapper should:
+ *       (a) declare timeout at ~5s
+ *       (b) kill the bash subprocess via `kill -9 $child_pid`
+ *       (c) emit CHILD_TASK_ERROR with error_type="timeout"
+ *     After the wrapper exits, `ps -p $child_pid` must report the bash PID as dead.
+ *     This is the empirical proof that AC #1's no-surviving-orphan claim holds.
+ *
+ *   - Path 2 (the next-fire-runs verification, AC #2): immediately after Path 1's
+ *     kill, re-invoke the wrapper with the same probe task. The wrapper's
+ *     `check_task_already_running` (`launchChildTask.sh:25-67`) should `pgrep -f`-find
+ *     no orphan (because Path 1's kill reaped the bash subprocess whose cmdline
+ *     carried the script path). The launch proceeds; a CHILD_TASK_START event
+ *     emits; NO TASK_LAUNCH_PREVENTED event lands between Path 1's CHILD_TASK_ERROR
+ *     and Path 2's CHILD_TASK_START.
+ *
+ * If either ASSERT-FAILs, the architecture in ADR 0025 §Decision is wrong for the
+ * installed wrapper script. STOP, re-open ADR 0025, attach this probe's output,
+ * and re-design.
+ *
+ * Run inside the tapestry container:
+ *
+ *   docker exec tapestry node \
+ *     /usr/local/lib/node_modules/brainstorm/test/probe-kill-timeout-orphans.js
+ *
+ * The probe creates a temporary probe-only task in taskRegistry.json (backup
+ * → modify → run → restore) and a temporary script in /tmp; both are cleaned
+ * up in a finally block. If the probe crashes mid-run, re-run it once — the
+ * cleanup is idempotent.
+ *
+ * This script is NOT registered in test/test.js — it's a one-shot empirical
+ * check, not a regression test. The test/kill-timeout-orphans-by-default.test.js
+ * sentinels (P0, P1) protect this file's existence + shape.
+ *
+ * Note on grandchildren: `kill -9 $child_pid` kills the bash subprocess only —
+ * its `sleep 15` child is reparented to init/supervisord and continues until
+ * natural completion. This is intentional. The script_relative_path (carried in
+ * the bash cmdline only, NOT in the sleep cmdline) is what
+ * `check_task_already_running` greps for; so the orphaned sleep doesn't block
+ * subsequent fires.
+ */
+
+const { spawn, spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const TASK_REGISTRY_PATH = path.join(REPO_ROOT, 'src/manage/taskQueue/taskRegistry.json');
+const WRAPPER_PATH       = path.join(REPO_ROOT, 'src/manage/taskQueue/launchChildTask.sh');
+
+const EVENTS_LOG = process.env.BRAINSTORM_EVENTS_LOG ||
+                   '/var/log/brainstorm/taskQueue/events.jsonl';
+
+const STAMP = Date.now();
+const PROBE_TASK_NAME       = `__probe_killorphan_${STAMP}`;
+const PROBE_SCRIPT_PATH     = `/tmp/probe-killorphan-script-${STAMP}.sh`;
+const PROBE_SCRIPT_RELATIVE = `tmp/probe-killorphan-script-${STAMP}.sh`;
+
+let assertCount = 0;
+let registryBackup = null;
+
+function assertTruthy(actual, label) {
+  assertCount++;
+  if (actual) {
+    console.log(`  ✓ ASSERT-PASS  ${label}`);
+  } else {
+    console.log(`  ✗ ASSERT-FAIL  ${label}: expected truthy, got ${JSON.stringify(actual)}`);
+    process.exitCode = 1;
+  }
+}
+function assertFalsy(actual, label) {
+  assertCount++;
+  if (!actual) {
+    console.log(`  ✓ ASSERT-PASS  ${label}`);
+  } else {
+    console.log(`  ✗ ASSERT-FAIL  ${label}: expected falsy, got ${JSON.stringify(actual)}`);
+    process.exitCode = 1;
+  }
+}
+
+function installProbeTask(sleepSeconds) {
+  const raw = fs.readFileSync(TASK_REGISTRY_PATH, 'utf8');
+  registryBackup = raw;
+  const registry = JSON.parse(raw);
+  registry.tasks[PROBE_TASK_NAME] = {
+    name: PROBE_TASK_NAME,
+    categories: ['maintenance'],
+    description: `Probe task for story #28 / ADR 0025 (sleeps ${sleepSeconds}s).`,
+    script: PROBE_SCRIPT_PATH,
+    script_relative_path: PROBE_SCRIPT_RELATIVE,
+    arguments: false,
+    scope: 'system',
+    priority: 'low',
+    frequency: 'on-demand',
+    status: 'active',
+    structuredLogging: true,
+    // Empty options → wrapper's hierarchical merge falls through to registry
+    // options_default. Post-fix, that resolves forceKill: true (the central
+    // change story #28 ships). No per-invocation forceKill is sent either
+    // (see runWrapper below), so the merge cleanly hits the new default.
+    options: {}
+  };
+  fs.writeFileSync(TASK_REGISTRY_PATH, JSON.stringify(registry, null, 2));
+}
+
+function restoreRegistry() {
+  if (registryBackup !== null) {
+    fs.writeFileSync(TASK_REGISTRY_PATH, registryBackup);
+    registryBackup = null;
+  }
+}
+
+function installProbeScript(sleepSeconds) {
+  // Body: just sleep, so the bash subprocess's cmdline is `bash <path>` (carries
+  // the script path — what `check_task_already_running` greps for) while the
+  // sleep grandchild's cmdline is `sleep N` (no path, no pgrep match after the
+  // bash is killed).
+  const content = `#!/bin/bash\n# Probe script for story #28 — sleeps ${sleepSeconds}s then exits cleanly.\nsleep ${sleepSeconds}\nexit 0\n`;
+  fs.writeFileSync(PROBE_SCRIPT_PATH, content);
+  fs.chmodSync(PROBE_SCRIPT_PATH, 0o755);
+}
+
+function removeProbeScript() {
+  try { fs.unlinkSync(PROBE_SCRIPT_PATH); } catch (_e) { /* ignore */ }
+}
+
+function eventsLogSizeBefore() {
+  try { return fs.statSync(EVENTS_LOG).size; }
+  catch (_e) { return 0; }
+}
+
+function readProbeEventsSince(fromOffset) {
+  let raw;
+  try {
+    const fd = fs.openSync(EVENTS_LOG, 'r');
+    const stats = fs.fstatSync(fd);
+    const len = Math.max(0, stats.size - fromOffset);
+    const buf = Buffer.alloc(len);
+    fs.readSync(fd, buf, 0, len, fromOffset);
+    fs.closeSync(fd);
+    raw = buf.toString('utf8');
+  } catch (_e) {
+    return [];
+  }
+  const lines = raw.split('\n').filter(Boolean);
+  const records = [];
+  for (const line of lines) {
+    try {
+      const rec = JSON.parse(line);
+      const childTask = rec && rec.metadata && rec.metadata.child_task;
+      const target = rec && rec.target;
+      if (childTask === PROBE_TASK_NAME || (target && target.startsWith(PROBE_TASK_NAME))) {
+        records.push(rec);
+      }
+    } catch (_e) { /* ignore malformed lines */ }
+  }
+  return records;
+}
+
+// Invoke launchChildTask.sh with a per-invocation options JSON.
+// Critically: we do NOT include forceKill in the per-invocation JSON. The
+// hierarchical merge in the wrapper will resolve it from per-task override (none
+// — probe task uses `options: {}`) or registry global default (post-fix: true).
+function runWrapper(optionsJson) {
+  return new Promise((resolve) => {
+    const args = [WRAPPER_PATH, PROBE_TASK_NAME, 'probe', optionsJson, ''];
+    const child = spawn('bash', args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, BRAINSTORM_STRUCTURED_LOGGING: 'true' }
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => { stdout += c.toString(); });
+    child.stderr.on('data', (c) => { stderr += c.toString(); });
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+    child.on('error', (err) => resolve({ code: null, stdout, stderr, error: err }));
+  });
+}
+
+// Check whether a PID is still alive. `kill -0` returns 0 if the process exists
+// (and is signalable), non-zero otherwise. Cleaner than parsing `ps` output.
+function isPidAlive(pid) {
+  if (pid === undefined || pid === null) return false;
+  const r = spawnSync('kill', ['-0', String(pid)]);
+  return r.status === 0;
+}
+
+// Sleep helper.
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function main() {
+  console.log(`probe task name: ${PROBE_TASK_NAME}`);
+  console.log(`probe script:    ${PROBE_SCRIPT_PATH}`);
+  console.log(`wrapper script:  ${WRAPPER_PATH}`);
+  console.log(`events log:      ${EVENTS_LOG}\n`);
+
+  installProbeTask(15);
+  installProbeScript(15);
+
+  // ---------------------------------------------------------------------
+  // Path 1: per-invocation `duration: 5000` against a 15-second sleep script.
+  //          No per-invocation forceKill — the wrapper's merge should resolve
+  //          forceKill: true from the registry global default (post-fix).
+  //          Expected: wrapper exits at ~5s, bash subprocess is killed,
+  //          CHILD_TASK_ERROR error_type="timeout" event lands.
+  //          Pre-fix: wrapper exits at ~5s with the CHILD_TASK_ERROR, but the
+  //          bash subprocess survives (forceKill resolved to false from the
+  //          pre-fix registry default), AND processor.js's hardcoded false
+  //          would override even if registry default was true. POST-FIX BOTH
+  //          LAYERS MUST CHANGE for this path to pass.
+  // ---------------------------------------------------------------------
+  console.log('Path 1: timeout=5000ms with NO per-invocation forceKill → expect kill via registry default');
+  const offset1 = eventsLogSizeBefore();
+  const t1Start = Date.now();
+  const result1 = await runWrapper(JSON.stringify({
+    completion: { failure: { timeout: { duration: 5000 } } }
+  }));
+  const t1Elapsed = Date.now() - t1Start;
+  console.log(`    wrapper exit code=${result1.code}, elapsed=${t1Elapsed}ms`);
+  if (result1.stderr) console.log(`    stderr: ${result1.stderr.trim().split('\n').slice(0, 3).join(' | ')}`);
+
+  const events1 = readProbeEventsSince(offset1);
+  const childTaskErrors1 = events1.filter(r => r.eventType === 'CHILD_TASK_ERROR' &&
+                                               r.metadata && r.metadata.error_type === 'timeout');
+
+  assertTruthy(
+    childTaskErrors1.length > 0,
+    `Path 1: events.jsonl contains a CHILD_TASK_ERROR error_type="timeout" for this run (got ${childTaskErrors1.length}). The wrapper should have fired the 5s timeout against the 15s sleep script and emitted CHILD_TASK_ERROR.`
+  );
+
+  // Capture the bash subprocess PID the wrapper reported, then verify it's dead.
+  let childPid = null;
+  if (childTaskErrors1.length > 0) {
+    childPid = childTaskErrors1[0].metadata && childTaskErrors1[0].metadata.child_pid;
+  }
+  // Give the kernel a beat to reap the killed bash subprocess before the
+  // liveness check. The kill is SIGKILL (immediate), but the OS process table
+  // entry can persist briefly during reaping.
+  await delay(500);
+  assertFalsy(
+    isPidAlive(childPid),
+    `Path 1: bash subprocess PID ${childPid} is dead after wrapper exit. With the (post-fix) registry default forceKill: true and no per-invocation override, the wrapper's force_kill branch should have executed kill -9. If this fails, the bash subprocess survived — meaning the resolved forceKill was false (either registry default not flipped, or processor.js's per-invocation override still wins, or the wrapper's read path broke).`
+  );
+
+  // ---------------------------------------------------------------------
+  // Path 2: immediately re-invoke same task. The pgrep-find in
+  //          check_task_already_running should find no orphan (the bash
+  //          subprocess from Path 1 was killed); launch proceeds;
+  //          CHILD_TASK_START event lands; NO TASK_LAUNCH_PREVENTED.
+  //          Pre-fix (with surviving orphan from Path 1): pgrep would match
+  //          the orphan; launchNew=false default would emit TASK_LAUNCH_PREVENTED
+  //          and silently skip — the exact bug story #28 fixes.
+  // ---------------------------------------------------------------------
+  console.log('\nPath 2: immediately re-invoke same task → expect CHILD_TASK_START, NO TASK_LAUNCH_PREVENTED');
+  const offset2 = eventsLogSizeBefore();
+  const t2Start = Date.now();
+  const result2 = await runWrapper(JSON.stringify({
+    completion: { failure: { timeout: { duration: 5000 } } }
+  }));
+  const t2Elapsed = Date.now() - t2Start;
+  console.log(`    wrapper exit code=${result2.code}, elapsed=${t2Elapsed}ms`);
+  if (result2.stderr) console.log(`    stderr: ${result2.stderr.trim().split('\n').slice(0, 3).join(' | ')}`);
+
+  const events2 = readProbeEventsSince(offset2);
+  const launchPrevented2 = events2.filter(r => r.eventType === 'TASK_LAUNCH_PREVENTED');
+  const childStarts2 = events2.filter(r => r.eventType === 'CHILD_TASK_START');
+
+  assertFalsy(
+    launchPrevented2.length,
+    `Path 2: events.jsonl contains NO TASK_LAUNCH_PREVENTED events for this run (got ${launchPrevented2.length}). After Path 1's kill, check_task_already_running should find no orphan PID with the script's cmdline pattern — so the new launch should proceed. If this fails, the orphan-suppression bug story #28 fixes is still in effect.`
+  );
+  assertTruthy(
+    childStarts2.length > 0,
+    `Path 2: events.jsonl contains a CHILD_TASK_START for this run (got ${childStarts2.length}). With no orphan blocking the path, the new fire should successfully start.`
+  );
+
+  console.log(`\n${assertCount} asserts; exit ${process.exitCode || 0}`);
+  if (process.exitCode) {
+    console.log('\nFAIL: launchChildTask.sh behavior does NOT match ADR 0025 §Decision.');
+    console.log('STOP. Re-open ADR 0025 with this probe output attached.');
+  } else {
+    console.log('\nPASS: launchChildTask.sh kills timeout-orphans by default; next fire is not suppressed.');
+    console.log('The two-layer fix is empirically verified at the wrapper-script level.');
+    console.log('Now run cycle-staging to verify end-to-end (no-downtime deploy, AC #5).');
+  }
+}
+
+(async () => {
+  try {
+    await main();
+  } catch (e) {
+    console.error('\nUNEXPECTED PROBE ERROR:', (e && e.stack) || e);
+    process.exitCode = 2;
+  } finally {
+    removeProbeScript();
+    restoreRegistry();
+  }
+})();

--- a/test/test.js
+++ b/test/test.js
@@ -45,6 +45,7 @@ const reconciliationRearchitecture = require('./reconciliation-rearchitecture.te
 const scheduledTasksWithArguments = require('./scheduled-tasks-with-arguments.test.js');
 const manualTaskRetriggerAfterFinish = require('./manual-task-retrigger-after-finish.test.js');
 const scheduledTaskTimeoutPropagation = require('./scheduled-task-timeout-propagation.test.js');
+const killTimeoutOrphansByDefault = require('./kill-timeout-orphans-by-default.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -118,6 +119,9 @@ async function main() {
   console.log('\nscheduled-task-timeout-propagation suite:');
   const scheduledTaskTimeoutPropagationResult = await scheduledTaskTimeoutPropagation.run();
 
+  console.log('\nkill-timeout-orphans-by-default suite:');
+  const killTimeoutOrphansByDefaultResult = await killTimeoutOrphansByDefault.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -187,6 +191,9 @@ async function main() {
   console.log(
     `scheduled-task-timeout-propagation suite:        ${scheduledTaskTimeoutPropagationResult.fail === 0 ? 'PASS' : 'FAIL'} (${scheduledTaskTimeoutPropagationResult.pass} passed, ${scheduledTaskTimeoutPropagationResult.fail} failed)`
   );
+  console.log(
+    `kill-timeout-orphans-by-default suite:           ${killTimeoutOrphansByDefaultResult.fail === 0 ? 'PASS' : 'FAIL'} (${killTimeoutOrphansByDefaultResult.pass} passed, ${killTimeoutOrphansByDefaultResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -211,7 +218,8 @@ async function main() {
     reconciliationRearchitectureResult.fail === 0 &&
     scheduledTasksWithArgumentsResult.fail === 0 &&
     manualTaskRetriggerAfterFinishResult.fail === 0 &&
-    scheduledTaskTimeoutPropagationResult.fail === 0;
+    scheduledTaskTimeoutPropagationResult.fail === 0 &&
+    killTimeoutOrphansByDefaultResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`. Ships the third and final fix in the post-2026-05-20 task-queue timeout series. ADR 0013's cap=1 `neo4j-heavy` semaphore contract was functionally broken since story #15 shipped on 2026-05-20; story #27 (PR #215) and Track A (PR #217) restored it for the no-timeout case; this PR closes the timeout case so a tagged task that hits its configured timeout is killed rather than left running as an orphan that silently blocks the next scheduled fire.

## Bundled

- **[#218](https://github.com/nous-clawds4/tapestry/pull/218)** — fix: kill timeout-orphans by default (story #28, ADR 0025). Two-layer change: registry global default `forceKill: false → true` + processor.js stops asserting per-invocation `forceKill: false`. Full 5-phase artifacts (story / ADR / test plan / 9 sentinel tests + empirical probe / review PASS).
- **`872303d6`** — docs: session handoff (post-timeout-fix state). Marks the prior handoff ADDRESSED.
- **`2764f79f`** — docs: intake (the two 2026-05-25 follow-ups surfaced by Track A prod verification — `forceKill: false` orphan-suppression bug and BullMQ stalled-tick artifact). The first of those intakes is what story #28 in this PR resolves.

## Net production impact

**Functional change is tiny — 2 lines of code in 2 source files.** Tasks that hit their configured timeout will now be killed (`kill -9` of the bash subprocess) instead of left running orphaned. Operators will observe: silent fire-suppression (the `TASK_LAUNCH_PREVENTED` events recorded against fresh scheduled ticks since 2026-05-20) drops dramatically; `CHILD_TASK_ERROR error_type="timeout"` events now correlate with PID-dead rather than orphan-persists.

**Per ADR 0025 §"Deployment dry-run":** no Redis migration, no scheduler pause, no manual cleanup. Pre-existing orphans from past timeouts run to natural completion (the deploy doesn't kill them). The new kill-on-timeout default applies to wrapper invocations post-restart only. In-flight wrapper invocations at deploy time finish with their pre-deploy resolved options.

**The 11 existing per-task `forceKill: false` overrides are explicitly preserved** (Architect's Option A vs D decision in ADR 0025 §Decision). A follow-up intake — appended to `engineering-team/stories/_intake.md` verbatim from ADR 0025 — captures the proper triage for those (9 redundant + 2 mis-sized 60s timeouts on syncWoT/syncProfiles that need separate investigation).

## Verification trail

- PR #218 staging deploy: [run 26426237119](https://github.com/nous-clawds4/tapestry/actions/runs/26426237119), ✓ 1m20s (warm Docker layer cache).
- Cycle-local empirical probe (`test/probe-kill-timeout-orphans.js`): **4/4 ASSERT-PASS** end-to-end against the actual installed wrapper script + jq + structured logging. Path 1 (kill verification, AC #1) + Path 2 (next-fire-runs, AC #2) both green.
- Host `npm test`: 9/9 new sentinels PASS + 22/22 prior suites PASS (240 tests total). No regressions.
- Staging smoke test: Tier 1 stability ✓ (3 consecutive 200s on first poll), Tier 2 sanity ✓ (all 12 endpoints 200; expected 504 on jack's `/api/get-user-data` per known gotcha), Tier 3 PR-specific ✓ (`/api/scheduled-tasks/list` returns valid JSON post-restart — scheduler read the registry cleanly with new `forceKill: true`), Tier 5 regression ✓ (`/admin/queues` correctly admin-gated).

Direct kill-behavior verification on staging was DEFERRED to passive observation over the next 24-48h per the prefer-passive-prod-verification pattern + the staging-graph-prod-scale reality. Synthesizing probe-shaped task entries on a prod-scale system was declined. The cycle-local probe is the empirical verification of record for AC #1/#2.

## Test plan

- [ ] After merge: `deploy-brainstorm.yml` runs to completion (~80s on warm cache).
- [ ] Stability poll on `brainstorm.world` reaches 3 consecutive 200s, then settle.
- [ ] Tier 2 sanity: all 12 endpoints return 200 (expecting 504 on `/api/get-user-data?pubkey=jack` per known gotcha; not a regression).
- [ ] Tier 3 PR-specific: `/api/scheduled-tasks/list` returns 200 with scheduled entries (confirms registry parsed cleanly post-restart).
- [ ] Tier 5 regression: `/admin/queues` 401 unauthenticated; other adjacent endpoints unaffected.
- [ ] Post-deploy passive verification over next 24-48h on prod:
  - `docker exec tapestry grep 'TASK_LAUNCH_PREVENTED' /var/log/brainstorm/taskQueue/events.jsonl | tail -20` — rate should drop dramatically.
  - `docker exec tapestry grep '"phase":"resource_class_released"' /var/log/brainstorm/taskQueue/events.jsonl | grep processCustomer | tail -5` — `held_seconds` continues to track actual task duration; kill-on-timeout doesn't introduce new abnormal-shape events.

The held branch `fix/launch-child-task-protection-audit` continues to wait on separate Implementer pickup per the prior `/discuss` Option C decision; independent from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)