### PR TITLE
Carve nostr-user-tag read + WoT-score core onto staging (for Communities)

### DIFF
--- a/VERIFY_TAG_CORE.md
+++ b/VERIFY_TAG_CORE.md
@@ -1,0 +1,81 @@
+# Verify: nostr-user-tag read/score core (for Communities)
+
+This branch (`chore/carve-nostr-user-tag-core`, off `staging`) lands **just the tag read + per-POV WoT-score core** so Communities can build membership rosters against it. It is **read-only** — there is no UI or publisher here. That matters for verification (see step 3).
+
+**What's in scope:** `src/api/profile-tags/index.js` (read/score engine), `src/api/_shared/pov.js`, firmware concepts `tag` / `nostr-user-tag` / `tag-pinning`, route wiring. **Out of scope:** the pin→Trusted-List publisher, all writers, all UI.
+
+## 1. Run it locally
+
+Standard local stack (see OPERATIONS.md §"first bring-up" for detail):
+
+```bash
+git fetch && git checkout chore/carve-nostr-user-tag-core
+sed -i 's/"80:80"/"127.0.0.1:8080:80"/' docker-compose.yml   # if not already remapped
+docker compose up -d --build
+docker compose ps                                            # tapestry, tapestry-redis, nostr-search-* up
+```
+
+## 2. Reinstall firmware — REQUIRED
+
+This branch adds three concepts (`tag`, `nostr-user-tag`, `tag-pinning`). The install pipeline must register them or every read returns empty:
+
+```bash
+curl -X POST http://localhost:8080/api/firmware/install
+```
+
+Confirm the concepts registered (orient via the concept-graph API, per AGENTS.md):
+
+```bash
+curl -s http://localhost:8080/api/concept-graph/summaries | jq '.[].slug' | grep -E 'nostr-user-tag|^"tag"'
+```
+
+## 3. Seed sample events — REQUIRED (this core is read-only)
+
+There is no UI to create tags here, and each instance's strfry is self-contained (OPERATIONS.md) — so a fresh local will have **zero** tag events and the endpoints will look empty. That's expected, not a bug. Two ways to get data:
+
+- **(a) Pull from another instance:** enable the `dcosl` router preset in `/tapestry/settings/relays` to mirror existing tag events into local strfry.
+- **(b) Seed directly with `nak` → strfry import.** Publish a tag-element + an assertion. **The `z`-tags below use the legacy literal pubkey** (`82b75e47…`) — that's intentional and deployment-independent (ADR-0015), and it's exactly what the read endpoints filter on (`TAG_Z_TAG` / `NOSTR_USER_TAG_Z_TAG` in `src/api/profile-tags/index.js`).
+
+> Your Claude should read the exact z-tag constants and the tag/nostr-user-tag json-schemas on this branch and adapt the commands below, then confirm against `/available-tags`. This is a representative shape, not a guaranteed copy-paste.
+
+```bash
+LEG=82b75e474dda005e912bcbb910391c60c2b89cc7faf5d3c30b7c59a324973833
+SEC=$(nak key generate)                 # throwaway asserter key
+TARGET=$(nak key generate | nak key public)   # a pubkey to "tag"
+
+# (i) a tag-element "bird"  (z = 39998:<LEG>:tag)
+TAGEL=$(nak event -k 39999 --sec "$SEC" -d tag-bird \
+  -t z="39998:$LEG:tag" -c '{"tag":{"slug":"bird","name":"bird","description":"likes birds"}}')
+echo "$TAGEL" | docker exec -i tapestry strfry import
+TAGID=$(echo "$TAGEL" | jq -r .id)
+
+# (ii) an assertion: asserter tags TARGET with "bird"  (z = 39998:<LEG>:nostr-user-tag)
+nak event -k 39999 --sec "$SEC" -d "profile-tag-bird-${TARGET:0:8}-x" \
+  -p "$TARGET" -e "$TAGID" -t z="39998:$LEG:nostr-user-tag" -t polarity=1 \
+  -c '{"nostrUserTag":{"taggedPubkey":"'"$TARGET"'","tagEventId":"'"$TAGID"'"}}' \
+  | docker exec -i tapestry strfry import
+```
+
+## 4. Hit the endpoints
+
+```bash
+# all tag-elements
+curl -s 'http://localhost:8080/api/profile-tags/available-tags' | jq
+
+# assertions on a target pubkey
+curl -s "http://localhost:8080/api/profile-tags/tags-for-profile?pubkey=$TARGET" | jq
+
+# per-target apply/dispute counts for a tag (the roster primitive Communities consumes)
+curl -s "http://localhost:8080/api/profile-tags/profiles-tagged?tagEventId=$TAGID&wotPov=house" | jq
+
+# tag index (all tags + counts)
+curl -s 'http://localhost:8080/api/profile-tags/index' | jq
+```
+
+`profiles-tagged` is the one closest to your use case — `aggregateProfilesTagged()` is the "weight asserters by POV WoT → net polarity → per-target counts" math you'd reuse for a community roster.
+
+## 5. Caveats to expect (not bugs)
+
+- **WoT filter degrades to "all" without a POV.** With no house POV / no `wot_rank_<suffix>` Meili columns provisioned, the asserter gate is bypassed and every assertion counts. That's the documented graceful degradation — fine for a functional smoke test. To exercise real POV gating you need a configured house POV + indexed WoT columns.
+- **Reads scan `#e`, not `#a` yet.** Per ADR-0022 we're moving to a hybrid `e`+`a` reference (consume by `#a`), but that's a follow-up touching this read path *and* the writer. Today seed/scan by `#e` (the assertion's `e` = tag-element id).
+- **Empty results on a fresh instance are expected** until you seed (step 3).

--- a/engineering-team/decisions/profile/0022-nostr-user-tag-hybrid-ea-reference.md
+++ b/engineering-team/decisions/profile/0022-nostr-user-tag-hybrid-ea-reference.md
@@ -1,0 +1,94 @@
+# ADR 0022: nostr-user-tag parent reference — hybrid `e` + `a`
+
+**Status:** Accepted — partially supersedes ADR-0001 (wire-shape / parent-reference section only)
+**Date:** 2026-06-05
+**Story:** none (wire-shape decision surfaced by the Communities cross-team dependency; tracked in `engineering-team/follow-ups.md` → "Revisit nostr-user-tag wire shape: `e` vs `a`")
+
+## Context
+
+ADR-0001 shipped the `nostr-user-tag` assertion (kind 39999) referencing its parent **tag-element** with a single `['e', tagEventId]` — a frozen, content-addressed event id. The tag-element is itself a kind-39999 **parameterized-replaceable** event, addressable by the NIP-01 coordinate `39999:<tagAuthorPubkey>:<slug>`.
+
+Two forces make the single-`e` reference worth revisiting now, before assertion volume grows:
+
+1. **Communities consumes nostr-user-tag as a membership atom** — "who carries tag X." That is a *consume-by-stable-identity* pattern: it wants "all assertions of tag X across its whole life," which is a clean `#a` scan but, under `e`, requires enumerating *every historical event-id* of X (the set splits every time the tag author edits the replaceable tag-element). This is the actual blocking dependency for Communities v1 membership.
+2. **nostr-user-tag is a trust/membership signal**, so the *mutability* of the parent matters. With pure `a`, the tag author can edit the tag-element's content (rename "early-supporter" → something else) and every existing assertion silently re-points to the new meaning. With `e`, the applied version is frozen.
+
+**Relevant facts (verified in code 2026-06-05):**
+- Current publisher: `ui/src/utils/publishProfileTag.js:43-67` — emits `['e', tag.eventId]`, no `a`. `tag` arg carries `{eventId, slug}` but **not** the tag-element author pubkey needed to build the `a` coord.
+- The assertion's own `d`-tag is `profile-tag-<slug>-<target8>-<asserter8>` — **slug-keyed (identity-based)**. So the assertion already identifies *itself* addressably, while pointing at its *parent* by frozen id — an internal inconsistency.
+- The **pin** events already use hybrid `e`+`a` (`ui/src/utils/publishTagPin.js:119-120`). Precedent exists in the same stack.
+- Nostr relays index **all single-character tags**. Both `e` and `a` are single-char → both are server-side filterable. Carrying both costs ~1 extra tag (~50 bytes) and *zero* query penalty; consumers pick `#a` (grouping/identity) or `#e` (provenance) at will.
+- `a` does not worsen slug collisions: the coord `39999:<author>:<slug>` already commits to a specific author, same as `e`.
+- The firmware schema `firmware/versions/v1.0.0/concepts/nostr-user-tag/json-schema.json` currently requires `tagEventId` (mirrors `e`) and declares no address field.
+
+## Options considered
+
+### Option A — keep `e` only (status quo)
+Frozen event-id reference.
+- **Pros:** smallest; perfect provenance; matches the pre-Story-1 relay-tag precedent.
+- **Cons:** "all assertions of tag X" splits across every historical event-id on each tag edit; orphaned by per-version kind-5 delete; doesn't express the tag as a stable identity — the exact thing Communities needs. Internally inconsistent with the slug-keyed `d`-tag.
+
+### Option B — switch to `a` only
+Addressable coordinate `39999:<tagAuthor>:<slug>`.
+- **Pros:** clean stable-identity grouping (`#a`); NIP-01-conventional for replaceables; survives edits and per-version deletes.
+- **Cons:** **loses provenance** — silently follows the tag author's later edits. For a *membership/trust* signal that is a real footgun (definition mutates under existing assertions). Also a breaking wire change.
+
+### Option C — hybrid `e` + `a`
+Carry both: `a` for stable identity, `e` for the applied version.
+- **Pros:** stable-identity grouping (`#a`) *and* provenance (`#e`); lets read endpoints choose granularity; enables drift detection (compare live `a`-content vs frozen `e`-content); consistent with the slug-keyed `d`-tag and with the pin events; both tags relay-indexed so no query cost; **additive** (see Consequences) so it doesn't break existing assertions.
+- **Cons:** ~1 extra tag per event; write code populates two refs; read code must pick which ref is authoritative per purpose.
+
+## Decision
+
+**Option C — hybrid `e` + `a`.** The assertion references its parent tag-element with **both** an `a` coordinate (stable identity) and an `e` event-id (applied-version provenance):
+
+```jsonc
+{
+  "kind": 39999,
+  "tags": [
+    ["d", "profile-tag-<slug>-<target8>-<asserter8>"],
+    ["p", "<targetPubkey>"],
+    ["a", "39999:<tagAuthorPubkey>:<slug>"],   // NEW — stable tag identity (consume by #a)
+    ["e", "<tagEventId>"],                      // retained — version-at-apply-time (provenance)
+    ["z", "39998:<TA>:nostr-user-tag"],
+    ["polarity", "1"]
+  ]
+}
+```
+
+**Consumer guidance (Communities and any other reader): group/scan by `#a`; treat `e` as provenance, not identity.** Everything else in ADR-0001 (the `z`/`p`/`polarity` semantics, the slug-keyed `d`-tag, polarity bucketing) stands unchanged. This ADR supersedes *only* ADR-0001's parent-reference choice.
+
+## Consequences
+
+**Enables:**
+- Communities' "who carries tag X" as a single `#a` subscription that survives tag edits — unblocks v1 membership without enumerating historical event-ids.
+- Drift detection for trust contexts: a consumer can compare the live `a`-resolved tag-element against the frozen `e` version to see if the tag's meaning changed since application.
+
+**Backward compatibility — additive, does not break existing assertions:**
+- Old assertions carry `e` only; new ones carry `e`+`a`. Adding `a` breaks nothing already published.
+- Read paths that scan `#e` (as today) match old and new events identically — **no read breakage**.
+- A consumer that scans `#a` (Communities) will not see `e`-only legacy events. **There is no TA/server-run backfill** — assertions are signed by each *individual asserter* (the `d`-tag is keyed to the asserter's pubkey), and a parameterized-replaceable can only be replaced by its **original author**. Re-emitting others' assertions would forge signatures and destroy the "who asserted" trust signal. The realistic paths:
+  - **(a) Born with `#a` going forward.** The moment the writer change ships, every *new* assertion carries `#a`. So any tag created afterward — including all Communities circle tag-elements and their member assertions — is pure-`#a` with **no legacy set at all**. This covers the Communities v1 case completely.
+  - **(b) Lazy client self-re-emit** for pre-change assertions on *pre-existing* tags: each user's client re-signs *their own* old assertion with `a` added on next interaction (a valid self-replace). Migrates over time; volume is small and instance-local (feature is ~weeks old; per OPERATIONS.md each strfry is self-contained).
+  - **(c) Bounded union** only where a consumer needs instant completeness over a pre-existing claimed tag: scan `#a` ∪ that tag's legacy `#e` ids during the transition.
+  - Our own UI is unaffected throughout — it keeps scanning `#e` and sees old + new.
+
+**Constrains / debt:**
+- Write code now needs the tag-element **author pubkey** at publish time to build the coord (it currently only has `{eventId, slug}`).
+- Two references to keep consistent; read code must document which is authoritative per query.
+
+**Firmware reinstall required?** **Yes.** The `nostr-user-tag` json-schema gains an optional `tagAddress` field. Run `POST /api/firmware/install` after the change (per CLAUDE.md house rule).
+
+## Implementation notes
+
+- **`ui/src/utils/publishProfileTag.js`** — extend the `tag` arg to `{eventId, slug, authorPubkey}`; add `['a', \`39999:${tag.authorPubkey}:${tag.slug}\`]` to the `tags` array (place it before `e`); add `tagAddress` to the `content` JSON mirror (`{ nostrUserTag: { taggedPubkey, tagEventId, tagAddress } }`). Keep the `e` tag. The `z`-tag literal (`LEGACY_Z_TAG_PUBKEY` per ADR-0015) is unchanged.
+- **Callers** (`ui/src/hooks/useProfileTags.js`, Tag page apply/dispute, `ui/src/components/TagPageRow.jsx` etc.) — thread the tag-element's author pubkey (the `.pubkey` of the kind-39999 tag-element event, already available where `availableTags` are fetched) into the `tag` object.
+- **Firmware `firmware/versions/v1.0.0/concepts/nostr-user-tag/json-schema.json`** — add an **optional** `tagAddress` property (string, the `39999:<author>:<slug>` coord) alongside the existing `tagEventId`. Keep `tagEventId` **required** so legacy `e`-only events still validate. Reinstall firmware.
+- **Read/score `src/api/profile-tags/index.js`** — current `#e`-based scans keep working; no forced change. Where stable-identity grouping is wanted (and for the consumer-facing endpoints Communities will hit), add support to scan/group by `#a` (`aggregateProfilesTagged` and friends), preferring `a` and falling back to `e` for legacy events during the transition.
+- **Lazy client self-re-emit (NOT a server backfill)** — assertions are user-signed and only the original author can replace one, so there is no TA/server script that migrates the legacy set. Instead, on next interaction the user's own client re-signs *their* `e`-only assertions with `a` added (same `d`-tag → valid self-replace). Optional, eventual; new assertions are born with `#a` regardless.
+
+## Out of scope
+- Changing the assertion's **own** `d`-tag (stays slug-keyed — already addressable).
+- The lazy client self-re-emit migration (separate, optional, eventual — and the *only* viable way to add `a` to pre-change assertions, since they're user-signed; there is no server backfill).
+- Extending the firmware schema engine to source fields from event-tags (still out, per ADR-0001).
+- Any community-specific coupling on the tag — the tag stays general, person-scoped, community-agnostic (Communities *claims* tags; the tag never points at a community).

--- a/firmware/versions/v1.0.0/concepts/nostr-user-tag/concept-header.json
+++ b/firmware/versions/v1.0.0/concepts/nostr-user-tag/concept-header.json
@@ -1,0 +1,21 @@
+{
+  "word": {
+    "slug": "concept-header-for-the-concept-of-nostr-user-tags",
+    "name": "concept header for the concept of nostr user tags",
+    "title": "Concept Header for the Concept of Nostr User Tags",
+    "wordTypes": ["word", "conceptHeader"]
+  },
+  "conceptHeader": {
+    "description": "A nostr-user-tag is an assertion that a specific nostr user (pubkey) belongs to a tag category. Each element links a target pubkey to a tag event ID (kind 39999 in the tag concept), with optional polarity expressed as an event-tag (1 = applied, -1 = disputed; absent = applied). Authors publish these assertions to express their opinion about which categories a profile fits or doesn't fit; aggregated across a web of trust, these assertions build reputation and power trust-weighted profile categorization.",
+    "oNames": { "singular": "nostr user tag", "plural": "nostr user tags" },
+    "oSlugs": { "singular": "nostr-user-tag", "plural": "nostr-user-tags" },
+    "oKeys": { "singular": "nostrUserTag", "plural": "nostrUserTags" },
+    "oTitles": { "singular": "Nostr User Tag", "plural": "Nostr User Tags" },
+    "oLabels": { "singular": "NostrUserTag", "plural": "NostrUserTags" },
+    "x-tapestry": {
+      "neo4j": {
+        "nodeLabelRequired": true
+      }
+    }
+  }
+}

--- a/firmware/versions/v1.0.0/concepts/nostr-user-tag/json-schema.json
+++ b/firmware/versions/v1.0.0/concepts/nostr-user-tag/json-schema.json
@@ -1,0 +1,50 @@
+{
+  "word": {
+    "slug": "json-schema-for-the-concept-of-nostr-user-tags",
+    "name": "JSON schema for the concept of nostr user tags",
+    "title": "JSON Schema for the Concept of Nostr User Tags",
+    "description": "the json schema for the concept of nostr user tags",
+    "wordTypes": ["word", "jsonSchema"],
+    "coreMemberOf": [
+      {
+        "slug": "concept-header-for-the-concept-of-nostr-user-tags",
+        "uuid": "<uuid>"
+      }
+    ]
+  },
+  "jsonSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "name": "nostr user tag",
+    "title": "Nostr User Tag",
+    "description": "JSON Schema for the concept of nostr user tags",
+    "required": ["nostrUserTag"],
+    "definitions": {},
+    "properties": {
+      "nostrUserTag": {
+        "type": "object",
+        "name": "nostr user tag",
+        "title": "Nostr User Tag",
+        "slug": "nostr-user-tag",
+        "description": "data about this nostr user tag assertion",
+        "required": ["taggedPubkey", "tagEventId"],
+        "properties": {
+          "taggedPubkey": {
+            "type": "string",
+            "name": "taggedPubkey",
+            "title": "Tagged Pubkey",
+            "slug": "tagged-pubkey",
+            "description": "The 64-char hex pubkey of the nostr user being tagged. Mirrors the event's `p` tag."
+          },
+          "tagEventId": {
+            "type": "string",
+            "name": "tagEventId",
+            "title": "Tag Event ID",
+            "slug": "tag-event-id",
+            "description": "The event ID of the kind 39999 tag element being applied. Mirrors the event's `e` tag."
+          }
+        }
+      }
+    }
+  }
+}

--- a/firmware/versions/v1.0.0/concepts/nostr-user-tag/manifest.json
+++ b/firmware/versions/v1.0.0/concepts/nostr-user-tag/manifest.json
@@ -1,0 +1,8 @@
+{
+    "HAS_ELEMENT": [
+
+    ],
+    "IS_A_SUPERSET_OF": [
+
+    ]
+}

--- a/firmware/versions/v1.0.0/concepts/tag-pinning/concept-header.json
+++ b/firmware/versions/v1.0.0/concepts/tag-pinning/concept-header.json
@@ -1,0 +1,17 @@
+{
+  "word": {
+    "slug": "concept-header-for-the-concept-of-tag-pinnings",
+    "name": "concept header for the concept of tag pinnings",
+    "title": "Concept Header for the Concept of Tag Pinnings",
+    "wordTypes": ["word", "conceptHeader"]
+  },
+  "conceptHeader": {
+    "description": "A tag-pinning is an assertion by a nostr user that they personally pin a specific tag — i.e., they opt that tag into their personal curated set, to be used as the basis for downstream features such as periodic Trusted List publication (Story 12) and 'most pinned' aggregation (Story 13). Each element links the pinning user (event author) to a tag event id and carries a curation-method describing how the user wants the eventual Trusted List computed. Pinning is permissionless: any user may pin any tag; unpinning is performed by publishing a NIP-09 kind-5 deletion targeting the pin event.",
+    "oNames": { "singular": "tag pinning", "plural": "tag pinnings" },
+    "oSlugs": { "singular": "tag-pinning", "plural": "tag-pinnings" },
+    "oKeys":  { "singular": "tagPinning", "plural": "tagPinnings" },
+    "oTitles":{ "singular": "Tag Pinning", "plural": "Tag Pinnings" },
+    "oLabels":{ "singular": "TagPinning", "plural": "TagPinnings" },
+    "x-tapestry": { "neo4j": { "nodeLabelRequired": true } }
+  }
+}

--- a/firmware/versions/v1.0.0/concepts/tag-pinning/json-schema.json
+++ b/firmware/versions/v1.0.0/concepts/tag-pinning/json-schema.json
@@ -1,0 +1,47 @@
+{
+  "word": {
+    "slug": "json-schema-for-the-concept-of-tag-pinnings",
+    "name": "JSON schema for the concept of tag pinnings",
+    "title": "JSON Schema for the Concept of Tag Pinnings",
+    "description": "the json schema for the concept of tag pinnings",
+    "wordTypes": ["word", "jsonSchema"],
+    "coreMemberOf": [
+      { "slug": "concept-header-for-the-concept-of-tag-pinnings", "uuid": "<uuid>" }
+    ]
+  },
+  "jsonSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "name": "tag pinning",
+    "title": "Tag Pinning",
+    "description": "JSON Schema for the concept of tag pinnings",
+    "required": ["tagPinning"],
+    "definitions": {},
+    "properties": {
+      "tagPinning": {
+        "type": "object",
+        "name": "tag pinning",
+        "title": "Tag Pinning",
+        "slug": "tag-pinning",
+        "description": "data about this tag-pinning assertion",
+        "required": ["tagEventId"],
+        "properties": {
+          "tagEventId": {
+            "type": "string",
+            "name": "tagEventId",
+            "title": "Tag Event ID",
+            "slug": "tag-event-id",
+            "description": "The event ID of the kind 39999 tag element being pinned. Mirrors the event's `e` tag."
+          },
+          "curationMethod": {
+            "type": "object",
+            "name": "curationMethod",
+            "title": "Curation Method",
+            "slug": "curation-method",
+            "description": "Parameters describing how the eventual Trusted List for this pinned tag should be computed. Mirrors the event's `curation-method` event-tag (which carries the stringified form). v1 fields: observer (hex pubkey), method ('nip85:rank' | 'follows' | 'trust-everyone' | 'trusted-list'), trustedList (optional a-tag ref when method='trusted-list'), cutoff (integer), includeScoreInTL (boolean)."
+          }
+        }
+      }
+    }
+  }
+}

--- a/firmware/versions/v1.0.0/concepts/tag/concept-header.json
+++ b/firmware/versions/v1.0.0/concepts/tag/concept-header.json
@@ -1,0 +1,21 @@
+{
+  "word": {
+    "slug": "concept-header-for-the-concept-of-tags",
+    "name": "concept header for the concept of tags",
+    "title": "Concept Header for the Concept of Tags",
+    "wordTypes": ["word", "conceptHeader"]
+  },
+  "conceptHeader": {
+    "description": "A tag is a first-class concept representing a category assertion. Tags categorize things — initially nostr relays, but eventually also profiles, notes, and other concepts. A tag is a 0–5 star rating without the stars field: an assertion that something belongs to a category.",
+    "oNames": { "singular": "tag", "plural": "tags" },
+    "oSlugs": { "singular": "tag", "plural": "tags" },
+    "oKeys": { "singular": "tag", "plural": "tags" },
+    "oTitles": { "singular": "Tag", "plural": "Tags" },
+    "oLabels": { "singular": "Tag", "plural": "Tags" },
+    "x-tapestry": {
+      "neo4j": {
+        "nodeLabelRequired": true
+      }
+    }
+  }
+}

--- a/firmware/versions/v1.0.0/concepts/tag/json-schema.json
+++ b/firmware/versions/v1.0.0/concepts/tag/json-schema.json
@@ -1,0 +1,69 @@
+{
+    "word": {
+        "slug": "json-schema-for-the-concept-of-tags",
+        "title": "JSON Schema for the Concept of Tags",
+        "name": "JSON Schema for the concept of tags",
+        "description": "",
+        "wordTypes": [
+            "word",
+            "jsonSchema"
+        ],
+        "coreMemberOf": [
+            {
+                "slug": "concept-header-for-the-concept-of-tags",
+                "uuid": "<uuid>"
+            }
+        ]
+    },
+    "jsonSchema": {
+        "name": "tag",
+        "title": "Tag",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "definitions": {},
+        "type": "object",
+        "required": [
+            "tag"
+        ],
+        "properties": {
+            "tag": {
+                "type": "object",
+                "name": "tag",
+                "title": "Tag",
+                "slug": "tag",
+                "description": "Metadata about this tag node",
+                "required": [
+                    "slug",
+                    "name"
+                ],
+                "properties": {
+                    "slug": {
+                        "type": "string",
+                        "name": "slug",
+                        "title": "Slug",
+                        "slug": "slug",
+                        "description": "Unique identifier for this tag"
+                    },
+                    "name": {
+                        "type": "string",
+                        "name": "name",
+                        "title": "Name",
+                        "slug": "name",
+                        "description": "Human-readable name for this tag"
+                    },
+                    "description": {
+                        "type": "string",
+                        "name": "description",
+                        "title": "Description",
+                        "slug": "description",
+                        "description": "Description of what this tag means and when to apply it"
+                    }
+                },
+                "x-tapestry": {
+                    "unique": [
+                        "slug"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/firmware/versions/v1.0.0/concepts/tag/manifest.json
+++ b/firmware/versions/v1.0.0/concepts/tag/manifest.json
@@ -1,0 +1,8 @@
+{
+    "HAS_ELEMENT": [
+
+    ],
+    "IS_A_SUPERSET_OF": [
+
+    ]
+}

--- a/firmware/versions/v1.0.0/manifest.json
+++ b/firmware/versions/v1.0.0/manifest.json
@@ -296,6 +296,34 @@
             "categories": [
                 "tapestry"
             ]
+        },
+        {
+            "slug": "tag",
+            "dir": "./concepts/tag/",
+            "conceptHeader": "concept-header.json",
+            "jsonSchema": "json-schema.json",
+            "categories": [
+                "tag"
+            ]
+        },
+        {
+            "slug": "nostr-user-tag",
+            "dir": "./concepts/nostr-user-tag/",
+            "conceptHeader": "concept-header.json",
+            "jsonSchema": "json-schema.json",
+            "categories": [
+                "tag",
+                "nostr"
+            ]
+        },
+        {
+            "slug": "tag-pinning",
+            "dir": "./concepts/tag-pinning/",
+            "conceptHeader": "concept-header.json",
+            "jsonSchema": "json-schema.json",
+            "categories": [
+                "tag"
+            ]
         }
     ],
     "enumerations": {

--- a/src/api/_shared/pov.js
+++ b/src/api/_shared/pov.js
@@ -1,0 +1,73 @@
+/**
+ * Shared POV resolution.
+ *
+ * Both the meili search proxy and the profile-tags endpoints need the same
+ * answer to "given a request, what is the active POV (delegated pubkey →
+ * 8-char suffix), and what filter/sort apply?". This helper is the single
+ * source of truth for that computation, per ADR-0002.
+ *
+ * Cascade:
+ *   1. If wotPov === 'user' && userPubkey is present → read user prefs file
+ *      (rankAuthor → delegatedPubkey, filters, sortConfig → sort).
+ *   2. Fall back to house prefs (settings.grapevine.searchPreferences) for
+ *      anything still unresolved.
+ *
+ * Returns: { delegatedPubkey, povSuffix, filters, sort, minRank }.
+ *   - povSuffix is delegatedPubkey.slice(0,8) or null.
+ *   - minRank is filters?.rank?.min when finite-numeric; otherwise null.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Hardcoded path matches the previous inline location in the meili proxy.
+// Override-by-env was not introduced — this is a pure code-extraction.
+const USER_PREFS_DIR = '/var/lib/brainstorm/user-prefs';
+
+function readUserPrefs(pubkey) {
+  if (!pubkey || pubkey.length !== 64) return {};
+  const filePath = path.join(USER_PREFS_DIR, `${pubkey.replace(/[^0-9a-f]/gi, '')}.json`);
+  try {
+    if (fs.existsSync(filePath)) {
+      return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    }
+  } catch { /* ignore */ }
+  return {};
+}
+
+function loadHousePrefs() {
+  try {
+    const { getSettings } = require('../../config/settings');
+    const settings = getSettings();
+    return settings.grapevine?.searchPreferences || {};
+  } catch { return {}; }
+}
+
+function resolvePov({ wotPov, userPubkey }) {
+  const housePrefs = loadHousePrefs();
+
+  let delegatedPubkey = null;
+  let filters = null;
+  let sort = null;
+
+  if (wotPov === 'user' && userPubkey) {
+    const userPrefs = readUserPrefs(userPubkey);
+    delegatedPubkey = userPrefs.rankAuthor || null;
+    filters = userPrefs.filters || null;
+    sort = userPrefs.sortConfig || null;
+  }
+
+  if (!delegatedPubkey) delegatedPubkey = housePrefs.delegatedPubkey || null;
+  if (!filters) filters = housePrefs.filters || null;
+  if (!sort) sort = housePrefs.sort || null;
+
+  const povSuffix = delegatedPubkey ? delegatedPubkey.slice(0, 8) : null;
+  const minRankRaw = filters?.rank?.min;
+  const minRank = (typeof minRankRaw === 'number' && Number.isFinite(minRankRaw))
+    ? minRankRaw
+    : null;
+
+  return { delegatedPubkey, povSuffix, filters, sort, minRank };
+}
+
+module.exports = { resolvePov, readUserPrefs };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -508,6 +508,10 @@ async function register(app) {
     const trustedList = require('./trustedList');
     trustedList.register(app);
 
+    // ── Profile Tags API (nostr-user-tag read + per-POV WoT scoring) ──
+    const { registerProfileTagsRoutes } = require('./profile-tags');
+    registerProfileTagsRoutes(app);
+
     // ── Tapestry I/O (Import/Export) API ──
     const { registerIORoutes } = require('./io');
     registerIORoutes(app);

--- a/src/api/profile-tags/index.js
+++ b/src/api/profile-tags/index.js
@@ -1,0 +1,1608 @@
+/**
+ * Profile Tags API.
+ *
+ * GET /api/profile-tags/available-tags
+ *   List tag elements (kind 39999 z-tagged to the firmware tag concept)
+ *   from local strfry. Returns { success, tags: [{ eventId, slug, name, description }] }.
+ *
+ * GET /api/profile-tags/tags-for-profile?pubkey=<hex>
+ *   List nostr-user-tag assertions on a target pubkey from local strfry.
+ *   Returns { success, applications: [...], disputes: [...] }, where polarity
+ *   comes from the ["polarity", ...] event-tag (default 1 / applied if absent).
+ *
+ * GET /api/profile-tags/wot-tags?viewer=<hex>
+ *   Returns the union of tagEventIds referenced by nostr-user-tag assertions
+ *   on local strfry. Currently does not filter by the viewer's WoT — returns
+ *   every tagEventId referenced by any assertion on the relay.
+ *
+ * Polarity is read from the ["polarity", ...] event-tag and bucketed:
+ *   >=  0.5 → applied
+ *   <= -0.5 → disputed
+ *   in between → neutral (dropped, not counted in either list)
+ * Absent polarity tag defaults to 1 (applied).
+ */
+
+const { exec } = require('child_process');
+const { getOwnerAssistantPubkey } = require('../../utils/assistantKeys');
+
+/**
+ * Legacy z-tag-composition pubkey — see ADR 0015.
+ *
+ * Historical kind-39999 events on every Brainstorm/Tapestry
+ * deployment have z-tags composed with this literal value,
+ * including events that pre-date any deployment realizing the
+ * literal didn't match the on-disk TA. The literal is wire-binding:
+ * changing it orphans historical data on non-dev deployments
+ * (this is exactly the d3a2640a / "lost tags" incident).
+ *
+ * This constant is used ONLY for z-tag composition. For any other
+ * use of "the TA pubkey" (signer reads, kind-30392 author
+ * filtering, signing operations), use the runtime `TA_PUBKEY`
+ * constant below — it resolves via `getOwnerAssistantPubkey()`
+ * per CLAUDE.md "Per-deployment TA pubkey".
+ *
+ * See ADR 0015
+ * (engineering-team/decisions/0015-restore-historical-data-and-fix-tl-author-filter.md)
+ * and engineering-team/stories/16-runtime-ta-pubkey-migration.md
+ * for the incident history that produced this exception.
+ */
+const LEGACY_Z_TAG_PUBKEY = '82b75e474dda005e912bcbb910391c60c2b89cc7faf5d3c30b7c59a324973833';
+
+// Runtime TA pubkey — used for kind-30392 author filtering (TLs
+// signed by the on-disk TA key). NEVER substitute the legacy
+// literal here; the bug we're fixing is exactly that mismatch.
+// For z-tag composition, see LEGACY_Z_TAG_PUBKEY above.
+const TA_PUBKEY = getOwnerAssistantPubkey();
+if (!TA_PUBKEY) {
+  console.warn('[profile-tags] TA pubkey not resolved at module load — pin/TL features will be broken until keys are provisioned');
+}
+const TAG_Z_TAG = `39998:${LEGACY_Z_TAG_PUBKEY}:tag`;
+const NOSTR_USER_TAG_Z_TAG = `39998:${LEGACY_Z_TAG_PUBKEY}:nostr-user-tag`;
+const TAG_PINNING_Z_TAG = `39998:${LEGACY_Z_TAG_PUBKEY}:tag-pinning`;
+const MEILI_URL = process.env.MEILI_URL || 'http://nostr-search-meili:7700';
+const MEILI_INDEX = process.env.MEILI_INDEX || 'profiles';
+
+function isHexPubkey(v) {
+  return typeof v === 'string' && /^[0-9a-f]{64}$/.test(v);
+}
+
+function strfryScan(filter) {
+  return new Promise((resolve, reject) => {
+    const safeFilter = JSON.stringify(filter).replace(/'/g, "'\\''");
+    const cmd = `strfry scan '${safeFilter}'`;
+    exec(cmd, { maxBuffer: 20 * 1024 * 1024 }, (err, stdout) => {
+      if (err) return reject(err);
+      const events = [];
+      for (const line of stdout.split('\n')) {
+        if (!line) continue;
+        try { events.push(JSON.parse(line)); } catch {}
+      }
+      resolve(events);
+    });
+  });
+}
+
+function readPolarity(event) {
+  const t = (event.tags || []).find((x) => x[0] === 'polarity');
+  if (!t || t[1] == null) return 1;
+  const n = Number(t[1]);
+  return Number.isFinite(n) ? n : 1;
+}
+
+function bucketize(polarity) {
+  if (polarity >= 0.5) return 'apply';
+  if (polarity <= -0.5) return 'dispute';
+  return 'neutral';
+}
+
+function dTagOf(event) {
+  const t = (event.tags || []).find((x) => x[0] === 'd');
+  return t ? t[1] : null;
+}
+
+// Keep only the latest event per (author, d-tag) pair to enforce
+// replaceable-event semantics defensively, in case strfry's index returns
+// duplicates for any reason.
+function dedupeReplaceable(events) {
+  const byKey = new Map();
+  for (const ev of events) {
+    const d = dTagOf(ev);
+    const key = `${ev.pubkey}|${d || ev.id}`;
+    const existing = byKey.get(key);
+    if (!existing || ev.created_at > existing.created_at) {
+      byKey.set(key, ev);
+    }
+  }
+  return Array.from(byKey.values());
+}
+
+async function handleAvailableTags(req, res) {
+  try {
+    const events = await strfryScan({
+      kinds: [39999],
+      '#z': [TAG_Z_TAG],
+    });
+
+    const deduped = dedupeReplaceable(events);
+    const tags = [];
+    for (const ev of deduped) {
+      // Firmware-published list elements carry their JSON payload in a
+      // ["json", ...] event-tag; user-published events conventionally use
+      // event.content. Accept either.
+      const jsonTag = (ev.tags || []).find((t) => t[0] === 'json');
+      const raw = (jsonTag && jsonTag[1]) || ev.content;
+      if (!raw) continue;
+      let parsed;
+      try { parsed = JSON.parse(raw); } catch { continue; }
+      const t = parsed?.tag;
+      if (!t || !t.slug) continue;
+      tags.push({
+        eventId: ev.id,
+        // Story 21 / ADR 0019: expose the tag author so the client-side
+        // re-export orchestrator can match an asserted tag to a pinned tag
+        // by its stable (authorPubkey, slug) identity.
+        authorPubkey: ev.pubkey,
+        slug: t.slug,
+        name: t.name || t.slug,
+        description: t.description || '',
+      });
+    }
+    tags.sort((a, b) => a.name.localeCompare(b.name));
+
+    res.json({ success: true, tags, count: tags.length });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+async function handleTagsForProfile(req, res) {
+  const { pubkey } = req.query;
+  if (!pubkey || !isHexPubkey(pubkey)) {
+    return res.status(400).json({
+      success: false,
+      error: 'pubkey is required (64-char lowercase hex)',
+    });
+  }
+
+  try {
+    // POV resolution per ADR-0006: optional wotPov + userPubkey query params.
+    // When a POV is configured, the WoT filter keeps only assertions whose
+    // author has wot_rank_<suffix> >= minRank. When no POV is configured,
+    // the filter is a no-op (backward-compat).
+    const { resolvePov } = require('../_shared/pov');
+    const { povSuffix, minRank } = resolvePov({
+      wotPov: req.query.wotPov || 'house',
+      userPubkey: req.query.userPubkey || null,
+    });
+    const wotFiltering = !!povSuffix && Number.isFinite(minRank);
+
+    const events = await strfryScan({
+      kinds: [39999],
+      '#z': [NOSTR_USER_TAG_Z_TAG],
+      '#p': [pubkey],
+    });
+
+    const deduped = dedupeReplaceable(events);
+
+    let authorAllowed = () => true;
+    if (wotFiltering) {
+      const authorPubkeys = Array.from(new Set(deduped.map((ev) => ev.pubkey)));
+      const authorDocs = await meiliFetchProfilesByPubkey(authorPubkeys);
+      const rankField = `wot_rank_${povSuffix}`;
+      authorAllowed = (authorPk) => {
+        const doc = authorDocs.get(authorPk);
+        if (!doc) return false;
+        const r = doc[rankField];
+        return typeof r === 'number' && r >= minRank;
+      };
+    }
+
+    const applications = [];
+    const disputes = [];
+    for (const ev of deduped) {
+      if (!authorAllowed(ev.pubkey)) continue;
+      const eTag = (ev.tags || []).find((t) => t[0] === 'e');
+      const tagEventId = eTag ? eTag[1] : null;
+      if (!tagEventId) continue;
+
+      const polarity = readPolarity(ev);
+      const bucket = bucketize(polarity);
+      const entry = {
+        eventId: ev.id,
+        authorPubkey: ev.pubkey,
+        tagEventId,
+        polarity,
+        createdAt: ev.created_at,
+      };
+      if (bucket === 'apply') applications.push(entry);
+      else if (bucket === 'dispute') disputes.push(entry);
+      // neutral polarity (between -0.5 and 0.5) is intentionally dropped
+    }
+
+    res.json({
+      success: true,
+      pubkey,
+      povSuffix: povSuffix || null,
+      minRank: Number.isFinite(minRank) ? minRank : null,
+      applications,
+      disputes,
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+async function handleWotTags(req, res) {
+  // POV-param contract per ADR-0006. The legacy `viewer` query param is
+  // replaced by the standard wotPov + userPubkey pair used by the rest of
+  // the read stack. Endpoint has no current consumers; the swap is for
+  // symmetry with the other POV-aware endpoints.
+  try {
+    const { resolvePov } = require('../_shared/pov');
+    const { povSuffix, minRank } = resolvePov({
+      wotPov: req.query.wotPov || 'house',
+      userPubkey: req.query.userPubkey || null,
+    });
+    const wotFiltering = !!povSuffix && Number.isFinite(minRank);
+
+    const events = await strfryScan({
+      kinds: [39999],
+      '#z': [NOSTR_USER_TAG_Z_TAG],
+    });
+    const deduped = dedupeReplaceable(events);
+
+    let authorAllowed = () => true;
+    if (wotFiltering) {
+      const authorPubkeys = Array.from(new Set(deduped.map((ev) => ev.pubkey)));
+      const authorDocs = await meiliFetchProfilesByPubkey(authorPubkeys);
+      const rankField = `wot_rank_${povSuffix}`;
+      authorAllowed = (authorPk) => {
+        const doc = authorDocs.get(authorPk);
+        if (!doc) return false;
+        const r = doc[rankField];
+        return typeof r === 'number' && r >= minRank;
+      };
+    }
+
+    const tagEventIds = new Set();
+    for (const ev of deduped) {
+      if (!authorAllowed(ev.pubkey)) continue;
+      const eTag = (ev.tags || []).find((t) => t[0] === 'e');
+      if (eTag && eTag[1]) tagEventIds.add(eTag[1]);
+    }
+
+    res.json({
+      success: true,
+      povSuffix: povSuffix || null,
+      minRank: Number.isFinite(minRank) ? minRank : null,
+      tagEventIds: Array.from(tagEventIds),
+      count: tagEventIds.size,
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+/**
+ * Find tag-element events whose tag.name contains `query` as a case-insensitive
+ * substring. Returns minimal metadata for each match.
+ */
+async function findTagsByNameSubstring(query) {
+  if (!query || !query.trim()) return [];
+  const q = query.trim().toLowerCase();
+  const events = await strfryScan({ kinds: [39999], '#z': [TAG_Z_TAG] });
+  const deduped = dedupeReplaceable(events);
+  const out = [];
+  for (const ev of deduped) {
+    const jsonTag = (ev.tags || []).find((t) => t[0] === 'json');
+    const raw = (jsonTag && jsonTag[1]) || ev.content;
+    if (!raw) continue;
+    let parsed;
+    try { parsed = JSON.parse(raw); } catch { continue; }
+    const t = parsed?.tag;
+    if (!t || !t.slug) continue;
+    const name = t.name || t.slug;
+    if (!name.toLowerCase().includes(q)) continue;
+    out.push({ eventId: ev.id, slug: t.slug, name, description: t.description || '' });
+  }
+  return out;
+}
+
+/**
+ * Fetch profile docs from Meilisearch by primary key. Returns a Map of
+ * pubkey → document; pubkeys with no Meili doc are absent from the map.
+ *
+ * Uses per-key GETs (`GET /indexes/profiles/documents/<pubkey>`), batched
+ * into chunks of `CHUNK` concurrent requests. Filter-based bulk fetch is
+ * not used because the `id` field is not declared filterable on the index.
+ */
+async function meiliFetchProfilesByPubkey(pubkeys) {
+  const out = new Map();
+  if (!pubkeys || pubkeys.length === 0) return out;
+  const unique = Array.from(new Set(pubkeys));
+  const CHUNK = 100;
+  for (let i = 0; i < unique.length; i += CHUNK) {
+    const batch = unique.slice(i, i + CHUNK);
+    await Promise.all(
+      batch.map(async (pk) => {
+        try {
+          const r = await fetch(`${MEILI_URL}/indexes/${MEILI_INDEX}/documents/${pk}`);
+          if (r.ok) {
+            const doc = await r.json();
+            if (doc && (doc.id || doc.pubkey)) out.set(pk, doc);
+          }
+        } catch {
+          /* tolerate Meili unreachable in dev */
+        }
+      })
+    );
+  }
+  return out;
+}
+
+/**
+ * Pure tag-match computation. For each tag whose name contains `q` as a
+ * case-insensitive substring, enumerate positive-polarity assertions from
+ * local strfry. If `povSuffix` AND a finite `minRank` are provided, filter
+ * assertions to authors whose `wot_rank_<povSuffix>` >= `minRank` (looked
+ * up against Meili profile docs). Otherwise (no POV configured) all
+ * positive assertions count.
+ *
+ * Exposed via `GET /api/profile-tags/match` (handleMatch) for direct
+ * callers, and consumed in-process by the meili search proxy.
+ *
+ * @param {object} opts
+ * @param {string} opts.q                Search query
+ * @param {string|null} opts.povSuffix   8-char POV suffix, or null/empty for no WoT filter
+ * @param {number|null} opts.minRank     Min `wot_rank_<suffix>` to count, or null/NaN for no filter
+ * @returns {Promise<{query, povSuffix, minRank, matches: Array<{pubkey, matchedTags}>}>}
+ */
+async function computeTagMatches({ q, povSuffix, minRank }) {
+  if (!q || !q.trim()) {
+    return { query: '', povSuffix: povSuffix || null, minRank: null, matches: [] };
+  }
+  const suffix = (povSuffix && /^[0-9a-f]{8}$/.test(povSuffix)) ? povSuffix : null;
+  const minRankN = (suffix && Number.isFinite(Number(minRank))) ? Number(minRank) : null;
+  const wotFiltering = suffix && Number.isFinite(minRankN);
+
+  const tagMatches = await findTagsByNameSubstring(q);
+  if (tagMatches.length === 0) {
+    return { query: q, povSuffix: suffix, minRank: minRankN, matches: [] };
+  }
+  const tagById = new Map(tagMatches.map((t) => [t.eventId, t]));
+
+  const assertionEvents = await strfryScan({
+    kinds: [39999],
+    '#z': [NOSTR_USER_TAG_Z_TAG],
+    '#e': tagMatches.map((t) => t.eventId),
+  });
+  const deduped = dedupeReplaceable(assertionEvents);
+  const positive = deduped.filter((ev) => bucketize(readPolarity(ev)) === 'apply');
+
+  let authorAllowed = () => true;
+  if (wotFiltering) {
+    const authorPubkeys = Array.from(new Set(positive.map((ev) => ev.pubkey)));
+    const authorDocs = await meiliFetchProfilesByPubkey(authorPubkeys);
+    const rankField = `wot_rank_${suffix}`;
+    authorAllowed = (authorPk) => {
+      const doc = authorDocs.get(authorPk);
+      if (!doc) return false;
+      const r = doc[rankField];
+      return typeof r === 'number' && r >= minRankN;
+    };
+  }
+
+  const byTarget = new Map();
+  for (const ev of positive) {
+    if (!authorAllowed(ev.pubkey)) continue;
+    const pTag = (ev.tags || []).find((t) => t[0] === 'p');
+    const eTag = (ev.tags || []).find((t) => t[0] === 'e');
+    if (!pTag?.[1] || !eTag?.[1]) continue;
+    const targetPk = pTag[1];
+    const tagInfo = tagById.get(eTag[1]);
+    if (!tagInfo) continue;
+    let entry = byTarget.get(targetPk);
+    if (!entry) {
+      entry = { pubkey: targetPk, matchedTags: new Map() };
+      byTarget.set(targetPk, entry);
+    }
+    const prev = entry.matchedTags.get(tagInfo.eventId) || { ...tagInfo, count: 0 };
+    prev.count += 1;
+    entry.matchedTags.set(tagInfo.eventId, prev);
+  }
+
+  const matches = Array.from(byTarget.values()).map((m) => ({
+    pubkey: m.pubkey,
+    matchedTags: Array.from(m.matchedTags.values()),
+  }));
+
+  return { query: q, povSuffix: suffix, minRank: minRankN, matches };
+}
+
+async function handleMatch(req, res) {
+  try {
+    const result = await computeTagMatches({
+      q: req.query.q,
+      povSuffix: req.query.povSuffix,
+      minRank: req.query.minRank,
+    });
+    res.json({ success: true, ...result });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+/**
+ * Parse the tag JSON payload from a kind-39999 tag-element event. Firmware
+ * elements carry the payload in a ["json", ...] event-tag; client-published
+ * elements may use event.content. Accept either; return null when neither
+ * carries a parseable {tag: {slug, ...}} payload.
+ */
+function parseTagPayload(ev) {
+  const jsonTag = (ev.tags || []).find((t) => t[0] === 'json');
+  const raw = (jsonTag && jsonTag[1]) || ev.content;
+  if (!raw) return null;
+  let parsed;
+  try { parsed = JSON.parse(raw); } catch { return null; }
+  const t = parsed?.tag;
+  if (!t || !t.slug) return null;
+  return t;
+}
+
+/**
+ * Extract the curation-method JSON payload from a Pin event (ADR 0009).
+ * Prefers the `curation-method` event-tag (which Story 12's TA cron will
+ * index against); falls back to `content.tagPinning.curationMethod`.
+ */
+function parseCurationMethod(ev) {
+  const cmTag = (ev.tags || []).find((t) => t[0] === 'curation-method');
+  if (cmTag && cmTag[1]) {
+    try { return JSON.parse(cmTag[1]); } catch { /* fall through */ }
+  }
+  if (ev.content) {
+    try {
+      const parsed = JSON.parse(ev.content);
+      const cm = parsed?.tagPinning?.curationMethod;
+      if (cm && typeof cm === 'object') return cm;
+    } catch { /* ignore */ }
+  }
+  return null;
+}
+
+/**
+ * Extract the pinned tag's event id from a Pin event. Prefers the `e` tag;
+ * falls back to `content.tagPinning.tagEventId`.
+ */
+function parsePinTagEventId(ev) {
+  const eTag = (ev.tags || []).find((t) => t[0] === 'e');
+  if (eTag && eTag[1] && /^[0-9a-f]{64}$/.test(eTag[1])) return eTag[1];
+  if (ev.content) {
+    try {
+      const parsed = JSON.parse(ev.content);
+      const id = parsed?.tagPinning?.tagEventId;
+      if (typeof id === 'string' && /^[0-9a-f]{64}$/.test(id)) return id;
+    } catch { /* ignore */ }
+  }
+  return null;
+}
+
+/**
+ * ADR 0010: pure aggregator for per-target endorsement/dispute counts on a
+ * tag, under an active POV's WoT-author filter. Shared by handleProfilesTagged
+ * (Story 3) and Story-11's refreshPinnedTags membership compute.
+ *
+ * Returns:
+ *   - byTarget: Map<targetPubkey, { pubkey, applications, disputes }>
+ *   - deduped: the replaceable-collapsed scan, so callers (handleProfilesTagged)
+ *     can reuse it for the viewer-union pre-pass without re-scanning strfry.
+ *   - wotFiltering: boolean indicating whether the WoT-author filter was applied.
+ *
+ * No response-shape enrichment (no displayName/picture, no sort, no viewer-union)
+ * — that's the caller's job.
+ */
+async function aggregateProfilesTagged({ tagEventId, povSuffix, minRank }) {
+  const wotFiltering = !!povSuffix && Number.isFinite(minRank);
+
+  const events = await strfryScan({
+    kinds: [39999],
+    '#z': [NOSTR_USER_TAG_Z_TAG],
+    '#e': [tagEventId],
+  });
+  const deduped = dedupeReplaceable(events);
+
+  let authorAllowed = () => true;
+  if (wotFiltering) {
+    const authorPubkeys = Array.from(new Set(deduped.map((ev) => ev.pubkey)));
+    const authorDocs = await meiliFetchProfilesByPubkey(authorPubkeys);
+    const rankField = `wot_rank_${povSuffix}`;
+    authorAllowed = (authorPk) => {
+      const doc = authorDocs.get(authorPk);
+      if (!doc) return false;
+      const r = doc[rankField];
+      return typeof r === 'number' && r >= minRank;
+    };
+  }
+
+  const byTarget = new Map();
+  for (const ev of deduped) {
+    if (!authorAllowed(ev.pubkey)) continue;
+    const pTag = (ev.tags || []).find((t) => t[0] === 'p');
+    if (!pTag?.[1]) continue;
+    const polarity = readPolarity(ev);
+    const bucket = bucketize(polarity);
+    if (bucket === 'neutral') continue;
+
+    const targetPk = pTag[1];
+    let entry = byTarget.get(targetPk);
+    if (!entry) {
+      entry = { pubkey: targetPk, applications: 0, disputes: 0 };
+      byTarget.set(targetPk, entry);
+    }
+    if (bucket === 'apply') entry.applications += 1;
+    else if (bucket === 'dispute') entry.disputes += 1;
+  }
+
+  return { byTarget, deduped, wotFiltering };
+}
+
+/**
+ * ADR 0012: pure aggregator for per-tag pin counts under an active POV's
+ * WoT-author filter, plus the viewer's own-pin set. Mirrors the shape of
+ * aggregateProfilesTagged but groups pins by referenced tagEventId.
+ *
+ * Returns:
+ *   - pinCountByTagEventId: Map<tagEventId, number> — distinct WoT-trusted
+ *     authors who have published a Pin event for that tag.
+ *   - viewerPinnedSet: Set<tagEventId> — tags the viewer has personally
+ *     pinned (independent of the WoT filter; per-viewer, not per-POV).
+ *
+ * Dedupe: dedupeReplaceable collapses pin events by (author, d-tag), so
+ * one surviving event per (author, tag) means the count equals "distinct
+ * WoT-trusted pinners" automatically.
+ */
+async function aggregateTagPins({ povSuffix, minRank, viewerPubkey }) {
+  const wotFiltering = !!povSuffix && Number.isFinite(minRank);
+
+  const pinEvents = await strfryScan({
+    kinds: [39999],
+    '#z': [TAG_PINNING_Z_TAG],
+  });
+  const deduped = dedupeReplaceable(pinEvents);
+
+  let authorAllowed = () => true;
+  if (wotFiltering) {
+    const authorPubkeys = Array.from(new Set(deduped.map((ev) => ev.pubkey)));
+    const authorDocs = await meiliFetchProfilesByPubkey(authorPubkeys);
+    const rankField = `wot_rank_${povSuffix}`;
+    authorAllowed = (authorPk) => {
+      const doc = authorDocs.get(authorPk);
+      if (!doc) return false;
+      const r = doc[rankField];
+      return typeof r === 'number' && r >= minRank;
+    };
+  }
+
+  const pinCountByTagEventId = new Map();
+  const viewerPinnedSet = new Set();
+  for (const ev of deduped) {
+    const tagEventId = parsePinTagEventId(ev);
+    if (!tagEventId) continue;
+    // Own-pin indicator is per-viewer, not per-POV. The viewer's own pin
+    // counts toward viewerPinnedSet regardless of the WoT filter on this
+    // request's POV.
+    if (viewerPubkey && ev.pubkey === viewerPubkey) {
+      viewerPinnedSet.add(tagEventId);
+    }
+    if (!authorAllowed(ev.pubkey)) continue;
+    pinCountByTagEventId.set(
+      tagEventId,
+      (pinCountByTagEventId.get(tagEventId) || 0) + 1
+    );
+  }
+
+  return { pinCountByTagEventId, viewerPinnedSet };
+}
+
+/**
+ * GET /api/profile-tags/by-id?tagEventId=<id>
+ *
+ * Fetch a single kind-39999 tag-element by event id. Returns the tag's
+ * slug/name/description/authorPubkey/createdAt plus an enriched author
+ * block ({displayName, picture}) when the author has a Meili profile doc.
+ * Author degrades to null when Meili lacks the doc; degrades to null when
+ * Meili is unreachable (does not fail the whole request).
+ */
+async function handleTagById(req, res) {
+  const { tagEventId, viewerPubkey } = req.query;
+  if (!tagEventId || !/^[0-9a-f]{64}$/.test(tagEventId)) {
+    return res.status(400).json({
+      success: false,
+      error: 'tagEventId is required (64-char lowercase hex)',
+    });
+  }
+  try {
+    const events = await strfryScan({ kinds: [39999], ids: [tagEventId] });
+    if (events.length === 0) {
+      return res.status(404).json({ success: false, error: 'tag not found' });
+    }
+    const ev = events[0];
+    const tagPayload = parseTagPayload(ev);
+    if (!tagPayload) {
+      return res.status(404).json({ success: false, error: 'tag payload malformed' });
+    }
+
+    let author = null;
+    try {
+      const docs = await meiliFetchProfilesByPubkey([ev.pubkey]);
+      const doc = docs.get(ev.pubkey);
+      if (doc) {
+        author = {
+          displayName: doc.display_name || doc.name || null,
+          picture: doc.picture || null,
+        };
+      }
+    } catch { /* meili unreachable → author stays null */ }
+
+    // ADR 0009: optional viewerPubkey threads a `viewerPin` field onto the
+    // response. Malformed viewerPubkey is silently treated as absent (read
+    // contract preserved for clients that send junk).
+    let viewerPin = null;
+    if (isHexPubkey(viewerPubkey)) {
+      try {
+        const pinEvents = await strfryScan({
+          kinds: [39999],
+          '#z': [TAG_PINNING_Z_TAG],
+          authors: [viewerPubkey],
+          '#e': [tagEventId],
+        });
+        const survivor = dedupeReplaceable(pinEvents)[0] || null;
+        if (survivor) {
+          viewerPin = {
+            pinEventId: survivor.id,
+            createdAt: survivor.created_at,
+            curationMethod: parseCurationMethod(survivor),
+          };
+        }
+      } catch { /* strfry failure on the pin scan must not break the read */ }
+    }
+
+    res.json({
+      success: true,
+      tag: {
+        eventId: ev.id,
+        slug: tagPayload.slug,
+        name: tagPayload.name || tagPayload.slug,
+        description: tagPayload.description || '',
+        authorPubkey: ev.pubkey,
+        createdAt: ev.created_at,
+      },
+      author,
+      viewerPin,
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+const PROFILES_TAGGED_VALID_SORTS = ['applied', 'disputed', 'divisive'];
+
+const PROFILES_TAGGED_SORTERS = {
+  applied: (a, b) =>
+    (b.applications - a.applications)
+    || (b.disputes - a.disputes)
+    || a.pubkey.localeCompare(b.pubkey),
+  disputed: (a, b) =>
+    (b.disputes - a.disputes)
+    || (b.applications - a.applications)
+    || a.pubkey.localeCompare(b.pubkey),
+  divisive: (a, b) =>
+    (Math.min(b.applications, b.disputes) - Math.min(a.applications, a.disputes))
+    || ((b.applications + b.disputes) - (a.applications + a.disputes))
+    || a.pubkey.localeCompare(b.pubkey),
+};
+
+/**
+ * GET /api/profile-tags/profiles-tagged
+ *   ?tagEventId=<id>
+ *   &wotPov=<house|user>
+ *   &userPubkey=<hex>
+ *   &sort=<applied|disputed|divisive>
+ *
+ * Aggregates per-target application/dispute counts for the tag, filtered to
+ * authors who pass the active POV's WoT threshold (wot_rank_<suffix> >=
+ * minRank). When no POV is configured (suffix or minRank null), all bucketed
+ * assertions count — same fallback as computeTagMatches.
+ *
+ * Counts are derived per-request from raw assertions (CLAUDE.md "filter at
+ * view time, not write time"). No persistent per-POV aggregate column.
+ *
+ * Sort is server-side so the contract is correct from day one and pagination
+ * (Story 4 follow-up) drops in cleanly without partial-set sort risk.
+ */
+async function handleProfilesTagged(req, res) {
+  const { tagEventId } = req.query;
+  const sort = req.query.sort || 'applied';
+
+  if (!tagEventId || !/^[0-9a-f]{64}$/.test(tagEventId)) {
+    return res.status(400).json({
+      success: false,
+      error: 'tagEventId is required (64-char lowercase hex)',
+    });
+  }
+  if (!PROFILES_TAGGED_VALID_SORTS.includes(sort)) {
+    return res.status(400).json({
+      success: false,
+      error: `sort must be one of: ${PROFILES_TAGGED_VALID_SORTS.join(', ')}`,
+    });
+  }
+
+  // Optional viewerPubkey for the viewer-union (Story 3 / ADR-0004). Malformed
+  // values are silently treated as absent so a junk client value doesn't
+  // break the read-only contract.
+  const viewerPubkeyRaw = typeof req.query.viewerPubkey === 'string' ? req.query.viewerPubkey : '';
+  const viewerPubkey = /^[0-9a-f]{64}$/.test(viewerPubkeyRaw) ? viewerPubkeyRaw : null;
+
+  try {
+    const { resolvePov } = require('../_shared/pov');
+    const { povSuffix, minRank } = resolvePov({
+      wotPov: req.query.wotPov || 'house',
+      userPubkey: req.query.userPubkey || null,
+    });
+
+    // ADR 0010: extracted pure helper. Returns the per-target endorsement/
+    // dispute aggregation under the active POV's WoT filter, plus the
+    // deduped scan (so the viewer-union below can reuse it without a
+    // second strfry round-trip).
+    const { byTarget, deduped, wotFiltering } = await aggregateProfilesTagged({
+      tagEventId, povSuffix, minRank,
+    });
+
+    // Viewer-union pre-pass: build a map of the viewer's per-target polarity
+    // from the same scan, before the WoT filter runs (the viewer's own
+    // assertion needn't pass the WoT filter — that's the whole point).
+    const viewerAssertions = {};
+    if (viewerPubkey) {
+      for (const ev of deduped) {
+        if (ev.pubkey !== viewerPubkey) continue;
+        const pTag = (ev.tags || []).find((t) => t[0] === 'p');
+        if (!pTag?.[1]) continue;
+        const bucket = bucketize(readPolarity(ev));
+        if (bucket === 'apply') viewerAssertions[pTag[1]] = 'applied';
+        else if (bucket === 'dispute') viewerAssertions[pTag[1]] = 'disputed';
+      }
+    }
+
+    // Viewer-union: ensure every target the viewer asserted on has a row,
+    // even if the WoT filter excluded the viewer's author.
+    for (const targetPk of Object.keys(viewerAssertions)) {
+      if (!byTarget.has(targetPk)) {
+        byTarget.set(targetPk, { pubkey: targetPk, applications: 0, disputes: 0 });
+      }
+    }
+
+    // Enrich each row with target Meili doc (displayName, picture). Targets
+    // without a Meili doc surface with both fields null.
+    const targetPubkeys = Array.from(byTarget.keys());
+    const targetDocs = await meiliFetchProfilesByPubkey(targetPubkeys);
+    for (const entry of byTarget.values()) {
+      const doc = targetDocs.get(entry.pubkey);
+      entry.displayName = doc ? (doc.display_name || doc.name || null) : null;
+      entry.picture = doc ? (doc.picture || null) : null;
+      // Story 17 / ADR 0014 Decision 12 — passthrough fields that feed the
+      // tag-detail page's client-side filter input. Always present so the
+      // client can read unconditionally; values default to null.
+      entry.nip05 = doc ? (doc.nip05 || null) : null;
+      entry.about = doc ? (doc.about || null) : null;
+      entry.website = doc ? (doc.website || null) : null;
+      // onlyViewerVisible is true when the only thing making this row appear
+      // is the viewer's own assertion (WoT-filtered counts are zero AND the
+      // viewer has a non-neutral assertion on this target). Always present
+      // (defaults to false) so the UI's row component can read it
+      // unconditionally.
+      entry.onlyViewerVisible = !!viewerAssertions[entry.pubkey]
+        && entry.applications === 0 && entry.disputes === 0;
+    }
+
+    const rows = Array.from(byTarget.values());
+    rows.sort(PROFILES_TAGGED_SORTERS[sort]);
+
+    res.json({
+      success: true,
+      povSuffix: povSuffix || null,
+      minRank: Number.isFinite(minRank) ? minRank : null,
+      sort,
+      viewerAssertions,
+      rows,
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+const TAG_INDEX_VALID_SORTS = ['used', 'endorsed', 'divisive', 'most-pinned'];
+
+const TAG_INDEX_SORTERS = {
+  used: (a, b) =>
+    ((b.applications + b.disputes) - (a.applications + a.disputes))
+    || a.tagEventId.localeCompare(b.tagEventId),
+  endorsed: (a, b) =>
+    (b.applications - a.applications)
+    || (b.disputes - a.disputes)
+    || a.tagEventId.localeCompare(b.tagEventId),
+  divisive: (a, b) =>
+    (Math.min(b.applications, b.disputes) - Math.min(a.applications, a.disputes))
+    || ((b.applications + b.disputes) - (a.applications + a.disputes))
+    || a.tagEventId.localeCompare(b.tagEventId),
+  // ADR 0012 — sort by distinct WoT-trusted pinners desc, ties on tagEventId.
+  'most-pinned': (a, b) =>
+    ((b.pinnedCount || 0) - (a.pinnedCount || 0))
+    || a.tagEventId.localeCompare(b.tagEventId),
+};
+
+/**
+ * GET /api/profile-tags/index
+ *   ?wotPov=<house|user>&userPubkey=<hex>
+ *   &sort=<used|endorsed|divisive>
+ *   &q=<substring>
+ *   &limit=<int>&offset=<int>
+ *
+ * The tag-index endpoint (Story 4 / ADR-0003). Returns every tag with at
+ * least one assertion authored by someone in the active POV's WoT, sorted
+ * server-side, optionally narrowed by a case-insensitive substring on name
+ * or description, and paginated via offset+limit. Counts are derived
+ * per-request from raw assertions — no persistent per-POV aggregate
+ * (CLAUDE.md "filter at view time, not write time").
+ */
+async function handleTagIndex(req, res) {
+  const sort = req.query.sort || 'used';
+  if (!TAG_INDEX_VALID_SORTS.includes(sort)) {
+    return res.status(400).json({
+      success: false,
+      error: `sort must be one of: ${TAG_INDEX_VALID_SORTS.join(', ')}`,
+    });
+  }
+
+  const limitRaw = parseInt(req.query.limit, 10);
+  const limit = Number.isFinite(limitRaw) ? Math.max(1, Math.min(limitRaw, 200)) : 50;
+  const offsetRaw = parseInt(req.query.offset, 10);
+  const offset = Number.isFinite(offsetRaw) ? Math.max(0, offsetRaw) : 0;
+  const q = (typeof req.query.q === 'string' ? req.query.q : '').trim();
+  const qLower = q.toLowerCase();
+
+  // Optional "show only tags authored by this pubkey" filter — used by the
+  // tag-index UI's "Only show mine" toggle. Silently ignored when malformed.
+  const authoredByRaw = typeof req.query.authoredBy === 'string' ? req.query.authoredBy : '';
+  const authoredBy = /^[0-9a-f]{64}$/.test(authoredByRaw) ? authoredByRaw : null;
+
+  // ADR 0012 — pin-aware fields. viewerPubkey drives own-pin marking;
+  // pinnedByMe narrows the listing to the viewer's pinned set. Malformed
+  // viewerPubkey is silently treated as absent (matches the authoredBy
+  // pattern). pinnedByMe is only honored when viewerPubkey is also valid.
+  const viewerPubkeyRaw = typeof req.query.viewerPubkey === 'string' ? req.query.viewerPubkey : '';
+  const viewerPubkey = /^[0-9a-f]{64}$/.test(viewerPubkeyRaw) ? viewerPubkeyRaw : null;
+  const pinnedByMeRaw = typeof req.query.pinnedByMe === 'string' ? req.query.pinnedByMe : '';
+  const pinnedByMe = pinnedByMeRaw === 'true' && !!viewerPubkey;
+
+  try {
+    const { resolvePov } = require('../_shared/pov');
+    const { povSuffix, minRank } = resolvePov({
+      wotPov: req.query.wotPov || 'house',
+      userPubkey: req.query.userPubkey || null,
+    });
+    const wotFiltering = !!povSuffix && Number.isFinite(minRank);
+
+    const assertions = await strfryScan({
+      kinds: [39999],
+      '#z': [NOSTR_USER_TAG_Z_TAG],
+    });
+    const deduped = dedupeReplaceable(assertions);
+
+    let authorAllowed = () => true;
+    if (wotFiltering) {
+      const authorPubkeys = Array.from(new Set(deduped.map((ev) => ev.pubkey)));
+      const authorDocs = await meiliFetchProfilesByPubkey(authorPubkeys);
+      const rankField = `wot_rank_${povSuffix}`;
+      authorAllowed = (authorPk) => {
+        const doc = authorDocs.get(authorPk);
+        if (!doc) return false;
+        const r = doc[rankField];
+        return typeof r === 'number' && r >= minRank;
+      };
+    }
+
+    // Group surviving assertions by referenced tagEventId.
+    const byTag = new Map();
+    for (const ev of deduped) {
+      if (!authorAllowed(ev.pubkey)) continue;
+      const eTag = (ev.tags || []).find((t) => t[0] === 'e');
+      if (!eTag?.[1]) continue;
+      const polarity = readPolarity(ev);
+      const bucket = bucketize(polarity);
+      if (bucket === 'neutral') continue;
+
+      const tagEventId = eTag[1];
+      let entry = byTag.get(tagEventId);
+      if (!entry) {
+        entry = { tagEventId, applications: 0, disputes: 0 };
+        byTag.set(tagEventId, entry);
+      }
+      if (bucket === 'apply') entry.applications += 1;
+      else if (bucket === 'dispute') entry.disputes += 1;
+    }
+
+    // ADR 0012 — pin aggregation under the same POV's WoT-author filter,
+    // plus the viewer's own-pin set. Union the result into byTag so tags
+    // that have pins-but-no-assertions still appear in the listing.
+    const { pinCountByTagEventId, viewerPinnedSet } = await aggregateTagPins({
+      povSuffix, minRank, viewerPubkey,
+    });
+    for (const tagEventId of pinCountByTagEventId.keys()) {
+      if (!byTag.has(tagEventId)) {
+        byTag.set(tagEventId, { tagEventId, applications: 0, disputes: 0 });
+      }
+    }
+
+    if (byTag.size === 0) {
+      return res.json({
+        success: true,
+        povSuffix: povSuffix || null,
+        minRank: Number.isFinite(minRank) ? minRank : null,
+        sort,
+        q,
+        authoredBy: authoredBy || null,
+        viewerPubkey: viewerPubkey || null,
+        pinnedByMe,
+        total: 0,
+        limit,
+        offset,
+        rows: [],
+      });
+    }
+
+    // Batch-scan tag-elements for every referenced tagEventId.
+    const tagEventIds = Array.from(byTag.keys());
+    const tagEvents = await strfryScan({ kinds: [39999], ids: tagEventIds });
+    const tagByEventId = new Map();
+    for (const ev of tagEvents) {
+      const payload = parseTagPayload(ev);
+      if (!payload) continue;
+      tagByEventId.set(ev.id, { event: ev, payload });
+    }
+
+    // Combine counts + tag metadata. Drop tagEventIds whose tag-element isn't
+    // locally available (assertions reference a tag we don't have).
+    const enriched = [];
+    for (const [tagEventId, counts] of byTag) {
+      const tag = tagByEventId.get(tagEventId);
+      if (!tag) continue;
+      enriched.push({
+        tagEventId,
+        slug: tag.payload.slug,
+        name: tag.payload.name || tag.payload.slug,
+        description: tag.payload.description || '',
+        authorPubkey: tag.event.pubkey,
+        applications: counts.applications,
+        disputes: counts.disputes,
+        // ADR 0012 — pin-aware fields. Always present so the UI can read
+        // them unconditionally. pinnedCount defaults to 0; viewerPinned
+        // defaults to false (no viewer or viewer hasn't pinned).
+        pinnedCount: pinCountByTagEventId.get(tagEventId) || 0,
+        viewerPinned: viewerPinnedSet.has(tagEventId),
+      });
+    }
+
+    // Apply q filter (case-insensitive substring on name or description).
+    let filtered = qLower
+      ? enriched.filter((r) => `${r.name} ${r.description}`.toLowerCase().includes(qLower))
+      : enriched;
+    // Apply authoredBy filter (exact pubkey match on tag-element signer).
+    if (authoredBy) {
+      filtered = filtered.filter((r) => r.authorPubkey === authoredBy);
+    }
+    // ADR 0012 — pinnedByMe filter: only rows the viewer has personally pinned.
+    if (pinnedByMe) {
+      filtered = filtered.filter((r) => r.viewerPinned);
+    }
+
+    filtered.sort(TAG_INDEX_SORTERS[sort]);
+    const total = filtered.length;
+    const slice = filtered.slice(offset, offset + limit);
+
+    // Enrich each row with its tag-author's Meili profile doc.
+    const authorPubkeys = Array.from(new Set(slice.map((r) => r.authorPubkey)));
+    const authorDocs = await meiliFetchProfilesByPubkey(authorPubkeys);
+    for (const row of slice) {
+      const doc = authorDocs.get(row.authorPubkey);
+      row.displayName = doc ? (doc.display_name || doc.name || null) : null;
+      row.picture = doc ? (doc.picture || null) : null;
+    }
+
+    res.json({
+      success: true,
+      povSuffix: povSuffix || null,
+      minRank: Number.isFinite(minRank) ? minRank : null,
+      sort,
+      q,
+      authoredBy: authoredBy || null,
+      viewerPubkey: viewerPubkey || null,
+      pinnedByMe,
+      total,
+      limit,
+      offset,
+      rows: slice,
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+const AUTHORED_BY_VALID_SORTS = ['recent', 'applied', 'disputed', 'most-backed', 'divisive'];
+
+// "Most-backed" uses the polarity-matched peer count: applied rows compete
+// on peerApplications, disputed rows compete on peerDisputes. Across the
+// two polarities the same numeric key intermixes them naturally.
+function backedKey(r) {
+  return r.polarity === 'applied' ? r.peerApplications : r.peerDisputes;
+}
+
+const AUTHORED_BY_SORTERS = {
+  recent: (a, b) =>
+    (b.createdAt - a.createdAt)
+    || a.assertionEventId.localeCompare(b.assertionEventId),
+  applied: (a, b) =>
+    (b.parentApplications - a.parentApplications)
+    || (b.createdAt - a.createdAt)
+    || a.assertionEventId.localeCompare(b.assertionEventId),
+  disputed: (a, b) =>
+    (b.parentDisputes - a.parentDisputes)
+    || (b.createdAt - a.createdAt)
+    || a.assertionEventId.localeCompare(b.assertionEventId),
+  'most-backed': (a, b) =>
+    (backedKey(b) - backedKey(a))
+    || (b.createdAt - a.createdAt)
+    || a.assertionEventId.localeCompare(b.assertionEventId),
+  divisive: (a, b) =>
+    (Math.min(b.parentApplications, b.parentDisputes) - Math.min(a.parentApplications, a.parentDisputes))
+    || ((b.parentApplications + b.parentDisputes) - (a.parentApplications + a.parentDisputes))
+    || (b.createdAt - a.createdAt)
+    || a.assertionEventId.localeCompare(b.assertionEventId),
+};
+
+/**
+ * GET /api/profile-tags/authored-by
+ *   ?authorPubkey=<hex>            (required, 64-char lowercase hex)
+ *   &wotPov=<house|user>&userPubkey=<hex>
+ *   &sort=<recent|applied|disputed|most-backed|divisive>
+ *
+ * Story 5 / ADR-0005. Returns the tagging activity the given pubkey has
+ * authored, filtered to rows whose TARGET is in the viewer's active POV
+ * WoT. Each row carries both Reading-A parent-tag aggregate counts (the
+ * tag's global WoT applications/disputes) AND Reading-B peer counts (other
+ * WoT-allowed authors who asserted the same (tag, target) pair, excluding
+ * the profile owner). Counts are derived per-request from raw assertions —
+ * no persistent per-POV aggregate (CLAUDE.md "filter at view time").
+ */
+async function handleAuthoredBy(req, res) {
+  const { authorPubkey } = req.query;
+  if (!authorPubkey || !/^[0-9a-f]{64}$/.test(authorPubkey)) {
+    return res.status(400).json({
+      success: false,
+      error: 'authorPubkey is required (64-char lowercase hex)',
+    });
+  }
+  const sort = req.query.sort || 'recent';
+  if (!AUTHORED_BY_VALID_SORTS.includes(sort)) {
+    return res.status(400).json({
+      success: false,
+      error: `sort must be one of: ${AUTHORED_BY_VALID_SORTS.join(', ')}`,
+    });
+  }
+
+  try {
+    const { resolvePov } = require('../_shared/pov');
+    const { povSuffix, minRank } = resolvePov({
+      wotPov: req.query.wotPov || 'house',
+      userPubkey: req.query.userPubkey || null,
+    });
+    const wotFiltering = !!povSuffix && Number.isFinite(minRank);
+
+    // Step 1: pull every nostr-user-tag assertion authored by the profile owner.
+    const ownerEvents = await strfryScan({
+      kinds: [39999],
+      '#z': [NOSTR_USER_TAG_Z_TAG],
+      authors: [authorPubkey],
+    });
+    const ownerDeduped = dedupeReplaceable(ownerEvents);
+
+    // Step 2: bucket polarity, capture candidate rows.
+    const candidates = [];
+    for (const ev of ownerDeduped) {
+      const pTag = (ev.tags || []).find((t) => t[0] === 'p');
+      const eTag = (ev.tags || []).find((t) => t[0] === 'e');
+      if (!pTag?.[1] || !eTag?.[1]) continue;
+      const polarity = readPolarity(ev);
+      const bucket = bucketize(polarity);
+      if (bucket === 'neutral') continue;
+      candidates.push({
+        assertionEventId: ev.id,
+        targetPubkey: pTag[1],
+        tagEventId: eTag[1],
+        polarity: bucket === 'apply' ? 'applied' : 'disputed',
+        createdAt: ev.created_at,
+      });
+    }
+
+    if (candidates.length === 0) {
+      return res.json({
+        success: true,
+        povSuffix: povSuffix || null,
+        minRank: Number.isFinite(minRank) ? minRank : null,
+        sort,
+        authorPubkey,
+        rows: [],
+      });
+    }
+
+    // Step 3: target-WoT filter. Drop rows whose target's rank doesn't clear
+    // the threshold. No-op when no POV is configured (graceful degradation,
+    // matches existing endpoints).
+    const targetPubkeys = Array.from(new Set(candidates.map((c) => c.targetPubkey)));
+    const targetDocs = await meiliFetchProfilesByPubkey(targetPubkeys);
+    let targetAllowed = () => true;
+    if (wotFiltering) {
+      const rankField = `wot_rank_${povSuffix}`;
+      targetAllowed = (pk) => {
+        const doc = targetDocs.get(pk);
+        if (!doc) return false;
+        const r = doc[rankField];
+        return typeof r === 'number' && r >= minRank;
+      };
+    }
+    const surviving = candidates.filter((c) => targetAllowed(c.targetPubkey));
+
+    if (surviving.length === 0) {
+      return res.json({
+        success: true,
+        povSuffix: povSuffix || null,
+        minRank: Number.isFinite(minRank) ? minRank : null,
+        sort,
+        authorPubkey,
+        rows: [],
+      });
+    }
+
+    // Step 4: parent-tag enrichment. Drop rows whose parent tag-element isn't
+    // locally available or fails to parse.
+    const tagEventIds = Array.from(new Set(surviving.map((c) => c.tagEventId)));
+    const tagElementEvents = await strfryScan({ kinds: [39999], ids: tagEventIds });
+    const tagByEventId = new Map();
+    for (const ev of tagElementEvents) {
+      const payload = parseTagPayload(ev);
+      if (!payload) continue;
+      tagByEventId.set(ev.id, payload);
+    }
+    const surviving2 = surviving.filter((c) => tagByEventId.has(c.tagEventId));
+
+    if (surviving2.length === 0) {
+      return res.json({
+        success: true,
+        povSuffix: povSuffix || null,
+        minRank: Number.isFinite(minRank) ? minRank : null,
+        sort,
+        authorPubkey,
+        rows: [],
+      });
+    }
+
+    // Step 5: parent-tag scan — yields BOTH parent-tag aggregate counts
+    // (Reading A) AND per-(tag, target) peer counts (Reading B) in one walk.
+    const remainingTagIds = Array.from(new Set(surviving2.map((c) => c.tagEventId)));
+    const parentAssertions = await strfryScan({
+      kinds: [39999],
+      '#z': [NOSTR_USER_TAG_Z_TAG],
+      '#e': remainingTagIds,
+    });
+    const parentDeduped = dedupeReplaceable(parentAssertions);
+
+    let parentAuthorAllowed = () => true;
+    if (wotFiltering) {
+      const parentAuthors = Array.from(new Set(parentDeduped.map((ev) => ev.pubkey)));
+      const parentAuthorDocs = await meiliFetchProfilesByPubkey(parentAuthors);
+      const rankField = `wot_rank_${povSuffix}`;
+      parentAuthorAllowed = (pk) => {
+        const doc = parentAuthorDocs.get(pk);
+        if (!doc) return false;
+        const r = doc[rankField];
+        return typeof r === 'number' && r >= minRank;
+      };
+    }
+
+    const parentCounts = new Map(); // tagEventId → { applications, disputes }
+    const peerCounts = new Map();   // `${tagEventId}|${targetPubkey}` → { applications, disputes }
+    for (const ev of parentDeduped) {
+      if (!parentAuthorAllowed(ev.pubkey)) continue;
+      const eTag = (ev.tags || []).find((t) => t[0] === 'e');
+      if (!eTag?.[1]) continue;
+      const pTag = (ev.tags || []).find((t) => t[0] === 'p');
+      const bucket = bucketize(readPolarity(ev));
+      if (bucket === 'neutral') continue;
+
+      // Parent-tag aggregate (Reading A) — include all WoT-allowed authors.
+      let pEntry = parentCounts.get(eTag[1]);
+      if (!pEntry) {
+        pEntry = { applications: 0, disputes: 0 };
+        parentCounts.set(eTag[1], pEntry);
+      }
+      if (bucket === 'apply') pEntry.applications += 1;
+      else if (bucket === 'dispute') pEntry.disputes += 1;
+
+      // Peer count (Reading B) — exclude the profile owner from their own
+      // peer count; the owner doesn't count themselves as a peer.
+      if (ev.pubkey === authorPubkey) continue;
+      if (!pTag?.[1]) continue;
+      const peerKey = `${eTag[1]}|${pTag[1]}`;
+      let peerEntry = peerCounts.get(peerKey);
+      if (!peerEntry) {
+        peerEntry = { applications: 0, disputes: 0 };
+        peerCounts.set(peerKey, peerEntry);
+      }
+      if (bucket === 'apply') peerEntry.applications += 1;
+      else if (bucket === 'dispute') peerEntry.disputes += 1;
+    }
+
+    // Step 6: compose rows.
+    const rows = surviving2.map((c) => {
+      const tagInfo = tagByEventId.get(c.tagEventId);
+      const targetDoc = targetDocs.get(c.targetPubkey);
+      const parent = parentCounts.get(c.tagEventId);
+      const peer = peerCounts.get(`${c.tagEventId}|${c.targetPubkey}`);
+      return {
+        assertionEventId: c.assertionEventId,
+        polarity: c.polarity,
+        createdAt: c.createdAt,
+        targetPubkey: c.targetPubkey,
+        targetDisplayName: targetDoc ? (targetDoc.display_name || targetDoc.name || null) : null,
+        targetPicture: targetDoc ? (targetDoc.picture || null) : null,
+        tagEventId: c.tagEventId,
+        tagSlug: tagInfo.slug,
+        tagName: tagInfo.name || tagInfo.slug,
+        parentApplications: parent?.applications ?? 0,
+        parentDisputes: parent?.disputes ?? 0,
+        peerApplications: peer?.applications ?? 0,
+        peerDisputes: peer?.disputes ?? 0,
+      };
+    });
+
+    // Step 7: server-side sort.
+    rows.sort(AUTHORED_BY_SORTERS[sort]);
+
+    res.json({
+      success: true,
+      povSuffix: povSuffix || null,
+      minRank: Number.isFinite(minRank) ? minRank : null,
+      sort,
+      authorPubkey,
+      rows,
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+/**
+ * GET /api/profile-tags/pins?viewerPubkey=<hex>
+ *
+ * List a single viewer's tag-pinning records, joined to each pinned tag's
+ * current metadata. Per ADR 0009:
+ *   - Strfry scan for Pin events authored by the viewer carrying the
+ *     `tag-pinning` z-tag, dedupe-replaceable.
+ *   - Bulk-fetch the referenced tag events (one extra strfry scan).
+ *   - Drop pins whose referenced tag event is missing or has a malformed
+ *     payload (dangling-pin filter).
+ *   - Sort by createdAt desc (most-recently-pinned first).
+ */
+async function handlePins(req, res) {
+  const { viewerPubkey } = req.query;
+  if (!isHexPubkey(viewerPubkey)) {
+    return res.status(400).json({
+      success: false,
+      error: 'viewerPubkey is required (64-char lowercase hex)',
+    });
+  }
+  try {
+    const pinEvents = await strfryScan({
+      kinds: [39999],
+      '#z': [TAG_PINNING_Z_TAG],
+      authors: [viewerPubkey],
+    });
+    const dedupedPins = dedupeReplaceable(pinEvents);
+
+    // Map each pin to its referenced tag event id; drop pins with no
+    // resolvable tagEventId.
+    const pinsWithTagIds = [];
+    for (const pin of dedupedPins) {
+      const tagEventId = parsePinTagEventId(pin);
+      if (!tagEventId) continue;
+      pinsWithTagIds.push({ pin, tagEventId });
+    }
+
+    // Bulk-fetch referenced tag events.
+    const uniqueTagIds = [...new Set(pinsWithTagIds.map((p) => p.tagEventId))];
+    let tagEventsById = new Map();
+    if (uniqueTagIds.length > 0) {
+      const tagEvents = await strfryScan({ kinds: [39999], ids: uniqueTagIds });
+      for (const ev of tagEvents) tagEventsById.set(ev.id, ev);
+    }
+
+    const pins = [];
+    for (const { pin, tagEventId } of pinsWithTagIds) {
+      const tagEv = tagEventsById.get(tagEventId);
+      if (!tagEv) continue; // dangling pin — referenced tag missing
+      const tagPayload = parseTagPayload(tagEv);
+      if (!tagPayload) continue; // malformed payload
+      const curationMethod = parseCurationMethod(pin);
+      pins.push({
+        pinEventId: pin.id,
+        createdAt: pin.created_at,
+        curationMethod,
+        tag: {
+          eventId: tagEv.id,
+          slug: tagPayload.slug,
+          name: tagPayload.name || tagPayload.slug,
+          description: tagPayload.description || '',
+          authorPubkey: tagEv.pubkey,
+          createdAt: tagEv.created_at,
+        },
+      });
+    }
+
+    pins.sort((a, b) => b.createdAt - a.createdAt);
+
+    // ADR 0010: enrich each row with tlStatus derived from strfry (no
+    // on-disk persistence). One batched scan covers all pins' d-tags;
+    // results are mapped back to per-row tlStatus objects.
+    const { tlByDTag, wantedDTags } = await enrichRowsWithTLStatus(pins);
+    // ADR 0017: also enrich each row with nip51ExportStatus (Story 19).
+    // Re-uses the d-tags + kind-30392 scan results from the previous call
+    // to avoid double-scanning strfry.
+    await enrichRowsWithNip51ExportStatus(pins, viewerPubkey, { tlByDTag, wantedDTags });
+
+    res.json({ success: true, pins });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+/**
+ * ADR 0010: per-pin tlStatus derived live from strfry. No status file.
+ *
+ * For each pin:
+ *   - If curationMethod.method !== 'nip85:rank' → status='unsupported'.
+ *   - Else compute the TL d-tag from (observer, tagAuthor, tagSlug) and
+ *     look up the latest kind-30392 with that d-tag signed by the TA. If
+ *     missing → status='never'. If present with ['status','retracted']
+ *     marker → status='retracted'. Otherwise → status='ok'.
+ */
+async function enrichRowsWithTLStatus(pins) {
+  // Default status on every row before we begin (so even on a strfry-scan
+  // failure the rows carry the field — the read contract stays uniform).
+  for (const row of pins) {
+    row.tlStatus = { status: 'never', lastRefreshAt: null, tlEventId: null, memberCount: null };
+  }
+
+  // Mark unsupported method rows; collect d-tags for the rest.
+  const wantedDTags = [];
+  for (const row of pins) {
+    const method = row.curationMethod?.method;
+    if (method !== 'nip85:rank') {
+      row.tlStatus = { status: 'unsupported', lastRefreshAt: null, tlEventId: null, memberCount: null };
+      row._tlDTag = null;
+      continue;
+    }
+    const observer = row.curationMethod?.observer;
+    if (!observer || !isHexPubkey(observer)) {
+      // Malformed observer → leave as 'never'; no d-tag to look up.
+      row._tlDTag = null;
+      continue;
+    }
+    const dTag = `tl-pin-${observer.slice(0, 8)}-${row.tag.authorPubkey.slice(0, 8)}-${row.tag.slug}`;
+    row._tlDTag = dTag;
+    wantedDTags.push(dTag);
+  }
+
+  // Latest per d-tag wins (kind-30392 is addressable replaceable; defensive).
+  // Returned to the caller so Story-19's nip51-export-status enricher can
+  // reuse the same scan results without round-tripping strfry again.
+  const tlByDTag = new Map();
+  if (wantedDTags.length === 0) {
+    return { tlByDTag, wantedDTags };
+  }
+
+  let tls = [];
+  try {
+    tls = await strfryScan({
+      kinds: [30392],
+      authors: [TA_PUBKEY],
+      '#d': wantedDTags,
+    });
+  } catch {
+    // strfry scan failed — leave default 'never' on each row.
+    return { tlByDTag, wantedDTags };
+  }
+
+  for (const ev of tls) {
+    const d = (ev.tags || []).find((t) => t[0] === 'd')?.[1];
+    if (!d) continue;
+    const cur = tlByDTag.get(d);
+    if (!cur || ev.created_at > cur.created_at) tlByDTag.set(d, ev);
+  }
+
+  for (const row of pins) {
+    const dTag = row._tlDTag;
+    if (!dTag) continue;
+    const tl = tlByDTag.get(dTag);
+    if (!tl) continue; // leave 'never'
+    const retracted = (tl.tags || []).some((t) => t[0] === 'status' && t[1] === 'retracted');
+    row.tlStatus = {
+      status: retracted ? 'retracted' : 'ok',
+      lastRefreshAt: tl.created_at,
+      tlEventId: tl.id,
+      memberCount: (tl.tags || []).filter((t) => t[0] === 'p').length,
+    };
+  }
+
+  return { tlByDTag, wantedDTags };
+}
+
+/**
+ * Story 19 / ADR 0017 + Story 22 / ADR 0020: per-pin export status for BOTH
+ * NIP-51 list kinds the user can publish from a pin — the kind-30000 Follow
+ * Set (`nip51ExportStatus`) and the kind-39089 Follow Pack
+ * (`followPackStatus`). Derived live from strfry (no on-disk state),
+ * mirroring enrichRowsWithTLStatus's derive-on-read pattern. Both status
+ * objects share the same shape/vocabulary; only the scanned kind differs.
+ *
+ * For each pin row:
+ *   - If unsupported method (per enrichRowsWithTLStatus) → nip51ExportStatus
+ *     status='never-exported'.
+ *   - Else fetch the user's latest kind-30000 with the same d-tag (signed
+ *     by viewerPubkey, NOT the TA). If absent → status='never-exported'.
+ *     If present → compare its p-tag set with the current kind-30392's
+ *     p-tag set (passed in via tlByDTag):
+ *       - same set → status='ok-fresh', diffVsTL={added:0, removed:0}
+ *       - differs   → status='stale',     diffVsTL={added:N, removed:M}
+ *
+ * Must be called AFTER enrichRowsWithTLStatus (which stashes row._tlDTag
+ * and we read tlByDTag from its return).
+ *
+ * ADR 0017 Amendment II: this enricher no longer surfaces writeRelays.
+ * The user's NIP-65 write-relay list is identity data fetched client-side
+ * via window.nostr.getRelays() at popover-open time.
+ */
+async function enrichRowsWithNip51ExportStatus(pins, viewerPubkey, { tlByDTag = new Map(), wantedDTags = [] } = {}) {
+  // Default: every row carries populated status objects (one per NIP-51
+  // list kind) so the UI doesn't have to null-check the fields.
+  const emptyStatus = () => ({
+    status: 'never-exported',
+    exportedAt: null,
+    exportEventId: null,
+    memberCount: null,
+    diffVsTL: null,
+    currentTitle: null,
+  });
+  for (const row of pins) {
+    row.nip51ExportStatus = emptyStatus(); // kind-30000 Follow Set
+    row.followPackStatus = emptyStatus();  // kind-39089 Follow Pack (ADR 0020)
+  }
+
+  // Cleanup: row._tlDTag was stashed by enrichRowsWithTLStatus; remove
+  // it after we've used it here.
+  const rowsByDTag = new Map();
+  for (const row of pins) {
+    if (row._tlDTag) rowsByDTag.set(row._tlDTag, row);
+  }
+
+  if (rowsByDTag.size === 0 || !isHexPubkey(viewerPubkey)) {
+    for (const row of pins) delete row._tlDTag;
+    return;
+  }
+
+  // One batched scan covering BOTH user-signed list kinds whose d-tag
+  // matches any wanted d-tag. Both are parameterized-replaceable; the
+  // (kind, pubkey, d) coordinate carries the latest by created_at. The
+  // kind-30000 and kind-39089 share a d-tag (distinct coords by kind).
+  let exports = [];
+  try {
+    exports = await strfryScan({
+      kinds: [30000, 39089],
+      authors: [viewerPubkey],
+      '#d': wantedDTags,
+    });
+  } catch {
+    for (const row of pins) delete row._tlDTag;
+    return;
+  }
+
+  // Latest per d-tag wins, bucketed per kind.
+  const followSetByDTag = new Map();  // kind 30000
+  const followPackByDTag = new Map(); // kind 39089
+  for (const ev of exports) {
+    const d = (ev.tags || []).find((t) => t[0] === 'd')?.[1];
+    if (!d) continue;
+    const bucket = ev.kind === 39089 ? followPackByDTag : followSetByDTag;
+    const cur = bucket.get(d);
+    if (!cur || ev.created_at > cur.created_at) bucket.set(d, ev);
+  }
+
+  // Compute one status object for an export event vs the current kind-30392.
+  // If no kind-30392, treat diff as zero (the export reflects "nothing in
+  // the TL yet" — not stale, not behind).
+  const statusFor = (exportEv, tl) => {
+    const exportMembers = (exportEv.tags || []).filter((t) => t[0] === 'p').map((t) => t[1]);
+    const exportTitle = (exportEv.tags || []).find((t) => t[0] === 'title')?.[1] || null;
+    let added = 0, removed = 0;
+    if (tl) {
+      const tlMembers = (tl.tags || []).filter((t) => t[0] === 'p').map((t) => t[1]);
+      const exportSet = new Set(exportMembers);
+      const tlSet = new Set(tlMembers);
+      for (const m of tlMembers) if (!exportSet.has(m)) added++;
+      for (const m of exportMembers) if (!tlSet.has(m)) removed++;
+    }
+    const status = (added + removed) === 0 ? 'ok-fresh' : 'stale';
+    return {
+      status,
+      exportedAt: exportEv.created_at,
+      exportEventId: exportEv.id,
+      memberCount: exportMembers.length,
+      diffVsTL: { added, removed },
+      currentTitle: exportTitle,
+    };
+  };
+
+  for (const row of pins) {
+    const dTag = row._tlDTag;
+    delete row._tlDTag;
+    if (!dTag) continue;
+    const tl = tlByDTag.get(dTag);
+    const followSetEv = followSetByDTag.get(dTag);
+    if (followSetEv) row.nip51ExportStatus = statusFor(followSetEv, tl); // else leave 'never-exported'
+    const followPackEv = followPackByDTag.get(dTag);
+    if (followPackEv) row.followPackStatus = statusFor(followPackEv, tl); // else leave 'never-exported'
+  }
+}
+
+function registerProfileTagsRoutes(app) {
+  app.get('/api/profile-tags/available-tags', handleAvailableTags);
+  app.get('/api/profile-tags/tags-for-profile', handleTagsForProfile);
+  app.get('/api/profile-tags/wot-tags', handleWotTags);
+  app.get('/api/profile-tags/match', handleMatch);
+  app.get('/api/profile-tags/by-id', handleTagById);
+  app.get('/api/profile-tags/profiles-tagged', handleProfilesTagged);
+  app.get('/api/profile-tags/index', handleTagIndex);
+  app.get('/api/profile-tags/authored-by', handleAuthoredBy);
+  app.get('/api/profile-tags/pins', handlePins);
+}
+
+module.exports = {
+  handleAvailableTags,
+  handleTagsForProfile,
+  handleWotTags,
+  handleMatch,
+  handleTagById,
+  handleProfilesTagged,
+  handleTagIndex,
+  handleAuthoredBy,
+  handlePins,
+  computeTagMatches,
+  findTagsByNameSubstring,
+  meiliFetchProfilesByPubkey,
+  aggregateProfilesTagged,
+  aggregateTagPins,
+  parseTagPayload,
+  parseCurationMethod,
+  parsePinTagEventId,
+  TAG_PINNING_Z_TAG,
+  NOSTR_USER_TAG_Z_TAG,
+  TA_PUBKEY,
+  registerProfileTagsRoutes,
+};


### PR DESCRIPTION
## What

Lands **just the nostr-user-tag read + per-POV WoT-score core** on staging so the Communities work can build per-POV membership rosters against it — without waiting on the full profile-tagging UI. Self-contained, **additive-only** port from `feat/pubkey-tagging-target` (2129 insertions, 0 deletions).

## Why

Communities consumes the tag as its membership atom ("who carries tag X, weighted by the viewer's WoT"). The only hard dependency is the primitive — schema + read/score — living on the shared branch. The tag stays general / person-scoped / community-agnostic; communities *claim* tags (many-to-many), the tag never points at a community.

## What's included

- `src/api/profile-tags/index.js` — read + per-POV WoT-score engine. Scans kind-39999 `nostr-user-tag` assertions, gates asserters by `wot_rank_<povSuffix> ≥ minRank`, nets polarity, aggregates per target. Only deps: `_shared/pov` + `utils/assistantKeys` (already on staging).
- `src/api/_shared/pov.js` — POV resolution (delegated pubkey → suffix / minRank).
- firmware concepts `tag` / `nostr-user-tag` / `tag-pinning` + manifest registration (append-only, +28 lines).
- `src/api/index.js` — registers the profile-tags routes (+4 lines, after `trustedList.register`).
- `engineering-team/decisions/profile/0022-…` — ADR for the hybrid `e`+`a` wire shape (the consume-by-`#a` contract).
- `VERIFY_TAG_CORE.md` — runbook to verify locally (can be removed post-integration).

## What's deliberately excluded

The pin→Trusted-List publisher (`trustedList/*`), all writers, and all UI — none are consumed by Communities, and excluding `trustedList` avoids a heavy reconcile. Reads scan `#e` today; the ADR-0022 hybrid `#a` support is a follow-up that touches both this read path and the writer.

## Consumer contract (for Communities)

- `GET /api/profile-tags/profiles-tagged?tagEventId=<id>&wotPov=house` → per-target `{applications, disputes}` (WoT-gated counts, **not** a weighted sum).
- Membership gate (our default, `refreshPinnedTags.js`): `applications ≥ cutoff AND applications > disputes` — count-based, valence-naive.
- `aggregateProfilesTagged` is also exported for in-process use.
- Tag-element coord = `39999:<author>:<slug>` (bare slug d-tag). Communities emit born-hybrid assertions (`e`+`a`) → no backfill on their side.

## ⚠️ After merge

**Firmware reinstall required** — three concepts are registered. Run `POST /api/firmware/install` (the staging deploy CI runs firmware install; confirm the `tag` / `nostr-user-tag` / `tag-pinning` concepts register).

## Verification status

Static-verified (modules load on a staging base, all exports present, JSON valid, manifest splice is surgical). **First runtime smoke happens on the staging deploy** — see `VERIFY_TAG_CORE.md` for endpoint checks (note: the core is read-only, so endpoints are empty until tag events exist; the runbook covers seeding).

## Notes

- ADR-0022 references ADR-0001, which arrives later with the full tagging-ADR refolder into `decisions/profile/` (ratified separately).
- Additive only; CI deploys only on merge to `staging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)