### PR TITLE
fix: hide own bounties from eligibility

### DIFF
--- a/src/api/bounties.js
+++ b/src/api/bounties.js
@@ -66,6 +66,10 @@ function bountyForClient(bounty, paymentState, { now = Math.floor(Date.now() / 1
   };
 }
 
+function isOwnBounty(bounty, viewer) {
+  return bounty?.issuer_pubkey?.toLowerCase() === viewer;
+}
+
 async function paymentStateForBounty(bounty, options = {}) {
   const claims = await listClaimsFor(bounty, options);
   return {
@@ -139,6 +143,7 @@ async function handleEligibleBounties(req, res) {
   const open = listOpenBounties({ limit: 500 });
   const now = Math.floor(Date.now() / 1000);
   const checked = await Promise.all(open.map(async b => {
+    if (isOwnBounty(b, viewer)) return null;
     const issuerRank = await rank(b.issuer_pubkey, viewer);
     if (issuerRank < 2) return null;
     const { paymentState } = await paymentStateForBounty(b, { trustFilter: true });
@@ -294,4 +299,4 @@ function register(app) {
   app.get('/api/bounties/:id', handleGetBounty);
 }
 
-module.exports = { register };
+module.exports = { register, _private: { isOwnBounty } };

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,7 @@ const {
   calculateBountyPaymentState,
   canAcceptNewClaimFrom,
 } = require('../src/lib/bounty-policy');
+const { _private: bountyApi } = require('../src/api/bounties');
 
 // Mock environment variables for testing
 process.env.BRAINSTORM_RELAY_URL = 'wss://test-relay.com';
@@ -140,18 +141,34 @@ function testBountyPaymentPolicy() {
   }
 }
 
+function testEligibleBountyFiltering() {
+  try {
+    const viewer = 'a'.repeat(64);
+    assert.strictEqual(bountyApi.isOwnBounty({ issuer_pubkey: viewer }, viewer), true);
+    assert.strictEqual(bountyApi.isOwnBounty({ issuer_pubkey: viewer.toUpperCase() }, viewer), true);
+    assert.strictEqual(bountyApi.isOwnBounty({ issuer_pubkey: 'b'.repeat(64) }, viewer), false);
+    assert.strictEqual(bountyApi.isOwnBounty({}, viewer), false);
+    return true;
+  } catch (error) {
+    console.error('Eligible bounty filtering failed:', error.message);
+    return false;
+  }
+}
+
 // Run tests
 console.log('Running Brainstorm tests...');
 const configTest = testConfigLoading();
 const bountyFieldsTest = testBountyFieldValidation();
 const bountyPolicyTest = testBountyPaymentPolicy();
+const eligibleBountyFilteringTest = testEligibleBountyFiltering();
 
 console.log('\nTest Results:');
 console.log('-------------');
 console.log(`Configuration Loading: ${configTest ? 'PASS' : 'FAIL'}`);
 console.log(`Bounty Field Validation: ${bountyFieldsTest ? 'PASS' : 'FAIL'}`);
 console.log(`Bounty Payment Policy: ${bountyPolicyTest ? 'PASS' : 'FAIL'}`);
-console.log(`Overall: ${configTest && bountyFieldsTest && bountyPolicyTest ? 'PASS' : 'FAIL'}`);
+console.log(`Eligible Bounty Filtering: ${eligibleBountyFilteringTest ? 'PASS' : 'FAIL'}`);
+console.log(`Overall: ${configTest && bountyFieldsTest && bountyPolicyTest && eligibleBountyFilteringTest ? 'PASS' : 'FAIL'}`);
 
 // Exit with appropriate code
-process.exit(configTest && bountyFieldsTest && bountyPolicyTest ? 0 : 1);
+process.exit(configTest && bountyFieldsTest && bountyPolicyTest && eligibleBountyFilteringTest ? 0 : 1);


### PR DESCRIPTION
Summary

Skip bounties issued by the current viewer when building `/api/bounties/eligible` results.
Add a focused regression check for own-bounty filtering.

Validation

`npm test`
`node --check src/api/bounties.js && node --check test/test.js && git diff --check`

Fixes #42