### PR TITLE
docs(BIBLE): §25 inherit-from tag `b` (story #31, ADR 0027)

### DIFF
--- a/BIBLE.md
+++ b/BIBLE.md
@@ -35,6 +35,7 @@
 22. [Community-Reference Model](#22-community-reference-model)
 23. [Class-Thread Membership Tags (`n`, `s`)](#23-class-thread-membership-tags-n-s)
 24. [Task Queue (BullMQ behind /api/run-task)](#24-task-queue-bullmq-behind-apirun-task)
+25. [The Inherit-From Tag (`b`)](#25-the-inherit-from-tag-b)
 
 ---
 
@@ -302,6 +303,7 @@ strfry replaces existing events (kind 39999 is replaceable), and Neo4j MERGEs on
 | `SUPERCEDES` | "I've evaluated your definition and replaced it with mine" — non-destructive |
 | `PROVIDED_THE_TEMPLATE_FOR` | Provenance link from original to forked node |
 | `REFERENCES` (concept-level) | Deferred non-committal pointer: local Concept Header → an external curator's Concept Header. Neo4j-only, carries `source`. NOT an explicit event, NOT agreement, NOT `IS_A_SUPERSET_OF`. Disambiguate from the tag-level `REFERENCES` (`NostrEventTag → NostrEvent`, every `e`/`a` tag) by endpoint labels + `source`. See §22. |
+| `INHERITS_FROM` | "My definition defers to the parent's, unless I override" — child→parent, live. NOT IMPORT (no absorption), NOT `IS_A_SUPERSET_OF`. Canonical (no `source`). Encoded as the single-char `b` tag, not a descriptor event. See §25. |
 
 #### Infrastructure
 | Relationship | Meaning |
@@ -1540,6 +1542,7 @@ docker compose exec tapestry strfry sync wss://dcosl.brainstorm.world \
 | **GrapeRank** | "PageRank for people" — iterative, personalized-per-observer trust scoring. Weighted average of raters' influence × rating × rating confidence, with an attenuation factor on non-observer raters. Converges to a fixed point determined purely by the observer pubkey and the rating graph. |
 | **Grapevine** | The Web of Trust system that determines which curations achieve community consensus. |
 | **IMPORT** | Editorial relationship: "I agree with your concept and want to benefit from your curated elements." |
+| **INHERITS_FROM** | Canonical child→parent definitional-inheritance edge from the `b` tag: "I defer to the parent's definition, live, unless I override." Distinct from IMPORT (absorption; implies IS_A_SUPERSET_OF) and REFERENCES (non-committal stub). No `source`. ADR 0027. See §25. |
 | **concept-graph (header tag)** | Self-describing tag on a kind-39998 ConceptHeader: `["concept-graph","39999:<pubkey>:<d-tag>-concept-graph"]` (computed). Resolution = tag-if-present else compute the same a-tag. Lets a single fetched Header resolve its full concept off-relay. ADR 0007. See §5. |
 | **communityReference** | A firmware-concept pointer `{ headerATag, relayHints[], knownGoodEventId? }` to an external curator's published concept. Resolved at install into a `REFERENCES` placeholder. See §22. |
 | **grapevine → firmware → none** | The community-reference resolution precedence: the user's Grapevine is the correct selector of "the community's definition"; the firmware-baked pointer is only a cold-start default; else nothing. Mirrors Warm Start's `self → owner → cold`. See §22. |
@@ -1561,6 +1564,7 @@ docker compose exec tapestry strfry sync wss://dcosl.brainstorm.world \
 | **Trust Assertions (TAs)** | Kind 30382 nostr events published by a `rankAuthor` that assign trust scores (rank, followers, etc.) to other pubkeys. Synced via negentropy and loaded into Meilisearch for WoT-powered search. |
 | **Warm Start** | An opt-in GrapeRank initialization mode that seeds scorecards from previously-computed scores instead of `[0,0,0,0]`. Three sources in tiered fallback: `self` (customer's own prior scores), `owner` (owner's `NostrUser` scores when the owner is within 3 directed FOLLOWS hops downstream of the customer), and `cold` (no seed available; legacy behavior). Typically cuts customer GrapeRank runtime from ~20 min to ~5 min. |
 | **Word-wrapper** | The canonical JSON format where every node's data includes a `word` section plus type-specific sections. |
+| **b tag** | Single-char inherit-from pointer on a kind-39998/39999 event: `["b","<parent-a-tag>","inherit"]`. Child-claims-parent — "my definition is the parent's, unless I override." Materializes `(child)-[:INHERITS_FROM]->(parent)`. ADR 0027. See §25. |
 | **z-tag** | The `z` tag on a ListItem that points to its parent concept's a-tag. Fundamental parent pointer. |
 
 ---
@@ -1576,6 +1580,8 @@ A firmware concept may carry a `communityReference` — `{ headerATag, relayHint
 **Resolution model.** The *correct* long-term selector of "the community's definition" is the user's Grapevine (WoT loose consensus over published curations). The firmware-baked pointer is a **cold-start default**, not the truth. Precedence: **`grapevine-resolved → firmware-blessed → none`** — mirroring the Warm Start tiered fallback (`self → owner → cold`).
 
 **Accepted compromise (Flaw A) and its exit.** A firmware-baked pointer is a *centralized* editorial choice (the dev team picks the blessed curator pubkey — currently the reference deployment's TA). Accepted **temporarily**; the exit is the **registry-as-DList**: the per-concept pointer itself becomes a community-curated, Grapevine-ranked DList, retiring the hardcoded choice.
+
+**Candidate exit mechanism — the `b` / `INHERITS_FROM` tag (ADR 0027).** A `b` tag (§25) is a published, `#b`-queryable, per-pubkey pointer naming a preferred definition. Aggregating a concept's **incoming `INHERITS_FROM` edges, weighted by each child author's GrapeRank influence from the observer's PoV**, yields "which definition my web of trust loosely agrees on" — exactly the `grapevine-resolved` selector above. This makes `b`-edges a **candidate mechanism** for the registry-as-DList exit. Recorded as candidate only; the registry design is not ratified here (a future ADR in the 0006 line).
 
 **Invariants & principles.**
 1. *Relay invariant:* concept export and `communityReference.relayHints` must target the same relay set (the purpose-built DList relay, not general-purpose relays) or the round-trip cannot close.
@@ -1611,14 +1617,14 @@ A firmware concept may carry a `communityReference` — `{ headerATag, relayHint
 **Trust constraints when consuming `n`/`s` tags from foreign curators (binding):**
 1. **Authorship gate:** materialize events only when `pubkey === curatorPk` (the same TA whose Header anchored the #11 `IS_A_SUPERSET_OF` edge). Prevents cross-instance election (someone publishing an event with `['n', '<myLocalSuperset-uuid>']` cannot trick a consumer into MERGEing edges into the consumer's local class thread).
 2. **Local-graph isolation:** the only cross-pubkey edge allowed in the graph is the #11 `(localSuperset)-[:IS_A_SUPERSET_OF]->(communitySuperset)` anchor, established by firmware install. Phase B's tag walk never MERGEs an edge whose parent endpoint is in the local TA's sub-graph.
-3. **Class-thread only:** consumers walking `n`/`s` MUST MERGE only `HAS_ELEMENT` and `IS_A_SUPERSET_OF` edges (canonical class-thread relationships); no editorial relationship types are inferable from these tags.
+3. **Class-thread only:** consumers walking `n`/`s` MUST MERGE only `HAS_ELEMENT` and `IS_A_SUPERSET_OF` edges (canonical class-thread relationships); no editorial relationship types are inferable from these tags. *(This constraint is specific to `n`/`s`; the editorial inherit-from relationship has its own single-char tag `b` — see §25.)*
 
-**Direction principle (reserved, codified):** lowercase single-char tags encode **child-claims-parent**. Uppercase single-char tags (currently unassigned) would encode **parent-claims-child** for the same logical relationship type if a future ADR adopts the inverse direction. **Do not assign uppercase forms speculatively** — only when a concrete consumer needs the inverse direction AND that inverse cannot be more cleanly expressed as a derived aggregate query (relay filter for `#n=X` already returns all children of X).
+**Direction principle (reserved, codified):** lowercase single-char tags encode **child-claims-parent**. Uppercase single-char tags (currently unassigned) would encode **parent-claims-child** for the same logical relationship type if a future ADR adopts the inverse direction. **Do not assign uppercase forms speculatively** — only when a concrete consumer needs the inverse direction AND that inverse cannot be more cleanly expressed as a derived aggregate query (relay filter for `#n=X` already returns all children of X). The inherit-from tag `b` (§25) follows this convention and reserves uppercase **`B`** for a future parent-claims-child / federation inverse.
 
 **Future-candidate relationship tags** (NOT implemented; documented for protocol hygiene so the next ADR-author doesn't accidentally repurpose neighboring letters):
 - `IS_A_PROPERTY_OF` (property tree). Candidate letter TBD. Hot-read-path candidate.
 - `REFERENCES` (Story #8 community-reference; flaw-A exit). Candidate letter TBD. Open question: publishing semantics — consumer-owned tag on consumer's concept Header, or separate "reference manifest" kind-39999 event?
-- Editorial relationships (`RECOMMENDED_BY`, `ENDORSES`, etc.). Designed deliberately in a future ADR (trust, provenance, first-class-vs-stub semantics).
+- Editorial relationships. The inherit-from relationship is now realized as the **`b` tag** → `INHERITS_FROM` (the first editorial single-char tag, also extending the single-char namespace to kind-39998) in **§25** / ADR 0027. Others (`RECOMMENDED_BY`, `ENDORSES`, etc.) remain for a future ADR (trust, provenance, first-class-vs-stub semantics).
 
 ---
 
@@ -1652,6 +1658,50 @@ The drift sentinels in `test/entrypoint-template-rendering.test.js` (T7 + T8) tr
 **Discoverability.** The dashboard at `/tapestry` shows an "Admin tools" panel (owner+admin only) with a one-click link to BullBoard — see OPERATIONS.md §10.2 for the operator-side details.
 
 **ADRs:** [0012](engineering-team/decisions/0012-task-queue-phase-1-bullmq.md) (BullMQ phase 1); [0013](engineering-team/decisions/0013-task-queue-neo4j-resource-class.md) (resource-class semaphore); [0014](engineering-team/decisions/0014-entrypoint-template-rendering.md) (template-driven config); [0015](engineering-team/decisions/0015-task-queue-on-by-default.md) (default flipped on); [0016](engineering-team/decisions/0016-bullboard-admin-access.md) (owner-or-admin gate); [0022](engineering-team/decisions/0022-manual-task-retrigger-dedup-fix.md) (wait/active-only dedup window via `removeOnComplete`+`removeOnFail`); [0023](engineering-team/decisions/0023-task-queue-semaphore-protection-audit.md) (entry-point tagging is load-bearing — audit closes subshell-chain coverage gaps); [0024](engineering-team/decisions/0024-scheduled-task-timeout-propagation.md) (scheduled-task timeout propagation fix); [0025](engineering-team/decisions/0025-kill-timeout-orphans-by-default.md) (kill timeout-orphans by default).
+
+---
+
+## 25. The Inherit-From Tag (`b`)
+
+**A general definitional-inheritance primitive.** The `b` tag lets any addressable DList object declare *"my definition is this parent's, unless I state otherwise."* It is the single-char, child-claims-parent sibling of the class-thread tags in §23 — but where `n`/`s` express *structure* (containment), `b` expresses *editorial inheritance* (deference). Established by ADR 0027 (ADR 0006/0011 lineage). The Communities Protocol's participant-affiliation pointer is its first consumer (`affiliation` → `b` with type `inherit`); it is **not** community-specific.
+
+| Tag | Logical relationship | On-wire (child carries tag) | Neo4j edge written by consumers |
+|---|---|---|---|
+| `b` | inherit-from (definitional inheritance with override) | child claims a parent it defers to | `(child)-[:INHERITS_FROM]->(parent)` |
+
+**Wire format:** `["b", "<parent-a-tag>", "<type>"]`. Element 2 is the parent's a-tag (`<kind>:<pubkey>:<dtag>` — same shape as `z`/`n`/`s`; the NIP-01-indexed value). Element 3 is the **affiliation type**, default `"inherit"`, carried as a non-indexed positional element (as NIP-01's `e` tag carries its `root`/`reply` marker). E.g. `['b', '39998:<alice>:dogs', 'inherit']` — "my `dogs` concept defers to Alice's."
+
+**Kinds:** defined for **kind-39998 and kind-39999** — any addressable DList object (concept headers *and* items/sets/Declarations). Broader than `n`/`s`, which are kind-39999-only.
+
+**Multi-parent:** an event may carry multiple `b` tags (inherit from multiple parents — rare; resolution order is a consumer concern, deferred). Same multi-tag pattern as `z`/`n`/`s`.
+
+**Edge direction — child→parent (diverges from `n`/`s`; do NOT flip).** `n`/`s` flip their child-claims-parent encoding into a *parent→child* Neo4j edge because their semantics are containment (the parent owns the child). `b` does **not** flip: it writes `(child)-[:INHERITS_FROM]->(parent)`, because (a) deference reads naturally child→parent, and (b) a parent's **incoming** `INHERITS_FROM` edges are exactly "everyone who defers to this definition" — the trust-weightable query the registry use case (§22) needs. Implementers must not copy the `n`/`s` direction-flip.
+
+**Edge properties.** `INHERITS_FROM` is a **canonical, asserted relationship** (the child published a `b` tag) — so, unlike the concept-level `REFERENCES` stub and like `HAS_ELEMENT`/`IS_A_SUPERSET_OF`, it carries **no `source` property**. It MAY carry a `type` property (default `"inherit"`) mirroring tag element 3.
+
+**Resolution — live, read-time.** A child's **effective definition** is computed on read, never snapshotted:
+```
+effective(node) = merge( effective(parent_via_b), node.statedFields )
+```
+- **Live:** the walk reads each ancestor's *current* state, so a child tracks the parent's future edits ("whatever Alice says"). Only the `INHERITS_FROM` edge is materialized; the definition is not copied into the child. (Same read-time pattern as the Communities Protocol's `effectiveCD`.)
+- **Override = the child's own stated fields.** A field the child states explicitly overrides the inherited value; an omitted field is inherited. An unedited child performs pure inheritance.
+- **Termination:** stop at a root (no `b` tag) or a `maxDepth` guard; a cycle guard (visited-set keyed on a-tag) prevents loops. Reuses the bounded-walk pattern of ADR 0010/0011.
+- **Scope today:** the pattern above plus **field-level (whole-field replace)** override. The **set-valued override algebra** — how a child adds/removes/replaces individual elements of an inherited *set* — is deferred to the first consumer that needs it (the first consumer, CD inheritance, overrides only scalars).
+
+**Place in the editorial-relationship family (§6).** `b` is the first editorial relationship encoded as a single-char tag rather than a relationship-descriptor event. It is distinct from the others:
+
+| Relationship | Posture | Liveness | Override | Implies `IS_A_SUPERSET_OF`? |
+|---|---|---|---|---|
+| `REFERENCES` (concept-level) | non-committal bookmark ("may pull later") | — | — | no |
+| `IMPORT` | absorb the parent's elements; **importer** authoritative | snapshot/pull | agreement, not override | **yes** |
+| `SUPERCEDES` | replace the parent with mine | — | — | no |
+| **`b` / `INHERITS_FROM`** | **defer; parent stays authoritative** | **live (re-resolved each read)** | **first-class "unless stated"** | **no** |
+
+**Trust-coupling (intrinsic to live deference).** Inheriting from a parent means inheriting its *future* edits and trust trajectory — if the parent drifts or is compromised, the child's effective definition drifts silently. The escape hatch is built in: the child's overrides pin what it wants fixed, and re-publishing the `b` tag (a different parent, or a future divergence type) detaches it. PoV/GrapeRank re-gate visibility on every resolution.
+
+**Direction principle / reserved `B`.** Per §23's convention, lowercase `b` = child-claims-parent. Uppercase **`B`** is **reserved** (not assigned) for a future parent-claims-child / federation inverse — e.g. a parent recognizing a child as "the same community." Do not assign speculatively.
+
+See ADR 0027 for the full rationale, the rejected alternatives (folding into `IMPORT`; multi-char tags), and the deferred design questions.
 
 ---
 

--- a/engineering-team/decisions/0027-inherit-from-tag-b.md
+++ b/engineering-team/decisions/0027-inherit-from-tag-b.md
@@ -1,0 +1,156 @@
+# ADR 0027: The inherit-from tag (`b`) — a general definitional-inheritance primitive
+
+**Status:** Accepted
+**Date:** 2026-06-05
+**Story:** `engineering-team/stories/31-b-tag-general-inherit-primitive.md`
+**Builds on:** ADR 0011 (class-thread single-char tags `n`/`s`; this ADR realizes that ADR's Reserved-Future "editorial relationships" candidate), ADR 0006 (community-reference theory; this ADR advances its deferred "registry-as-DList" Flaw-A exit as a *candidate*, not a ratification), ADR 0008 (community Superset anchor).
+**Supersedes:** nothing. It amends the *scope wording* of BIBLE §23 (single-char tags are no longer "class-thread only") but does not contradict ADR 0011's decision — ADR 0011 explicitly invited this follow-up.
+
+## Context
+
+We are drafting the Tapestry Communities Protocol. Its mechanism for a participant Community Declaration (CD) to defer to a parent CD — provisionally the `affiliation` tag — is being recast as a single-character tag following the `n`/`s` convention in BIBLE §23 (single-char ⇒ relay-indexed by NIP-01; child-claims-parent; value = parent a-tag). Story #31 establishes that the underlying relationship — *"accept the parent's definition unless this event states otherwise"* — is **not community-specific**. It is general to any addressable DList object: concept↔concept, set↔set, Declaration↔Declaration.
+
+Worked example (from the story): Alice publishes a `dogs` concept (`39998:<alice>:dogs`). Bob mints his own `dogs` concept carrying `["b", "39998:<alice>:dogs", "inherit"]`, meaning *"my notion of dogs is whatever Alice says, unless I say otherwise."*
+
+**Constraints and grounding (all from BIBLE; the Concept Graph API was unreachable at both planning and architecture time — the BIBLE relationship tables are the authoritative source for the vocabulary `b` joins):**
+
+1. **The single-char tag namespace is shared on a kind.** ADR 0011 / BIBLE §23 define `n`/`s` for **kind-39999 only**, child-claims-parent, value = parent a-tag. The namespace already spends `d`, `z`, `p`, `n`, `s` on kind-39999, plus NIP-01-reserved letters (`e`, `a`, `t`, `r`, `i`, `g`, `k`, `q`, `l`/`L`, `m`, `x`). CDs and concepts are kind-39999/39998 events, so any new single-char tag shares this namespace and must not collide.
+2. **There is an existing editorial-relationship family** (BIBLE §6 table, lines 298–304; §21 glossary; §22): `IMPORT` ("I agree with your concept definition — implies IS_A_SUPERSET_OF between supersets"), `SUPERCEDES` ("evaluated and replaced with mine"), `PROVIDED_THE_TEMPLATE_FOR`, and concept-level `REFERENCES` (non-committal Neo4j-only stub, carries `source`, NOT agreement). If `b` lands without an explicit boundary against these, it reintroduces the "two parallel schemas" problem.
+3. **`b` would be the first editorial relationship encoded as a single-char tag.** Today, editorial relationships are explicit *relationship-descriptor events* (z-tagged to the firmware `:relationship` concept — ADR 0011 §Context). `b` follows the `n`/`s` single-tier pattern (the structural claim lives as a tag on the source event), NOT the legacy descriptor-event pattern. BIBLE §23 currently asserts that consumers walking `n`/`s` "MUST MERGE only HAS_ELEMENT and IS_A_SUPERSET_OF… no editorial relationship types are inferable from these tags" (BIBLE:1614). That statement is correct *for `n`/`s`*; this ADR must scope it accordingly and establish `b` as a distinct editorial single-char tag with its own edge and walk.
+4. **The REFERENCES collision contract (BIBLE §22, line 1574) is precedent.** `REFERENCES` is overloaded (tag-level `(:NostrEventTag)→(:NostrEvent)` vs concept-level `(:ListHeader)→(:ListHeader)`), disambiguated by endpoint labels + `source`. Any new edge name must either be collision-free or carry an analogous contract.
+5. **Project rules:** no new lint/typecheck/build tooling (CLAUDE.md). **This story's deliverable is documentation only** — the three BIBLE edits plus this ADR. All code (tag emission, the resolver, the Neo4j edge MERGE, event materialization) is out of scope and deferred to future implementation stories.
+
+## Options considered
+
+### Option A — A new single-char tag `b` writing a child→parent `INHERITS_FROM` edge, resolved live (chosen)
+
+A kind-39998 **or** kind-39999 event carries `["b", "<parent-a-tag>", "inherit"]` to claim *"my definition inherits from this parent, unless I state otherwise."* Relay-side filtering by `#b=<parent-a-tag>` (NIP-01-indexed since single-char) returns every child that defers to that parent in one round-trip. Consumers materialize a canonical `(child)-[:INHERITS_FROM]->(parent)` edge. A child's **effective definition** is computed at read time by walking `INHERITS_FROM` to the root, with the child's explicitly-stated fields overriding inherited ones.
+
+**Pros:**
+- Reuses the `n`/`s` mechanics wholesale (relay-indexed, child-claims-parent, decentralized — no parent maintains a children list), so the mental model is already internalized.
+- One `#b` filter enumerates every event that defers to a given parent → enables the §22 "registry-as-DList" use case (trust-weighted incoming edges = loose consensus on a definition) with no new infrastructure.
+- `INHERITS_FROM` is collision-free against every existing relationship type (§6 tables) → no REFERENCES-style disambiguation contract needed.
+- Generalizes cleanly: the Communities Protocol's affiliation pointer becomes a *consumer* (`affiliation` → `b` with type `inherit`), not a community-only tag.
+
+**Cons:**
+- New protocol-level commitment to the letter `b` (and, by the direction convention, reserves `B`). Forward-compatible but not free to undo.
+- `b` is the first editorial single-char tag → requires scoping BIBLE §23's "no editorial relationships inferable" wording and widening the single-char namespace claim to kind-39998.
+- Live read-time resolution has a per-read walk cost (bounded by max-depth) and couples the child to the parent's *future* edits (see Consequences).
+
+### Option B — Fold inheritance into the existing `IMPORT` editorial relationship (rejected)
+
+No new tag/edge: express "Bob's dogs = Alice's dogs unless overridden" by reusing `IMPORT`.
+
+**Why rejected:** `IMPORT` and `b` are near-opposite postures. `IMPORT` means *absorption* — the importer agrees with and pulls the parent's curated elements **into their own concept**, and it **implies `IS_A_SUPERSET_OF` between supersets** (BIBLE:301): the importer becomes the structurally-larger, authoritative node. `b` means *deference* — the **parent stays authoritative**, the child's definition *is* the parent's by live reference with overrides, and it **must NOT imply `IS_A_SUPERSET_OF`** (Bob's dogs is a derivative of Alice's, not a superset of it). Folding the two would conflate "I absorb you" with "I defer to you," and would wrongly attach `IS_A_SUPERSET_OF` semantics to a deference edge. They are distinct relationships and need distinct edges.
+
+### Option C — A multi-character tag (e.g., `inherit` / `based-on`) (rejected)
+
+Same semantics as Option A but a human-readable multi-char tag name.
+
+**Why rejected:** identical reasoning to ADR 0011 Option C. NIP-01 relay-side indexing is opt-in for multi-char tags; `#inherit=X` becomes a scan instead of an index hit on many relays, which breaks the §22 "enumerate everyone who defers to parent X" use case at scale. Single-char also signals "canonical protocol primitive," not ad-hoc extension.
+
+## Decision
+
+Adopt **Option A.**
+
+### The tag
+
+| Tag | Logical relationship | On-wire (child carries tag) | Neo4j edge written by consumers |
+|---|---|---|---|
+| `b` | inherit-from (definitional inheritance with override) | child event claims a parent it defers to | `(child)-[:INHERITS_FROM]->(parent)` |
+
+- **Wire format:** `["b", "<parent-a-tag>", "<type>"]`. Element 2 is the parent's a-tag (`<kind>:<pubkey>:<dtag>` — same shape as `z`/`n`/`s` values; the NIP-01-indexed value). Element 3 is the **affiliation type**, default `"inherit"`; it rides as a non-indexed positional element (exactly as NIP-01's `e` tag carries a `root`/`reply` marker). Reserved future types (e.g. a deliberate-divergence marker) are **not** defined here.
+- **Kinds:** defined for **kind-39998 and kind-39999** — any addressable DList object (concept headers *and* items/sets/CDs). This widens ADR 0011's "kind-39999 only" namespace note to include 39998, because concept-to-concept inheritance is the general case.
+- **Multi-parent:** an event may carry multiple `b` tags (inherit from multiple parents — rare; resolution order is a consumer concern, flagged in Out of scope). Same multi-tag pattern as `z`/`n`/`s`.
+- **Letter check:** `b` is unused by Tapestry (`d`/`z`/`p`/`n`/`s`) and is not a NIP-01-reserved single-char tag. Mnemonic: *based-on / branch*. Collision-free.
+
+### Edge direction — child→parent (a deliberate divergence from `n`/`s`)
+
+`n`/`s` flip the on-wire child-claims-parent encoding into a **parent→child** Neo4j edge (`(parent)-[:HAS_ELEMENT]->(child)`), because their semantics are *containment* (the parent owns the child) and to match `install.js` pass-1d byte-equivalence (ADR 0011 line 179). **`b` does not flip.** It writes `(child)-[:INHERITS_FROM]->(parent)` because:
+
+1. The semantics are *deference/derivation*, which reads naturally child→parent ("Bob's dogs INHERITS_FROM Alice's dogs").
+2. The §22 registry use case wants **incoming edges to a parent** = the set of children that defer to it; `MATCH (parent)<-[:INHERITS_FROM]-(child)` is the trust-weightable endorsement query. Child→parent makes that an indexed in-edge scan.
+3. `b` carries no legacy install.js constraint.
+
+Implementers must therefore **not** blindly copy the `n`/`s` direction-flip. This is a documented, intentional difference.
+
+### Edge properties
+
+`INHERITS_FROM` is a **canonical, asserted relationship** (the child explicitly published a `b` tag), not a deferred stub — so, like `HAS_ELEMENT`/`IS_A_SUPERSET_OF` and unlike `REFERENCES`, it carries **no `source` property**. It MAY carry a `type` property (string, default `"inherit"`) mirroring tag element 3, so consumers can filter by affiliation type without re-reading the event. No collision contract is required (the relationship type is unique), but consumers SHOULD still scope traversals by endpoint labels where a concept-vs-CD distinction matters.
+
+### Resolution — live read-time walk; field-level override now, set-valued algebra deferred
+
+A child's **effective definition** is computed at **read time**, not stored:
+
+```
+effective(node) = merge( effective(parent_via_b), node.statedFields )
+```
+
+- **Live:** the walk reads each ancestor's *current* state, so a child tracks the parent's future edits ("whatever Alice says"). The `INHERITS_FROM` edge itself is a materialized structural fact (idempotent MERGE); the *definition* is never snapshotted into the child. This mirrors the Communities draft's `effectiveCD` (§3.5) and the bounded-walk pattern of ADR 0010/0011.
+- **Override = the child's own stated fields.** A field the child states explicitly overrides the inherited value; a field the child omits is inherited. An unedited child performs pure inheritance.
+- **Termination:** walk stops at a root (no `b` tag) or a `maxDepth` guard; a cycle guard (visited-set keyed on a-tag) prevents loops. (Reuses ADR 0010/0011's guards.)
+- **Scope of this ADR:** the universal pattern above plus **field-level (whole-field replace)** override. The **set-valued override algebra** — how a child adds/removes/replaces individual elements of an inherited *set* (e.g. "Alice's dogs minus dingoes plus my strays") — is **deferred** to the first consumer that needs it. Rationale: the first shipping consumer (CD inheritance) overrides only scalars (cutoffs, method preset); defining add/remove/replace semantics before a concrete consumer is exactly the speculative over-design the story warns against.
+
+### Boundary against the editorial family (to be written into BIBLE §6/§21/§25)
+
+| Relationship | Posture | Liveness | Override | Implies `IS_A_SUPERSET_OF`? |
+|---|---|---|---|---|
+| `REFERENCES` (concept-level) | non-committal bookmark ("may pull later") | n/a (no merge) | n/a | no |
+| `IMPORT` | absorb the parent's elements; **importer** authoritative | snapshot/pull | agreement, not override | **yes** |
+| `SUPERCEDES` | replace the parent with mine | n/a | n/a | no |
+| **`b` / `INHERITS_FROM`** | **defer; parent stays authoritative** | **live (re-resolved each read)** | **first-class "unless stated"** | **no** |
+
+### Answers to the story's forwarded questions
+
+1. **Neo4j edge name** → `INHERITS_FROM` (chosen over `DERIVES_FROM`/`DELEGATES_TO`: most recognizable, accurately names definitional inheritance, collision-free).
+2. **Set-valued override algebra** → **deferred** to the first set-overriding consumer (concept element-set inheritance). Field-level replace is the v1 default. Documented here so it isn't silently assumed.
+3. **First editorial single-char tag** → yes; `b` is given its own BIBLE section (§25) and edge (`INHERITS_FROM`). §23's "no editorial relationships inferable from these tags" is **scoped to `n`/`s`** (a doc amendment), and the single-char namespace claim is **widened to kind-39998**.
+4. **Uppercase `B`** → **reserved, not assigned.** Per §23's direction principle, lowercase = child-claims-parent (`b`). Uppercase `B` is reserved for a future parent-claims-child / federation inverse (a parent recognizing a child as "same community" — the Communities Protocol's deferred multi-root federation). Do not assign speculatively.
+5. **Live vs snapshot** → **live** (read-time effective-definition walk; the edge is the only materialized artifact). This is the "whatever Alice says" intent.
+
+### Registry-as-DList (advances ADR 0006 / §22 Flaw-A exit — candidate, not ratified)
+
+A `b` tag is a published, `#b`-queryable, per-pubkey pointer naming a preferred definition. Aggregating a parent's **incoming `INHERITS_FROM` edges, weighted by each child author's GrapeRank influence from the observer's PoV**, yields "which definition my web of trust loosely agrees on" — exactly the grapevine selector §22 defers (BIBLE:1576–1578, `grapevine-resolved → firmware → none`). This ADR records `b` as the **candidate mechanism** for that exit; it does **not** ratify the registry design (that is a separate ADR in the ADR 0006 line).
+
+## Consequences
+
+### Positive
+- A single, general inherit-from primitive for any DList object; the Communities Protocol consumes it instead of owning a community-only tag.
+- `#b` relay-indexing enables affiliation-graph / registry-as-DList discovery with zero new infrastructure.
+- Clear, written boundary against `IMPORT`/`REFERENCES`/`SUPERCEDES` prevents the "two parallel schemas" failure.
+- Realizes ADR 0011's Reserved-Future "editorial relationships" candidate deliberately, as that ADR intended.
+
+### Negative / risk
+- **Protocol-level commitment to `b`** (and reservation of `B`). Mitigated by deliberate letter choice + single-ADR ratification + registering it in §23/§25 so future ADR-authors don't repurpose it.
+- **Live resolution couples a child to the parent's future edits and trust trajectory** — if the parent is later compromised or drifts, the child's effective definition drifts silently. Mitigation is intrinsic: the override mechanism is the pin, and a child can re-publish its `b` tag (different parent, or a future divergence type) to detach. PoV/GrapeRank re-gates visibility on every resolution. Worth an explicit callout in §25.
+- **First editorial single-char tag** widens the single-char namespace's remit (class-thread *and* editorial). §23's wording must be scoped or a reader will think single-char = class-thread-only.
+
+### Neutral
+- Additive: parsers that don't walk `b` ignore it. Zero impact on instances that don't consume it.
+- No `n`/`s` behavior changes; ADR 0011 stands unmodified.
+
+**Firmware reinstall required?** **No** for this story — the deliverable is documentation (BIBLE prose) only; no concept definitions or schemas change. (A *future* implementation story that materializes `INHERITS_FROM` from `b` tags may touch firmware/graph-engine code and should re-evaluate then.)
+
+## Implementation notes
+
+**Phase 4 is documentation-only — edit `BIBLE.md`, no source.** The sketches below are illustrative; the Implementer writes the final prose and places the section. Five edits:
+
+1. **New `BIBLE.md` §25 — "The Inherit-From Tag (`b`)"** (append after §24 Task Queue; add to the Table of Contents). Mirror §23's structure: the tag table (above), wire-format + kinds (39998/39999) + multi-parent, the child→parent edge direction with the explicit "diverges from `n`/`s`, do not flip" note, the live read-time resolution contract + field-level override (set-valued deferred), the editorial-boundary table, the reserved-`B` direction note, and the live-resolution trust-coupling callout. Cross-link to §6, §22, §23.
+   - *Placement note:* appended as §25 (not inserted as §24) to avoid renumbering the existing §24 Task Queue section, which is referenced externally (story #20, OPERATIONS). Discoverability is preserved via cross-references from §22/§23/§6. If the user prefers physical adjacency to §23, the alternative is insert-as-§24 + renumber Task Queue→§25 + sweep all "§24" references — higher churn; recommended against.
+2. **`BIBLE.md` §6 editorial-relationships table (lines 298–304)** — add a row:
+   `| `INHERITS_FROM` | "My definition defers to the parent's, unless I override" — child→parent, live; NOT `IS_A_SUPERSET_OF`, NOT IMPORT. Encoded as the single-char `b` tag (not a descriptor event). See §25. |`
+3. **`BIBLE.md` §21 glossary** — add two entries: a **`b` tag** entry (single-char inherit-from pointer, value = parent a-tag, type in element 3; see §25) and an **`INHERITS_FROM`** entry (canonical child→parent definitional-inheritance edge; distinguish from IMPORT/REFERENCES per the boundary table).
+4. **`BIBLE.md` §22 (Community-Reference Model)** — near the "Accepted compromise (Flaw A) and its exit" paragraph (line 1578) and the resolution-precedence paragraph (line 1576), add a note: incoming, GrapeRank-weighted `INHERITS_FROM` (`#b`) edges are a **candidate mechanism** for the deferred registry-as-DList / grapevine-resolved-definition exit. Mark explicitly as candidate, not ratified.
+5. **`BIBLE.md` §23 amendment** — scope the binding statement at line 1614 to `n`/`s` ("consumers walking **`n`/`s`** MUST MERGE only HAS_ELEMENT/IS_A_SUPERSET_OF…"), and add a one-line pointer that `b` (§25) is a separate editorial single-char tag, that the single-char namespace now spans kind-39998 + 39999, and that `B` is reserved. Update the §23 "Future-candidate relationship tags" note so it no longer implies the inherit-from/editorial slot is unclaimed.
+
+No source files, tests, or firmware are touched by this ADR's story.
+
+## Out of scope (named, deferred)
+
+- **All code:** `b`-tag emission at mutation sites, the effective-definition resolver/merge-walk, the `INHERITS_FROM` MERGE, foreign-event materialization, and any migration of existing events. Future implementation stories.
+- **Set-valued override algebra** (add/remove/replace for inherited element sets) — deferred to the first consumer that needs it.
+- **Multi-parent `b` resolution order** (which parent wins when a child carries multiple `b` tags) — deferred; the first consumers are single-parent.
+- **Uppercase `B`** assignment (parent-claims-child / federation inverse) — reserved, not designed.
+- **Ratifying the registry-as-DList / grapevine-resolution exit** — a separate ADR in the ADR 0006 line; this ADR only nominates `b` as the candidate.
+- **The Communities Protocol itself** and its §11 ratification items — queued in `_intake.md` (2026-06-05), depends on this.
+- **Caching of effective-definition resolution** — a consumer/perf concern, not a protocol decision.

--- a/engineering-team/reviews/31-b-tag-general-inherit-primitive.md
+++ b/engineering-team/reviews/31-b-tag-general-inherit-primitive.md
@@ -1,0 +1,72 @@
+# Review: Story 31 — Establish the `b` tag as a general inherit-from primitive
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-05
+**Diff:** `git diff staging...HEAD` (commits `6406ef46` story, `dbe96476` adr, `69faaa6d` impl)
+**Story:** `engineering-team/stories/31-b-tag-general-inherit-primitive.md`
+**ADR:** `engineering-team/decisions/0027-inherit-from-tag-b.md` (Accepted)
+**Test plan:** none — Test Design skipped per story resolved-Q2 (docs-only, no executable behavior). Verified by claim-accuracy audit + unchanged test gate, following the story #20 precedent.
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **PASS**, independently re-run. 26/26 suites pass, Overall PASS (Configuration Loading + 25 named suites; 0 failed). No source touched → no regression, as expected.
+- [x] _Lint not configured — skipped._
+- [x] _Typecheck not configured — skipped._
+- [x] _Build not configured — skipped._
+- [x] **Diff scope:** `git diff staging --name-only` = `BIBLE.md` + three engineering-team artifacts (ADR 0027, story #31, `_intake.md`). **No source/test/firmware files touched** (verified). No new lint/typecheck/build tooling.
+
+## Spec adherence (story acceptance criteria)
+
+All six ACs satisfied:
+
+- [x] **AC1 — general primitive, not community-only.** New §25 opener (BIBLE:1666) + "**Kinds:** defined for kind-39998 and kind-39999 — any addressable DList object" (BIBLE:1674).
+- [x] **AC2 — canonical meaning in one place.** §25 tag table (BIBLE:1670) + wire format (BIBLE:1672) + resolution (BIBLE:1682–1689): child-claims-parent, value = parent a-tag, "accept the parent's definition unless this event states otherwise," parent-authoritative + child override. Communities affiliation pointer characterized as consumer (`affiliation` → `b`/`inherit`, BIBLE:1666).
+- [x] **AC3 — distinguished from IMPORT/REFERENCES/SUPERCEDES + glossary/table.** §25 editorial-boundary table (BIBLE:1694–1698); §6 `INHERITS_FROM` row (BIBLE:306); §21 glossary `b tag` (BIBLE:1567) + `INHERITS_FROM` (BIBLE:1545).
+- [x] **AC4 — §22 candidate registry-as-DList mechanism.** BIBLE:1584, explicitly "**candidate mechanism**… Recorded as candidate only; the registry design is not ratified here."
+- [x] **AC5 — ADR records decision + rejected IMPORT alt + deferred questions.** ADR 0027 §Options (B = fold into IMPORT, rejected), §Decision (answers to all 5 forwarded questions), §Out-of-scope.
+- [x] **AC6 — no test regression / no new tooling.** Confirmed above.
+
+## ADR adherence (fidelity to ADR 0027 Implementation notes)
+
+- [x] **Five edits all present:** new §25 + TOC (BIBLE:38, 1664); §6 row (306); §21 glossary ×2 (1545, 1567); §22 note (1584); §23 amendments ×3 (1622 reserved-`B`, 1626/1627 future-candidate + namespace, 1620 `n`/`s`-scoping clause).
+- [x] **Child→parent edge, NOT the `n`/`s` flip.** `(child)-[:INHERITS_FROM]->(parent)` with explicit "diverges from `n`/`s`; do NOT flip" warning (BIBLE:1678). Matches ADR §"Edge direction."
+- [x] **Live read-time resolution** (BIBLE:1682–1686), edge as the only materialized artifact. Matches ADR Q5.
+- [x] **No `source` property** (canonical, not a stub) (BIBLE:1680, 306, 1545). Matches ADR §"Edge properties."
+- [x] **Reserved uppercase `B`** (BIBLE:1622, 1702). Matches ADR Q4.
+- [x] **Namespace widened to kind-39998** (BIBLE:1627, 1674). Matches ADR Q3.
+- [x] **Set-valued override deferred; field-level now** (BIBLE:1689). Matches ADR Q2.
+- [x] **§22 note marked candidate, not ratified** (BIBLE:1584). Matches ADR §"Registry-as-DList."
+- [x] **Placement:** appended as §25; §24 Task Queue **not** renumbered (verified TOC + headings). Matches ADR placement note.
+
+## Internal consistency / accuracy audit
+
+- [x] **§23 scoping is correct, no contradiction.** The "no editorial relationships inferable" line (BIBLE:1620) is now explicitly scoped to `n`/`s` with a pointer to §25 — does not contradict `b` being an editorial single-char tag.
+- [x] **Boundary table matches existing BIBLE wording.** "IMPORT… implies IS_A_SUPERSET_OF" (BIBLE:1698 / 1545) agrees with §6:301. "REFERENCES… non-committal stub, carries `source`" agrees with §6:304 / §22:1572. `b` canonical/no-`source` agrees with the canonical-edge convention (ADR 0011 / §22 Phase B).
+- [x] **"First editorial single-char tag" is accurate.** Existing editorial relationships are descriptor-events or Neo4j-only stubs (§6 header "explicit events"; REFERENCES "Neo4j-only… NOT an explicit event") — none is a single-char tag.
+- [x] **Cross-references resolve.** TOC anchor `#25-the-inherit-from-tag-b` (BIBLE:38) matches heading (BIBLE:1664); §25↔§6/§22/§23 textual refs valid; story Linked-artifacts → ADR 0027 path resolves; ADR → story path resolves.
+- [x] **Markdown well-formed.** Both new §25 tables (4-col tag table, 5-col boundary table) have matching header/separator/row column counts.
+
+## Concept-graph integrity
+- [x] **N/A — no concepts, handles, or schemas changed.** This is documentation of a *future* tag/edge; no firmware concept definitions were edited, no graph nodes created. Handles referenced in prose are illustrative (`39998:<alice>:dogs`) and in correct `kind:pubkey:slug` form.
+- [x] **Firmware reinstall:** **not required** (ADR 0027 §Consequences: "No — deliverable is documentation only"). Correctly called out. A future *implementation* story that materializes `INHERITS_FROM` will re-evaluate.
+
+## Things tests can't catch
+- [x] No secrets, no debug logging, no commented-out code (prose-only diff).
+- [x] No scope creep in implementation: commit `69faaa6d` touches **only** `BIBLE.md`. The `_intake.md` addition (queued Communities Protocol) rides in the *story* commit `6406ef46` as legitimate Planning-phase intake hygiene, referenced by the story's Out-of-scope — not implementation scope creep.
+- [x] No silent AC drop; no behavior added beyond the story.
+
+## House rules check
+- [x] Concept Graph API authority respected (API was down; grounding in BIBLE was ratified by the user at the Architecture gate — appropriate here since the deliverable *is* BIBLE prose and the subject is a new tag absent from the graph).
+- [x] No new lint/typecheck/build tooling.
+
+## Findings
+
+### Blocking
+_None._
+
+### Non-blocking
+1. **BIBLE.md:1686 / 1666** — §25 forward-references the Communities Protocol and its `effectiveCD` resolver, which are not yet in the BIBLE (queued in `_intake.md`, 2026-06-05). This is intentional (§25 names the Communities Protocol as the first *consumer*) and consistent with how the BIBLE references in-progress work elsewhere, so it is not a defect. **Follow-up:** when the Communities Protocol lands, ensure `effectiveCD` is actually defined there so the analogy resolves.
+2. **Process note (not a diff issue)** — git is recording commits under an auto-derived identity (`Clawds4 <clawds4@Davids-MacBook-Pro.local>`). Harmless for content, but the author may wish to set `git config user.name/user.email` before the deploy chain so the merge history carries a proper identity.
+
+## Verdict
+**PASS** — the diff matches the story (all 6 ACs), conforms to ADR 0027 (all five edits, all five forwarded-question decisions reflected), is internally consistent and accurate against existing BIBLE wording, every cross-reference resolves, and the test gate is clean (26/26, independently re-run). Documentation-only; no source, test, or firmware touched. One non-blocking follow-up noted (`effectiveCD` definition when the Communities Protocol lands).

--- a/engineering-team/stories/31-b-tag-general-inherit-primitive.md
+++ b/engineering-team/stories/31-b-tag-general-inherit-primitive.md
@@ -66,4 +66,4 @@ The Concept Graph API at `http://localhost:8877` was **not reachable at planning
 ## Linked artifacts
 - ADR: [../decisions/0027-inherit-from-tag-b.md](../decisions/0027-inherit-from-tag-b.md) — **Accepted** (2026-06-05).
 - Test plan: _n/a — Test Design skipped (docs-only, no executable behavior; doc-content sentinels covered in Review, per the story #20 precedent)._
-- Review: _(filled in after Review)_
+- Review: [../reviews/31-b-tag-general-inherit-primitive.md](../reviews/31-b-tag-general-inherit-primitive.md) — **PASS** (2026-06-05): 6/6 ACs met, ADR 0027-conformant, 26/26 test suites green, BIBLE-only diff. One non-blocking follow-up (`effectiveCD` definition when the Communities Protocol lands).

--- a/engineering-team/stories/31-b-tag-general-inherit-primitive.md
+++ b/engineering-team/stories/31-b-tag-general-inherit-primitive.md
@@ -1,0 +1,69 @@
+# Story 31: Establish the `b` tag as a general inherit-from primitive
+
+**Status:** Approved
+**Created:** 2026-06-05
+**Type:** Doc (protocol-definition — runs Planning → Architecture → Implementation → Review; **not** fast-tracked, because it carries a ratifiable design decision captured as ADR 0027)
+
+## Background
+
+We are drafting the Tapestry Communities Protocol. Its mechanism for a participant Community Declaration to defer to a parent Declaration — currently called the `affiliation` tag — is being recast as a single-character `b` tag, following the `n`/`s` convention in BIBLE §23 (single-char ⇒ relay-indexed per NIP-01; child-claims-parent; a-tag value; reserve uppercase `B` for the parent-claims-child inverse).
+
+In discussion it became clear this relationship — *"accept the parent's definition unless this event states otherwise"* — is **not community-specific**. It is general to any addressable DList object. Worked example: Alice publishes a `dogs` concept; Bob mints his own `dogs` concept carrying `["b", "<Alice's-dogs a-tag>", "inherit"]`, meaning *"my notion of dogs is whatever Alice says, unless I say otherwise."* The same shape serves concept↔concept, set↔set, and Declaration↔Declaration.
+
+The risk if we ship `b` only inside the Communities Protocol: it lands beside the BIBLE's existing editorial relationships — **IMPORT** (absorb the parent's curated elements; importer becomes authoritative), **REFERENCES** (non-committal bookmark, may-pull-later, §22), **SUPERCEDES** (replace) — without an explicit boundary, reintroducing the "two parallel schemas" problem the protocol itself warns against. `b` is genuinely distinct: **live deference** (the parent stays the authority), with a **first-class "unless otherwise stated" override**. That distinction has to be written down, or implementers will conflate `b` with IMPORT.
+
+Doing this now — before the Communities Protocol's tag set is ratified — means the Communities Protocol *consumes* a core primitive rather than owning a community-only tag. It also surfaces a bonus: aggregated, trust-weighted incoming `b`-edges are a candidate mechanism for §22's long-deferred "grapevine-resolved community definition" (Flaw A) exit.
+
+## User-facing description
+
+**As an implementer or reviewer** reading the BIBLE, **I want** `b` defined once as a general inherit-from primitive with an explicit boundary against IMPORT / REFERENCES / SUPERCEDES, **so that** I know when to use it and never confuse live-deference with absorption or bookmarking.
+
+**As a protocol designer**, **I want** the decision — with its rejected alternatives and its open design questions — recorded in an ADR, **so that** the Communities Protocol and future curators build on a ratified primitive instead of an ad-hoc community tag.
+
+**As a curator**, **I want** to express "my concept of X defers to another curator's, with my own overrides," **so that** I can stand on a trusted definition without copying it.
+
+## Acceptance criteria
+
+Testable from the outside (content assertions on `BIBLE.md` and the ADR; exact section placement is the Implementer's call).
+
+- [ ] The BIBLE defines a single, general-purpose **inherit-from primitive — the `b` tag** — described as applying to *any* addressable DList object (concept↔concept, set↔set, Community Declaration↔Declaration), explicitly **not** scoped to communities.
+- [ ] In one canonical place, the BIBLE states `b`'s meaning: **child-claims-parent**; the tag value is the **parent's a-tag**; semantics are *"accept the parent's definition unless this event states otherwise"*; the **parent remains the authority** and the child may override specific fields. The Communities Protocol's affiliation pointer is characterized as a *consumer* of this primitive (`affiliation` → `b` with type `inherit`), not a separate tag.
+- [ ] The BIBLE **distinguishes `b` from IMPORT, REFERENCES (concept-level), and SUPERCEDES** so a reader can choose between them — naming `b`'s live-deference + override posture against IMPORT's absorption and REFERENCES's non-committal bookmark. This includes a glossary (§21) entry for `b` and its placement in the editorial-relationship family/table (the ~§301 region).
+- [ ] The Community-Reference Model (§22) names `b` as a **candidate mechanism for the deferred "registry-as-DList / grapevine-resolved community definition" exit (Flaw A)** — i.e. aggregated, trust-weighted incoming `b`-edges as the selector of a community's preferred definition.
+- [ ] An ADR (expected **0027**, in the 0006/0011 lineage) records the decision, the **rejected alternative of folding `b` into IMPORT**, and the design questions it resolves or defers (listed under "Forwarded to the Architect" below).
+- [ ] Quality: no regression in the npm test suites (no source touched); no new lint/typecheck/build tooling introduced.
+
+## Concepts touched
+
+The Concept Graph API at `http://localhost:8877` was **not reachable at planning time** — Architect should resolve handles via `/api/concept-graph/summaries` when orienting.
+
+- **Editorial relationships** — IMPORT, SUPERCEDES, REFERENCES (concept-level) — BIBLE §21/§22 + relationship table (~§301). Likely correspond to firmware "relationship" concepts in the graph.
+- **Class-thread membership tags** `n` / `s` / `z` — BIBLE §23 (the convention `b` extends).
+- **The `b` / inherit-from relationship** — *new*; this story defines it.
+- *(Indirectly)* Community Declaration / the Communities Protocol — the first consumer.
+
+## Out of scope
+
+- **All code** — tag emission, the resolver/merge-walk, the Neo4j edge MERGE, and migration of existing events. Future implementation stories.
+- **The rest of the Communities Protocol draft** and its other §11 ratification items (canonical membership, single-root, Tag wire format, membership threshold, CD term). Separate effort — logged in `_intake.md` (2026-06-05).
+- **Adding the full Communities Protocol document to the BIBLE.** This story adds only the general `b` primitive and its placement; incorporating the Communities draft is separate.
+- **Pre-deciding the deferred design specifics** (edge name, override algebra, etc.) — those are resolved *in* the ADR (Phase 2), not in this story.
+- Renaming or repurposing any other single-char tag.
+
+## Open questions
+
+**Resolved at planning (2026-06-05):**
+1. **Scope** → confirmed = the `b` primitive only (three BIBLE-core edits + ADR 0027). The broader Communities Protocol is deliberately deferred to a follow-up effort, logged in `_intake.md` (2026-06-05), to be picked up after this story.
+2. **Phase path** → Planning → Architecture → Implementation → Review, with **Test Design skipped** (no executable behavior; doc-content sentinels are covered in Review, per the story #20 precedent). A light structural-sentinel pass may be added at Implementer/Reviewer discretion if useful.
+
+**Forwarded to the Architect (resolve or defer in ADR 0027 — not blocking this story):**
+3. Which Neo4j edge `b` writes (candidates: `INHERITS_FROM` / `DERIVES_FROM` / `DELEGATES_TO`), analogous to `n`→HAS_ELEMENT, `s`→IS_A_SUPERSET_OF.
+4. Set-valued override algebra (overriding a concept's element set needs add/remove/replace semantics; the CD case only overrode scalars).
+5. Carving `b` out of §23's "no editorial relationships inferable" constraint (BIBLE:1614) — `b` would be the first *editorial* single-char tag — and widening the single-char namespace claim to kind-**39998** (concepts are headers).
+6. Reserving uppercase **`B`** for the parent-claims-child / federation inverse.
+7. Whether resolution is a **live walk** (re-resolved against the parent's current state) or a **snapshot at MERGE time**.
+
+## Linked artifacts
+- ADR: _(filled in after Architecture — expected `0027`)_
+- Test plan: _(n/a unless a light sentinel pass is requested — see resolved question 2)_
+- Review: _(filled in after Review)_

--- a/engineering-team/stories/31-b-tag-general-inherit-primitive.md
+++ b/engineering-team/stories/31-b-tag-general-inherit-primitive.md
@@ -1,6 +1,6 @@
 # Story 31: Establish the `b` tag as a general inherit-from primitive
 
-**Status:** Approved
+**Status:** In Progress
 **Created:** 2026-06-05
 **Type:** Doc (protocol-definition — runs Planning → Architecture → Implementation → Review; **not** fast-tracked, because it carries a ratifiable design decision captured as ADR 0027)
 
@@ -64,6 +64,6 @@ The Concept Graph API at `http://localhost:8877` was **not reachable at planning
 7. Whether resolution is a **live walk** (re-resolved against the parent's current state) or a **snapshot at MERGE time**.
 
 ## Linked artifacts
-- ADR: _(filled in after Architecture — expected `0027`)_
-- Test plan: _(n/a unless a light sentinel pass is requested — see resolved question 2)_
+- ADR: [../decisions/0027-inherit-from-tag-b.md](../decisions/0027-inherit-from-tag-b.md) — **Accepted** (2026-06-05).
+- Test plan: _n/a — Test Design skipped (docs-only, no executable behavior; doc-content sentinels covered in Review, per the story #20 precedent)._
 - Review: _(filled in after Review)_

--- a/engineering-team/stories/_intake.md
+++ b/engineering-team/stories/_intake.md
@@ -618,3 +618,28 @@ Today the `forceKill: false` override masks the impact (wrapper declares timeout
 - Part B (bug): properly-scoped story + ADR (the right duration value is an architectural choice that affects operator expectations + may have a follow-on on auto-tune Track B).
 
 **Classification:** Mixed (cleanup + bug). **Priority:** Medium — incomplete coverage of story #28's intended fix; cosmetic + 2 latent bugs.
+
+---
+
+## 2026-06-05 — Feature: Tapestry Communities Protocol (full draft → BIBLE)
+
+**Surfaced during:** the story #31 planning conversation (the `b` / inherit-from primitive). Story #31 carves out and ratifies just the general `b` tag; the broader protocol it came from is deferred here at the operator's request ("I do want to address the broader Communities Protocol, but we can do that after"). **Depends on story #31 landing first** — the affiliation pointer is now the general `b` primitive #31 defines.
+
+**Scope:** Land the Tapestry Communities Protocol (Draft v1). A community is *computed*, per resolution, from **Tags + a Community Declaration (CD) + a Point of View (PoV)** → roster; no hand-kept membership state. The CD is an editable kind-39999 event; a founding author publishes the root CD (House PoV = founder), and participants publish child CDs that defer to a parent via the `b` tag (story #31) under "accept the parent unless otherwise stated." Membership is GrapeRank-gated (author influence ≥ role cutoff from the PoV); roles are predicates (v1: `applicant` = self-tag, `member` = vouched by an existing member who clears the cutoff; `admin` off). Disputes are trust-weighted negatives, never a one-person veto. The community survives the founding author going inactive (every participant CD still resolves against the last known parent state). Reuses existing primitives only — no new infra (GrapeRank scorecards, influence cutoffs, PoV selection already exist).
+
+**Open §11 ratification items carried from the draft (decide during Planning/Architecture):**
+1. Affiliation tag → now `b` per story #31 (largely settled; confirm wire form `["b", "<parent-cd-a-tag>", "inherit"]`, type in element 3).
+2. **Canonical membership:** House-PoV roster is authoritative for a safe space; Personalized PoV is a *lens* (how a viewer sees/orders the community via their affiliated CD), not a private redefinition of who is a member. Must be decided explicitly, not left to whatever the resolver does first.
+3. Single-root v1; multi-root federation deferred (reserve uppercase `B` for the parent-claims-child inverse per #31).
+4. **Tag wire format** — reconcile the community input-Tag with the `feat/pubkey-tagging-target` work; a view over those pubkey-tag events is preferred over a second parallel schema.
+5. Membership threshold (1 qualifying vouch vs N≥2 for a safe space) — growth rate vs ease of entry.
+6. CD term: "Declaration" vs "Definition" (draft uses *Declaration*).
+
+**Deferred within the protocol (not v1 gaps — deliberate later steps):** Admin/community-curator role; affiliation *types* beyond `inherit`; multi-root federation; per-viewer membership forking (only if §5.3 is decided against the safe-space recommendation); full tags-as-rating-edges GrapeRank (v1 may ship the simpler reachability-plus-cutoff form).
+
+**Worked example to preserve:** Les Femmes Orange (LFO), a membership / safe-space community, used throughout the draft.
+
+**Classification:** Feature (protocol + likely resolver + UI/API). **Large — expect to split** into multiple stories, e.g.: (a) CD event shape + effective-CD merge-walk resolver; (b) the input Tag primitive + reconciliation with `feat/pubkey-tagging-target`; (c) PoV resolution + roster computation; (d) trust-weighted disputes; (e) onboarding / cross-site (House vs Personalized PoV) flow.
+**Strictness:** Standard.
+**Phase path:** `/discuss` to settle the §11 decisions and the story split → then Planning → Architecture → Test Design → Implementation → Review per sub-story.
+**Priority:** Medium — operator wants it next, after story #31. **Depends on:** story #31 (the `b` inherit-from primitive).


### PR DESCRIPTION
## Summary

Documents the **`b` tag** as a general *definitional-inheritance* primitive: any addressable DList object can declare "my definition is this parent's, unless I state otherwise" via `["b","<parent-a-tag>","inherit"]`, materializing a child→parent `INHERITS_FROM` edge resolved live at read time. It generalizes the Communities Protocol's affiliation pointer (the first consumer) and is placed explicitly against the existing editorial relationships (IMPORT/REFERENCES/SUPERCEDES) so the two aren't conflated. **Documentation-only** — no source, test, or firmware touched.

Story #31 · ADR 0027 (Accepted) · Review **PASS** (no blocking findings).

## Changes

- **`BIBLE.md` §25 (new):** "The Inherit-From Tag (`b`)" — spec, child→parent edge (diverges from `n`/`s`; no flip), live resolution + field-level override (set-valued deferred), editorial-boundary table, reserved uppercase `B`. + Table of Contents entry.
- **`BIBLE.md` §6:** `INHERITS_FROM` row in the editorial-relationships table.
- **`BIBLE.md` §21:** glossary entries for `b tag` and `INHERITS_FROM`.
- **`BIBLE.md` §22:** `b`-edges noted as the **candidate** (not ratified) registry-as-DList / grapevine Flaw-A exit mechanism.
- **`BIBLE.md` §23:** scoped the "no editorial relationships" note to `n`/`s`; reserved `B`; namespace widened to kind-39998.
- **engineering-team/**: ADR 0027, story #31, review (PASS), `_intake.md` (queued the broader Communities Protocol as a dependent follow-up).

## Test plan

- [ ] After merge: `deploy-staging.yml` runs green.
- [ ] Smoke test on staging.brainstorm.world — **formality** (docs-only; no runtime behavior changed). Confirm staging is still healthy post-deploy.
- [x] `npm test` — 26/26 suites PASS (run at impl + independently at review).
- [x] Diff scope confirmed BIBLE.md + engineering-team artifacts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)