### PR TITLE
engineering-team: book-close return edge (audit + PRD addendum/seed)

### DIFF
--- a/.claude/commands/close-book.md
+++ b/.claude/commands/close-book.md
@@ -1,0 +1,33 @@
+---
+description: Close a book of work. Act as Reviewer at book scope — write the build audit and the PRD addendum (or seed), the return edge back to the product team.
+---
+
+You are entering **Book Close** — a milestone phase of the Tapestry engineering harness. It runs once per book of work, not per story.
+
+**State at the top of your first response:** "I'm acting as the Reviewer, at book scope. Phase: Book Close."
+
+**Role:** Follow [engineering-team/roles/reviewer.md](engineering-team/roles/reviewer.md) → "Book-scope audit". You audit what shipped and reconcile it against intent. You do NOT write code or change product-team files.
+
+**Workflow:** Follow [engineering-team/workflows/6-book-close.md](engineering-team/workflows/6-book-close.md).
+
+**Templates:**
+- [engineering-team/templates/build-audit.md](engineering-team/templates/build-audit.md) → `engineering-team/audits/<book-slug>/audit.md`
+- PRD-backed book → [engineering-team/templates/prd-addendum.md](engineering-team/templates/prd-addendum.md) → `audits/<book-slug>/prd-addendum.md`
+- No-PRD book → [engineering-team/templates/prd-seed.md](engineering-team/templates/prd-seed.md) → `audits/<book-slug>/prd-seed.md`
+
+**Inputs:**
+- The book manifest `engineering-team/audits/<book-slug>/book.md` (anchor + epics). If the user didn't name a book, list open books (`book.md` with `Status: Open`) and ask which to close. If none exists, reconstruct the anchor from `_intake.md` + git and mark provenance = reconstructed, confidence = low.
+- The stories/ADRs/reviews under the book's epics, and the book diff.
+
+**House rules:**
+- Aggregate existing fields (ADR `Consequences`, story `Out of scope`/`Open questions`, review notes, Implementer `## Deviations` logs) — don't re-derive rationale. Then reconcile against the actual diff.
+- Be honest about confidence. A reconstructed, no-anchor close is a low-confidence hypothesis — say so in the header, don't dress it up.
+- Engineering authors both artifacts under `engineering-team/`. Never write into `product-team/`.
+
+**Gate (mandatory):** After writing both artifacts and flipping the book to Closed, ask:
+
+> Book closed. Audit + {addendum|seed} are ready for the product team to scope the next phase. Anything to correct before I commit?
+
+**Per-phase commit:** Commit audit + feedback doc + updated `book.md` together: `git commit -m "book-close: <book-slug>"`.
+
+$ARGUMENTS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Between phases the gate is **conversational, never a command**: "I've captured t
 |---|---|
 | "let's implement," "write the code," "build this story" | `/plan-feature` (new story) or `/implement-feature` (story with tests) |
 | "review the code," "is this ready to ship" | `/review-changes` |
+| "I think that's everything," "that's all I needed," "looks done," "we're done" | **Offer to close the book** → `/close-book` (don't auto-run; the user's "yes" is the trigger) |
 
 **Advisory — thinking out loud** (no artifacts):
 
@@ -81,8 +82,10 @@ The harness lives in two places:
 
 - **`engineering-team/`** — roles, workflows, templates, and accumulating decisions/stories/reviews. Source of truth for behavior. Read [engineering-team/README.md](./engineering-team/README.md) for the layout and phase wiring.
 - **`.claude/`** — wiring only:
-  - `.claude/commands/<phase>.md` — slash commands: `/plan-feature`, `/design-architecture`, `/design-tests`, `/implement-feature`, `/review-changes`, `/discuss`.
+  - `.claude/commands/<phase>.md` — slash commands: `/plan-feature`, `/design-architecture`, `/design-tests`, `/implement-feature`, `/review-changes`, `/close-book`, `/discuss`.
   - `.claude/agents/<role>.md` — subagents with role-appropriate tool whitelists. The Architect cannot Edit source. The Reviewer cannot Edit source.
+
+Phases 1–5 are the **per-story** cycle. Above them sits one **per-book** milestone, `/close-book` — see "Books of work and the return edge" below.
 
 ### How to operate
 
@@ -108,6 +111,14 @@ The harness lives in two places:
 | ADRs | enabled |
 | Clean working tree before starting a feature | yes |
 | Commit at each phase boundary | yes |
+
+### Books of work and the return edge
+
+The per-story cycle sits inside a larger unit — a **book of work**: a PRD, one roadmap phase of a PRD, or (with no PRD) a bounded ask. Books bracket the loop back to the product team:
+
+- **Open (eager anchor).** At intake, a new book opens `engineering-team/audits/<book-slug>/book.md` recording its intent anchor — the PRD it realizes, or a short **acceptance frame** (the ask restated and confirmed) when there's no PRD. This is the durable definition of "done"; without it, completion can't be detected across sessions and the close drops to low confidence.
+- **Detect completion (offer, don't auto-run).** After every per-story PASS — or when the user signals "I think that's everything" — check whether the book now looks complete (computed for PRD-backed books; judged against the acceptance frame otherwise). If it does, *offer* to close it. The system never declares done; it proposes done and the user ratifies. Their "yes" is the trigger for `/close-book`.
+- **Close (`/close-book`).** The Reviewer, at book scope, writes two artifacts under `audits/<book-slug>/`: `audit.md` (the as-built record) and either `prd-addendum.md` (PRD-backed — deltas vs the PRD) or `prd-seed.md` (no PRD — a reconstructed baseline). These are the **return edge**: the product team reads them to scope the next phase. Engineering authors them under `engineering-team/` and never writes into `product-team/` — the mirror image of engineering reading the product team's `stories-queue.md`. See [engineering-team/README.md](./engineering-team/README.md) → "The return edge".
 
 ## House rules
 

--- a/engineering-team/README.md
+++ b/engineering-team/README.md
@@ -17,7 +17,9 @@ engineering-team/
 │   ├── <epic-slug>/    in-flight stories for that epic: <n>-<slug>.md (+ .test-plan.md)
 │   └── done/<epic-slug>/   shipped epics — the whole epic folder is moved here at epic close
 ├── decisions/          ADRs, scoped by epic: <epic-slug>/<NNNN>-<slug>.md (+ done/<epic-slug>/)
-└── reviews/            review reports, scoped by epic: <epic-slug>/<n>-<slug>.md (+ done/<epic-slug>/)
+├── reviews/            review reports, scoped by epic: <epic-slug>/<n>-<slug>.md (+ done/<epic-slug>/)
+└── audits/             one folder per book of work: <book-slug>/ — book.md (opened at
+                        kickoff) + audit.md & prd-addendum.md|prd-seed.md (at close); done/<book-slug>/
 ```
 
 ## Epic-scoped docs — why the subfolders
@@ -44,6 +46,7 @@ The Claude Code wiring lives elsewhere:
 | Write tests for a story + ADR | `/design-tests` |
 | Implement a story that has tests | `/implement-feature` |
 | Review a diff before commit | `/review-changes` |
+| Close a finished book of work — audit + product feedback | `/close-book` |
 
 `/discuss` defaults to the **Product Expert** — a read-only thinking partner who knows the domain, stack, and existing decisions. Use `as <role> <topic>` for a different lens, or `roundtable <topic>` for multi-perspective.
 
@@ -58,6 +61,31 @@ The Claude Code wiring lives elsewhere:
 ```
 
 The user is the approval gate between phases. After each phase output, Claude asks you to confirm before continuing.
+
+Phases 1–5 are the **per-story** cycle. Above them sits one **per-book** milestone:
+
+```
+  /close-book             → audits/<book>/audit.md          (as-built record)
+                          → audits/<book>/prd-addendum.md   (PRD-backed: deltas vs the PRD)
+                            …or prd-seed.md                 (no PRD: reconstructed baseline)
+```
+
+## The return edge — closing the loop with the product team
+
+The product team's flow (`product-team/`, see its README) hands work *into* engineering: a PRD and an epic-aware `stories-queue.md`. **Book Close is the edge that hands learning back out.** When a book of work finishes — a PRD, a roadmap phase, or a no-PRD ask captured as an acceptance frame — `/close-book` reconciles what shipped against what was intended and writes two artifacts the product team reads to scope the next phase:
+
+```
+product PRD ─▶ eng epics/stories ─▶ build ─▶ /close-book ─▶ audit.md + prd-addendum.md
+     ▲                                                              │
+     └──────────  product /discover (next phase) ◀─────────────────┘
+```
+
+Two mechanisms make this reliable rather than something a human has to remember:
+
+- **Eager anchor (open bracket).** At intake (`workflows/0-intake.md`), a new book opens a `book.md` recording its intent anchor — the PRD it realizes, or, with no PRD, a short **acceptance frame** (the ask restated and confirmed). The thing you reconcile against at close is the thing you anchored to at open; skipping the anchor just drops the close to lower confidence.
+- **Completion detection (the offer).** After every per-story PASS, the Reviewer checks whether the book now looks complete (computed for PRD-backed books, judged against the frame otherwise) and *offers* to close it — it never auto-runs. The human's "yes" is the invocation. See `workflows/5-review.md` → "Completion detection".
+
+The boundary stays clean and symmetric: each team writes only in its own tree and reads across the line. Engineering reads the product team's `stories-queue.md`; the product team reads engineering's `audits/`. Neither writes into the other.
 
 ## Role isolation
 

--- a/engineering-team/audits/.gitkeep
+++ b/engineering-team/audits/.gitkeep
@@ -1,0 +1,6 @@
+# Build audits accumulate here.
+
+One folder per book of work: `audits/<book-slug>/` holding `book.md` (opened at
+kickoff), and at close `audit.md` plus `prd-addendum.md` (PRD-backed) or
+`prd-seed.md` (no PRD). Closed books move to `audits/done/<book-slug>/` once the
+product team has ingested them. See `engineering-team/workflows/6-book-close.md`.

--- a/engineering-team/roles/implementer.md
+++ b/engineering-team/roles/implementer.md
@@ -44,7 +44,8 @@ Make the failing tests pass. Write the **minimum** code that satisfies the test 
    - If you change concept definitions in firmware, run `curl -X POST http://localhost:8877/api/firmware/install` after editing.
    - Don't add lint or typecheck tooling without an explicit ADR.
 8. **If something forces you outside the ADR**, stop. Surface it to the user. The Architect needs to amend the ADR before you proceed.
-9. **Hand off:** "Implementation done. Tests green. Run `/review-changes`."
+9. **Log smaller deviations as you go.** Judgment calls too small for an ADR amendment — reading an ambiguous acceptance criterion one way, a minor shape change, an edge case the story didn't name — get one line under a `## Deviations` heading in the story file: what you did and why. The book-close audit harvests these, so un-logged rationale is lost rationale. (Hard deviations still go to step 8; this is for the small stuff that would otherwise vanish.)
+10. **Hand off:** "Implementation done. Tests green. Run `/review-changes`."
 
 ## Per-phase commits
 This project uses per-phase commits. Commit at the end of implementation with a message that references the story and ADR (e.g., `impl: <slug> (story #<n>, ADR <NNNN>)`).

--- a/engineering-team/roles/reviewer.md
+++ b/engineering-team/roles/reviewer.md
@@ -50,3 +50,22 @@ End with one of:
 
 ## Calibration
 Be skeptical, not pedantic. A diff with passing tests, full coverage of acceptance criteria, and ADR conformance is enough to PASS. Don't block on style preferences not codified in house rules.
+
+## Book-scope audit (milestone — the return edge)
+
+Besides per-story review, you also run **Book Close** — the milestone where a whole *book of work* (a PRD, a roadmap phase, or a no-PRD ask captured as an acceptance frame) is reconciled against intent. This is a meta-review at book scope: same evidence-first, built-vs-spec mindset, one level up. See `engineering-team/workflows/6-book-close.md` and the `/close-book` command.
+
+You produce two artifacts under `engineering-team/audits/<book-slug>/`:
+
+1. **Build Audit** (`audit.md`, template `templates/build-audit.md`) — the **as-built record**: what the product *is* now, source-linked, audience-neutral. It does not propose changes.
+2. **Product feedback** — what *changed* and what's *next*, written for the product team to ingest:
+   - **PRD-backed book** → `prd-addendum.md` (template `templates/prd-addendum.md`): precise deltas onto the existing PRD.
+   - **No-PRD book** → `prd-seed.md` (template `templates/prd-seed.md`): a reverse-engineered baseline PRD, every section tagged `[FROM FRAME]` / `[INFERRED]` / `[UNKNOWN]`.
+
+Principles for the audit:
+- **Aggregate, don't re-derive.** Most rationale already exists — harvest it from ADR `Consequences`, story `Out of scope`/`Open questions`, review notes, and Implementer `## Deviations` logs. Then reconcile against the actual `git diff`.
+- **The doc/diff gap is a finding.** Anything the diff shows that no story/ADR covers is undocumented work — log it.
+- **Be honest about confidence.** A reconstructed, no-anchor close is a low-confidence hypothesis. Say so in the header; don't dress it up.
+- **Stay on your side of the boundary.** Both artifacts live under `engineering-team/`. You never write into `product-team/`. The product team reads your audit to scope the next phase — the mirror image of engineering reading the product team's `stories-queue.md`.
+
+You also own **completion detection**: after a per-story PASS, check whether the story's book now looks complete and, if so, *offer* (never auto-run) to close it. See `workflows/5-review.md` → "Completion detection".

--- a/engineering-team/templates/book.md
+++ b/engineering-team/templates/book.md
@@ -1,0 +1,29 @@
+# Book of Work: <title>
+
+**Slug:** <book-slug>
+**Status:** Open | Closed
+**Opened:** <DATE>
+**Closed:** <DATE or —>
+
+## Intent anchor
+How "done" is defined for this book. One of:
+
+- **PRD-backed** — `product-team/prd/<slug>.md` §<sections> (e.g. §8.1 In Scope / MVP). Completion is *computed*: every story tracing to these sections is `Done` and its epic is closed.
+- **Acceptance frame (no PRD)** — the human's ask, restated and confirmed at kickoff. Completion is *judged* against the bullets below.
+
+### Acceptance frame
+*(Only when there is no PRD. A few bullets — what "done" means, in the human's own terms, confirmed at kickoff. This is the durable definition of done; it also doubles as the skeleton for the PRD seed at close.)*
+
+- [ ] <observable outcome 1>
+- [ ] <observable outcome 2>
+
+## Epics in this book
+- `<epic-slug>` — <one line>
+
+## Provenance
+- **Mode:** PRD-backed | Acceptance-frame | Reconstructed *(no anchor captured at kickoff — intent inferred from `_intake.md` + git at close)*
+- **Confidence at close:** high | medium | low
+
+## Close artifacts *(filled by `/close-book`)*
+- Build audit: `engineering-team/audits/<book-slug>/audit.md`
+- Product feedback: `engineering-team/audits/<book-slug>/prd-addendum.md` | `prd-seed.md`

--- a/engineering-team/templates/build-audit.md
+++ b/engineering-team/templates/build-audit.md
@@ -1,0 +1,47 @@
+# Build Audit: <book title>
+
+**Book:** `engineering-team/audits/<book-slug>/book.md`
+**Date:** <DATE>
+**Branch / commit range:** <base>..<head>
+**Provenance:** PRD-backed | Acceptance-frame | Reconstructed
+**Confidence:** high | medium | low
+
+> The Build Audit is the **as-built record** — what the product *is* now, factual and source-linked. It is audience-neutral: the product team reads it to scope the next phase; a future engineer reads it to understand what shipped. It does **not** propose changes — that's the addendum/seed's job.
+
+## 1. What shipped
+The capabilities this book delivered, in plain language. One bullet per observable capability, each linked to the story/epic that delivered it.
+
+- <capability> — `stories/<epic>/<n>-<slug>.md`
+
+## 2. Epics & stories rolled up
+
+### Epic: `<epic-slug>`
+| Story | Delivered | Status | Review |
+|---|---|---|---|
+| #<n> <slug> | <one line> | Done | `reviews/<epic>/<n>-<slug>.md` |
+
+## 3. As-built inventory
+The concrete surface that now exists — **derived from the diff, not just the docs:**
+- **User-facing:** screens / endpoints / commands added or changed.
+- **Domain:** concepts/handles touched (`kind:pubkey:slug`), schema changes, firmware reinstalls.
+- **Data & contracts:** event kinds, API routes, stored shapes.
+
+## 4. Deviations from intent
+The heart of the audit. Every place the built product differs from the anchor (PRD §refs, or acceptance-frame bullets). **Harvested** from ADR `Consequences`, story `Out of scope` / `Open questions`, review notes, and Implementer `## Deviations` logs — then reconciled against the diff. Rationale is *sourced*, never re-invented.
+
+| # | Specified (anchor) | Built | Type | Rationale (source) | Product impact | Carry-forward |
+|---|---|---|---|---|---|---|
+| 1 | §X.Y "<quote>" / frame bullet | <what shipped> | intentional-change · deferred · added-beyond-scope · constraint-discovered · interpretation | <why> (ADR <NNNN> / impl note) | <does it change what a user can do?> | <follow-up, or —> |
+
+**Undocumented work** — anything the diff shows that no story/ADR covers (the gap between docs-say-shipped and diff-shows-shipped is itself a finding):
+- <item> — `<file>` — no story/ADR provenance.
+
+## 5. Quality state at close
+- Test gate: `npm test` result at close.
+- Known open issues / accepted bugs (linked).
+- Debt logged by ADRs (`Consequences → new debt`), rolled up.
+
+## 6. Carry-forward register
+The consolidated list of everything the next phase should consider — deferred scope, new debt, opened questions. This is the bridge into the addendum/seed.
+
+- [ ] <item> (from §4 #<n> / story #<n> Open questions)

--- a/engineering-team/templates/prd-addendum.md
+++ b/engineering-team/templates/prd-addendum.md
@@ -1,0 +1,41 @@
+# PRD Addendum: <product slug> — <book title>
+
+**Reconciles:** `product-team/prd/<slug>.md` *(immutable — never edited)*
+**Build audit:** `engineering-team/audits/<book-slug>/audit.md`
+**Date:** <DATE>
+**Authored by:** engineering (Reviewer at book scope)
+
+> This addendum stands **beside** the original PRD; it never edits it. It records where the built product diverged from the plan, why, and what the next product cycle should pick up. The product team reads this when scoping the next phase, then issues a superseding `prd/<slug>-v2.md`. Engineering does not write into `product-team/` — this is the read-across-the-boundary return edge, mirroring how engineering reads the product team's `stories-queue.md`.
+
+## 1. Summary
+2–4 sentences: what this book set out to do (per the PRD), what actually shipped, and the headline divergences.
+
+## 2. Deviations from the PRD
+Promoted from build audit §4, framed for product — **impact-first, not implementation-first.**
+
+### 2.1 Intentional changes
+What we built differently on purpose, with PRD §ref and rationale.
+
+### 2.2 Deferred (cut to a later phase)
+PRD scope that did **not** ship, and the phase it's now assigned to. *(An un-phased deferral is a graveyard — give each a home.)*
+
+### 2.3 Added beyond the PRD
+Capabilities that shipped but weren't in the PRD. Why they were necessary; whether they should be ratified into the product model.
+
+### 2.4 Constraints discovered
+Where the PRD was infeasible as written, and what that implies for the product's assumptions (personas, journeys, domain model).
+
+## 3. Impact on the product model
+Which PRD sections the next version must revise:
+- **Personas / journeys:** <if any deviation changes them>
+- **Scope / roadmap:** <reslotted items, new phase boundaries>
+- **Domain model:** <entities/relationships that changed shape in practice>
+- **Design rules:** <guide rules that proved wrong or incomplete>
+
+## 4. Recommended scope for the next phase
+Engineering's read on what the carry-forward register implies — **input, not decision.** The product team owns the actual re-scope.
+- <recommendation> (from audit carry-forward #<n>)
+
+## 5. Open questions for product
+Numbered, specific decisions the next product cycle must make.
+1. <question> — options: <A / B>.

--- a/engineering-team/templates/prd-seed.md
+++ b/engineering-team/templates/prd-seed.md
@@ -1,0 +1,31 @@
+# PRD Seed: <inferred product name>
+
+**Mode:** reconstructed from as-built *(no prior PRD)*
+**Build audit:** `engineering-team/audits/<book-slug>/audit.md`
+**Anchor:** acceptance frame in `book.md` | none *(reconstructed from `_intake.md` + git)*
+**Confidence:** high | medium | low
+**Date:** <DATE>
+
+> This is a **reverse-engineered baseline** in the product-team PRD shape, built from what shipped. It is a *strawman for the product team*, not a ratified spec. Every section is tagged — `[FROM FRAME]` (grounded in the kickoff acceptance frame), `[INFERRED]` (read off the as-built system), or `[UNKNOWN — product input needed]`. The product team adopts this as the starting point for `/discover` on the next phase and validates each section. **Be honest about confidence:** a no-anchor reconstruction is a hypothesis, not ground truth — don't dress it up.
+
+## 1. Product vision
+`[INFERRED]` what the built product appears to do, and for whom. `[UNKNOWN]` the underlying problem/opportunity if it was never stated.
+
+## 2. Personas
+`[INFERRED]` from story "As a <user>" lines and the acceptance frame. Behavior-based. Flag the guesses.
+
+## 3. Scope (as-built)
+`[FROM FRAME]` / `[INFERRED]` everything that actually shipped, framed as the current in-scope set.
+
+## 4. Domain model
+`[INFERRED]` from concepts touched (`kind:pubkey:slug`), ADRs, and stored shapes — entities, attributes, relationships.
+
+## 5. Design rules (as-built)
+`[INFERRED]` from the shipped UI, any guides, and review notes. Flag where no rule was ever recorded.
+
+## 6. Carry-forward & open questions
+Promoted from build audit §6 — the obvious candidates for the next phase.
+
+## 7. What product must validate
+The `[INFERRED]` / `[UNKNOWN]` items that need a human product decision before this seed becomes a real PRD.
+- [ ] <item>

--- a/engineering-team/workflows/0-intake.md
+++ b/engineering-team/workflows/0-intake.md
@@ -23,8 +23,14 @@ Any new user request.
    | Refactor | All phases | Skip Tests if no behavior change | Implementer + Reviewer |
    | Doc / one-liner | Skip Tests + Architecture | Skip Tests + Architecture | Implementer only |
 
-4. **Confirm the path with the user.** "This looks like a {type} — under Standard, the path is: {phases}. OK?"
-5. **Hand off** to the first applicable phase.
+4. **Bracket the book of work (eager anchor).** A *book* is a PRD (or one roadmap phase of one), or — with no PRD — a bounded ask. Decide whether this request starts a new book or joins an open one (`engineering-team/audits/*/book.md` with `Status: Open`):
+   - **Joins an open book** → add its epic to that `book.md`. Nothing else to capture.
+   - **Starts a new book, PRD-backed** → create `engineering-team/audits/<book-slug>/book.md` from `templates/book.md`, anchor pointing at the PRD §sections it realizes. Completion will be *computed*.
+   - **Starts a new book, no PRD** → restate the ask as a short **acceptance frame** (a few bullets — what "done" means, in the user's own terms), confirm it, and save it in `book.md`. This is the durable definition of done: without it, completion can't be detected across sessions and the close drops to low-confidence. The frame doubles as the skeleton for the PRD seed at close.
+   - *Doc / typo / one-liner requests don't need a book.*
+5. **Confirm the path with the user.** "This looks like a {type} — under Standard, the path is: {phases}. OK?"
+6. **Hand off** to the first applicable phase.
 
 ## Output
-A note in `engineering-team/stories/_intake.md` recording the request, classification, and chosen phase path.
+- A note in `engineering-team/stories/_intake.md` recording the request, classification, and chosen phase path.
+- For a new book of work: an opened `engineering-team/audits/<book-slug>/book.md` carrying the intent anchor (PRD ref or acceptance frame). This is the open-bracket that the book-close milestone (`workflows/6-book-close.md`) reconciles against.

--- a/engineering-team/workflows/5-review.md
+++ b/engineering-team/workflows/5-review.md
@@ -37,6 +37,22 @@ Yes. Commit the review file regardless of verdict. Accumulated reviews are valua
 
 When the verdict is PASS, set `**Status:** Done` at the top of the story file in the same review commit. **That's the whole per-story close-out — do not move individual files.** Retirement happens per-epic, not per-story, so an epic's stories stay together in `stories/<epic-slug>/` while the epic is still in flight (even if some are already Done). Save your review under the epic too: `engineering-team/reviews/<epic-slug>/<n>-<slug>.md`.
 
+## Completion detection — offer to close the book
+
+The moment a *book of work* can become complete is always "the last story just passed review." So after a PASS, check the book this story belongs to (`engineering-team/audits/<book-slug>/book.md`):
+
+- **PRD-backed (structural):** are all stories tracing to the anchor's §sections now `Done` and their epics closed? If yes → the book looks complete.
+- **No-PRD (semantic):** is every bullet of the acceptance frame now satisfied by what shipped? If yes → the book looks complete.
+
+When a book looks complete, **offer — don't auto-run:**
+
+> Your original ask was *<anchor summary>*. What's shipped now covers it: *<evidence, linked to stories>*. This book of work looks complete — want me to close it? I'll generate the build audit and the PRD {addendum|seed}.
+
+- **Yes** → run `/close-book` (Phase 6). The human's "yes" is the invocation.
+- **Not yet / also need X** → extend the acceptance frame (or note the remaining PRD scope), leave the book `Open`, write nothing.
+
+The system never *declares* a book done — it *proposes* done and the human ratifies. That's the safety valve against false-positive completion. A natural-language "I think that's everything" triggers the same offer — see `CLAUDE.md` → "Intent Detection".
+
 ## Epic close-out
 
 When an epic ships (its branch is merged to the shared line), move the epic's whole folders under `done/` — **one `git mv` per area, on the directory, not per file:**

--- a/engineering-team/workflows/6-book-close.md
+++ b/engineering-team/workflows/6-book-close.md
@@ -1,0 +1,55 @@
+# Phase 6: Book Close (milestone — not a per-story phase)
+
+## Role
+Reviewer, operating at **book scope**. See `engineering-team/roles/reviewer.md` → "Book-scope audit".
+
+## Cadence
+This phase does **not** run per story or per epic. It runs once, when a **book of work** completes — a PRD (or one roadmap phase of a PRD), or, with no PRD, the ask captured in the book's acceptance frame. The per-story cycle (Phases 1–5) is orthogonal and keeps running underneath.
+
+## Trigger
+Human-ratified. Engineering **offers** to close; the human's "yes" is the invocation. See `workflows/5-review.md` → "Completion detection" for how the offer fires at the review boundary, and `CLAUDE.md` → "Intent Detection" for the natural-language completion triggers. `/close-book` is the explicit override.
+
+## Input
+- The book manifest `engineering-team/audits/<book-slug>/book.md` (anchor + epic set). If none exists, reconstruct one first (see Provenance in step 1).
+- The anchor: the PRD §sections, or the acceptance frame.
+- All stories / ADRs / reviews under the book's epics, plus their incremental `## Deviations` logs.
+- The book diff: `git diff <base>..<head>` across the book's epics.
+
+## Output
+Two artifacts under `engineering-team/audits/<book-slug>/`:
+1. `audit.md` — the **Build Audit** (as-built record), using `templates/build-audit.md`.
+2. `prd-addendum.md` **or** `prd-seed.md` — the product feedback, using the matching template:
+   - **PRD-backed** → addendum (deltas onto the existing PRD).
+   - **No PRD** → seed (reconstructed baseline in PRD shape).
+
+Both are **engineering-authored and live under `engineering-team/`.** The product team *reads* them to scope the next phase — engineering never writes into `product-team/`. This mirrors the forward handoff, where engineering reads the product team's `stories-queue.md`.
+
+## Steps
+1. **Resolve the anchor & provenance.** Read `book.md`; set the mode (PRD-backed / acceptance-frame / reconstructed) and confidence. No manifest *and* no PRD → reconstruct intent from `_intake.md` + git history, mode = reconstructed, confidence = low — and say so loudly in the audit header.
+2. **Roll up the per-story record.** Aggregate, don't re-derive: ADR `Consequences`/`Out of scope`, story `Out of scope`/`Open questions`, review verdicts, and Implementer `## Deviations` logs across the book's epics.
+3. **Walk the diff.** Confirm what actually shipped. Flag anything in the diff with no story/ADR provenance — that's undocumented work, a finding in its own right.
+4. **Build the deviation log.** For each gap between anchor and as-built: Specified / Built / Type / Rationale (sourced) / Product impact / Carry-forward.
+5. **Write the Build Audit** (`audit.md`).
+6. **Write the feedback doc** (addendum or seed) — promote deviations and the carry-forward register into product-facing framing. Recommendations are *input*, not decisions.
+7. **Run the gate** at close: `npm test`; record the result in the audit.
+8. **Flip the book to Closed.** Set `**Status:** Closed`, fill the close-artifact links and confidence in `book.md`.
+9. **Gate:** "Book closed. Audit + {addendum|seed} written to `audits/<book-slug>/`. Ready for the product team to scope the next phase. Anything to correct?"
+
+## Per-phase commit
+Commit the audit, feedback doc, and updated `book.md` together: `git add engineering-team/audits/<book-slug> && git commit -m "book-close: <book-slug>"`.
+
+## Book retirement
+Like epics, a closed book's folder moves under `audits/done/<book-slug>/` once the next phase has ingested it (one `git mv` on the directory). Everything outside `done/` is live; everything under it is shipped and read-only by convention.
+
+## The return edge — closing the loop
+This phase is the return edge that turns the one-way product→engineering pipeline into an iterative loop:
+
+```
+product PRD ─▶ eng epics/stories ─▶ build ─▶ /close-book ─▶ audit.md + prd-addendum.md
+     ▲                                                              │
+     └──────────  product /discover (next phase) ◀─────────────────┘
+                  opens grounded: "here's what shipped, here's where it
+                  drifted from plan and why, here's the carry-forward"
+```
+
+With no PRD, the seed *bootstraps* the product side: the product team adopts it as the baseline for `/discover` instead of starting cold.

--- a/product-team/README.md
+++ b/product-team/README.md
@@ -77,6 +77,10 @@ The stories queue is **epic-aware**. Its blocks map onto engineering *epics*. Ea
 
 The product team does not attend engineering phases. The artifacts are the communication layer. If engineering has a product question, they kick back via `/discuss-product`.
 
+### The return edge — what comes back
+
+The handoff is not one-way. When engineering finishes a book of work, it runs `/close-book` and writes two artifacts under `engineering-team/audits/<book-slug>/`: a **build audit** (what actually shipped) and a **PRD addendum** (where the build diverged from the PRD, why, and the carry-forward) — or, if the work was built with no PRD, a **PRD seed** (a reconstructed baseline in this team's PRD shape). When you scope the *next* phase, Discovery reads those first, so you start grounded in what was built rather than from a blank page. The boundary stays symmetric: engineering reads our `stories-queue.md`; we read engineering's `audits/`. Neither team writes into the other's tree. See `engineering-team/README.md` → "The return edge".
+
 ## Role isolation
 
 Each phase has a corresponding subagent in `.claude/agents/`. Subagents run in isolated context with constrained tools — every product role can Write only into `product-team/`, so none of them can touch source code, and the Product Advisor has no Write tool at all. The slash commands invoke role behavior in the main session for interactive phases; the subagents are useful when you want a role to run autonomously or in the background.

--- a/product-team/workflows/1-discovery.md
+++ b/product-team/workflows/1-discovery.md
@@ -6,6 +6,8 @@ Product Strategist. See `product-team/roles/product-strategist.md`.
 ## Input
 The user's free-form description of what they want — a sentence, a paragraph, a voice-note transcript, a bullet list.
 
+**If this is the *next* phase of an existing product** (not a cold start), read the engineering team's return edge first: any `engineering-team/audits/<book-slug>/audit.md` (what shipped last cycle) and its `prd-addendum.md` or `prd-seed.md` (where it drifted from plan, and the carry-forward). Open the conversation grounded in that — "here's what got built, here's where it diverged and why, here's what's still open" — rather than from scratch. A `prd-seed.md` means engineering built without a PRD; adopt it as the strawman baseline and validate it here. This is the loop closing: engineering reads the product team's `stories-queue.md`; the product team reads engineering's `audits/`.
+
 ## Output
 A discovery brief at `product-team/discoveries/<slug>.md`, using the `discovery-brief.md` template. **The product slug is chosen in this phase** and reused by every later phase.
 


### PR DESCRIPTION
## What this adds

The product-team harness (merged in #237) hands work **into** engineering one-directionally. This adds the missing **return edge** that closes the loop: when a *book of work* finishes, engineering reconciles what shipped against what was intended and hands learning back to the product team to scope the next phase.

A **book of work** is a PRD, one roadmap phase of a PRD, or — when there's no PRD/product-team at all — a bounded ask. It sits one level above the per-story 1–5 cycle, which keeps running underneath.

## The loop

```
product PRD ─▶ eng epics/stories ─▶ build ─▶ /close-book ─▶ audit.md + prd-addendum.md
     ▲                                                              │
     └──────────  product /discover (next phase) ◀─────────────────┘
```

## Two artifacts at close (`/close-book`, Reviewer at book scope)

- **`audit.md`** — the as-built record: what the product *is* now, source-linked, audience-neutral.
- **`prd-addendum.md`** (PRD-backed) — precise deltas vs the PRD: intentional changes, deferrals, additions, discovered constraints, each with rationale and carry-forward.
- **`prd-seed.md`** (no PRD) — a reverse-engineered baseline in the product team's PRD shape, every section tagged `[FROM FRAME]` / `[INFERRED]` / `[UNKNOWN]`, with explicit confidence. Lets the product team adopt a strawman instead of starting cold.

## What makes it reliable (not "remember to run a command")

- **Eager anchor (open bracket).** At intake, a new book opens `audits/<book-slug>/book.md` recording its intent anchor — the PRD, or an **acceptance frame** (the ask restated + confirmed) when there's no PRD. *The thing you reconcile against at close is the thing you anchored to at open.*
- **Incremental capture.** The Implementer logs small deviations under `## Deviations` as they happen, so the audit **aggregates** real rationale (ADR Consequences, story Out-of-scope/Open-questions, review notes) rather than reconstructing it at the end.
- **Completion detection.** After every per-story PASS — or on a natural-language "I think that's everything" — the Reviewer checks whether the book looks complete (computed for PRD-backed; judged against the frame otherwise) and **offers** to close it. The system never declares done; it proposes done and the user ratifies.

## Graceful degradation

| Kickoff anchor | Detection | Close fidelity |
|---|---|---|
| PRD | structural (computed) | high — precise addendum |
| Acceptance frame (no PRD) | semantic + NL signal | medium — seed from the frame |
| Nothing persisted | NL signal only | low — seed reconstructed from code/git, flagged |

## Boundary stays symmetric

Each team writes only its own tree and reads across the line: engineering reads the product team's `stories-queue.md`; the product team reads engineering's `audits/`. Neither writes into the other.

## Files

New: `/close-book` command, `workflows/6-book-close.md`, `templates/{book,build-audit,prd-addendum,prd-seed}.md`, `engineering-team/audits/`.
Wired: `0-intake` (eager anchor), `implementer` (deviation log), `5-review` (completion offer), `reviewer` (book-scope audit), `CLAUDE.md` (mode + intent detection), product-team Discovery + README (reads the return edge).

All design/markdown — no code, consistent with the rest of the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)