### PR TITLE
Promote staging → main: website-link fix (#30) + story-29 Done

### DIFF
--- a/engineering-team/reviews/30-profile-website-link-scheme.md
+++ b/engineering-team/reviews/30-profile-website-link-scheme.md
@@ -1,0 +1,39 @@
+# Review: Story 30 — Profile "Website" link broken for scheme-less URLs
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-05-29
+**Diff:** `git diff origin/staging..HEAD` (impl commit `8ff9c14a`), branch `fix/profile-website-href`
+**ADR:** none (Architecture skipped — obvious bug)
+
+## Quality gates (run by reviewer)
+- [x] **`test/profile-website-link.test.js` — 5/5** (T1 unit + T2/T3 wiring + R1/R2 sentinels).
+- [x] **`test/profile-follows-list.test.js` — 27/27** (story-#29 suite; no regression from the `BrainstormProfile.jsx` edit).
+- [x] **`npm --prefix ui run build` — clean** (~18s).
+- [n/a] lint/typecheck/server build — not configured.
+
+## Spec adherence
+- [x] **Scheme-less → external.** `href={toExternalUrl(profile.website)}` in both clickable-link views; a bare `kate-cate.com` now yields `https://kate-cate.com` (absolute), not a relative `/user/...` path.
+- [x] **Already-absolute unchanged** (`/^https?:\/\//i` guard); **empty → '' → no link**; **www / path / query preserved**; **case-insensitive scheme**. All pinned by the T1 unit test.
+- [x] **New tab + safe rel** preserved on both links (R1). **Primary-profile display** still scheme-stripped (R2). Diff confirms the display/`target`/`rel` lines are untouched.
+- [x] No behavior added beyond the story.
+
+## Design / scope
+- [x] No ADR needed; the helper lives in `ui/src/utils/url.js`, matching the existing `ui/src/utils/*` convention (named export, like `dtag.js`/`nodeName.js`).
+- [x] **Pure helper** — no React/DOM imports, so it's genuinely unit-tested from node (the T1 dynamic `import()` works because `ui/` is `type: module`).
+- [x] **No scope creep:** only `url.js` + the two views (+ tests/story/plan). The non-clickable search-card spans (`BrainstormSearch.jsx`, `users/Search.jsx`) were correctly left alone. `UserDetail.jsx`'s raw display text was intentionally not touched (out of scope, noted in the story).
+
+## Things tests can't catch
+- [x] No secrets / debug / commented-out code. Helper is 3 lines, readable, well-documented.
+- [x] Security: `rel="noopener noreferrer"` retained on both `target="_blank"` links — no reverse-tabnabbing regression. The helper only prepends a scheme; it does not introduce `javascript:`/`data:` execution (those would already lack `http(s)://` and get `https://` prepended → inert).
+
+## Findings
+
+### Blocking
+_None._
+
+### Non-blocking (optional hardening, not gating — both out of the story's stated scope)
+1. **`ui/src/utils/url.js`** — a **protocol-relative** input (`//example.com`) becomes `https:////example.com` (extra slashes). Extremely rare in kind-0 `website` fields; the story scoped to http(s) values. Optional: also treat a leading `//` as already-absolute (`https:` + value).
+2. **`ui/src/utils/url.js`** — no whitespace trim; `' kate-cate.com '` would become `'https:// kate-cate.com '`. Sloppy-input edge; optional `.trim()` hardening. Neither is worth blocking the fix.
+
+## Verdict
+**PASS** — minimal, correct fix of the confirmed root cause across both affected views; pure, well-tested helper; safe-rel + display preserved; no scope creep or regression; gates green. The deterministic unit test covers the logic; the supplementary Playwright spec gives real-browser proof at the staging smoke (live-data dependent). Ship to staging, re-verify the kate-cate link, then promote.

--- a/engineering-team/stories/29-profile-follows-list.md
+++ b/engineering-team/stories/29-profile-follows-list.md
@@ -1,9 +1,10 @@
 # Story 29: Follows list on the primary profile page
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-05-28
 **Type:** Feature
 **Amended:** 2026-05-28 — customer-observer support deferred to a follow-up; **v1 is owner-POV only**. See "Deferred to a follow-up" below and ADR 0026.
+**Shipped:** 2026-05-29 — v1 live on brainstorm.world. Feature #226; staging-caught fixes #227 (Name-column /api/profiles 50-cap) + #228 (mobile search height); promotion #229.
 
 ## Background
 The primary user-facing profile (`/user/<pubkey>`) shows a bare **"Following"** count with no way to act on it. To actually *see and evaluate* who someone follows — ranked by local trust signals, from a chosen point of view — users today must leave for the legacy grapevine-analysis page, which is styled and structured for a different context. This story brings that capability into the primary profile experience as a native, standalone follows page, reusing the trust data this instance already computes locally.

--- a/engineering-team/stories/30-profile-website-link-scheme.md
+++ b/engineering-team/stories/30-profile-website-link-scheme.md
@@ -1,0 +1,47 @@
+# Story 30: Profile "Website" link broken for scheme-less URLs
+
+**Status:** Approved
+**Created:** 2026-05-29
+**Type:** Bug
+
+## Background
+A profile's "Website" link is built from the kind-0 `website` field. When that value has no URL scheme (e.g. `kate-cate.com`), the browser treats the link as **relative** and navigates inside the app (`/user/kate-cate.com`) instead of to the external site. Many nostr users enter a bare domain, so this hits a meaningful share of profiles, and it's live in production.
+
+Confirmed this session on `https://brainstorm.world/user/a366c6a73754786fcb8007a78388f3e62e7c58579a6282a74ebd7c0b2f041044` (website stored as `kate-cate.com` → link points at `/user/kate-cate.com`). The same clickable-link pattern exists in two React views; the search views render the website as plain (non-clickable) text and are unaffected.
+
+## User-facing description
+As someone viewing a profile, I want the "Website" link to take me to the person's actual external site — even when they entered the address without `https://` — so that I can actually visit it.
+
+## Acceptance criteria
+Apply to **every profile view that renders the website as a clickable link**: the primary profile (`/user/<pubkey>`) and the makeshift page (`/tapestry/users/<pubkey>`).
+
+- [ ] **Scheme-less → external.** Given a profile whose website is scheme-less (e.g. `kate-cate.com`), when I activate the Website link, then I'm taken to the **external** site (`https://kate-cate.com`) — not an in-app `/user/...` (or `/tapestry/...`) path.
+- [ ] **Already-absolute unchanged.** Given a website that already includes an `http(s)://` scheme (e.g. `https://example.com/foo`), when I activate the link, then I'm taken to that exact URL.
+- [ ] **New tab + safe rel.** The link opens in a new tab with `rel="noopener noreferrer"` (as today, both views).
+- [ ] **Primary-profile display unchanged.** On `/user/<pubkey>`, the visible link text still shows the website without the scheme / trailing slash (as today).
+- [ ] **No website → no link.** A profile without a website still shows no Website link (unchanged).
+
+## Concepts touched
+*(UI-only; no concept-graph definition changes, no firmware reinstall. Named in plain language.)*
+- **Profile** — the kind-0 `website` field, rendered as a clickable link.
+
+## Out of scope
+- **Search-result cards** (`BrainstormSearch.jsx`, `users/Search.jsx`) — they show the website as a non-clickable `<span>`, so there's no broken link to fix.
+- **Legacy `public/legacy/profile.html`** — no matching website-link pattern found; appears unaffected.
+- **Non-http(s) values** (e.g. `mailto:`, `ftp:`) — we only guarantee a correct **http(s)** absolute link; other schemes aren't special-cased.
+- Reconciling the makeshift page's display text (it currently shows the raw value rather than scheme-stripped) — cosmetic, not the reported bug; the link *target* is what this story fixes.
+
+## Open questions
+Resolved during planning:
+- **Which views?** → **Both clickable-link views** (`BrainstormProfile.jsx`, `users/UserDetail.jsx`). Search cards are display-only and excluded.
+
+None open.
+
+## Notes for the next phase
+- **Bug with an obvious cause → Architecture is skipped** (per CLAUDE.md). Next phase is Test Design.
+- Confirmed root cause for the Implementer: both `ui/src/pages/BrainstormProfile.jsx:305` and `ui/src/pages/users/UserDetail.jsx:160` set `href={profile.website}` from the raw value; a scheme-less value resolves relative to the current path. The fix normalizes the href to an absolute `http(s)://` URL (prepend `https://` when no scheme is present).
+
+## Linked artifacts
+- ADR: *(skipped — obvious bug, no design decision)*
+- Test plan: *(filled in after Test Design)*
+- Review: *(filled in after Review)*

--- a/engineering-team/stories/30-profile-website-link-scheme.md
+++ b/engineering-team/stories/30-profile-website-link-scheme.md
@@ -44,4 +44,4 @@ None open.
 ## Linked artifacts
 - ADR: *(skipped — obvious bug, no design decision)*
 - Test plan: `engineering-team/stories/30-profile-website-link-scheme.test-plan.md`
-- Review: *(filled in after Review)*
+- Review: `engineering-team/reviews/30-profile-website-link-scheme.md` — **PASS** (2026-05-29)

--- a/engineering-team/stories/30-profile-website-link-scheme.md
+++ b/engineering-team/stories/30-profile-website-link-scheme.md
@@ -43,5 +43,5 @@ None open.
 
 ## Linked artifacts
 - ADR: *(skipped — obvious bug, no design decision)*
-- Test plan: *(filled in after Test Design)*
+- Test plan: `engineering-team/stories/30-profile-website-link-scheme.test-plan.md`
 - Review: *(filled in after Review)*

--- a/engineering-team/stories/30-profile-website-link-scheme.test-plan.md
+++ b/engineering-team/stories/30-profile-website-link-scheme.test-plan.md
@@ -1,0 +1,70 @@
+# Test Plan: Story 30 — Profile "Website" link broken for scheme-less URLs
+
+**Story:** `engineering-team/stories/30-profile-website-link-scheme.md`
+**ADR:** none (Architecture skipped — obvious bug)
+**Date:** 2026-05-29
+
+## Fix contract (set here, since there's no ADR)
+The two clickable-link views need identical normalization, so the cleanly-testable form is a **pure helper**:
+
+- `ui/src/utils/url.js` (joining the existing `ui/src/utils/*` convention) exports **`toExternalUrl(value)`** that:
+  - prepends `https://` when `value` has no `http(s)://` scheme,
+  - leaves already-absolute `http(s)` URLs unchanged (scheme detection case-insensitive),
+  - returns a **falsy** value for empty input.
+- The module must stay **pure** (no React/DOM imports) so the node unit test can `import()` it (`ui/` is `type: module`).
+- `BrainstormProfile.jsx` and `users/UserDetail.jsx` build the website `href` via `toExternalUrl(profile.website)`; the displayed text is unchanged.
+
+If the Implementer prefers a different structure, kick back — but the unit test pins this contract.
+
+## Coverage map
+
+| Acceptance criterion | Test(s) | Level |
+|---|---|---|
+| Scheme-less website → absolute external URL (not a relative path) | `T1` (helper logic) + `T2`/`T3` (both views use it) + PW spec | unit + source + e2e |
+| Already-absolute website → unchanged | `T1` (https/http/cased cases) | unit |
+| New tab + `rel="noopener noreferrer"` (both views) | `R1` | source (sentinel) |
+| Primary-profile display still scheme-stripped | `R2` | source (sentinel) |
+| No website → no link | structurally preserved (the `{profile?.website && …}` guard is untouched by the fix); `T1` also pins empty→falsy | — |
+
+Node suite: `test/profile-website-link.test.js` (wired into `test/test.js`).
+Playwright: `tests/brainstorm/profile-website-link.spec.js` (supplementary, live-data dependent).
+
+## Edge cases (in `T1`)
+- [x] `www.`-prefixed bare host → `https://www.…`
+- [x] path + query preserved (`example.com/path?q=1` → `https://example.com/path?q=1`)
+- [x] `http://…` left unchanged (don't force https on an explicit scheme)
+- [x] case-insensitive scheme detection (`HTTPS://…` unchanged, not double-prefixed)
+- [x] empty string → falsy (no link)
+
+## Regression sentinels (must pass before AND after)
+- `R1` — both views keep `target="_blank"` + `rel="noopener noreferrer"` on the website link.
+- `R2` — `BrainstormProfile.jsx` keeps `profile.website.replace(/^https?:…/)` for the **display** text (the fix changes the href, not the display).
+
+## Test infrastructure
+- **Node runner:** `npm test` (entry `test/test.js`) now includes the `profile-website-link` suite. The unit test (`T1`) dynamic-`import()`s the ESM helper — works because `ui/package.json` is `type: module` and the helper is pure. Standalone:
+  ```
+  node -e "require('./test/profile-website-link.test.js').run().then(r=>{console.log(r);process.exit(0)})"
+  ```
+- **Playwright:** `tests/brainstorm/profile-website-link.spec.js` — navigates to a real profile with a scheme-less website (`/user/a366c6a7…041044`, website `kate-cate.com`) and asserts the link `href` is absolute. **Fragility:** depends on that account keeping a scheme-less website (live data); it's supplementary to the deterministic unit test. Exercised at the staging smoke (`baseURL` defaults to `:7778`; override with `BRAINSTORM_BASE_URL`).
+- No Concept Graph dependency (UI-only; no concept/firmware change).
+
+## How to run
+```
+npm test                 # node suites (includes profile-website-link)
+npm run test:playwright  # browser/e2e (needs a deployed instance with a scheme-less-website profile)
+```
+
+## Verification
+Node suite confirmed **failing for the right reason** on 2026-05-29 (pre-implementation):
+
+```
+✗ T1 — ui/src/utils/url.js does not exist … create a PURE module exporting toExternalUrl
+✗ T2 — BrainstormProfile.jsx must not pass raw profile.website to href
+✗ T3 — UserDetail.jsx must not pass raw profile.website to href
+✓ R1 — both views keep target=_blank + rel=noopener noreferrer
+✓ R2 — BrainstormProfile.jsx still scheme-strips the displayed website text
+
+RESULT: 2 passed, 3 failed
+```
+
+Playwright spec: not run pre-implementation (it tests deployed state; current staging/prod still has the bug). It will be exercised against staging after the fix deploys.

--- a/test/profile-website-link.test.js
+++ b/test/profile-website-link.test.js
@@ -1,0 +1,125 @@
+/**
+ * Story #30: profile "Website" link broken for scheme-less URLs.
+ * See engineering-team/stories/30-profile-website-link-scheme.test-plan.md
+ *
+ * Bug: ui/src/pages/BrainstormProfile.jsx and ui/src/pages/users/UserDetail.jsx
+ * render `<a href={profile.website}>` from the RAW kind-0 website value, so a
+ * scheme-less value (e.g. "kate-cate.com") is treated by the browser as a path
+ * relative to the current /user/<pk> page → it navigates in-app instead of to
+ * the external site.
+ *
+ * Fix contract (Architecture skipped — obvious bug; the Tester pins this minimal
+ * structure because the two views need identical logic and a pure helper is the
+ * cleanly-testable form): a PURE, node-importable ESM module
+ *   ui/src/utils/url.js  (joining the existing ui/src/utils/* convention)
+ * exporting `toExternalUrl(value)` that:
+ *   - prepends "https://" when the value has no http(s):// scheme,
+ *   - leaves already-absolute http(s) URLs unchanged,
+ *   - returns a falsy value for empty input.
+ * Both clickable-link views build their website href via that helper.
+ *
+ * The helper must stay pure (no React/DOM imports) so this unit test can import it.
+ *
+ * T* fail pre-fix and pass post-fix. R* are regression sentinels (pass before AND after).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+const URL_HELPER   = path.resolve(__dirname, '../ui/src/utils/url.js');
+const PROFILE_PAGE = path.resolve(__dirname, '../ui/src/pages/BrainstormProfile.jsx');
+const USERDETAIL   = path.resolve(__dirname, '../ui/src/pages/users/UserDetail.jsx');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+
+// ---------------------------------------------------------------------------
+// T1 — the normalization helper's behavior (the heart of the fix)
+// ---------------------------------------------------------------------------
+test('T1: ui/src/utils/url.js exports toExternalUrl(value) — prepends https:// for scheme-less values, leaves absolute URLs unchanged', async () => {
+  let mod;
+  try {
+    mod = await import(pathToFileURL(URL_HELPER).href);
+  } catch (e) {
+    throw new Error('ui/src/utils/url.js does not exist or failed to import (' + e.message +
+      '). Create a PURE module (no React/DOM imports) exporting `toExternalUrl(value)`.');
+  }
+  const fn = mod.toExternalUrl || (mod.default && mod.default.toExternalUrl);
+  assert(typeof fn === 'function', 'ui/src/utils/url.js must export `toExternalUrl` (a function).');
+
+  const cases = [
+    ['kate-cate.com',          'https://kate-cate.com'],          // the reported bug
+    ['www.kate-cate.com',      'https://www.kate-cate.com'],      // bare host with www
+    ['example.com/path?q=1',   'https://example.com/path?q=1'],   // path + query preserved
+    ['https://example.com/foo','https://example.com/foo'],        // already absolute (https)
+    ['http://example.com',     'http://example.com'],             // already absolute (http) — unchanged
+    ['HTTPS://Example.com',    'HTTPS://Example.com'],            // scheme detection is case-insensitive
+  ];
+  for (const [input, expected] of cases) {
+    const got = fn(input);
+    assert(got === expected,
+      `toExternalUrl(${JSON.stringify(input)}) → expected ${JSON.stringify(expected)}, got ${JSON.stringify(got)}`);
+  }
+  assert(!fn(''), "toExternalUrl('') must be falsy (an empty website yields no link).");
+});
+
+// ---------------------------------------------------------------------------
+// T2/T3 — both clickable-link views use the helper, not the raw value
+// ---------------------------------------------------------------------------
+test('T2: BrainstormProfile.jsx builds the website href via toExternalUrl (no raw href={profile.website})', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(!/href=\{\s*profile\.website\s*\}/.test(src),
+    'BrainstormProfile.jsx must NOT pass the raw `profile.website` to the link href — a scheme-less value resolves relative to /user/<pk>. Normalize it with toExternalUrl.');
+  assert(/toExternalUrl/.test(src),
+    'BrainstormProfile.jsx must build the website href via toExternalUrl(profile.website).');
+});
+
+test('T3: users/UserDetail.jsx builds the website href via toExternalUrl (no raw href={profile.website})', () => {
+  const src = safeRead(USERDETAIL);
+  assert(src.length > 0, 'UserDetail.jsx missing — unexpected.');
+  assert(!/href=\{\s*profile\.website\s*\}/.test(src),
+    'UserDetail.jsx (makeshift /tapestry/users page) must NOT pass the raw `profile.website` to the link href. Normalize it with toExternalUrl.');
+  assert(/toExternalUrl/.test(src),
+    'UserDetail.jsx must build the website href via toExternalUrl(profile.website).');
+});
+
+// ---------------------------------------------------------------------------
+// R1/R2 — sentinels (must PASS before AND after the fix)
+// ---------------------------------------------------------------------------
+test('R1: both views keep the website link safe — target="_blank" + rel="noopener noreferrer"', () => {
+  for (const [name, p] of [['BrainstormProfile.jsx', PROFILE_PAGE], ['UserDetail.jsx', USERDETAIL]]) {
+    const src = safeRead(p);
+    assert(src.length > 0, name + ' missing — unexpected.');
+    assert(/target="_blank"/.test(src) && /rel="noopener noreferrer"/.test(src),
+      name + ' must keep target="_blank" + rel="noopener noreferrer" on the website link (AC: new tab + safe rel).');
+  }
+});
+
+test('R2: BrainstormProfile.jsx still scheme-strips the website DISPLAY text (AC: primary-profile display unchanged)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/profile\.website\.replace\([\s\S]{0,12}https\?/.test(src),
+    'BrainstormProfile.jsx must keep stripping the scheme from the DISPLAYED website text (profile.website.replace(/^https?:.../)). The fix changes the href, not the display.');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -48,6 +48,7 @@ const scheduledTaskTimeoutPropagation = require('./scheduled-task-timeout-propag
 const killTimeoutOrphansByDefault = require('./kill-timeout-orphans-by-default.test.js');
 const taskQueueSemaphoreProtectionAudit = require('./task-queue-semaphore-protection-audit.test.js');
 const profileFollowsList = require('./profile-follows-list.test.js');
+const profileWebsiteLink = require('./profile-website-link.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -130,6 +131,9 @@ async function main() {
   console.log('\nprofile-follows-list suite:');
   const profileFollowsListResult = await profileFollowsList.run();
 
+  console.log('\nprofile-website-link suite:');
+  const profileWebsiteLinkResult = await profileWebsiteLink.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -208,6 +212,9 @@ async function main() {
   console.log(
     `profile-follows-list suite:                      ${profileFollowsListResult.fail === 0 ? 'PASS' : 'FAIL'} (${profileFollowsListResult.pass} passed, ${profileFollowsListResult.fail} failed)`
   );
+  console.log(
+    `profile-website-link suite:                      ${profileWebsiteLinkResult.fail === 0 ? 'PASS' : 'FAIL'} (${profileWebsiteLinkResult.pass} passed, ${profileWebsiteLinkResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -235,7 +242,8 @@ async function main() {
     scheduledTaskTimeoutPropagationResult.fail === 0 &&
     killTimeoutOrphansByDefaultResult.fail === 0 &&
     taskQueueSemaphoreProtectionAuditResult.fail === 0 &&
-    profileFollowsListResult.fail === 0;
+    profileFollowsListResult.fail === 0 &&
+    profileWebsiteLinkResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/tests/brainstorm/profile-website-link.spec.js
+++ b/tests/brainstorm/profile-website-link.spec.js
@@ -1,0 +1,39 @@
+/**
+ * Playwright behavioral check for story #30: profile "Website" link must resolve
+ * to an absolute external URL even when the kind-0 website value has no scheme.
+ * See engineering-team/stories/30-profile-website-link-scheme.test-plan.md
+ *
+ * Preconditions / fragility:
+ *   - A reachable Brainstorm instance (BRAINSTORM_BASE_URL or http://localhost:7778),
+ *     with the change deployed.
+ *   - This relies on LIVE DATA: the profile below currently has a scheme-less
+ *     website ("kate-cate.com"). If that account updates its kind-0 to include a
+ *     scheme, the test no longer exercises the scheme-less path (it would still
+ *     pass, just not meaningfully). This is supplementary to the deterministic
+ *     node unit test (test/profile-website-link.test.js, which has no live-data
+ *     dependency). Flagged in the test plan.
+ *
+ * Fails pre-fix (raw href renders `href="kate-cate.com"`, a relative URL), passes
+ * once the href is normalized to an absolute https:// URL.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = process.env.BRAINSTORM_BASE_URL || 'http://localhost:7778';
+// Profile whose kind-0 `website` is "kate-cate.com" (no scheme).
+const SCHEMELESS_WEBSITE_PUBKEY = 'a366c6a73754786fcb8007a78388f3e62e7c58579a6282a74ebd7c0b2f041044';
+
+test.describe('Story 30 — profile website link (scheme-less URLs)', () => {
+  test('the Website link resolves to an absolute external URL, not a relative /user path', async ({ page }) => {
+    await page.goto(`${BASE_URL}/user/${SCHEMELESS_WEBSITE_PUBKEY}`);
+
+    // The website link's visible text is the scheme-stripped host ("kate-cate.com").
+    const link = page.getByRole('link', { name: /kate-cate/i });
+    await expect(link).toBeVisible();
+
+    const href = await link.getAttribute('href');
+    expect(href, `Website link href should be an absolute http(s) URL, got: ${href}`).toMatch(/^https?:\/\//i);
+    // And specifically NOT a relative same-origin /user/... path (the bug).
+    expect(href).not.toMatch(/\/user\//);
+  });
+});

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -8,6 +8,7 @@ import useUserCounts from '../hooks/useUserCounts';
 import useNip05Verification from '../hooks/useNip05Verification';
 import ConfirmDialog from '../components/ConfirmDialog';
 import ReportModal from '../components/ReportModal';
+import { toExternalUrl } from '../utils/url';
 
 /* ── Helpers ──────────────────────────────────────────── */
 
@@ -302,7 +303,7 @@ export default function BrainstormProfile() {
                 {profile?.website && (
                   <div className="bsp-id-row">
                     <span className="bsp-id-label">Website</span>
-                    <a href={profile.website} target="_blank" rel="noopener noreferrer" className="bsp-id-link">
+                    <a href={toExternalUrl(profile.website)} target="_blank" rel="noopener noreferrer" className="bsp-id-link">
                       {profile.website.replace(/^https?:\/\//, '').replace(/\/$/, '')}
                     </a>
                   </div>

--- a/ui/src/pages/users/UserDetail.jsx
+++ b/ui/src/pages/users/UserDetail.jsx
@@ -6,6 +6,7 @@ import useProfiles from '../../hooks/useProfiles';
 import useNip05Verification from '../../hooks/useNip05Verification';
 import { useTrust } from '../../context/TrustContext';
 import { useConfig } from '../../context/ConfigContext';
+import { toExternalUrl } from '../../utils/url';
 import { useAuth } from '../../context/AuthContext';
 import { useCypher } from '../../hooks/useCypher';
 import { queryRelay } from '../../api/relay';
@@ -157,7 +158,7 @@ export default function UserDetail() {
               {profile?.website && (
                 <tr>
                   <td className="detail-label">Website</td>
-                  <td><a href={profile.website} target="_blank" rel="noopener noreferrer">{profile.website}</a></td>
+                  <td><a href={toExternalUrl(profile.website)} target="_blank" rel="noopener noreferrer">{profile.website}</a></td>
                 </tr>
               )}
               {profile?.lud16 && (

--- a/ui/src/utils/url.js
+++ b/ui/src/utils/url.js
@@ -1,0 +1,20 @@
+/**
+ * URL helpers. Pure — no DOM/React imports (kept unit-testable from node).
+ */
+
+/**
+ * Normalize a user-entered website value to an absolute, externally-navigable
+ * http(s) URL.
+ *
+ * A scheme-less value (e.g. "example.com") used directly as an `<a href>` is
+ * treated by the browser as a path relative to the current page, so it must get
+ * a scheme. Values that already carry an http(s):// scheme are returned
+ * unchanged; empty/falsy input yields '' (caller renders no link).
+ *
+ * @param {string} value - raw website string (e.g. from a kind-0 `website` field)
+ * @returns {string} absolute http(s) URL, or '' for empty input
+ */
+export function toExternalUrl(value) {
+  if (!value) return '';
+  return /^https?:\/\//i.test(value) ? value : `https://${value}`;
+}


### PR DESCRIPTION
## Summary

Promotes staging to main after clean verification on `staging.brainstorm.world`. Two low-risk changes.

## Bundled

- **#233** — story #30: fix the profile "Website" link for **scheme-less URLs**. New pure helper `ui/src/utils/url.js` `toExternalUrl()` prepends `https://` when the kind-0 `website` has no scheme; both clickable-link views (`BrainstormProfile.jsx`, `users/UserDetail.jsx`) use it. Was sending users to an in-app `/user/<text>` path instead of the external site.
- **#231** — story #29 bookkeeping: mark story #29 `Status: Done` (docs-only markdown).

## Net production impact

Profile "Website" links now open the person's actual external site even when they entered a bare domain (e.g. `kate-cate.com` → `https://kate-cate.com`), instead of bouncing to an in-app path. No concept/schema/firmware change, no auth/session change → **no forced sign-out**. The #231 change is documentation only.

## Verification trail

- Staging deploy #233 run `26813613976` (1m22s); #231 was a prior docs-only staging deploy.
- Staging smoke (#233): kate-cate profile (`a366c6a7…041044`) Website link now `rawHref "https://kate-cate.com"` (absolute external), `pointsToInAppUserPath: false`, display text unchanged, console clean; new JS bundle `index-9naVQOcx.js`. node `profile-website-link` 5/5, `profile-follows-list` 27/27, ui build clean.

## Test plan

- [ ] After merge: deploy-brainstorm.yml runs to completion.
- [ ] Passive smoke on brainstorm.world: kate-cate profile Website link href = `https://kate-cate.com` (read-only); new bundle served.
- [ ] Regression: a neighbor page still 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)