### PR TITLE
Promote staging → main: forceKill override cleanup Part A

### DIFF
--- a/src/manage/taskQueue/taskRegistry.json
+++ b/src/manage/taskQueue/taskRegistry.json
@@ -107,8 +107,7 @@
           "failure": {
             "timeout": {
               "comments": "21600000 = 6 hours - generous timeout to accommodate all child tasks including long-running reconciliation (1.5h), syncWoT (1h), and customer processing",
-              "duration": 21600000,
-              "forceKill": false
+              "duration": 21600000
             }
           }
         }
@@ -288,8 +287,7 @@
           "failure": {
             "timeout": {
               "comments": "3600000 = 1 hour",
-              "duration": 3600000,
-              "forceKill": false
+              "duration": 3600000
             }
           }
         }
@@ -339,8 +337,7 @@
           "failure": {
             "timeout": {
               "comments": "1800000 = 30 minutes (incremental run is minutes; generous ceiling)",
-              "duration": 1800000,
-              "forceKill": false
+              "duration": 1800000
             }
           }
         }
@@ -370,8 +367,7 @@
           "failure": {
             "timeout": {
               "comments": "28800000 = 8 hours (full graph sweep)",
-              "duration": 28800000,
-              "forceKill": false
+              "duration": 28800000
             }
           }
         }
@@ -400,8 +396,7 @@
           "failure": {
             "timeout": {
               "comments": "600000 = 10 minutes (single author)",
-              "duration": 600000,
-              "forceKill": false
+              "duration": 600000
             }
           }
         }
@@ -432,8 +427,7 @@
           "failure": {
             "timeout": {
               "comments": "3600000 = 60 minutes (bounded by the network predicate; <1h target)",
-              "duration": 3600000,
-              "forceKill": false
+              "duration": 3600000
             }
           }
         }
@@ -1429,8 +1423,7 @@
         "completion": {
           "failure": {
             "timeout": {
-              "duration": 600000,
-              "forceKill": false
+              "duration": 600000
             }
           }
         }
@@ -1458,8 +1451,7 @@
         "completion": {
           "failure": {
             "timeout": {
-              "duration": 600000,
-              "forceKill": false
+              "duration": 600000
             }
           }
         }
@@ -1487,8 +1479,7 @@
         "completion": {
           "failure": {
             "timeout": {
-              "duration": 600000,
-              "forceKill": false
+              "duration": 600000
             }
           }
         }

--- a/test/kill-timeout-orphans-by-default.test.js
+++ b/test/kill-timeout-orphans-by-default.test.js
@@ -43,22 +43,14 @@ const QUEUE_INDEX_MODULE   = path.join(ROOT, 'src/manage/taskQueue/queue/index.j
 const INTAKE_FILE          = path.join(ROOT, 'engineering-team/stories/_intake.md');
 const PROBE_SCRIPT         = path.join(ROOT, 'test/probe-kill-timeout-orphans.js');
 
-// The 11 per-task forceKill: false overrides ADR 0025 §Decision specifies
-// must remain unchanged for this story. (Architect chose Option A over Option D;
-// cleanup is deferred to the follow-up intake.)
-const PER_TASK_OVERRIDES_PRESERVED = [
-  'processAllTasks',
-  'syncWoT',
-  'syncProfiles',
-  'callBatchTransfer',
-  'reconcileRecent',
-  'reconcileAll',
-  'reconcileAuthor',
-  'reconcileNetwork',
-  'applicationHealthMonitor',
-  'neo4jPerformanceMonitor',
-  'externalNetworkConnectivityMonitor'
-];
+// Part A of the ADR 0025 follow-up intake (shipped 2026-05-26 via fast-track)
+// deleted 9 of the 11 redundant per-task `forceKill: false` overrides so they
+// inherit the new global default `true` from story #28. Only syncWoT +
+// syncProfiles retain the explicit override — Part B's deferred investigation
+// must settle the correct timeout duration on those two before their overrides
+// can also be removed (their current 60s duration is mis-sized for tasks with
+// estimatedDuration "30-60 minutes" and averageDuration 44500ms).
+const PER_TASK_OVERRIDES_PRESERVED_POST_PART_A = ['syncProfiles', 'syncWoT'];
 
 function readSafe(p) {
   try { return fs.readFileSync(p, 'utf8'); }
@@ -220,41 +212,42 @@ test('R3: queue/index.js still wraps tagged-task Worker callback with semaphore.
   );
 });
 
-test('R4: the 11 per-task forceKill: false overrides remain unchanged in taskRegistry.json (ADR 0025 §Decision — explicit non-change)', () => {
+test('R4 (post-Part-A): only syncWoT + syncProfiles retain explicit forceKill: false (Part B deferred — _intake.md 2026-05-25)', () => {
   const raw = readSafe(TASK_REGISTRY_PATH);
   assert(raw !== null, 'taskRegistry.json missing — S1 must pass first.');
   let registry;
   try { registry = JSON.parse(raw); }
   catch (e) { throw new Error('taskRegistry.json failed to parse: ' + e.message); }
 
-  // ADR 0025 §Decision chose Option A: preserve all 11 per-task `forceKill: false`
-  // overrides as-is for this story. The follow-up intake (I1) carries the proper
-  // triage for these. Touching them in this story = scope creep into Option D.
-  //
-  // Each preserved task must have its per-task override at
-  //   tasks.<name>.options.completion.failure.timeout.forceKill === false
-  for (const taskName of PER_TASK_OVERRIDES_PRESERVED) {
-    const task = registry.tasks && registry.tasks[taskName];
-    assert(
-      task !== undefined,
-      `Task \`${taskName}\` must exist in taskRegistry.json. ADR 0025 §Decision specifies this task's ` +
-      "explicit per-task `forceKill: false` override as a preserved non-change for story #28."
-    );
-    const fk = task &&
-      task.options &&
-      task.options.completion &&
-      task.options.completion.failure &&
-      task.options.completion.failure.timeout &&
-      task.options.completion.failure.timeout.forceKill;
-    assert(
-      fk === false,
-      `Task \`${taskName}\` must retain its explicit per-task \`forceKill: false\` override ` +
-      `(got ${JSON.stringify(fk)}). ADR 0025 §Decision chose Option A — preserve all 11 per-task ` +
-      "overrides; the cleanup is captured in the follow-up intake (Part A: 9 redundant overrides, " +
-      "Part B: 2 mis-sized durations on syncWoT/syncProfiles). Removing this override in story #28 " +
-      "is scope creep into Option D, which the Architect explicitly rejected."
-    );
-  }
+  // Iterate ALL tasks, collect those with explicit `forceKill: false`. After
+  // Part A (2026-05-26 fast-track), the set should equal exactly
+  // {syncProfiles, syncWoT} — Part B's deferred 60s-duration investigation
+  // is what blocks removing those last two. Any other task carrying explicit
+  // `forceKill: false` would be a regression or scope creep worth flagging
+  // during review.
+  const tasksWithExplicitForceKillFalse = Object.entries(registry.tasks || {})
+    .filter(([_, task]) => {
+      const fk = task && task.options && task.options.completion &&
+                 task.options.completion.failure && task.options.completion.failure.timeout &&
+                 task.options.completion.failure.timeout.forceKill;
+      return fk === false;
+    })
+    .map(([name, _]) => name)
+    .sort();
+
+  const expected = PER_TASK_OVERRIDES_PRESERVED_POST_PART_A;
+  assert(
+    JSON.stringify(tasksWithExplicitForceKillFalse) === JSON.stringify(expected),
+    `Exactly two tasks should retain explicit \`forceKill: false\` after Part A: ${JSON.stringify(expected)}. ` +
+    `Got: ${JSON.stringify(tasksWithExplicitForceKillFalse)}. ` +
+    "Part A (2026-05-26 fast-track, per _intake.md follow-up filed by ADR 0025) deleted the 9 redundant " +
+    "per-task overrides on processAllTasks, callBatchTransfer, reconcileRecent, reconcileAll, " +
+    "reconcileAuthor, reconcileNetwork, applicationHealthMonitor, neo4jPerformanceMonitor, " +
+    "externalNetworkConnectivityMonitor — those tasks now inherit `forceKill: true` from the global " +
+    "default (story #28). syncWoT + syncProfiles retain the override pending Part B's investigation " +
+    "of their clearly-wrong 60s timeout duration. If a new task gains explicit `forceKill: false` in " +
+    "the registry, surface it during review — the global default should be the path of least resistance."
+  );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Promotes staging to main after clean verification on `staging.brainstorm.world`. Part A of ADR 0025's filed follow-up intake — deletes the 9 redundant per-task `forceKill: false` overrides from `taskRegistry.json` so those tasks finally inherit story #28's prod-verified global default `forceKill: true`. Closes the gap where story #28's kill-on-timeout fix wasn't reaching 9 tasks because of copy-paste override artifacts.

## Bundled

- **[#222](https://github.com/nous-clawds4/tapestry/pull/222)** — fix: forceKill override cleanup Part A. Deletes the 9 redundant per-task `forceKill: false` overrides on `processAllTasks`, `callBatchTransfer`, `reconcileRecent`, `reconcileAll`, `reconcileAuthor`, `reconcileNetwork`, `applicationHealthMonitor`, `neo4jPerformanceMonitor`, `externalNetworkConnectivityMonitor`. Preserves the 2 overrides on `syncWoT` + `syncProfiles` (Part B's deferred 60s-duration investigation — separate intake item).

## Net production impact

**Functional change is 9 lines of deletion in `taskRegistry.json`** — each deletion makes the affected task inherit `forceKill: true` from the global default that story #28 shipped at 01:40Z (live + clean on prod for ~1.5 hr).

Operators will observe: when any of the 9 affected tasks hits its configured timeout (most are generous: 6h for `processAllTasks`, 8h for `reconcileAll`, 10min-1h for the others), the wrapper now kills the bash subprocess (`kill -9 $child_pid`) instead of leaving it orphaned. The orphan-suppression bug (next scheduled fire silently skipped) is closed for these 9 tasks as well. `syncWoT` and `syncProfiles` continue with `forceKill: false` until Part B fixes their clearly-wrong 60s timeout duration.

**No deploy disruption.** Pure registry data change. No Redis migration, no scheduler pause, no manual cleanup. In-flight wrapper invocations at deploy time finish under their pre-deploy resolved options; new invocations post-restart pick up the new defaults via the wrapper's hierarchical merge (which reads the registry fresh per `jq` lookup).

## Verification trail

- PR #222 staging deploy: [run 26430430428](https://github.com/nous-clawds4/tapestry/actions/runs/26430430428), ✓ 1m20s.
- Host `npm test`: 246 tests across 24 suites all PASS. R4 sentinel updated to assert exactly `{syncWoT, syncProfiles}` retain explicit `forceKill: false` (regression guard against accidental re-addition on other tasks).
- Staging smoke: Tier 1 stability ✓ (3 consecutive 200s first poll), Tier 2 sanity ✓, Tier 3 PR-specific ✓ (`/api/scheduled-tasks/list` returns 200 — confirms 54 tasks still parsed cleanly after 9 deletions), Tier 5 regression ✓ (admin gate intact).
- Underlying mechanism (registry default → wrapper's hierarchical merge → kill -9 on timeout) is the same mechanism that shipped to prod at 01:40Z in story #28, empirically verified at cycle-local time. This PR just extends that to 9 more tasks via existing-mechanism activation. No new code paths.

## Test plan

- [ ] After merge: `deploy-brainstorm.yml` runs to completion (~80s on warm cache).
- [ ] Stability poll on `brainstorm.world` reaches 3 consecutive 200s.
- [ ] Tier 2 sanity: all 12 endpoints 200 (expecting 504 on jack's `/api/get-user-data` per known gotcha).
- [ ] Tier 3 PR-specific: `/api/scheduled-tasks/list` 200 (confirms registry parsed cleanly post-restart with 9 deletions).
- [ ] Tier 5 regression: `/admin/queues` 401.
- [ ] Post-deploy passive verification: when any of the 9 affected tasks next fires on prod, `events.jsonl` `CHILD_TASK_ERROR error_type="timeout"` events (if any fire — most have generous timeouts) should now correlate with PID-dead via `pgrep -f $script_path`. Track A's verification pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)