### PR TITLE
Follows list on the primary profile page (story #29, v1)

### DIFF
--- a/engineering-team/decisions/0026-profile-follows-list.md
+++ b/engineering-team/decisions/0026-profile-follows-list.md
@@ -1,0 +1,100 @@
+# ADR 0026: Follows list on the primary profile page
+
+**Status:** Accepted
+**Date:** 2026-05-28
+**Story:** `engineering-team/stories/29-profile-follows-list.md`
+
+> **v1 scope (2026-05-28 amendment):** customer-observer support is **deferred**; v1 is **owner point-of-view only**. The point-of-view selector, customer-relative metrics, and customer-default-observer behavior move to a follow-up story. This ADR designs owner-only v1 and documents the customer path as a named extension point.
+
+## Context
+
+Story 29 adds a standalone `/user/:pubkey/follows` page to the primary (React) profile, listing the accounts a user follows with trust metrics (rank, hops, verified follower/muter/reporter counts), client-side search/pagination, persisted column prefs, and a "computed locally, not NIP-85" disclosure. Default sort: **verified-followers count, descending**, across the whole follow set. **For v1, all metrics are computed from the instance owner's point of view.**
+
+Code facts (verified against source; stack live at `:7778`):
+
+- **The existing `follows` query is not observer-relative — and already serves the owner POV.** `src/api/grapevineInteractions/queries/cypherQueries.js:20-24` returns `followee.influence`/`followee.hops` (single global properties on the `NostrUser` node) and never uses `$observer`. Those node properties **are** the owner's GrapeRank run — exactly what v1 needs — but the query returns **no verified counts**.
+- **Owner vs. customer is one endpoint with an internal branch, not separate endpoints.** `src/api/export/users/queries/userdata.js` takes a single `observerPubkey` param (`:24`) and flips an internal `source` (`:40-54`): `'owner'`/absent ⇒ read the **`NostrUser` node** itself; any customer pubkey ⇒ read a purpose-built **`NostrUserWotMetricsCard {observer_pubkey, observee_pubkey}`** node (`:75-85`), with the same `RETURN` field list either way (`:148-156`). The owner has **no** card (its scores live inline on `NostrUser`); each customer gets its own card set. **v1 implements only the `NostrUser`-node (owner) branch;** the card branch is the documented customer-phase extension.
+- **All five per-row metrics are co-located.** `influence`, `hops`, `verifiedFollowerCount`, `verifiedMuterCount`, `verifiedReporterCount` all live together on the source node (`NostrUser` for owner; the card for a customer) — `userdata.js:148-156`.
+- **A third metrics store exists** (context for the POV-naming divergence, not used here). The profile's *Reputation* section reads Meilisearch POV-namespaced `wot_*_<8char>` fields (`ui/src/pages/BrainstormProfile.jsx:119-188`) — which is why the profile uses `?pov=<8char>` while the grapevine APIs use `observer=<full pubkey | 'owner'>`.
+- **`Following: N` (strfry) and the follow-list length (Neo4j) can diverge.** `handleGetUserCounts` (`userdata.js:301-352`) counts kind-3 `p` tags from strfry because Neo4j `FOLLOWS` lags the kind-3 event by hours/days. The list comes from Neo4j. Badge ≠ list length is expected.
+- **Neo4j calls here are timeout-sensitive.** `userdata.js:60,176,271-280` wraps queries in a `NEO4J_QUERY_TIMEOUT_MS` deadline (default 15000) → **504** (the #6 / ADR 0024–0025 hardening). `get-grapevine-interaction` (`index.js:52`) has **no** such deadline.
+- **UI stack:** Vite 7 + React 19 + react-router-dom 7 (`createBrowserRouter`, `useParams`/`useSearchParams`); built by `npm run build` in `ui/` into `dist/`, static-served by `bin/control-panel.js`. Reusable `ui/src/components/DataTable.jsx` gives header-click sort + a cross-column text filter + custom `render` + `onRowClick` — but **no pagination, no column-visibility, no fixed default sort**. Modal/overlay pattern in `ConfirmDialog.jsx`/`ReportModal.jsx`. `nip19.npubEncode` (nostr-tools) inline for npub. Raw `fetch` + AbortController is the hook convention (`hooks/useUserCounts.js`).
+
+Project constraints: **no new lint/typecheck/build tooling** (the `ui/` Vite build is pre-existing; the control-panel server stays JS-without-build); honor the Neo4j query-deadline pattern; **no concept-graph or firmware change** — `graperank`/`web-of-trust` are touched conceptually but their definitions are unchanged (the metrics are runtime Neo4j node/card properties, not concept-graph nodes). **Firmware reinstall: not required.**
+
+## Options considered
+
+### Option A — New, purpose-built endpoint *(chosen)*
+
+`GET /api/get-grapevine-follows?observee=<pk>[&observer=<pk|'owner'>]`. **v1 Cypher (owner only):**
+```
+MATCH (observee:NostrUser {pubkey:$observee})
+OPTIONAL MATCH (observee)-[:FOLLOWS]->(f:NostrUser)
+RETURN f.pubkey AS pubkey, f.influence AS influence, f.hops AS hops,
+       f.verifiedFollowerCount AS verifiedFollowerCount,
+       f.verifiedMuterCount   AS verifiedMuterCount,
+       f.verifiedReporterCount AS verifiedReporterCount
+```
+— essentially the existing follows query plus the three node-resident verified counts. **Customer-phase extension (deferred):** branch on `observer` exactly like `userdata.js:75-85` — `OPTIONAL MATCH (card:NostrUserWotMetricsCard {observer_pubkey:$observer, observee_pubkey:f.pubkey})` and read metrics from `card` instead of `f`. Apply the `NEO4J_QUERY_TIMEOUT_MS` deadline + 504. The page sorts/searches/paginates client-side over the full array; names/pics via `/api/profiles?pubkeys=`.
+
+- **Pros:** isolates from the shared, timeout-sensitive `get-grapevine-interaction` and the legacy page (zero regression); the page points at the endpoint that will *grow* the card branch, so **no future page migration** when customer support lands; adds the deadline the old endpoint lacks; clean single-purpose contract with the default-sort field present.
+- **Cons:** duplicates the `FOLLOWS` traversal; one more endpoint to maintain; for owner-only v1 it's only marginally more code than Option B.
+
+### Option B — Add the three verified-count fields to the existing `follows` query ("B-lite")
+
+For owner-only v1, just append `verifiedFollowerCount/MuterCount/ReporterCount` (node properties) to `cypherQueries.js`'s `follows` `RETURN` + the `index.js:57-71` row mapping; the page calls `get-grapevine-interaction?interactionType=follows&observee=<pk>`.
+
+- **Pros:** smallest possible change (~6 lines), fully additive/backward-compatible, no new route. (The owner-only scope *removes* what made the original Option B messy — no card join, no per-variant gating, no touching the other 19 queries.)
+- **Cons:** when customer support lands, metrics must become observer-relative — forcing either a card-branch retrofit into the shared 20-query endpoint (the surface we want to avoid) or a dedicated endpoint built *then* + a **page migration** (churn). Doesn't add the missing deadline. Touches the shared endpoint recent timeout work (#5/#6/#27) was stabilizing.
+
+### Option C — Source metrics from Meilisearch (rejected)
+
+Meili has a ready-made 0–100 `rank` and native sort/paginate, but holds per-user docs, **not** the follow adjacency — forcing a cross-store join over a multi-thousand pubkey set (Meili `filter id IN [...]` impractical at that size); POV is a collision-prone 8-char suffix. Note only as a *future* server-side sort/paginate option.
+
+## Decision
+
+We chose **Option A**, implementing only the **owner (`NostrUser`-node) branch** for v1. The owner-only scope makes B-lite tempting (it's tiny), but customer support is **deferred, not cancelled** — so A's endpoint is the right home for the eventual card branch, lets v1 ship against the final URL/contract (no later page migration), isolates from the fragile shared endpoint, and picks up the missing query deadline. We accept duplicating the `FOLLOWS` traversal as the price. Sort/search/pagination stay **client-side** for v1 (legacy parity; avoids needing names in Neo4j).
+
+*(If you'd rather minimize v1 code and accept a later page migration, B-lite is the lean alternative — say so at the gate and I'll switch the decision.)*
+
+## Consequences
+
+- **Enables:** native follows exploration on the primary profile, built from existing patterns (node sourcing, `DataTable`, the Neo4j deadline, `/api/profiles` batch, `nip19`); a clean home for the deferred customer phase.
+- **Watch-outs (v1):**
+  - **Count vs list divergence** — `Following: N` (strfry) ≠ list length (Neo4j) is expected; UI copy + tests must **not** assume equality.
+  - **UI rebuild required** — `ui/src` changes need `npm run build` (Vite → `dist/`) to appear; the local Docker bind-mount serves `dist/`, so testing includes a rebuild.
+  - **Owner-only** — logged-in customers and logged-out visitors all see the owner POV; no selector.
+- **Deferred / follow-ups (customer phase):** add the card branch to this endpoint (`observer` param + `NostrUserWotMetricsCard` join, per `userdata.js:75-85`), the POV selector, customer-default-observer, and `?observer=<customer>` URL support. At that point **verify an index on `NostrUserWotMetricsCard(observer_pubkey, observee_pubkey)`** (large follow sets multiply card lookups → 504 risk without it). Also: generalize to other interaction types; consider server-side sort/paginate; reconcile the two POV schemes.
+- **Firmware reinstall required?** **No** — no concept definitions change.
+
+## Implementation notes
+
+**Backend (v1, owner only)**
+- New file `src/api/grapevineInteractions/queries/followsWithMetrics.js` exporting `handleGetGrapevineFollows(req, res)`:
+  - Params: `observee` (required, 64-hex; validate via `nip19.npubEncode` round-trip like `userdata.js:30-35`). `observer` is accepted but **v1 honors only owner**; recommend returning **400 `customer observers not yet supported`** for a non-owner `observer` so the contract is explicit (rather than silently coercing to owner).
+  - v1 Cypher as in Option A. Parse Neo4j ints via `.toNumber()`/`parseInt` (cf. `index.js:57-71`, `userdata.js:222-254`); skip the null `f` row when observee has no follows.
+  - Run with `{ timeout: queryTimeoutMs }` + the 504-on-`TransactionTimedOut` handling from `userdata.js:60,176,271-280`.
+  - Response: `{ success:true, observer:'owner', observee, count, data:[…] }`.
+  - **Extension point (deferred):** for a customer POV, branch the source on `observer` exactly like `userdata.js:40-54,75-85` (`NostrUserWotMetricsCard` via `OPTIONAL MATCH`).
+- Register in `src/api/index.js` next to line 317: `app.get('/api/get-grapevine-follows', handleGetGrapevineFollows);`.
+
+**Frontend (`ui/src`, Vite — `npm run build` to reflect)**
+- Route: add `{ path:'/user/:pubkey/follows', element:<BrainstormFollows/> }` to `ui/src/App.jsx` (mirror `:80-82`); import the page.
+- New `ui/src/pages/BrainstormFollows.jsx`: `useParams()` → observee; top bar + `BrainstormUserMenu` (mirror `BrainstormProfile:193-201`); `<Link to={`/user/${pubkey}`}>← Back to profile</Link>`; info popover; the table. **No POV selector in v1.**
+- New hook `ui/src/hooks/useGrapevineFollows.js` (mirror `useUserCounts.js`): fetch `/api/get-grapevine-follows?observee=<pk>` → `{data,loading,error}`.
+- Names/pics: batch `GET /api/profiles?pubkeys=` (mirror `BrainstormProfile:108-112`), **chunk** (≤~200/req); merge `display_name`/`name`/`picture`.
+- Derived cells: `rank = influence==null ? '—' : Math.round(influence*100)`; `name = display_name || name || shortenedNpub`; `npub = nip19.npubEncode(pubkey)` (cf. `BrainstormProfile:99,101`); avatar = the `<img>`/initials pattern (`BrainstormProfile:216-227`).
+- Table: reuse `DataTable.jsx` (header-sort + `render` + `onRowClick` → `navigate('/user/'+row.pubkey)`). **Default sort:** pre-sort the data array by `verifiedFollowerCount` desc before passing in (DataTable's initial `sortKey` is null → preserves order). Add at the **page level** (keep `DataTable` changes minimal): client pagination, a "Columns" show/hide toggle, and keep name/npub searchable regardless of visibility.
+- Column-visibility persistence: small `useColumnPrefs` hook backed by `localStorage` (key e.g. `bsp-follows-columns`); defaults pic/name/rank shown, npub/hops/verified* hidden; a "Reset to defaults" control.
+- Info popover: a small `<InfoPopover>` reusing the overlay+box+`stopPropagation` pattern of `ConfirmDialog.jsx`, opened by a tappable ⓘ button (tap toggles — not hover). Copy: "All data on this page is computed locally by this Tapestry instance and is not imported via NIP-85."
+- "Following" badge → link: in `BrainstormProfile.jsx:236-241`, wrap the count in `<Link to={`/user/${pubkey}/follows`}>` (import `Link`).
+- Styles: add `bsp-`-prefixed rules in `ui/src/styles.css`; reuse `data-table`/`bsp-*` classes where possible.
+
+## Out of scope (this ADR / v1)
+
+- **Customer observers** — the card branch, POV selector, customer-default-observer, and `?observer=<customer>` support (deferred; see story #29 "Deferred to a follow-up").
+- Other interaction types (followers/mutes/reports/frens/…).
+- Changing `get-grapevine-interaction` or the legacy `grapevine-analysis.html`.
+- Reconciling the profile's `?pov=<8char>`/Meili POV scheme with the new `?observer=`.
+- Server-side sort/search/pagination, and Meilisearch as the metrics source.
+- Persisting column prefs server-side (localStorage only).

--- a/engineering-team/decisions/0026-profile-follows-list.md
+++ b/engineering-team/decisions/0026-profile-follows-list.md
@@ -64,6 +64,7 @@ We chose **Option A**, implementing only the **owner (`NostrUser`-node) branch**
   - **Count vs list divergence** — `Following: N` (strfry) ≠ list length (Neo4j) is expected; UI copy + tests must **not** assume equality.
   - **UI rebuild required** — `ui/src` changes need `npm run build` (Vite → `dist/`) to appear; the local Docker bind-mount serves `dist/`, so testing includes a rebuild.
   - **Owner-only** — logged-in customers and logged-out visitors all see the owner POV; no selector.
+- **Verification (two options, both available):** interactively via the **Claude-in-Chrome** extension (real session, no install) and deterministically via the **Playwright** spec `tests/brainstorm/profile-follows-list.spec.js` (browsers installed via `npx playwright install`; runs headless in CI / across mobile viewports). See the test plan.
 - **Deferred / follow-ups (customer phase):** add the card branch to this endpoint (`observer` param + `NostrUserWotMetricsCard` join, per `userdata.js:75-85`), the POV selector, customer-default-observer, and `?observer=<customer>` URL support. At that point **verify an index on `NostrUserWotMetricsCard(observer_pubkey, observee_pubkey)`** (large follow sets multiply card lookups → 504 risk without it). Also: generalize to other interaction types; consider server-side sort/paginate; reconcile the two POV schemes.
 - **Firmware reinstall required?** **No** — no concept definitions change.
 

--- a/engineering-team/reviews/29-profile-follows-list.md
+++ b/engineering-team/reviews/29-profile-follows-list.md
@@ -1,0 +1,56 @@
+# Review: Story 29 — Follows list on the primary profile page (v1, owner POV)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-28
+**Diff:** `git diff 6484e29c..HEAD` (implementation commit `3b0cc9e0`)
+**Artifacts:** story `engineering-team/stories/29-profile-follows-list.md`; ADR `engineering-team/decisions/0026-profile-follows-list.md`; test plan `…29-profile-follows-list.test-plan.md`
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] **`npm test` — PASS.** Full suite green: all 25 sibling suites pass **and** `profile-follows-list suite: PASS (25 passed, 0 failed)` (22 contract tests + 3 regression sentinels). **Overall: PASS** — no sibling regression from the shared-file (`DataTable.jsx`, `index.js`) edits.
+- [x] **`npm --prefix ui run build` — PASS.** Vite build clean (3582 modules, built in ~37s; only the pre-existing chunk-size warning).
+- [~] **`npm run test:playwright` — not run.** Browsers are installed, but the spec needs populated data; the local dev graph has **no FOLLOWS edges** (see Verification gap). Deferred to staging.
+- [n/a] Lint / typecheck / server build — not configured (JS-without-build); skipped per CLAUDE.md.
+
+## Spec adherence
+- [x] Every v1 acceptance criterion maps to a passing test (test-plan coverage map; suite green). Spot-checked the behavioral ones against source: page-level search (`BrainstormFollows.jsx`) matches name/npub/pubkey **regardless of column visibility** (honors "npub searchable when hidden"); default sort pre-sorts the full set by `verifiedFollowerCount` desc before `DataTable`, so pagination shows the true top rows.
+- [x] No criterion silently dropped.
+- [x] Deferred scope correctly **not** built: no POV selector, no `NostrUserWotMetricsCard` branch; a non-owner `observer` is rejected 400 (`followsWithMetrics.js` ~L62-68). Matches the story's "Deferred to a follow-up" section.
+
+## ADR adherence (0026 — Option A)
+- [x] **New endpoint, shared query untouched.** `GET /api/get-grapevine-follows` added (`followsWithMetrics.js`; registered `src/api/index.js` L31/L318). The shared `follows` query in `cypherQueries.js` is byte-for-byte unchanged (sentinel R1 green) — Option A, not B-lite.
+- [x] **Owner-POV metrics from the NostrUser node:** `MATCH (observee)-[:FOLLOWS]->(f:NostrUser) RETURN f.influence, f.hops, f.verifiedFollowerCount/MuterCount/ReporterCount`. No card join. Correct for v1.
+- [x] **Neo4j deadline + 504** mirrors `userdata.js` (`NEO4J_QUERY_TIMEOUT_MS`, `{ timeout }`, 504 on `TransactionTimedOut`, `.finally` closes session+driver — no leak). Live-verified: missing observee→400, non-owner observer→400, owner→`{success,observer:'owner',count,data}`.
+- [x] **No concept/firmware change.** No firmware reinstall required (correct — metrics are runtime node properties, not concept-graph definitions).
+- [x] **DataTable change is backward compatible:** `pageSize` + `showFilter` are optional (`DataTable.jsx` L11; default `showFilter=true`, no `pageSize`→no pagination). Existing callers pass neither → identical behavior; the full suite (incl. `admin-tools-dashboard-panel`) stays green.
+- [x] No new dependencies introduced.
+
+## Concept-graph integrity
+- [x] No concepts touched; no handles introduced; no firmware reinstall; new code does not read BIBLE.md/firmware JSON. N/A but clean.
+
+## Things tests can't catch
+- [x] **Security:** `observee` validated (`/^[0-9a-f]{64}$/i` + `nip19` round-trip) and passed as a **Cypher parameter** (`$observee`), not string-interpolated → no injection. Non-owner `observer` rejected before any DB access. (Note: this is *safer* than the legacy `userdata.js`, which interpolates the pubkey.)
+- [x] No secrets committed; `dist/` gitignored.
+- [x] No leftover `console.log` debug (only `console.error` on real error paths); no commented-out code.
+- [x] Error/edge paths handled: 400 (bad/missing observee, non-owner observer), 500 (generic), 504 (timeout), empty-follows → `count:0`/empty-state.
+- [x] Concurrency: hook uses `AbortController`; request-scoped Neo4j session/driver closed in `.finally`.
+
+## House rules check
+- [x] Concept Graph API authority respected (N/A — no concept change).
+- [x] No new lint/typecheck/build tooling (`ui/` Vite build pre-existing; server stays JS-without-build).
+
+## Findings
+
+### Blocking
+_None._
+
+### Non-blocking (optional follow-ups, not gating)
+1. **`ui/src/pages/BrainstormFollows.jsx`** — the picture column carries `sortable: false`, but `DataTable` doesn't honor that flag (all headers are clickable-to-sort). Harmless no-op; either drop the prop or teach `DataTable` to respect it later.
+2. **`ui/src/pages/BrainstormFollows.jsx`** — the Columns dropdown closes via `onMouseLeave`, which has no touch equivalent; on mobile it closes only by re-tapping the "Columns" button. Minor, given the page's mobile-friendly intent. Consider an outside-tap/click handler in a polish pass.
+3. **`src/api/grapevineInteractions/queries/followsWithMetrics.js`** — creates a Neo4j driver per request. This matches the existing repo pattern (`userdata.js`, `grapevineInteractions/queries/index.js`), so not a regression; flagging only as shared tech-debt.
+
+### Verification gap (not a code defect — required before prod)
+- The **populated-list behaviors** (sort, pagination, search over real rows; rank/hops/verified-count rendering) were **not** exercised: the local dev graph has no FOLLOWS edges. The endpoint contract + validations and the empty-state UI are verified locally. **Before promoting to prod, verify the populated UI against `staging`** (prod-scale data) via Claude-in-Chrome and/or the committed Playwright spec. The test plan already designates staging for this.
+
+## Verdict
+**PASS** — the diff matches the story (v1 scope), conforms to ADR 0026 (Option A), is fully covered by the green test suite, builds clean, and has no blocking issues. Ship to staging, then complete the populated-UI verification there before prod.

--- a/engineering-team/stories/29-profile-follows-list.md
+++ b/engineering-team/stories/29-profile-follows-list.md
@@ -81,4 +81,4 @@ None open.
 ## Linked artifacts
 - ADR: `engineering-team/decisions/0026-profile-follows-list.md`
 - Test plan: `engineering-team/stories/29-profile-follows-list.test-plan.md`
-- Review: *(filled in after Review phase)*
+- Review: `engineering-team/reviews/29-profile-follows-list.md` — **PASS** (2026-05-28)

--- a/engineering-team/stories/29-profile-follows-list.md
+++ b/engineering-team/stories/29-profile-follows-list.md
@@ -3,6 +3,7 @@
 **Status:** Approved
 **Created:** 2026-05-28
 **Type:** Feature
+**Amended:** 2026-05-28 — customer-observer support deferred to a follow-up; **v1 is owner-POV only**. See "Deferred to a follow-up" below and ADR 0026.
 
 ## Background
 The primary user-facing profile (`/user/<pubkey>`) shows a bare **"Following"** count with no way to act on it. To actually *see and evaluate* who someone follows — ranked by local trust signals, from a chosen point of view — users today must leave for the legacy grapevine-analysis page, which is styled and structured for a different context. This story brings that capability into the primary profile experience as a native, standalone follows page, reusing the trust data this instance already computes locally.
@@ -16,7 +17,7 @@ Testable from the outside. Each criterion gets at least one test.
 **Navigation & URL**
 - [ ] **Entry point.** Given a profile at `/user/<pubkey>`, when it renders, then the "Following" count is a link that navigates **in the same tab** to `/user/<pubkey>/follows`.
 - [ ] **Return.** Given the follows page, when the user activates a "← Back to profile" control (and likewise the browser back button), then they return to `/user/<pubkey>`.
-- [ ] **Direct load with POV.** Given `/user/<pubkey>/follows?observer=<obs>`, when loaded directly, then the page shows `<pubkey>`'s follows computed from `<obs>`'s point of view.
+- [ ] **Direct load.** Given `/user/<pubkey>/follows`, when loaded directly, then the page shows `<pubkey>`'s follows computed from the **instance owner's** point of view. *(Honoring `?observer=<customer>` for other points of view is deferred — see below.)*
 - [ ] **Row navigation.** Given a row (an account `<pubkey>` follows), when the viewer activates it, then they navigate **in the same tab** to that account's own `/user/<that-pubkey>` profile.
 
 **The list**
@@ -33,13 +34,20 @@ Testable from the outside. Each criterion gets at least one test.
 - [ ] **Name fallback.** Each row's name column shows the display name; if absent, the name; if both absent, a shortened npub.
 - [ ] **Rank.** The rank column shows an integer **0–100**, equal to `round(influence × 100)` from the selected point of view (not a raw decimal).
 
-**Point of view**
-- [ ] **Observer-relative data.** Given two different selected points of view, when each is selected, then the **rank, hops, and all three verified counts** change to reflect the selected point of view.
-- [ ] **POV selector.** The page provides a point-of-view selector listing the instance's customers plus a **"Global / owner"** option; selecting one updates the displayed data and the `observer` value in the URL.
-- [ ] **Default observer.** With no `observer` specified: if the logged-in user is a customer, the default point of view is themselves; otherwise (including logged-out visitors) the default point of view is the instance owner.
+**Point of view (v1: owner only)**
+- [ ] **Owner point of view.** All metrics (rank, hops, verified counts) are computed from the **instance owner's** point of view, for every viewer (including logged-in customers and logged-out visitors). Per-row values are read directly from the `NostrUser` node.
+
+*(The point-of-view selector, customer-relative metrics, and customer-default-observer behavior are **deferred** — see "Deferred to a follow-up" below.)*
 
 **Disclosure**
 - [ ] **Local-data disclosure.** The page provides a **tappable** ⓘ affordance that reveals a note stating all data here is computed **locally by this Tapestry instance and is not imported via NIP-85**; the affordance works by tap on touch devices (not hover-only).
+
+## Deferred to a follow-up (customer observers)
+In the original story; deferred per the 2026-05-28 amendment because customer-observer trust scores live on a different node type (`NostrUserWotMetricsCard`) requiring a distinct query path (see ADR 0026). Tracked for a follow-up story:
+- **Observer-relative data.** Switching point of view changes rank, hops, and the three verified counts.
+- **POV selector.** A selector listing the instance's customers plus a "Global / owner" option; selecting one updates the data and the `observer` URL param.
+- **Customer-default observer.** If the logged-in user is a customer, default the point of view to themselves; otherwise the instance owner.
+- **`?observer=<customer>` URL support** for non-owner points of view.
 
 ## Concepts touched
 *(Concept Graph API at `:8877` was unreachable during planning — concepts named in plain language; the Architect should resolve handles via `/api/concept-graph/summaries`.)*
@@ -68,8 +76,9 @@ None open.
 ## Notes for the Architect
 - This is a **large story** (16 criteria spanning the UI plus a trust-data dependency). It's one coherent unit of value — the page is useless without its data — so it was kept whole, but the Architect is free to **propose phasing the implementation** (e.g., the data-availability work before the UI) within a single ADR.
 - A key known constraint: the default sort is **verified-followers descending across the entire follow set**, so those counts (and the other observer-relative values) need to be available for ranking the whole list, not fetched lazily per visible row. Prior art for the data + POV selector exists in the legacy grapevine-analysis page; reuse vs. extension of existing endpoints is the Architect's call.
+- **Amendment outcome (2026-05-28):** v1 scoped to owner POV; metrics read from the `NostrUser` node (no card join). Customer observers deferred. Disambiguation precedent: a single endpoint branches internally on `observerPubkey === 'owner'` (read `NostrUser`) vs. a customer pubkey (read `NostrUserWotMetricsCard`) — see `src/api/export/users/queries/userdata.js:24,40-54,75-85` and ADR 0026.
 
 ## Linked artifacts
-- ADR: *(filled in after Architecture phase)*
+- ADR: `engineering-team/decisions/0026-profile-follows-list.md`
 - Test plan: *(filled in after Test Design phase)*
 - Review: *(filled in after Review phase)*

--- a/engineering-team/stories/29-profile-follows-list.md
+++ b/engineering-team/stories/29-profile-follows-list.md
@@ -80,5 +80,5 @@ None open.
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/0026-profile-follows-list.md`
-- Test plan: *(filled in after Test Design phase)*
+- Test plan: `engineering-team/stories/29-profile-follows-list.test-plan.md`
 - Review: *(filled in after Review phase)*

--- a/engineering-team/stories/29-profile-follows-list.md
+++ b/engineering-team/stories/29-profile-follows-list.md
@@ -1,0 +1,75 @@
+# Story 29: Follows list on the primary profile page
+
+**Status:** Approved
+**Created:** 2026-05-28
+**Type:** Feature
+
+## Background
+The primary user-facing profile (`/user/<pubkey>`) shows a bare **"Following"** count with no way to act on it. To actually *see and evaluate* who someone follows — ranked by local trust signals, from a chosen point of view — users today must leave for the legacy grapevine-analysis page, which is styled and structured for a different context. This story brings that capability into the primary profile experience as a native, standalone follows page, reusing the trust data this instance already computes locally.
+
+## User-facing description
+As someone viewing a profile, I want to open that person's follows as a list ranked by trust signals from a point of view I can choose, so that I can explore and judge who they follow without leaving the primary UI for the legacy interface.
+
+## Acceptance criteria
+Testable from the outside. Each criterion gets at least one test.
+
+**Navigation & URL**
+- [ ] **Entry point.** Given a profile at `/user/<pubkey>`, when it renders, then the "Following" count is a link that navigates **in the same tab** to `/user/<pubkey>/follows`.
+- [ ] **Return.** Given the follows page, when the user activates a "← Back to profile" control (and likewise the browser back button), then they return to `/user/<pubkey>`.
+- [ ] **Direct load with POV.** Given `/user/<pubkey>/follows?observer=<obs>`, when loaded directly, then the page shows `<pubkey>`'s follows computed from `<obs>`'s point of view.
+- [ ] **Row navigation.** Given a row (an account `<pubkey>` follows), when the viewer activates it, then they navigate **in the same tab** to that account's own `/user/<that-pubkey>` profile.
+
+**The list**
+- [ ] **Listing.** Given the profile user follows N accounts, when the page loads, then each followed account appears as one row. If N = 0, an empty-state message is shown.
+- [ ] **Default sort.** When the page loads, all N rows are ordered by **verified-followers count, descending**, across the whole list (not just a visible page).
+- [ ] **Re-sort.** Given the list, when the user sorts by any visible column, then the rows reorder accordingly; the default remains verified-followers descending.
+- [ ] **Search.** Given the list, when the user types in an in-page search, then rows are filtered by name / display name or npub.
+- [ ] **Pagination.** Given more rows than fit one page, then results are paginated; moving between pages preserves the current sort, search text, selected point of view, and column visibility.
+
+**Columns**
+- [ ] **Default visibility.** On first load with no saved preferences, the visible columns are **picture, name, rank**; the hidden columns are **npub, hops, verified followers, verified muters, verified reporters**.
+- [ ] **Toggle.** Every column can be shown or hidden by the user.
+- [ ] **Persistence.** A user's column show/hide choices persist across reloads and sessions; a "reset to defaults" control restores the default visibility above.
+- [ ] **Name fallback.** Each row's name column shows the display name; if absent, the name; if both absent, a shortened npub.
+- [ ] **Rank.** The rank column shows an integer **0–100**, equal to `round(influence × 100)` from the selected point of view (not a raw decimal).
+
+**Point of view**
+- [ ] **Observer-relative data.** Given two different selected points of view, when each is selected, then the **rank, hops, and all three verified counts** change to reflect the selected point of view.
+- [ ] **POV selector.** The page provides a point-of-view selector listing the instance's customers plus a **"Global / owner"** option; selecting one updates the displayed data and the `observer` value in the URL.
+- [ ] **Default observer.** With no `observer` specified: if the logged-in user is a customer, the default point of view is themselves; otherwise (including logged-out visitors) the default point of view is the instance owner.
+
+**Disclosure**
+- [ ] **Local-data disclosure.** The page provides a **tappable** ⓘ affordance that reveals a note stating all data here is computed **locally by this Tapestry instance and is not imported via NIP-85**; the affordance works by tap on touch devices (not hover-only).
+
+## Concepts touched
+*(Concept Graph API at `:8877` was unreachable during planning — concepts named in plain language; the Architect should resolve handles via `/api/concept-graph/summaries`.)*
+
+- **Follows** — the kind:3 follow relationship being listed (the legacy API term is "follows"; the profile UI labels the count "Following").
+- **GrapeRank influence / rank** — per-account trust score (0–1), displayed scaled to an integer 0–100 ("rank").
+- **Hops** — graph distance from the observer.
+- **Verified followers / verified muters / verified reporters** — counts of accounts that follow / mute / report the row's account and cross the instance's verification influence cutoff, computed from the observer's point of view.
+- **Observer / point of view ("grapevine")** — the pubkey all scores are computed relative to.
+- **Customer** and **instance owner** — drive the POV selector contents and the default-observer logic.
+- **Profile** — picture / name / display_name used for the picture and name columns.
+
+## Out of scope
+- **Other interaction types** (followers, mutes, reports, frens, idols, etc.). The underlying capability generalizes to many interaction types, but this story ships **follows only**; generalizing the page is deferred.
+- The makeshift `/tapestry/users/<pubkey>` page and the legacy pages themselves — unchanged.
+- Serving or importing these metrics over **NIP-85** — the data is explicitly local-only, and the disclosure says so.
+
+## Open questions
+Resolved during planning (recorded for the audit trail):
+- **Column-pref persistence?** → **Persist** across reloads/sessions, with a reset-to-defaults control.
+- **Large-list handling for v1?** → **Include in-page search + pagination** (legacy parity).
+- **Row click behavior?** → **Navigate to that account's `/user/<pubkey>` profile** (same tab).
+
+None open.
+
+## Notes for the Architect
+- This is a **large story** (16 criteria spanning the UI plus a trust-data dependency). It's one coherent unit of value — the page is useless without its data — so it was kept whole, but the Architect is free to **propose phasing the implementation** (e.g., the data-availability work before the UI) within a single ADR.
+- A key known constraint: the default sort is **verified-followers descending across the entire follow set**, so those counts (and the other observer-relative values) need to be available for ranking the whole list, not fetched lazily per visible row. Prior art for the data + POV selector exists in the legacy grapevine-analysis page; reuse vs. extension of existing endpoints is the Architect's call.
+
+## Linked artifacts
+- ADR: *(filled in after Architecture phase)*
+- Test plan: *(filled in after Test Design phase)*
+- Review: *(filled in after Review phase)*

--- a/engineering-team/stories/29-profile-follows-list.test-plan.md
+++ b/engineering-team/stories/29-profile-follows-list.test-plan.md
@@ -1,0 +1,101 @@
+# Test Plan: Story 29 — Follows list on the primary profile page (v1, owner POV)
+
+**Story:** `engineering-team/stories/29-profile-follows-list.md`
+**ADR:** `engineering-team/decisions/0026-profile-follows-list.md`
+**Date:** 2026-05-28
+
+Scope: **v1 = owner POV only.** Customer-observer features (POV selector, `NostrUserWotMetricsCard` branch, observer-relative switching, `?observer=<customer>`) are in the story's "Deferred to a follow-up" section and are **not** tested here (except the v1 contract that a non-owner `observer` is rejected — T5).
+
+Two test levels, matching repo precedent:
+- **Node source-regex suite** `test/profile-follows-list.test.js` (wired into `test/test.js`) — pins the backend endpoint contract and the spec-bearing frontend source, the way `per-query-neo4j-timeout-safety-net.test.js` and `admin-tools-dashboard-panel.test.js` do. Runs with no browser and (for the source checks) no live server. **Confirmed failing today.**
+- **Playwright spec** `tests/brainstorm/profile-follows-list.spec.js` — the browser-observable behaviors (clicking, persistence across reload, popover tap, navigation). Requires `npx playwright install` + the UI built into `dist/` + a reachable instance. **Expected failing until implemented** (the route/page/link don't exist).
+
+## Coverage map
+
+| Acceptance criterion | Test(s) | File | Level |
+|---|---|---|---|
+| Entry point (Following → /follows, same tab) | `T11` + PW "Entry point" | `test/profile-follows-list.test.js`, `tests/brainstorm/profile-follows-list.spec.js` | source + e2e |
+| Return (Back to profile + browser back) | `T12` + PW "Direct load + Return" | both | source + e2e |
+| Direct load (owner-POV page renders) | `T6`, `T8` + PW "Direct load + Return" | both | source + e2e |
+| Row navigation (row → /user/&lt;pk&gt;) | `T13` + PW "Row navigation" | both | source + e2e |
+| Listing (one row per follow; empty state) | `T9` + PW "Listing", PW "Listing (N=0)" | both | source + e2e |
+| Default sort (verifiedFollowerCount desc, whole set) | `T20` | node | source |
+| Re-sort (any column) | `T18` (DataTable reuse) | node | source |
+| Search (name / npub) | `T18` + PW "Search" | both | source + e2e |
+| Pagination (preserves sort/search/columns) | `T19` + PW "Search"/reload | both | source + e2e |
+| Default visibility (pic/name/rank shown; rest hidden) | `T14` + PW "Default visibility" | both | source + e2e |
+| Toggle (show/hide any column) | `T14` + PW "Toggle + Persistence" | both | source + e2e |
+| Persistence (localStorage + reset-to-defaults) | `T21` + PW "Toggle + Persistence" | both | source + e2e |
+| Name fallback (display_name → name → npub) | `T16` | node | source |
+| Rank (round(influence×100), 0–100, "—" when null) | `T15` | node | source |
+| Owner point of view (metrics from NostrUser node) | `T3`, `T5` | node | source |
+| Local-data disclosure (tappable ⓘ, "not via NIP-85") | `T22` + PW "Local-data disclosure" | both | source + e2e |
+
+Backend endpoint contract (ADR-required, supports Direct load + Owner POV):
+
+| Contract | Test |
+|---|---|
+| Handler file + export `handleGetGrapevineFollows` | `T1` |
+| `observee` required + 64-hex validated → 400 | `T2` |
+| Cypher traverses FOLLOWS + returns the 6 per-row fields | `T3` |
+| Neo4j deadline (`NEO4J_QUERY_TIMEOUT_MS`) + 504 `{success:false}` | `T4` |
+| Non-owner `observer` → 400 (customer observers deferred) | `T5` |
+| Route registered `GET /api/get-grapevine-follows` | `T6` |
+| Response shape `{success, observer, observee, count, data[]}` | `T7` |
+
+## Regression sentinels (must stay green before AND after)
+
+- `R1` — the shared `follows` Cypher in `cypherQueries.js` is **unchanged** (RETURN still `{pubkey, hops, influence}`). Enforces ADR Option A (new endpoint), i.e. guards against an accidental "B-lite" edit to the shared `get-grapevine-interaction`.
+- `R2` — `BrainstormProfile.jsx` still renders the Following count value + "Following" label via `useUserCounts` (the link wraps the count; it isn't removed).
+- `R3` — the existing `/api/get-grapevine-interaction` route stays registered (legacy grapevine-analysis page unregressed).
+
+## Edge cases
+
+- [x] **N = 0** (user follows no one) → empty-state message (`T9` source; PW "Listing (N=0)" using the all-zero pubkey).
+- [x] **`influence` null** → rank renders "—" (`T15`).
+- [x] **Non-owner observer** in v1 → 400, not a silent owner coercion (`T5`).
+- [x] **Search no-match** → visible rows shrink (PW "Search").
+- [ ] **Count vs list divergence (intentionally NOT asserted):** the profile's "Following: N" badge (strfry kind-3) and the follows-list row count (Neo4j FOLLOWS) legitimately differ by crawl lag (ADR Context). No test asserts equality — doing so would be a false constraint.
+- [ ] **Very large follow sets** (thousands): client-side sort/paginate performance is verified manually via cycle-local, not pinned by an automated test (v1 accepts legacy-parity client-side handling).
+
+## Test infrastructure
+
+- **Node runner:** `npm test` (entry `test/test.js`) now includes the `profile-follows-list` suite. The source checks need neither a browser nor a live server. Standalone:
+  ```
+  node -e "require('./test/profile-follows-list.test.js').run().then(r=>{console.log(r);process.exit(0)})"
+  ```
+- **Playwright:** `npm run test:playwright` (or scope: `npx playwright test tests/brainstorm/profile-follows-list.spec.js --project=chromium`).
+  - One-time per machine: `npx playwright install`.
+  - Requires the UI **built into `dist/`** (`npm run build` in `ui/`) and a reachable instance. `baseURL` defaults to `http://localhost:7778` (override with `BRAINSTORM_BASE_URL`). Browsers installed on this machine via `npx playwright install` on 2026-05-28 (chromium/firefox/webkit).
+- **Browser verification — two options, both available:**
+  - **Claude-in-Chrome extension** — interactive, agent-driven checks in a real Chrome with the user's session/auth; no install. Best for the Verify step (walking ACs live, judging the mobile popover UX) and for the deferred customer-observer auth'd flows. Not deterministic; not a CI gate.
+  - **Playwright** (`tests/brainstorm/profile-follows-list.spec.js`) — the deterministic, committed regression net; the only path that runs headless in CI and across the configured mobile viewports (Pixel 5, iPhone 12). Browsers now installed.
+- **Port note:** the live control panel here is on **`:7778`** (`CONTROL_PANEL_PORT`), not the `:8877` mentioned in some role/template docs. No Concept Graph dependency — this story changes no concept definitions, so **no `POST /api/firmware/install` prerequisite**.
+- **Fixtures (Playwright):**
+  - `POPULATED_PUBKEY = 2efaa715…d987331` — follows many accounts (populated-list checks).
+  - `EMPTY_PUBKEY = 0000…0000` — empty-state check.
+
+## How to run
+
+```
+npm test                 # node suites (includes profile-follows-list)
+npm run test:playwright  # browser/e2e (needs npx playwright install + a built, running UI)
+```
+
+## Verification
+
+Node suite confirmed **failing for the right reason** on 2026-05-28 (pre-implementation, at the test-design commit):
+
+```
+22 T-tests FAIL — each reporting the missing artifact, e.g.:
+  ✗ T1 … followsWithMetrics.js does not exist yet — the Implementer must create the new endpoint handler
+  ✗ T6 … src/api/index.js must register the route '/api/get-grapevine-follows'
+  ✗ T8 … App.jsx must declare a route with path '/user/:pubkey/follows'
+  ✗ T11 … BrainstormProfile.jsx must link the Following count to `/user/${pubkey}/follows`
+  … (T2–T5, T7, T9–T10, T12–T22)
+3 R-sentinels PASS (R1 shared follows query unchanged, R2 profile count intact, R3 legacy route present)
+
+=== RESULT: 3 passed, 22 failed ===
+```
+
+Playwright spec: browsers are now **installed** (`npx playwright install`, 2026-05-28: chromium/firefox/webkit). The spec is intentionally **not run pre-implementation** — it would only re-confirm the route is absent, which the node suite already shows. It is written to fail until implemented and will be exercised in the **Verify step** after `npm run build` — via Playwright (`npm run test:playwright`) and/or interactively via the Claude-in-Chrome extension.

--- a/src/api/grapevineInteractions/queries/followsWithMetrics.js
+++ b/src/api/grapevineInteractions/queries/followsWithMetrics.js
@@ -1,0 +1,141 @@
+/**
+ * Story #29 / ADR 0026 — follows list with owner-POV metrics.
+ *
+ *   GET /api/get-grapevine-follows?observee=<pk>[&observer=owner]
+ *
+ * Lists the accounts <observee> follows, with the owner's GrapeRank metrics read
+ * straight from each followee's NostrUser node: influence (→ rank), hops, and the
+ * three verified counts. v1 is OWNER POV ONLY. Customer observers are deferred:
+ * their scores live on NostrUserWotMetricsCard (see ADR 0026 §Decision and the
+ * userdata.js:40-85 node/card branch), so a non-owner `observer` is rejected 400.
+ *
+ * Mirrors the per-query Neo4j deadline + 504 pattern from
+ * src/api/export/users/queries/userdata.js (story #5 / ADRs 0024-0025): the
+ * shared /api/get-grapevine-interaction endpoint is intentionally left untouched
+ * (ADR Option A — a new endpoint, not a B-lite edit).
+ */
+
+const neo4j = require('neo4j-driver');
+const { getConfigFromFile } = require('../../../utils/config');
+const { nip19 } = require('nostr-tools');
+
+function toInt(v) {
+  if (v == null) return null;
+  if (typeof v.toNumber === 'function') return v.toNumber();
+  if (typeof v === 'object' && typeof v.low === 'number') return v.low;
+  const n = parseInt(v.toString(), 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+function toFloat(v) {
+  if (v == null) return null;
+  const n = parseFloat(v.toString());
+  return Number.isNaN(n) ? null : n;
+}
+
+function isValidHexPubkey(pk) {
+  return typeof pk === 'string' && /^[0-9a-f]{64}$/i.test(pk);
+}
+
+/**
+ * GET /api/get-grapevine-follows
+ */
+function handleGetGrapevineFollows(req, res) {
+  try {
+    const observee = req.query.observee;
+    const observer = req.query.observer; // v1: owner only (see below)
+
+    // --- Validate observee: 64-char hex, cross-checked via nip19 (cf. userdata.js:30-35).
+    if (!observee || !isValidHexPubkey(observee)) {
+      return res.status(400).json({
+        success: false,
+        message: 'Missing or invalid observee parameter (expected a 64-character hex pubkey)'
+      });
+    }
+    try {
+      const npub = nip19.npubEncode(observee);
+      if (!npub.startsWith('npub')) throw new Error('bad encode');
+    } catch {
+      return res.status(400).json({ success: false, message: 'Invalid observee parameter' });
+    }
+
+    // --- v1 is OWNER POV only. Customer observers are deferred (ADR 0026): their
+    // metrics live on NostrUserWotMetricsCard, which this endpoint does not yet read.
+    const ownerPubkey = getConfigFromFile('BRAINSTORM_OWNER_PUBKEY', '');
+    if (observer && observer !== 'owner' && observer !== ownerPubkey) {
+      return res.status(400).json({
+        success: false,
+        message: 'customer observers not yet supported — this endpoint currently serves the owner point of view only'
+      });
+    }
+
+    // --- Neo4j with a driver-layer deadline (story #5 / ADR 0024-0025 pattern).
+    const neo4jUri = getConfigFromFile('NEO4J_URI', 'bolt://localhost:7687');
+    const neo4jUser = getConfigFromFile('NEO4J_USER', 'neo4j');
+    const neo4jPassword = getConfigFromFile('NEO4J_PASSWORD', 'neo4j');
+    const queryTimeoutMs = parseInt(getConfigFromFile('NEO4J_QUERY_TIMEOUT_MS', 15000), 10);
+
+    const driver = neo4j.driver(neo4jUri, neo4j.auth.basic(neo4jUser, neo4jPassword));
+    const session = driver.session();
+
+    // Owner POV: the metrics ARE the followee NostrUser node's own GrapeRank
+    // properties (the same ones the legacy follows query reads for influence/hops),
+    // plus the three verified counts. No NostrUserWotMetricsCard join in v1.
+    const cypherQuery = `
+      MATCH (observee:NostrUser {pubkey: $observee})
+      OPTIONAL MATCH (observee)-[:FOLLOWS]->(f:NostrUser)
+      RETURN f.pubkey AS pubkey,
+             f.influence AS influence,
+             f.hops AS hops,
+             f.verifiedFollowerCount AS verifiedFollowerCount,
+             f.verifiedMuterCount AS verifiedMuterCount,
+             f.verifiedReporterCount AS verifiedReporterCount
+    `;
+
+    const queryStartMs = Date.now();
+    session.run(cypherQuery, { observee }, { timeout: queryTimeoutMs })
+      .then(result => {
+        const data = result.records
+          .map(r => ({
+            pubkey: r.get('pubkey') ?? null,
+            influence: toFloat(r.get('influence')),
+            hops: toInt(r.get('hops')),
+            verifiedFollowerCount: toInt(r.get('verifiedFollowerCount')),
+            verifiedMuterCount: toInt(r.get('verifiedMuterCount')),
+            verifiedReporterCount: toInt(r.get('verifiedReporterCount'))
+          }))
+          // OPTIONAL MATCH yields a single null-pubkey row when observee follows no one.
+          .filter(row => row.pubkey);
+
+        res.status(200).json({
+          success: true,
+          observer: 'owner',
+          observee,
+          count: data.length,
+          data
+        });
+      })
+      .catch(error => {
+        const elapsedMs = Date.now() - queryStartMs;
+        const isTimeout = error && typeof error.code === 'string' && /TransactionTimedOut/i.test(error.code);
+        if (isTimeout) {
+          console.error('Neo4j query timeout fetching grapevine follows:', { observee, elapsedMs, limitMs: queryTimeoutMs, code: error.code });
+          return res.status(504).json({
+            success: false,
+            message: `Neo4j query timeout after ${elapsedMs}ms (limit ${queryTimeoutMs}ms) fetching follows for ${observee}.`
+          });
+        }
+        console.error('Error fetching grapevine follows:', error);
+        res.status(500).json({ success: false, message: `Error fetching grapevine follows: ${error.message}` });
+      })
+      .finally(() => {
+        session.close();
+        driver.close();
+      });
+  } catch (error) {
+    console.error('Error in handleGetGrapevineFollows:', error);
+    res.status(500).json({ success: false, message: `Server error: ${error.message}` });
+  }
+}
+
+module.exports = { handleGetGrapevineFollows };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -29,6 +29,7 @@ const { handleGetUserClassification } = require('./auth/getUserClassification');
 const { handleSignUpNewCustomer } = require('./auth/signUpNewCustomer');
 const { handleGetOwnerInfo } = require('./owner/ownerInfo');
 const { handleGetGrapevineInteraction } = require('./grapevineInteractions/queries');
+const { handleGetGrapevineFollows } = require('./grapevineInteractions/queries/followsWithMetrics');
 const { handleOldSearchProfiles, handleOldSearchProfilesStream } = require('./search/profiles');
 const { handleKeywordSearchProfiles } = require('./search/profiles/keyword');
 const { handlePrecomputeWhitelistMaps, handlePrecomputeWhitelistStatus } = require('./search/profiles/whitelistPrecompute');
@@ -315,6 +316,8 @@ async function register(app) {
 
     // Grapevine Interactions endpoint
     app.get('/api/get-grapevine-interaction', handleGetGrapevineInteraction);
+    // Follows list with owner-POV metrics (story #29 / ADR 0026)
+    app.get('/api/get-grapevine-follows', handleGetGrapevineFollows);
 
     // Search endpoint
     app.get('/api/search/profiles', handleOldSearchProfiles);

--- a/test/profile-follows-list.test.js
+++ b/test/profile-follows-list.test.js
@@ -1,0 +1,301 @@
+/**
+ * Story #29: Follows list on the primary profile page (v1 — owner POV only).
+ * ADR 0026. See engineering-team/stories/29-profile-follows-list.test-plan.md
+ *
+ * v1 ships a standalone /user/:pubkey/follows React page backed by a NEW
+ * endpoint GET /api/get-grapevine-follows that lists who <observee> follows
+ * with owner-POV metrics (rank from influence, hops, and the three verified
+ * counts) read straight from the NostrUser node. Customer observers (the
+ * NostrUserWotMetricsCard branch, POV selector, ?observer=<customer>) are
+ * DEFERRED and intentionally NOT tested here.
+ *
+ * Tests are intentionally source-regex (matching the per-query-neo4j-timeout
+ * and admin-tools-dashboard-panel precedents) so the spec is pinned without
+ * prescribing the exact wiring the Implementer chooses. Browser-level behavior
+ * (clicking, persistence across reload, popover tap) is covered by the
+ * Playwright spec tests/brainstorm/profile-follows-list.spec.js.
+ *
+ * T* tests must FAIL pre-implementation and PASS post-implementation.
+ * R* sentinels must PASS both before and after (they guard existing behavior
+ * and the ADR's Option-A decision); if an R* flips to FAIL, something regressed.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const FOLLOWS_HANDLER = path.resolve(__dirname, '../src/api/grapevineInteractions/queries/followsWithMetrics.js');
+const API_INDEX       = path.resolve(__dirname, '../src/api/index.js');
+const CYPHER          = path.resolve(__dirname, '../src/api/grapevineInteractions/queries/cypherQueries.js');
+const APP_JSX         = path.resolve(__dirname, '../ui/src/App.jsx');
+const FOLLOWS_PAGE    = path.resolve(__dirname, '../ui/src/pages/BrainstormFollows.jsx');
+const FOLLOWS_HOOK    = path.resolve(__dirname, '../ui/src/hooks/useGrapevineFollows.js');
+const PROFILE_PAGE    = path.resolve(__dirname, '../ui/src/pages/BrainstormProfile.jsx');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+
+// ===========================================================================
+// BACKEND — new endpoint GET /api/get-grapevine-follows (owner POV)
+// ===========================================================================
+
+test('T1: src/api/grapevineInteractions/queries/followsWithMetrics.js exists and exports handleGetGrapevineFollows (ADR 0026 §Impl)', () => {
+  const src = safeRead(FOLLOWS_HANDLER);
+  assert(src.length > 0,
+    'followsWithMetrics.js does not exist yet — the Implementer must create the new endpoint handler (ADR 0026 chose Option A: a new endpoint).');
+  assert(/handleGetGrapevineFollows/.test(src),
+    'followsWithMetrics.js must define handleGetGrapevineFollows.');
+  assert(/module\.exports\s*=\s*\{[\s\S]*handleGetGrapevineFollows/.test(src),
+    'followsWithMetrics.js must export handleGetGrapevineFollows so src/api/index.js can register it.');
+});
+
+test('T2: handler requires + 64-hex-validates `observee`, returning 400 otherwise (AC: Listing / input validation)', () => {
+  const src = safeRead(FOLLOWS_HANDLER);
+  assert(src.length > 0, 'followsWithMetrics.js does not exist yet.');
+  assert(/req\.query\.observee/.test(src),
+    'handler must read the `observee` query param (req.query.observee).');
+  assert(/\.status\(\s*400\s*\)/.test(src),
+    'handler must return HTTP 400 for a missing/invalid observee.');
+  assert(/[0-9a-f]\{64\}|\{\s*64\s*\}|npubEncode/i.test(src),
+    'handler must validate the pubkey shape (64-hex, e.g. /^[0-9a-f]{64}$/i, or a nip19.npubEncode round-trip like userdata.js:30-35).');
+});
+
+test('T3: owner-POV Cypher traverses (observee)-[:FOLLOWS]->(followee) and RETURNs all six per-row fields from the node (AC: Owner point of view)', () => {
+  const src = safeRead(FOLLOWS_HANDLER);
+  assert(src.length > 0, 'followsWithMetrics.js does not exist yet.');
+  assert(/:FOLLOWS\s*\]\s*->/.test(src),
+    'handler Cypher must traverse the FOLLOWS edge: (observee)-[:FOLLOWS]->(followee).');
+  for (const field of ['pubkey', 'influence', 'hops', 'verifiedFollowerCount', 'verifiedMuterCount', 'verifiedReporterCount']) {
+    assert(new RegExp('\\b' + field + '\\b').test(src),
+      `handler must surface \`${field}\` per row (AC: rank derives from influence; hops; the three verified counts — all read from the NostrUser node for owner POV).`);
+  }
+});
+
+test('T4: handler enforces the Neo4j query deadline (NEO4J_QUERY_TIMEOUT_MS) and has a 504 {success:false} branch (AC: 504 on timeout; ADR §Impl, mirrors userdata.js)', () => {
+  const src = safeRead(FOLLOWS_HANDLER);
+  assert(src.length > 0, 'followsWithMetrics.js does not exist yet.');
+  assert(/NEO4J_QUERY_TIMEOUT_MS/.test(src),
+    'handler must read NEO4J_QUERY_TIMEOUT_MS (same deadline pattern as userdata.js:60).');
+  assert(/session\.(run|executeRead|readTransaction)\s*\([\s\S]{0,400}\btimeout\s*:/.test(src),
+    'handler must pass a driver-layer { timeout: ... } to session.run/executeRead so a runaway query fails fast (userdata.js:176).');
+  const win = src.match(/\.status\(\s*504\s*\)\s*\.json\(\s*\{[\s\S]{0,400}?\}/);
+  assert(win, 'handler must return HTTP 504 with a JSON object body when the query times out (no `.status(504).json({...})` found).');
+  assert(/success\s*:\s*false/.test(win[0]),
+    'the 504 JSON body must include `success: false` (userdata.js:276-279).');
+});
+
+test('T5: a non-owner `observer` is rejected with 400 (customer observers deferred — story §Deferred, ADR §Impl)', () => {
+  const src = safeRead(FOLLOWS_HANDLER);
+  assert(src.length > 0, 'followsWithMetrics.js does not exist yet.');
+  assert(/observer/.test(src),
+    'handler must look at the `observer` param to reject non-owner values in v1.');
+  assert(/\.status\(\s*400\s*\)[\s\S]{0,260}(customer|owner[\s-]?only|not\s*(yet\s*)?support)/i.test(src) ||
+         /(customer|owner[\s-]?only|not\s*(yet\s*)?support)[\s\S]{0,260}\.status\(\s*400\s*\)/i.test(src),
+    'a non-owner `observer` must return 400 with a message that customer observers are not yet supported (v1 is owner-only). ' +
+    'This encodes the deferred-scope contract so the Implementer does not silently coerce to owner.');
+});
+
+test('T6: GET /api/get-grapevine-follows is registered in src/api/index.js → handleGetGrapevineFollows (AC: Direct load)', () => {
+  const src = safeRead(API_INDEX);
+  assert(src.length > 0, 'src/api/index.js missing — unexpected.');
+  assert(/['"]\/api\/get-grapevine-follows['"]/.test(src),
+    "src/api/index.js must register the route '/api/get-grapevine-follows' (alongside get-grapevine-interaction near line 317).");
+  assert(/handleGetGrapevineFollows/.test(src),
+    'src/api/index.js must wire the route to handleGetGrapevineFollows.');
+});
+
+test('T7: success response carries success:true, observer, observee, count, data[] (ADR §Impl response shape)', () => {
+  const src = safeRead(FOLLOWS_HANDLER);
+  assert(src.length > 0, 'followsWithMetrics.js does not exist yet.');
+  for (const key of ['success', 'observer', 'observee', 'count', 'data']) {
+    assert(new RegExp('\\b' + key + '\\b').test(src),
+      `the success response must include \`${key}\` (ADR: { success:true, observer:'owner', observee, count, data:[…] }).`);
+  }
+});
+
+// ===========================================================================
+// FRONTEND — route, page, hook, and the profile "Following" link
+// (spec-bearing source pins; browser behavior is in the Playwright spec)
+// ===========================================================================
+
+test('T8: ui/src/App.jsx registers the /user/:pubkey/follows route → BrainstormFollows (AC: Direct load)', () => {
+  const src = safeRead(APP_JSX);
+  assert(src.length > 0, 'ui/src/App.jsx missing — unexpected.');
+  assert(/\/user\/:pubkey\/follows/.test(src),
+    "App.jsx must declare a route with path '/user/:pubkey/follows'.");
+  assert(/BrainstormFollows/.test(src),
+    'App.jsx must map the follows route to the BrainstormFollows page component.');
+});
+
+test('T9: ui/src/pages/BrainstormFollows.jsx exists, reads :pubkey, and loads the follows data (AC: Listing)', () => {
+  const src = safeRead(FOLLOWS_PAGE);
+  assert(src.length > 0,
+    'BrainstormFollows.jsx does not exist yet — the Implementer must create the follows page.');
+  assert(/useParams/.test(src),
+    'BrainstormFollows.jsx must read the :pubkey route param via useParams.');
+  assert(/useGrapevineFollows|get-grapevine-follows/.test(src),
+    'BrainstormFollows.jsx must source rows from the follows endpoint (via the useGrapevineFollows hook or a direct fetch).');
+  assert(/empty|no follows|follows nobody|0 follows/i.test(src),
+    'BrainstormFollows.jsx must render an empty-state message when the user follows no one (AC: Listing, N=0).');
+});
+
+test('T10: ui/src/hooks/useGrapevineFollows.js fetches /api/get-grapevine-follows (AC: Listing)', () => {
+  const src = safeRead(FOLLOWS_HOOK);
+  assert(src.length > 0,
+    'useGrapevineFollows.js does not exist yet — the Implementer must create the data hook (ADR §Impl).');
+  assert(/get-grapevine-follows/.test(src),
+    'useGrapevineFollows.js must call the /api/get-grapevine-follows endpoint.');
+  assert(/fetch\s*\(/.test(src),
+    'useGrapevineFollows.js must use fetch (matching the useUserCounts.js convention).');
+});
+
+test('T11: the profile "Following" count links to /user/:pubkey/follows in the same tab (AC: Entry point)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/\/user\/\$\{pubkey\}\/follows/.test(src),
+    'BrainstormProfile.jsx must link the Following count to `/user/${pubkey}/follows`.');
+  assert(/\bLink\b/.test(src) && /react-router-dom/.test(src),
+    'BrainstormProfile.jsx must use react-router-dom <Link> (same-tab client navigation, not target=_blank).');
+});
+
+test('T12: the follows page has a "Back to profile" link to /user/:pubkey (AC: Return)', () => {
+  const src = safeRead(FOLLOWS_PAGE);
+  assert(src.length > 0, 'BrainstormFollows.jsx does not exist yet.');
+  assert(/back to profile/i.test(src),
+    'BrainstormFollows.jsx must render a "Back to profile" control.');
+  assert(/\/user\/\$\{pubkey\}(?!\/follows)/.test(src) || /to=\{`\/user\/\$\{pubkey\}`\}/.test(src),
+    'the back control must navigate to `/user/${pubkey}` (the profile, not the follows page).');
+});
+
+test('T13: each row navigates to that account\'s own /user/<pubkey> profile (AC: Row navigation)', () => {
+  const src = safeRead(FOLLOWS_PAGE);
+  assert(src.length > 0, 'BrainstormFollows.jsx does not exist yet.');
+  assert(/onRowClick|navigate\s*\(|to=\{`\/user\//.test(src),
+    'BrainstormFollows.jsx must make rows navigate to /user/<that-pubkey> (e.g. DataTable onRowClick → navigate(`/user/${row.pubkey}`)).');
+  assert(/\/user\//.test(src),
+    'row navigation target must be a /user/<pubkey> profile route.');
+});
+
+test('T14: the page defines all eight columns incl. default visibility (pic/name/rank shown; npub/hops/verified* hidden) (AC: Default visibility)', () => {
+  const src = safeRead(FOLLOWS_PAGE);
+  assert(src.length > 0, 'BrainstormFollows.jsx does not exist yet.');
+  for (const key of ['name', 'rank', 'npub', 'hops', 'verifiedFollowerCount', 'verifiedMuterCount', 'verifiedReporterCount']) {
+    assert(new RegExp('\\b' + key + '\\b').test(src),
+      `BrainstormFollows.jsx must define the \`${key}\` column.`);
+  }
+  assert(/pic|picture|avatar/i.test(src),
+    'BrainstormFollows.jsx must define the picture/avatar column.');
+  assert(/default/i.test(src) && /(hidden|visible|show|hide)/i.test(src),
+    'BrainstormFollows.jsx must encode default column visibility (pic/name/rank shown; npub/hops/verified* hidden).');
+});
+
+test('T15: rank is rendered as round(influence*100) with a "—" fallback when influence is null (AC: Rank)', () => {
+  const src = safeRead(FOLLOWS_PAGE);
+  assert(src.length > 0, 'BrainstormFollows.jsx does not exist yet.');
+  assert(/Math\.round\(\s*[\w.?]+\s*\*\s*100\s*\)/.test(src),
+    'rank must be computed as Math.round(influence * 100) — an integer 0–100, not a raw decimal.');
+  assert(/[—–-]|null|== *null|=== *null/.test(src) && /—/.test(src),
+    'rank must fall back to "—" when influence is null/absent.');
+});
+
+test('T16: the name column falls back display_name → name → shortened npub (AC: Name fallback)', () => {
+  const src = safeRead(FOLLOWS_PAGE);
+  assert(src.length > 0, 'BrainstormFollows.jsx does not exist yet.');
+  assert(/display_name\s*\|\|\s*[\w.?[\]'"()]*\bname\b/.test(src),
+    'the name cell must use the fallback chain display_name || name || <shortened npub>.');
+});
+
+test('T17: npub is derived via nip19.npubEncode (AC: Name fallback / npub column)', () => {
+  const src = safeRead(FOLLOWS_PAGE);
+  assert(src.length > 0, 'BrainstormFollows.jsx does not exist yet.');
+  assert(/npubEncode/.test(src),
+    'BrainstormFollows.jsx must derive npub via nip19.npubEncode(pubkey) (cf. BrainstormProfile:99).');
+});
+
+test('T18: the page reuses DataTable for sort + search/filter (AC: Re-sort, Search)', () => {
+  const src = safeRead(FOLLOWS_PAGE);
+  assert(src.length > 0, 'BrainstormFollows.jsx does not exist yet.');
+  assert(/DataTable/.test(src),
+    'BrainstormFollows.jsx must reuse ui/src/components/DataTable.jsx (header-click sort + cross-column filter), per ADR §Impl.');
+});
+
+test('T19: the page implements pagination (AC: Pagination)', () => {
+  const src = safeRead(FOLLOWS_PAGE);
+  assert(src.length > 0, 'BrainstormFollows.jsx does not exist yet.');
+  assert(/page\s*size|pagesize|currentPage|setPage|pageIndex|\bpaginat/i.test(src),
+    'BrainstormFollows.jsx must paginate results (DataTable has no pagination — add it at the page level).');
+});
+
+test('T20: default sort is verifiedFollowerCount descending across the whole set (AC: Default sort)', () => {
+  const src = safeRead(FOLLOWS_PAGE);
+  assert(src.length > 0, 'BrainstormFollows.jsx does not exist yet.');
+  // ADR: pre-sort the data array by verifiedFollowerCount desc before handing to DataTable.
+  assert(/verifiedFollowerCount/.test(src) && /sort\s*\(/.test(src),
+    'BrainstormFollows.jsx must sort the full data set by verifiedFollowerCount (descending) before render — the default order is not just a visible page.');
+});
+
+test('T21: column show/hide choices persist via localStorage with a reset-to-defaults (AC: Persistence)', () => {
+  const src = safeRead(FOLLOWS_PAGE);
+  assert(src.length > 0, 'BrainstormFollows.jsx does not exist yet.');
+  assert(/localStorage/.test(src),
+    'column visibility prefs must persist across reloads/sessions via localStorage (AC: Persistence).');
+  assert(/reset/i.test(src),
+    'the page must offer a "reset to defaults" control for column visibility (AC: Persistence).');
+});
+
+test('T22: the local-data ⓘ disclosure states data is computed locally and NOT imported via NIP-85, and opens on tap (AC: Local-data disclosure)', () => {
+  const src = safeRead(FOLLOWS_PAGE);
+  assert(src.length > 0, 'BrainstormFollows.jsx does not exist yet.');
+  assert(/NIP-?85/i.test(src),
+    'the disclosure must mention NIP-85 (that the data is NOT imported via NIP-85).');
+  assert(/comput(e|ed)\s+locally|locally by this|this Tapestry instance/i.test(src),
+    'the disclosure must state the data is computed locally by this Tapestry instance.');
+  assert(/onClick/.test(src),
+    'the ⓘ affordance must open on tap/click (mobile-friendly), not hover-only — expect an onClick handler.');
+});
+
+// ===========================================================================
+// REGRESSION SENTINELS (must PASS before AND after implementation)
+// ===========================================================================
+
+test('R1: the shared `follows` Cypher in cypherQueries.js is UNCHANGED — ADR chose a new endpoint, not B-lite (no edit to get-grapevine-interaction)', () => {
+  const src = safeRead(CYPHER);
+  assert(src.length > 0, 'cypherQueries.js missing — unexpected.');
+  assert(/interactionType:\s*'follows'[\s\S]{0,400}RETURN\s+followee\.pubkey AS pubkey,\s*followee\.hops AS hops,\s*followee\.influence AS influence/.test(src),
+    "the existing `follows` query must still RETURN exactly {pubkey, hops, influence}. ADR 0026 chose Option A (a NEW endpoint); if this sentinel fails the Implementer modified the shared get-grapevine-interaction query (Option B-lite) instead.");
+});
+
+test('R2: BrainstormProfile.jsx still shows the Following count value + label via useUserCounts (we wrap it in a link, not remove it)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/useUserCounts/.test(src),
+    'BrainstormProfile.jsx must keep using useUserCounts for the Following count.');
+  assert(/bsp-count-value/.test(src) && /Following/.test(src),
+    'BrainstormProfile.jsx must still render the Following count value and "Following" label (the link wraps the existing count; it is not replaced).');
+});
+
+test('R3: the existing /api/get-grapevine-interaction route remains registered (legacy page unregressed)', () => {
+  const src = safeRead(API_INDEX);
+  assert(src.length > 0, 'src/api/index.js missing — unexpected.');
+  assert(/['"]\/api\/get-grapevine-interaction['"]/.test(src),
+    'the existing /api/get-grapevine-interaction registration must remain (the legacy grapevine-analysis page depends on it).');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -47,6 +47,7 @@ const manualTaskRetriggerAfterFinish = require('./manual-task-retrigger-after-fi
 const scheduledTaskTimeoutPropagation = require('./scheduled-task-timeout-propagation.test.js');
 const killTimeoutOrphansByDefault = require('./kill-timeout-orphans-by-default.test.js');
 const taskQueueSemaphoreProtectionAudit = require('./task-queue-semaphore-protection-audit.test.js');
+const profileFollowsList = require('./profile-follows-list.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -126,6 +127,9 @@ async function main() {
   console.log('\ntask-queue-semaphore-protection-audit suite:');
   const taskQueueSemaphoreProtectionAuditResult = await taskQueueSemaphoreProtectionAudit.run();
 
+  console.log('\nprofile-follows-list suite:');
+  const profileFollowsListResult = await profileFollowsList.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -201,6 +205,9 @@ async function main() {
   console.log(
     `task-queue-semaphore-protection-audit suite:     ${taskQueueSemaphoreProtectionAuditResult.fail === 0 ? 'PASS' : 'FAIL'} (${taskQueueSemaphoreProtectionAuditResult.pass} passed, ${taskQueueSemaphoreProtectionAuditResult.fail} failed)`
   );
+  console.log(
+    `profile-follows-list suite:                      ${profileFollowsListResult.fail === 0 ? 'PASS' : 'FAIL'} (${profileFollowsListResult.pass} passed, ${profileFollowsListResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -227,7 +234,8 @@ async function main() {
     manualTaskRetriggerAfterFinishResult.fail === 0 &&
     scheduledTaskTimeoutPropagationResult.fail === 0 &&
     killTimeoutOrphansByDefaultResult.fail === 0 &&
-    taskQueueSemaphoreProtectionAuditResult.fail === 0;
+    taskQueueSemaphoreProtectionAuditResult.fail === 0 &&
+    profileFollowsListResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/tests/brainstorm/profile-follows-list.spec.js
+++ b/tests/brainstorm/profile-follows-list.spec.js
@@ -1,0 +1,125 @@
+/**
+ * Playwright UI checks for story #29: follows list on the primary profile (v1, owner POV).
+ * See engineering-team/stories/29-profile-follows-list.test-plan.md and ADR 0026.
+ *
+ * Preconditions:
+ *   - A reachable Brainstorm instance with the Implementer's changes BUILT into dist/
+ *     (the UI is Vite-built: `npm run build` in ui/). Defaults to BRAINSTORM_BASE_URL
+ *     or http://localhost:7778.
+ *   - First Playwright run on a machine needs `npx playwright install`.
+ *
+ * These are intentionally FAILING pre-implementation: the /user/:pubkey/follows route,
+ * the page, and the profile "Following" link do not exist yet. They use the story's
+ * user-facing vocabulary as selectors (Following, Back to profile, Name, Rank,
+ * Verified Followers, npub, Hops, NIP-85, Reset) rather than incidental markup.
+ *
+ * Customer-observer behavior (POV selector, ?observer=<customer>) is DEFERRED and not tested.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = process.env.BRAINSTORM_BASE_URL || 'http://localhost:7778';
+
+// A profile known to follow many accounts (used across the populated-list checks).
+const POPULATED_PUBKEY = '2efaa715bbb46dd5be6b7da8d7700266d11674b913b8178addb5c2e63d987331';
+// A pubkey that follows no one → exercises the empty state.
+const EMPTY_PUBKEY = '0000000000000000000000000000000000000000000000000000000000000000';
+
+const profileUrl = (pk) => `${BASE_URL}/user/${pk}`;
+const followsUrl = (pk) => `${BASE_URL}/user/${pk}/follows`;
+
+test.describe('Story 29 — follows list on the primary profile (v1, owner POV)', () => {
+  test('AC Entry point: the "Following" count links (same tab) to /user/:pubkey/follows', async ({ page }) => {
+    await page.goto(profileUrl(POPULATED_PUBKEY));
+
+    // The Following count should be a link whose target is the follows sub-path.
+    const followingLink = page.getByRole('link', { name: /following/i });
+    await expect(followingLink).toBeVisible();
+    await expect(followingLink).toHaveAttribute('href', /\/user\/[0-9a-f]{64}\/follows$/);
+    // Must NOT open a new tab.
+    await expect(followingLink).not.toHaveAttribute('target', '_blank');
+
+    await followingLink.click();
+    await expect(page).toHaveURL(new RegExp(`/user/${POPULATED_PUBKEY}/follows`));
+  });
+
+  test('AC Direct load + Return: the follows page loads directly and "Back to profile" returns to /user/:pubkey', async ({ page }) => {
+    await page.goto(followsUrl(POPULATED_PUBKEY));
+
+    // The page rendered (a table is present) — not a 404 / blank SPA fallback.
+    await expect(page.locator('table')).toBeVisible();
+
+    const back = page.getByRole('link', { name: /back to profile/i })
+      .or(page.getByRole('button', { name: /back to profile/i }));
+    await expect(back.first()).toBeVisible();
+    await back.first().click();
+    await expect(page).toHaveURL(new RegExp(`/user/${POPULATED_PUBKEY}$`));
+  });
+
+  test('AC Listing: a populated profile renders at least one follow row', async ({ page }) => {
+    await page.goto(followsUrl(POPULATED_PUBKEY));
+    await expect(page.locator('table tbody tr').first()).toBeVisible();
+  });
+
+  test('AC Default visibility: Name and Rank columns show by default; npub / Hops / Verified columns are hidden', async ({ page }) => {
+    await page.goto(followsUrl(POPULATED_PUBKEY));
+
+    await expect(page.getByRole('columnheader', { name: /^name$/i })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: /^rank$/i })).toBeVisible();
+
+    await expect(page.getByRole('columnheader', { name: /npub/i })).toHaveCount(0);
+    await expect(page.getByRole('columnheader', { name: /hops/i })).toHaveCount(0);
+    await expect(page.getByRole('columnheader', { name: /verified followers/i })).toHaveCount(0);
+  });
+
+  test('AC Toggle + Persistence: enabling a hidden column survives reload, and reset-to-defaults hides it again', async ({ page }) => {
+    await page.goto(followsUrl(POPULATED_PUBKEY));
+
+    // Open the column controls and enable "Hops".
+    await page.getByRole('button', { name: /columns/i }).click();
+    await page.getByRole('checkbox', { name: /hops/i })
+      .or(page.getByLabel(/hops/i)).first().check();
+    await expect(page.getByRole('columnheader', { name: /hops/i })).toBeVisible();
+
+    // Persists across reload (localStorage).
+    await page.reload();
+    await expect(page.getByRole('columnheader', { name: /hops/i })).toBeVisible();
+
+    // Reset to defaults hides it again.
+    await page.getByRole('button', { name: /columns/i }).click();
+    await page.getByRole('button', { name: /reset/i }).click();
+    await expect(page.getByRole('columnheader', { name: /hops/i })).toHaveCount(0);
+  });
+
+  test('AC Search: typing in the in-page search filters the rows', async ({ page }) => {
+    await page.goto(followsUrl(POPULATED_PUBKEY));
+    const before = await page.locator('table tbody tr').count();
+
+    const search = page.getByPlaceholder(/filter|search/i).first();
+    await search.fill('zzzzzznomatchexpectedzzzzzz');
+    const after = await page.locator('table tbody tr').count();
+
+    expect(after).toBeLessThan(before); // a no-match query must shrink the visible set
+  });
+
+  test('AC Row navigation: clicking a row opens that account\'s /user/<pubkey> profile (same tab)', async ({ page }) => {
+    await page.goto(followsUrl(POPULATED_PUBKEY));
+    await page.locator('table tbody tr').first().click();
+    await expect(page).toHaveURL(/\/user\/[0-9a-f]{64}$/);
+  });
+
+  test('AC Local-data disclosure: tapping the info affordance reveals the "not imported via NIP-85" note', async ({ page }) => {
+    await page.goto(followsUrl(POPULATED_PUBKEY));
+
+    // Tappable info affordance (works on touch — opened by click, not hover).
+    const info = page.getByRole('button', { name: /info|computed locally|ⓘ|about this data/i }).first();
+    await info.click();
+    await expect(page.getByText(/NIP-?85/i)).toBeVisible();
+    await expect(page.getByText(/comput(e|ed) locally|this Tapestry instance/i)).toBeVisible();
+  });
+
+  test('AC Listing (N=0): a profile that follows no one shows an empty-state message', async ({ page }) => {
+    await page.goto(followsUrl(EMPTY_PUBKEY));
+    await expect(page.getByText(/no follows|follows no one|isn'?t following anyone|nobody|0 follows/i)).toBeVisible();
+  });
+});

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -65,6 +65,7 @@ import ImportPage from './pages/io/ImportPage';
 import Dashboard from './pages/Dashboard';
 import BrainstormSearch from './pages/BrainstormSearch';
 import BrainstormProfile from './pages/BrainstormProfile';
+import BrainstormFollows from './pages/BrainstormFollows';
 import BrainstormSettings from './pages/BrainstormSettings';
 import BrainstormPersonalization from './pages/BrainstormPersonalization';
 import BrainstormHowSearchWorks from './pages/BrainstormHowSearchWorks';
@@ -79,6 +80,10 @@ const router = createBrowserRouter([
   {
     path: '/user/:pubkey',
     element: <BrainstormProfile />,
+  },
+  {
+    path: '/user/:pubkey/follows',
+    element: <BrainstormFollows />,
   },
   {
     path: '/settings',

--- a/ui/src/components/DataTable.jsx
+++ b/ui/src/components/DataTable.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 
 /**
  * Reusable sortable data table.
@@ -7,11 +7,19 @@ import { useState, useMemo } from 'react';
  * @param {Array<Object>} props.data
  * @param {Function} props.onRowClick - Optional row click handler
  * @param {string} props.emptyMessage
+ * @param {number} [props.pageSize] - If set, paginate to this many rows per page.
+ * @param {boolean} [props.showFilter=true] - Show the built-in text filter input.
+ *
+ * `pageSize` and `showFilter` are additive/optional; callers that omit them get
+ * the original behavior (no pagination, filter shown). Sorting always applies to
+ * the full (filtered) set before pagination, so the default order and any
+ * header re-sort are correct across all pages, not just the visible one.
  */
-export default function DataTable({ columns, data, onRowClick, emptyMessage = 'No data' }) {
+export default function DataTable({ columns, data, onRowClick, emptyMessage = 'No data', pageSize, showFilter = true }) {
   const [sortKey, setSortKey] = useState(null);
   const [sortDir, setSortDir] = useState('asc');
   const [filter, setFilter] = useState('');
+  const [page, setPage] = useState(0);
 
   const filtered = useMemo(() => {
     if (!filter) return data;
@@ -34,6 +42,15 @@ export default function DataTable({ columns, data, onRowClick, emptyMessage = 'N
     });
   }, [filtered, sortKey, sortDir]);
 
+  // Pagination (opt-in via pageSize). Reset to the first page whenever the
+  // underlying set changes so we never strand the user on a now-empty page.
+  const pageCount = pageSize ? Math.max(1, Math.ceil(sorted.length / pageSize)) : 1;
+  useEffect(() => { setPage(0); }, [filter, sortKey, sortDir, data, pageSize]);
+  const safePage = Math.min(page, pageCount - 1);
+  const visibleRows = pageSize
+    ? sorted.slice(safePage * pageSize, safePage * pageSize + pageSize)
+    : sorted;
+
   function handleSort(key) {
     if (sortKey === key) {
       setSortDir(d => d === 'asc' ? 'desc' : 'asc');
@@ -46,13 +63,15 @@ export default function DataTable({ columns, data, onRowClick, emptyMessage = 'N
   return (
     <div className="data-table-wrapper">
       <div className="table-controls">
-        <input
-          type="text"
-          placeholder="Filter..."
-          value={filter}
-          onChange={e => setFilter(e.target.value)}
-          className="table-filter"
-        />
+        {showFilter && (
+          <input
+            type="text"
+            placeholder="Filter..."
+            value={filter}
+            onChange={e => setFilter(e.target.value)}
+            className="table-filter"
+          />
+        )}
         <span className="table-count">{sorted.length} items</span>
       </div>
       <table className="data-table">
@@ -67,12 +86,12 @@ export default function DataTable({ columns, data, onRowClick, emptyMessage = 'N
           </tr>
         </thead>
         <tbody>
-          {sorted.length === 0 ? (
+          {visibleRows.length === 0 ? (
             <tr><td colSpan={columns.length} className="empty-row">{emptyMessage}</td></tr>
           ) : (
-            sorted.map((row, i) => (
+            visibleRows.map((row, i) => (
               <tr
-                key={row.uuid || row.id || i}
+                key={row.uuid || row.id || row.pubkey || i}
                 onClick={() => onRowClick?.(row)}
                 className={onRowClick ? 'clickable' : ''}
               >
@@ -86,6 +105,21 @@ export default function DataTable({ columns, data, onRowClick, emptyMessage = 'N
           )}
         </tbody>
       </table>
+      {pageSize && pageCount > 1 && (
+        <div className="table-pagination">
+          <button
+            className="table-page-btn"
+            onClick={() => setPage(p => Math.max(0, p - 1))}
+            disabled={safePage === 0}
+          >‹ Prev</button>
+          <span className="table-page-info">Page {safePage + 1} of {pageCount}</span>
+          <button
+            className="table-page-btn"
+            onClick={() => setPage(p => Math.min(pageCount - 1, p + 1))}
+            disabled={safePage >= pageCount - 1}
+          >Next ›</button>
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/hooks/useGrapevineFollows.js
+++ b/ui/src/hooks/useGrapevineFollows.js
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook: fetch the accounts <observee> follows, with owner-POV GrapeRank metrics,
+ * from `/api/get-grapevine-follows`. Returns { data, loading, error }.
+ *
+ * v1 is owner POV only (ADR 0026), so `observer` is not sent — the endpoint
+ * defaults to the instance owner. Mirrors the useUserCounts.js fetch convention.
+ */
+export default function useGrapevineFollows(observee) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!observee) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    fetch(`/api/get-grapevine-follows?observee=${observee}`, { signal: controller.signal })
+      .then(r => r.json())
+      .then(json => {
+        if (json?.success && Array.isArray(json.data)) {
+          setData(json.data);
+        } else {
+          setData(null);
+          setError(json?.message || json?.error || 'No data');
+        }
+      })
+      .catch(err => {
+        if (err.name === 'AbortError') return;
+        setError(err.message || 'Fetch failed');
+        setData(null);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [observee]);
+
+  return { data, loading, error };
+}

--- a/ui/src/pages/BrainstormFollows.jsx
+++ b/ui/src/pages/BrainstormFollows.jsx
@@ -1,0 +1,232 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { nip19 } from 'nostr-tools';
+import { useAuth } from '../context/AuthContext';
+import BrainstormUserMenu from '../components/BrainstormUserMenu';
+import DataTable from '../components/DataTable';
+import useGrapevineFollows from '../hooks/useGrapevineFollows';
+
+/* ── Helpers ──────────────────────────────────────────── */
+
+function safeNpub(pubkey) {
+  try { return nip19.npubEncode(pubkey); } catch { return pubkey; }
+}
+function shortNpub(npub) {
+  if (!npub) return '—';
+  return npub.length > 20 ? `${npub.slice(0, 12)}…${npub.slice(-6)}` : npub;
+}
+
+const PAGE_SIZE = 50;
+const STORAGE_KEY = 'bsp-follows-columns';
+
+// Column definitions + default visibility (pic/name/rank shown; the rest hidden).
+const ALL_COLUMNS = [
+  { key: 'picture', label: '', sortable: false, render: (_v, row) => (
+    row.picture
+      ? <img src={row.picture} alt="" className="bsp-follows-avatar" onError={e => { e.target.style.display = 'none'; }} />
+      : <div className="bsp-follows-avatar bsp-follows-avatar-ph">{(row.name || '?')[0].toUpperCase()}</div>
+  ) },
+  { key: 'name', label: 'Name', render: v => v || '—' },
+  { key: 'rank', label: 'Rank', render: v => (v == null ? '—' : v) },
+  { key: 'npub', label: 'npub', render: v => <code className="bsp-follows-npub">{shortNpub(v)}</code> },
+  { key: 'hops', label: 'Hops', render: v => (v == null ? '—' : v) },
+  { key: 'verifiedFollowerCount', label: 'Verified Followers', render: v => (v == null ? '—' : v) },
+  { key: 'verifiedMuterCount', label: 'Verified Muters', render: v => (v == null ? '—' : v) },
+  { key: 'verifiedReporterCount', label: 'Verified Reporters', render: v => (v == null ? '—' : v) },
+];
+const DEFAULT_VISIBLE = {
+  picture: true, name: true, rank: true,
+  npub: false, hops: false,
+  verifiedFollowerCount: false, verifiedMuterCount: false, verifiedReporterCount: false,
+};
+
+function loadVisible() {
+  try {
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    if (saved && typeof saved === 'object') return { ...DEFAULT_VISIBLE, ...saved };
+  } catch { /* ignore */ }
+  return { ...DEFAULT_VISIBLE };
+}
+
+// Batch-fetch kind-0 profiles (names + pictures), chunked for large follow sets.
+async function fetchProfiles(pubkeys) {
+  const out = {};
+  const CHUNK = 100;
+  for (let i = 0; i < pubkeys.length; i += CHUNK) {
+    const batch = pubkeys.slice(i, i + CHUNK);
+    try {
+      const r = await fetch(`/api/profiles?pubkeys=${batch.join(',')}`);
+      const j = await r.json();
+      if (j?.profiles) Object.assign(out, j.profiles);
+    } catch { /* tolerate partial profile failures */ }
+  }
+  return out;
+}
+
+/* ── Local-data disclosure popover (tap to open; mobile-friendly) ── */
+
+function InfoPopover({ open, onClose }) {
+  if (!open) return null;
+  return (
+    <div className="bsp-confirm-overlay" onClick={onClose}>
+      <div className="bsp-confirm-box bsp-follows-info" onClick={e => e.stopPropagation()}>
+        <h3 className="bsp-confirm-title">About this data</h3>
+        <p className="bsp-confirm-message">
+          All data on this page is computed locally by this Tapestry instance and is not imported via NIP-85.
+        </p>
+        <div className="bsp-confirm-buttons">
+          <button className="bsp-confirm-ok" onClick={onClose}>Got it</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Main component ──────────────────────────────────── */
+
+export default function BrainstormFollows() {
+  const { pubkey } = useParams();
+  const navigate = useNavigate();
+  const { user, login, logout } = useAuth();
+
+  const { data: follows, loading, error } = useGrapevineFollows(pubkey);
+
+  const [profiles, setProfiles] = useState({});
+  const [search, setSearch] = useState('');
+  const [visible, setVisible] = useState(loadVisible);
+  const [showCols, setShowCols] = useState(false);
+  const [showInfo, setShowInfo] = useState(false);
+
+  // Persist column show/hide choices across reloads/sessions.
+  useEffect(() => {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(visible)); } catch { /* ignore */ }
+  }, [visible]);
+
+  // Batch-load names/pics for the followed pubkeys.
+  useEffect(() => {
+    if (!follows || follows.length === 0) { setProfiles({}); return; }
+    let cancelled = false;
+    fetchProfiles(follows.map(f => f.pubkey)).then(p => { if (!cancelled) setProfiles(p); });
+    return () => { cancelled = true; };
+  }, [follows]);
+
+  // Build rows: merge metrics + profile, derive rank/name/npub.
+  const rows = useMemo(() => {
+    const list = (follows || []).map(f => {
+      const p = profiles[f.pubkey] || {};
+      const npub = safeNpub(f.pubkey);
+      return {
+        pubkey: f.pubkey,
+        picture: p.picture || null,
+        name: p.display_name || p.name || shortNpub(npub),
+        npub,
+        rank: f.influence == null ? null : Math.round(f.influence * 100),
+        hops: f.hops,
+        verifiedFollowerCount: f.verifiedFollowerCount,
+        verifiedMuterCount: f.verifiedMuterCount,
+        verifiedReporterCount: f.verifiedReporterCount,
+      };
+    });
+    // Default sort: verified followers, descending, across the whole set.
+    list.sort((a, b) => (b.verifiedFollowerCount ?? -1) - (a.verifiedFollowerCount ?? -1));
+    return list;
+  }, [follows, profiles]);
+
+  // Page-level search — matches name / npub / pubkey even when those columns are hidden.
+  const searched = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter(r =>
+      (r.name && r.name.toLowerCase().includes(q)) ||
+      (r.npub && r.npub.toLowerCase().includes(q)) ||
+      r.pubkey.toLowerCase().includes(q)
+    );
+  }, [rows, search]);
+
+  const columns = useMemo(() => ALL_COLUMNS.filter(c => visible[c.key]), [visible]);
+
+  return (
+    <div className="bsp-page">
+      {/* Top bar */}
+      <div className="bsp-top-bar">
+        <a href="/" className="bsp-logo">
+          <img src="/brainstorm.svg" alt="" className="bsp-logo-img" />
+        </a>
+        <div className="bsp-auth">
+          <BrainstormUserMenu user={user} login={login} logout={logout} />
+        </div>
+      </div>
+
+      <div className="bsp-content">
+        {/* Header + back link */}
+        <div className="bsp-follows-header">
+          <Link to={`/user/${pubkey}`} className="bsp-back-link">← Back to profile</Link>
+          <h1 className="bsp-follows-title">Following</h1>
+          <button
+            type="button"
+            className="bsp-info-btn"
+            aria-label="About this data"
+            title="About this data"
+            onClick={() => setShowInfo(true)}
+          >ⓘ</button>
+        </div>
+
+        {/* Controls: search + columns toggle */}
+        <div className="bsp-follows-controls">
+          <input
+            type="search"
+            className="bsp-follows-search"
+            placeholder="Search by name or npub…"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+          <div className="bsp-follows-colmenu">
+            <button type="button" className="bsp-follows-colbtn" onClick={() => setShowCols(s => !s)}>
+              Columns ▾
+            </button>
+            {showCols && (
+              <div className="bsp-follows-colpanel" onMouseLeave={() => setShowCols(false)}>
+                {ALL_COLUMNS.map(c => (
+                  <label key={c.key} className="bsp-follows-colopt">
+                    <input
+                      type="checkbox"
+                      checked={!!visible[c.key]}
+                      onChange={() => setVisible(v => ({ ...v, [c.key]: !v[c.key] }))}
+                    />
+                    {c.label || 'Picture'}
+                  </label>
+                ))}
+                <button
+                  type="button"
+                  className="bsp-follows-colreset"
+                  onClick={() => setVisible({ ...DEFAULT_VISIBLE })}
+                >Reset to defaults</button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Body */}
+        {loading && <div className="bsp-loading">Loading follows…</div>}
+        {error && !loading && (
+          <div className="bsp-trust-unavailable"><span className="bsp-trust-icon">🔒</span><span>{error}</span></div>
+        )}
+        {!loading && !error && rows.length === 0 && (
+          <div className="bsp-empty">No follows found for this account.</div>
+        )}
+        {!loading && !error && rows.length > 0 && (
+          <DataTable
+            columns={columns}
+            data={searched}
+            pageSize={PAGE_SIZE}
+            showFilter={false}
+            onRowClick={row => navigate(`/user/${row.pubkey}`)}
+            emptyMessage="No matching accounts."
+          />
+        )}
+      </div>
+
+      <InfoPopover open={showInfo} onClose={() => setShowInfo(false)} />
+    </div>
+  );
+}

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams, Link } from 'react-router-dom';
 import { nip19 } from 'nostr-tools';
 import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu from '../components/BrainstormUserMenu';
@@ -234,10 +234,10 @@ export default function BrainstormProfile() {
 
             {/* Following count */}
             <div className={`bsp-counts ${userCountsLoading ? 'bsp-counts-loading' : ''}`}>
-              <span className="bsp-count">
+              <Link to={`/user/${pubkey}/follows`} className="bsp-count bsp-count-link">
                 <span className="bsp-count-value">{fmtCount(followingCount)}</span>
                 <span className="bsp-count-label">Following</span>
-              </span>
+              </Link>
             </div>
 
             {/* Action buttons */}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -4146,3 +4146,115 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   .bss-top-bar { padding: 0.5rem 1rem; flex-wrap: wrap; }
 }
 
+/* ── Follows list page (story #29 / ADR 0026) ──────────── */
+.bsp-count-link { cursor: pointer; text-decoration: none; color: inherit; }
+.bsp-count-link:hover .bsp-count-value { text-decoration: underline; }
+
+.bsp-follows-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+.bsp-back-link { font-size: 0.85rem; opacity: 0.75; text-decoration: none; }
+.bsp-back-link:hover { opacity: 1; text-decoration: underline; }
+.bsp-follows-title { margin: 0; font-size: 1.4rem; }
+.bsp-info-btn {
+  margin-left: auto;
+  border: 1px solid rgba(127, 127, 127, 0.4);
+  background: transparent;
+  color: inherit;
+  border-radius: 999px;
+  width: 1.75rem;
+  height: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  font-size: 1rem;
+}
+.bsp-info-btn:hover { background: rgba(127, 127, 127, 0.15); }
+
+.bsp-follows-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+.bsp-follows-search {
+  flex: 1 1 16rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(127, 127, 127, 0.35);
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+}
+.bsp-follows-colmenu { position: relative; }
+.bsp-follows-colbtn,
+.bsp-follows-colreset {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(127, 127, 127, 0.35);
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+.bsp-follows-colpanel {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.25rem);
+  z-index: 20;
+  min-width: 12rem;
+  padding: 0.5rem;
+  border: 1px solid rgba(127, 127, 127, 0.35);
+  border-radius: 8px;
+  background: var(--bsp-bg, #1b1b1f);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.bsp-follows-colopt { display: flex; align-items: center; gap: 0.5rem; font-size: 0.9rem; cursor: pointer; }
+.bsp-follows-colreset { margin-top: 0.35rem; }
+
+.bsp-follows-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  display: inline-block;
+  vertical-align: middle;
+}
+.bsp-follows-avatar-ph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(127, 127, 127, 0.25);
+  font-weight: 600;
+}
+.bsp-follows-npub { font-size: 0.8rem; opacity: 0.85; }
+.bsp-empty { padding: 2rem; text-align: center; opacity: 0.7; }
+
+.table-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 0.75rem;
+}
+.table-page-btn {
+  padding: 0.35rem 0.75rem;
+  border: 1px solid rgba(127, 127, 127, 0.35);
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+.table-page-btn:disabled { opacity: 0.4; cursor: default; }
+.table-page-info { font-size: 0.85rem; opacity: 0.75; }
+
+@media (max-width: 600px) {
+  .bsp-follows-controls { flex-direction: column; align-items: stretch; }
+  .bsp-follows-colpanel { right: auto; left: 0; }
+}
+


### PR DESCRIPTION
## Summary

Adds a standalone follows-list page to the primary profile (`/user/:pubkey/follows`), reachable by clicking the profile's "Following" count. v1 is **owner point-of-view only** — metrics come straight from each followee's `NostrUser` node. Customer observers (POV selector, `NostrUserWotMetricsCard` branch) are deferred to a follow-up. Story #29 / ADR 0026; full process trail in `engineering-team/`.

## Changes

- **NEW** `src/api/grapevineInteractions/queries/followsWithMetrics.js` — `GET /api/get-grapevine-follows?observee=<pk>` (owner POV): returns `{success, observer:'owner', observee, count, data:[{pubkey, influence, hops, verifiedFollowerCount, verifiedMuterCount, verifiedReporterCount}]}`. 64-hex `observee` validation → 400; non-owner `observer` → 400; `NEO4J_QUERY_TIMEOUT_MS` deadline → 504. Registered in `src/api/index.js`. The shared `get-grapevine-interaction` follows query is **untouched** (ADR Option A).
- **NEW** `ui/src/pages/BrainstormFollows.jsx` + `ui/src/hooks/useGrapevineFollows.js`; route in `ui/src/App.jsx`. Reuses `DataTable` (extended with optional, backward-compatible `pageSize` + `showFilter`). Columns w/ localStorage-persisted visibility + reset, default sort verified-followers desc, page-level search (name/npub even when hidden), `rank=round(influence*100)`, npub via nip19, row→profile nav, tappable NIP-85 disclosure popover, empty state.
- `ui/src/pages/BrainstormProfile.jsx` — "Following" count wrapped in a `<Link>` to the follows page.
- Story/ADR/test-plan/review under `engineering-team/`; failing→passing tests in `test/profile-follows-list.test.js` (+ wired into `test/test.js`) and `tests/brainstorm/profile-follows-list.spec.js`.

## Test plan

- [x] `npm test` green locally (all suites + `profile-follows-list` 25/25); `ui` Vite build clean.
- [x] Endpoint live-verified locally (shape + missing-observee 400 + non-owner-observer 400). Page mounts clean (empty-state) — local dev graph has no follow edges.
- [ ] After merge: `deploy-staging.yml` runs.
- [ ] **Populated-UI smoke on staging.brainstorm.world** (the local verification gap): open a profile with real follows → click "Following" → `/user/<pk>/follows` renders rows (pic/name/rank default; npub/hops/verified* hidden), rank is 0–100, default sort verified-followers desc, column toggle + reset persist across reload, search filters by name/npub, row click → that profile, ⓘ popover shows the "computed locally … not via NIP-85" note, "← Back to profile" returns.
- [ ] Regression sweep (Tier 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)