### PR TITLE
fix: align launchChildTask.sh jq fallback to post-story-#28 default

### DIFF
--- a/src/manage/taskQueue/launchChildTask.sh
+++ b/src/manage/taskQueue/launchChildTask.sh
@@ -400,7 +400,7 @@ launchChildTask() {
         error_type="timeout"
         
         # Check if we should force kill
-        local force_kill=$(echo "$resolved_options" | jq -r '.failure.timeout.forceKill // false')
+        local force_kill=$(echo "$resolved_options" | jq -r '.failure.timeout.forceKill // true')
         echo "$(date): Task timed out, force_kill=$force_kill" >> ${LOG_FILE}
         if [[ "$force_kill" == "true" ]]; then
             # Try to force kill the process with cross-user compatibility

--- a/test/kill-timeout-orphans-by-default.test.js
+++ b/test/kill-timeout-orphans-by-default.test.js
@@ -153,10 +153,13 @@ test('R1: launchChildTask.sh\'s force_kill block at :402-412 still reads from re
   // The fix does NOT touch this file; it only flips the *resolved value* that
   // the merge will produce. The kill machinery itself must remain intact.
   assert(
-    /force_kill=\$\(\s*echo\s+["']?\$resolved_options["']?\s*\|\s*jq\s+-r\s+['"]\.failure\.timeout\.forceKill\s*\/\/\s*false['"]/.test(src),
-    "launchChildTask.sh must still read `force_kill` from `resolved_options` via jq lookup at " +
-    "`.failure.timeout.forceKill // false`. The fix flips the resolved value upstream, but the " +
-    "wrapper's read path must remain. (AC #1, AC #4)"
+    /force_kill=\$\(\s*echo\s+["']?\$resolved_options["']?\s*\|\s*jq\s+-r\s+['"]\.failure\.timeout\.forceKill\s*\/\/\s*true['"]/.test(src),
+    "launchChildTask.sh must read `force_kill` from `resolved_options` via jq lookup at " +
+    "`.failure.timeout.forceKill // true`. The `// true` jq fallback aligns with the global " +
+    "registry default `forceKill: true` (story #28); the fallback only engages on deep registry " +
+    "corruption when resolved_options has no forceKill at all, but the value should match the " +
+    "rest of the system's default. The hygiene alignment shipped 2026-05-26 closes the " +
+    "documentation lie left behind by story #28's flip. (AC #1, AC #4; post-story-#28 hygiene)"
   );
   assert(
     /if\s*\[\[\s*["']?\$force_kill["']?\s*==\s*["']true["']\s*\]\]/.test(src),


### PR DESCRIPTION
## Summary

One-line defensive-default alignment. After story #28 flipped the global registry default `forceKill: false → true`, the bash-level jq fallback at [`launchChildTask.sh:403`](src/manage/taskQueue/launchChildTask.sh) still read `// false` — a documentation lie pointing the wrong way relative to the rest of the system. This was flagged as Non-blocking #1 in the [story #28 review](engineering-team/reviews/28-kill-timeout-orphans-by-default.md) and is the natural alignment item alongside today's forceKill Part A cleanup.

The fallback only engages on deep registry corruption (when `resolved_options` has no `forceKill` field at all — which is impossible in normal operation since the global default lives in `options_default.completion`). But the value should match the rest of the system's default for readability.

## Changes

- `src/manage/taskQueue/launchChildTask.sh:403` — `'.failure.timeout.forceKill // false'` → `'... // true'`
- `test/kill-timeout-orphans-by-default.test.js` — R1 sentinel updated to pin the new fallback value; message documents post-story-#28 hygiene context.

2 files, +8/-5 net.

## Test plan

- [x] Host `npm test` clean: 246 tests across 24 suites all PASS. No regressions.
- [ ] After merge: `deploy-staging.yml` runs cleanly.
- [ ] Smoke test on `staging.brainstorm.world` — confirm `/api/scheduled-tasks/list` 200 + Tier 1+2+5 clean.
- [ ] No behavioral change expected at any observable layer — the fallback that was changed is normally unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)