### PR TITLE
Fix follows Name column: respect /api/profiles 50-pubkey cap (#29)

### DIFF
--- a/engineering-team/reviews/29-profile-follows-list-fix.md
+++ b/engineering-team/reviews/29-profile-follows-list-fix.md
@@ -1,0 +1,39 @@
+# Review: Story 29 — follows-list fix (Name-column / `/api/profiles` 50-cap)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-29
+**Diff:** `git show fefd39d0` (branch `fix/follows-profiles-chunk-cap`)
+**Scope:** Follow-up to `engineering-team/reviews/29-profile-follows-list.md` (PASS). Covers **only** the staging-smoke-caught bug fix, not the whole feature.
+
+## Defect (caught by cycle-staging smoke, not local)
+On `staging.brainstorm.world` the follows page's **Name column never resolved** — every row showed the npub fallback + "N" placeholder. Root cause: `/api/profiles` returns **400 for >50 pubkeys** (`src/api/profiles/fetchProfiles.js:148-149`), but `BrainstormFollows.jsx` batched at `CHUNK = 100`, so every profile request 400'd, the `catch` swallowed it, and names/pictures never merged. Verified live: 100→400, 50→200, 10→200. Local missed it because the dev graph has no follow edges (the profile-fetch path never ran).
+
+## Quality gates (run by reviewer)
+- [x] **node suite — 26/26.** T23 (new guard) passes; the prior 22 + 3 sentinels still green (incl. R1 — shared `get-grapevine-interaction` query untouched).
+- [x] **`npm --prefix ui run build` — clean** (~37s, only the pre-existing chunk-size warning).
+- [n/a] lint/typecheck/server-build — not configured.
+
+## Audit of the fix (`fefd39d0`, 2 files)
+
+`ui/src/pages/BrainstormFollows.jsx`:
+- [x] **Root cause addressed:** `PROFILE_CHUNK = 50` (≤ the server cap). The old `CHUNK = 100` helper is removed (no dead code left).
+- [x] **Incremental merge is correct:** the effect resets `setProfiles({})` on observee change, then an async loop fetches each ≤50 batch and merges via a **functional** update `setProfiles(prev => ({ ...prev, ...j.profiles }))` — no stale-closure. The `!cancelled` guard is checked both in the loop condition and before each `setProfiles`, and the cleanup sets `cancelled = true`, so a unmount/observee-change aborts cleanly. Deps `[follows]` (stable hook state) → runs once; no infinite loop (it never sets `follows`).
+- [x] Names now fill in **progressively** per chunk rather than all-at-once at the end, and a *failed* chunk no longer aborts the rest (each chunk independent + `catch`).
+
+`test/profile-follows-list.test.js`:
+- [x] **Guard test T23** extracts `PROFILE_CHUNK = <n>` and asserts `1 ≤ n ≤ 50`, cross-referencing `fetchProfiles.js:148`. Confirmed red→green across the fix (failed at 100, passes at 50). Meaningful regression guard.
+
+## Spec / ADR / scope
+- [x] No ADR change — same design (owner-POV, new endpoint). Shared `follows` Cypher untouched (R1 green).
+- [x] No scope creep — exactly the 2 files; the other story-29 ACs are undisturbed (suite green).
+- [x] No secrets / debug logging / commented-out code introduced.
+
+## Findings
+### Blocking
+_None._
+
+### Non-blocking
+1. **Sequential chunking at scale:** with `PROFILE_CHUNK = 50`, jack's 1,659 follows still fetch in ~34 sequential requests. The incremental merge means earlier names appear quickly, but a *slow* (not failed) chunk still delays later ones. Acceptable for v1; a future enhancement could fetch only the visible page's profiles, or parallelize bounded batches. (Commit message's "one slow chunk no longer blocks the whole list" is slightly generous — a *failed* chunk doesn't block; a *slow* one still serializes — but earlier results already render.)
+
+## Verdict
+**PASS** — the fix targets the confirmed root cause, the incremental-merge effect is correct and cancel-safe, the guard test prevents regression, gates are green, and scope is minimal. Re-run `cycle-staging` to re-smoke the populated Name column on staging before any prod promotion.

--- a/engineering-team/stories/29-profile-follows-list.md
+++ b/engineering-team/stories/29-profile-follows-list.md
@@ -81,4 +81,4 @@ None open.
 ## Linked artifacts
 - ADR: `engineering-team/decisions/0026-profile-follows-list.md`
 - Test plan: `engineering-team/stories/29-profile-follows-list.test-plan.md`
-- Review: `engineering-team/reviews/29-profile-follows-list.md` — **PASS** (2026-05-28)
+- Review: `engineering-team/reviews/29-profile-follows-list.md` — **PASS** (2026-05-28); staging-fix follow-up `engineering-team/reviews/29-profile-follows-list-fix.md` — **PASS** (2026-05-29)

--- a/test/profile-follows-list.test.js
+++ b/test/profile-follows-list.test.js
@@ -255,6 +255,19 @@ test('T22: the local-data ⓘ disclosure states data is computed locally and NOT
     'the ⓘ affordance must open on tap/click (mobile-friendly), not hover-only — expect an onClick handler.');
 });
 
+test('T23: the /api/profiles batch size respects the server cap (PROFILE_CHUNK ≤ 50) — regression guard for the staging Name-column bug', () => {
+  const src = safeRead(FOLLOWS_PAGE);
+  assert(src.length > 0, 'BrainstormFollows.jsx does not exist yet.');
+  // /api/profiles returns 400 for >50 pubkeys (src/api/profiles/fetchProfiles.js:148). The page must
+  // batch profile lookups at <= 50, or the Name column silently falls back to npub for every row
+  // (caught on staging: PROFILE_CHUNK was 100, every /api/profiles chunk 400'd, names never resolved).
+  const m = src.match(/PROFILE_CHUNK\s*=\s*(\d+)/);
+  assert(m, 'BrainstormFollows.jsx must define `PROFILE_CHUNK` (the /api/profiles batch size) so this invariant is guarded.');
+  const chunk = parseInt(m[1], 10);
+  assert(chunk >= 1 && chunk <= 50,
+    `the /api/profiles batch size (PROFILE_CHUNK=${chunk}) must be 1..50 — /api/profiles 400s for >50 pubkeys (fetchProfiles.js:148).`);
+});
+
 // ===========================================================================
 // REGRESSION SENTINELS (must PASS before AND after implementation)
 // ===========================================================================

--- a/ui/src/pages/BrainstormFollows.jsx
+++ b/ui/src/pages/BrainstormFollows.jsx
@@ -48,20 +48,9 @@ function loadVisible() {
   return { ...DEFAULT_VISIBLE };
 }
 
-// Batch-fetch kind-0 profiles (names + pictures), chunked for large follow sets.
-async function fetchProfiles(pubkeys) {
-  const out = {};
-  const CHUNK = 100;
-  for (let i = 0; i < pubkeys.length; i += CHUNK) {
-    const batch = pubkeys.slice(i, i + CHUNK);
-    try {
-      const r = await fetch(`/api/profiles?pubkeys=${batch.join(',')}`);
-      const j = await r.json();
-      if (j?.profiles) Object.assign(out, j.profiles);
-    } catch { /* tolerate partial profile failures */ }
-  }
-  return out;
-}
+// /api/profiles caps at 50 pubkeys per request (src/api/profiles/fetchProfiles.js:148),
+// so profile lookups are batched at PROFILE_CHUNK and merged chunk-by-chunk as they arrive.
+const PROFILE_CHUNK = 50;
 
 /* ── Local-data disclosure popover (tap to open; mobile-friendly) ── */
 
@@ -102,11 +91,24 @@ export default function BrainstormFollows() {
     try { localStorage.setItem(STORAGE_KEY, JSON.stringify(visible)); } catch { /* ignore */ }
   }, [visible]);
 
-  // Batch-load names/pics for the followed pubkeys.
+  // Batch-load names/pics for the followed pubkeys. /api/profiles caps at 50 pubkeys/request,
+  // so chunk at PROFILE_CHUNK and merge each chunk as it returns (names fill in progressively;
+  // one slow/failed chunk no longer blocks the whole list).
   useEffect(() => {
     if (!follows || follows.length === 0) { setProfiles({}); return; }
     let cancelled = false;
-    fetchProfiles(follows.map(f => f.pubkey)).then(p => { if (!cancelled) setProfiles(p); });
+    setProfiles({});
+    const pubkeys = follows.map(f => f.pubkey);
+    (async () => {
+      for (let i = 0; i < pubkeys.length && !cancelled; i += PROFILE_CHUNK) {
+        const batch = pubkeys.slice(i, i + PROFILE_CHUNK);
+        try {
+          const r = await fetch(`/api/profiles?pubkeys=${batch.join(',')}`);
+          const j = await r.json();
+          if (!cancelled && j?.profiles) setProfiles(prev => ({ ...prev, ...j.profiles }));
+        } catch { /* tolerate partial profile failures */ }
+      }
+    })();
     return () => { cancelled = true; };
   }, [follows]);
 


### PR DESCRIPTION
## Summary

Fixes the story #29 follows page defect caught by the previous staging smoke: the **Name column showed the npub fallback for every row**. Root cause — the page batched `/api/profiles` at 100 pubkeys, but that endpoint returns **400 for >50 pubkeys** (`src/api/profiles/fetchProfiles.js:148`), so every profile request failed (swallowed by `catch`) and names/pictures never merged. Local missed it (dev graph has no follow edges).

## Changes

- `ui/src/pages/BrainstormFollows.jsx` — `PROFILE_CHUNK` 100 → **50** (≤ the server cap); profiles now merged **incrementally per chunk** (`setProfiles(prev => ({...prev, ...chunk}))`) instead of once at the end, so names fill in progressively and a failed chunk no longer blocks the rest.
- `test/profile-follows-list.test.js` — guard test **T23** asserts `PROFILE_CHUNK ≤ 50` (cross-refs fetchProfiles.js:148) so this can't regress.
- Review: `engineering-team/reviews/29-profile-follows-list-fix.md` (PASS); story link updated.

Diff vs staging = just these two commits (the feature itself is already merged via #226).

## Test plan

- [x] node suite 26/26 (incl. new T23); `ui` Vite build clean.
- [ ] After merge: deploy-staging.yml runs.
- [ ] **Re-smoke the Name column** on staging: `/user/04c915da…ecc9/follows` rows now show real display names (e.g. pubkey `6b4ec98f…272e` → "Dr. Fernando Morales", not `npub1…`); console clean.
- [ ] `GET /api/profiles?pubkeys=<50 pubkeys>` → 200 (the >50 case was the 400).
- [ ] Regression: endpoint still `count:1659` with correct ranks; pagination/columns/popover intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)