### PR TITLE
Fix follows search input height on mobile portrait (story #29)

### DIFF
--- a/engineering-team/reviews/29-profile-follows-list-mobile-fix.md
+++ b/engineering-team/reviews/29-profile-follows-list-mobile-fix.md
@@ -1,0 +1,38 @@
+# Review: Story 29 — follows search input mobile-height fix
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-29
+**Diff:** `git show 1a5b6779` (branch `fix/follows-search-mobile-height`, 1 commit over `origin/staging` `101ff518`)
+**Scope:** Follow-up to `29-profile-follows-list.md` (PASS) and `29-profile-follows-list-fix.md` (PASS). Covers **only** this responsive-CSS fix.
+
+## Defect (caught on staging, smartphone portrait)
+The follows page "Search by name or npub…" input rendered ~10× too tall in portrait; fine on desktop/landscape. Root cause: `.bsp-follows-search` used a fixed-length flex-basis (`flex: 1 1 16rem`); the `@media (max-width:600px)` rule flips `.bsp-follows-controls` to `flex-direction: column`, where flex-basis governs the **main axis (height)** → 16rem became the input height. Landscape width >600px drops the media query → row layout → basis is width again (why rotating "fixed" it).
+
+## Quality gates (run by reviewer)
+- [x] **node suite — 27/27** (new T24 green; the prior 23 T-tests + 3 sentinels still green, incl. R1).
+- [x] **`npm --prefix ui run build` — clean** (~18s).
+- [n/a] lint/typecheck/server build — not configured.
+
+## Audit (`1a5b6779`, 2 files)
+
+`ui/src/styles.css` — `.bsp-follows-search`:
+- [x] **Root cause addressed:** `flex: 1 1 16rem` → `flex: 1 1 auto` + `min-width: 12rem`. With basis `auto`, the mobile column layout no longer derives a height from the basis (height is content-based); `min-width` carries the row-layout "don't get too narrow" intent on the cross axis without affecting height.
+- [x] **No row-layout regression:** `flex-grow: 1` + `auto` basis still fills the row; `min-width: 12rem` (192px) floors it. On phones (≥320px) the 12rem min-width can't cause horizontal overflow in the column/stretch layout.
+- [x] Clear explanatory comment added; no other CSS rules touched.
+
+`test/profile-follows-list.test.js`:
+- [x] **Guard T24** matches the `.bsp-follows-search { … }` block and asserts its `flex` shorthand has no fixed-length basis (`flex: <n> <n> <n>(rem|px|em|vh|vw)`). Verified red→green across the fix. **No false-positive risk:** `min-width: 12rem` is a separate declaration, not part of the `flex:` value, and the regex is anchored to `flex\s*:`; the explanatory comment contains no `flex: n n n<unit>` pattern. Added a `STYLES` path const.
+
+## Spec / ADR / scope
+- [x] No ADR change (responsive styling only). Shared `follows` Cypher untouched (R1 green). Only the 2 files changed; other story-29 ACs undisturbed (suite green).
+- [x] No secrets / debug / dead code.
+
+## Findings
+### Blocking
+_None._
+
+### Non-blocking
+1. The T24 source guard prevents *this specific* regression (fixed-length flex-basis) but can't prove the rendered height is correct — appropriate, since pixel-accurate responsive assertions are brittle. Real proof is the **visual mobile re-verify** at the re-cycle-staging smoke (Chrome at phone-portrait width). Recorded as the verification step, not a gap in the code.
+
+## Verdict
+**PASS** — minimal, correct fix of the confirmed root cause; row-layout behavior preserved; meaningful non-brittle regression guard; gates green; no scope creep. Re-deploy to staging and **visually re-verify the search input at a phone-portrait width** before prod.

--- a/engineering-team/stories/29-profile-follows-list.md
+++ b/engineering-team/stories/29-profile-follows-list.md
@@ -81,4 +81,4 @@ None open.
 ## Linked artifacts
 - ADR: `engineering-team/decisions/0026-profile-follows-list.md`
 - Test plan: `engineering-team/stories/29-profile-follows-list.test-plan.md`
-- Review: `engineering-team/reviews/29-profile-follows-list.md` — **PASS** (2026-05-28); staging-fix follow-up `engineering-team/reviews/29-profile-follows-list-fix.md` — **PASS** (2026-05-29)
+- Review: `engineering-team/reviews/29-profile-follows-list.md` — **PASS** (2026-05-28); staging-fix follow-up `engineering-team/reviews/29-profile-follows-list-fix.md` — **PASS** (2026-05-29); mobile-fix follow-up `engineering-team/reviews/29-profile-follows-list-mobile-fix.md` — **PASS** (2026-05-29)

--- a/test/profile-follows-list.test.js
+++ b/test/profile-follows-list.test.js
@@ -30,6 +30,7 @@ const APP_JSX         = path.resolve(__dirname, '../ui/src/App.jsx');
 const FOLLOWS_PAGE    = path.resolve(__dirname, '../ui/src/pages/BrainstormFollows.jsx');
 const FOLLOWS_HOOK    = path.resolve(__dirname, '../ui/src/hooks/useGrapevineFollows.js');
 const PROFILE_PAGE    = path.resolve(__dirname, '../ui/src/pages/BrainstormProfile.jsx');
+const STYLES          = path.resolve(__dirname, '../ui/src/styles.css');
 
 const tests = [];
 function test(name, fn) { tests.push({ name, fn }); }
@@ -266,6 +267,18 @@ test('T23: the /api/profiles batch size respects the server cap (PROFILE_CHUNK �
   const chunk = parseInt(m[1], 10);
   assert(chunk >= 1 && chunk <= 50,
     `the /api/profiles batch size (PROFILE_CHUNK=${chunk}) must be 1..50 — /api/profiles 400s for >50 pubkeys (fetchProfiles.js:148).`);
+});
+
+test('T24: the follows search input must not use a fixed-length flex-basis (mobile column layout turns it into a giant height) — regression guard', () => {
+  const css = safeRead(STYLES);
+  assert(css.length > 0, 'ui/src/styles.css missing — unexpected.');
+  const block = css.match(/\.bsp-follows-search\s*\{[^}]*\}/);
+  assert(block, 'styles.css must define a `.bsp-follows-search` rule.');
+  // The controls container becomes `flex-direction: column` under @media (max-width: 600px), so a
+  // fixed-length flex-basis on the search input governs its HEIGHT, not width (caught on smartphone
+  // portrait: input ~10x too tall; fine in landscape where the media query is off).
+  assert(!/flex\s*:\s*\d+(\.\d+)?\s+\d+(\.\d+)?\s+\d+(\.\d+)?\s*(rem|px|em|vh|vw)\b/.test(block[0]),
+    'the .bsp-follows-search `flex` shorthand must not use a fixed-length flex-basis (e.g. `flex: 1 1 16rem`) — in the mobile column layout that becomes the input height. Use `flex: 1 1 auto` + `min-width`.');
 });
 
 // ===========================================================================

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -4182,7 +4182,11 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   margin-bottom: 1rem;
 }
 .bsp-follows-search {
-  flex: 1 1 16rem;
+  /* flex-basis stays `auto` (not a rem length) so the mobile column layout
+     can't turn the basis into a giant input height; min-width covers the
+     row-layout "don't get too narrow" intent. */
+  flex: 1 1 auto;
+  min-width: 12rem;
   padding: 0.5rem 0.75rem;
   border: 1px solid rgba(127, 127, 127, 0.35);
   border-radius: 6px;


### PR DESCRIPTION
## Summary

Fixes the story #29 follows page "Search by name or npub…" input rendering **~10× too tall on smartphone portrait** (correct on desktop and in landscape). Root cause: `.bsp-follows-search` used a fixed-length flex-basis (`flex: 1 1 16rem`); the `@media (max-width:600px)` rule flips `.bsp-follows-controls` to `flex-direction: column`, where flex-basis governs the **main axis (height)** — so `16rem` became the input's height. Landscape width >600px drops the media query → row layout → basis is width again (why rotating the phone "fixed" it).

## Changes

- `ui/src/styles.css` — `.bsp-follows-search`: `flex: 1 1 16rem` → `flex: 1 1 auto` + `min-width: 12rem` (basis no longer becomes a height in the column layout; min-width keeps the row-layout intent).
- `test/profile-follows-list.test.js` — guard test **T24** forbids a fixed-length flex-basis on the search input.
- Review: `engineering-team/reviews/29-profile-follows-list-mobile-fix.md` (PASS); story link updated.

Diff vs staging = just these two commits.

## Test plan

- [x] node suite 27/27 (incl. T24); `ui` Vite build clean.
- [ ] After merge: deploy-staging.yml runs.
- [ ] **Visual re-verify at phone-portrait width** (~390×844) on `/user/04c915da…ecc9/follows`: the search input renders at normal height (~40px), not ~250px. Crisp check: `document.querySelector('.bsp-follows-search').offsetHeight` ≈ 35–48px.
- [ ] Regression: Name column still resolves real names; endpoint still `count:1659`; console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)