### PR TITLE
Promote staging → main: launchChildTask.sh jq fallback hygiene

### DIFF
--- a/src/manage/taskQueue/launchChildTask.sh
+++ b/src/manage/taskQueue/launchChildTask.sh
@@ -400,7 +400,7 @@ launchChildTask() {
         error_type="timeout"
         
         # Check if we should force kill
-        local force_kill=$(echo "$resolved_options" | jq -r '.failure.timeout.forceKill // false')
+        local force_kill=$(echo "$resolved_options" | jq -r '.failure.timeout.forceKill // true')
         echo "$(date): Task timed out, force_kill=$force_kill" >> ${LOG_FILE}
         if [[ "$force_kill" == "true" ]]; then
             # Try to force kill the process with cross-user compatibility

--- a/test/kill-timeout-orphans-by-default.test.js
+++ b/test/kill-timeout-orphans-by-default.test.js
@@ -153,10 +153,13 @@ test('R1: launchChildTask.sh\'s force_kill block at :402-412 still reads from re
   // The fix does NOT touch this file; it only flips the *resolved value* that
   // the merge will produce. The kill machinery itself must remain intact.
   assert(
-    /force_kill=\$\(\s*echo\s+["']?\$resolved_options["']?\s*\|\s*jq\s+-r\s+['"]\.failure\.timeout\.forceKill\s*\/\/\s*false['"]/.test(src),
-    "launchChildTask.sh must still read `force_kill` from `resolved_options` via jq lookup at " +
-    "`.failure.timeout.forceKill // false`. The fix flips the resolved value upstream, but the " +
-    "wrapper's read path must remain. (AC #1, AC #4)"
+    /force_kill=\$\(\s*echo\s+["']?\$resolved_options["']?\s*\|\s*jq\s+-r\s+['"]\.failure\.timeout\.forceKill\s*\/\/\s*true['"]/.test(src),
+    "launchChildTask.sh must read `force_kill` from `resolved_options` via jq lookup at " +
+    "`.failure.timeout.forceKill // true`. The `// true` jq fallback aligns with the global " +
+    "registry default `forceKill: true` (story #28); the fallback only engages on deep registry " +
+    "corruption when resolved_options has no forceKill at all, but the value should match the " +
+    "rest of the system's default. The hygiene alignment shipped 2026-05-26 closes the " +
+    "documentation lie left behind by story #28's flip. (AC #1, AC #4; post-story-#28 hygiene)"
   );
   assert(
     /if\s*\[\[\s*["']?\$force_kill["']?\s*==\s*["']true["']\s*\]\]/.test(src),


### PR DESCRIPTION
## Summary

Promotes staging to main after clean verification on `staging.brainstorm.world`. Closes Non-blocking #1 from the story #28 review report: aligns `launchChildTask.sh:403`'s defensive bash-level jq fallback `// false → // true` to match the global registry default `forceKill: true` that shipped via story #28 at 01:40Z.

## Bundled

- **[#224](https://github.com/nous-clawds4/tapestry/pull/224)** — fix: align launchChildTask.sh jq fallback to post-story-#28 default. One-line bash change + R1 sentinel update.

## Net production impact

**Zero observable behavior change.** The fallback that was changed (`'.failure.timeout.forceKill // false'`) is only evaluated if `resolved_options` has no `forceKill` field at all — which is impossible in normal operation since the global default lives in `options_default.completion` and the wrapper's hierarchical merge always starts from it. Changing the fallback value is pure defensive alignment: the rest of the system says `true`; the bash-level safety net should too.

No deploy disruption. In-flight wrapper invocations finish under their pre-deploy state; new invocations use the aligned fallback (which continues to be unreachable in practice).

## Verification trail

- PR #224 staging deploy: [run 26431555005](https://github.com/nous-clawds4/tapestry/actions/runs/26431555005), ✓ 1m20s.
- Host `npm test`: 246 tests across 24 suites all PASS. R1 sentinel updated to pin `// true`.
- Staging smoke clean.

## Test plan

- [ ] After merge: `deploy-brainstorm.yml` runs cleanly.
- [ ] Stability poll on `brainstorm.world` reaches 3 consecutive 200s.
- [ ] Tier 2 sanity + Tier 5 regression clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)