### PR TITLE
docs(BIBLE): §26 Resolved Definition (story #32, ADR 0028)

### DIFF
--- a/BIBLE.md
+++ b/BIBLE.md
@@ -36,6 +36,7 @@
 23. [Class-Thread Membership Tags (`n`, `s`)](#23-class-thread-membership-tags-n-s)
 24. [Task Queue (BullMQ behind /api/run-task)](#24-task-queue-bullmq-behind-apirun-task)
 25. [The Inherit-From Tag (`b`)](#25-the-inherit-from-tag-b)
+26. [Resolved Definition](#26-resolved-definition)
 
 ---
 
@@ -1673,7 +1674,7 @@ The drift sentinels in `test/entrypoint-template-rendering.test.js` (T7 + T8) tr
 
 **Kinds:** defined for **kind-39998 and kind-39999** — any addressable DList object (concept headers *and* items/sets/Declarations). Broader than `n`/`s`, which are kind-39999-only.
 
-**Multi-parent:** an event may carry multiple `b` tags (inherit from multiple parents — rare; resolution order is a consumer concern, deferred). Same multi-tag pattern as `z`/`n`/`s`.
+**Multi-parent:** an event may carry multiple `b` tags (inherit from multiple parents — rare; resolution order is **defined in §26 (Resolved Definition)** — first-listed `b` wins). Same multi-tag pattern as `z`/`n`/`s`.
 
 **Edge direction — child→parent (diverges from `n`/`s`; do NOT flip).** `n`/`s` flip their child-claims-parent encoding into a *parent→child* Neo4j edge because their semantics are containment (the parent owns the child). `b` does **not** flip: it writes `(child)-[:INHERITS_FROM]->(parent)`, because (a) deference reads naturally child→parent, and (b) a parent's **incoming** `INHERITS_FROM` edges are exactly "everyone who defers to this definition" — the trust-weightable query the registry use case (§22) needs. Implementers must not copy the `n`/`s` direction-flip.
 
@@ -1683,7 +1684,7 @@ The drift sentinels in `test/entrypoint-template-rendering.test.js` (T7 + T8) tr
 ```
 effective(node) = merge( effective(parent_via_b), node.statedFields )
 ```
-- **Live:** the walk reads each ancestor's *current* state, so a child tracks the parent's future edits ("whatever Alice says"). Only the `INHERITS_FROM` edge is materialized; the definition is not copied into the child. (Same read-time pattern as the Communities Protocol's `effectiveCD`.)
+- **Live:** the walk reads each ancestor's *current* state, so a child tracks the parent's future edits ("whatever Alice says"). Only the `INHERITS_FROM` edge is materialized; the definition is not copied into the child. (This live read-time merge is the general **Resolved Definition** primitive — see §26; the Communities Protocol's `effectiveCD` is a named instance of it.)
 - **Override = the child's own stated fields.** A field the child states explicitly overrides the inherited value; an omitted field is inherited. An unedited child performs pure inheritance.
 - **Termination:** stop at a root (no `b` tag) or a `maxDepth` guard; a cycle guard (visited-set keyed on a-tag) prevents loops. Reuses the bounded-walk pattern of ADR 0010/0011.
 - **Scope today:** the pattern above plus **field-level (whole-field replace)** override. The **set-valued override algebra** — how a child adds/removes/replaces individual elements of an inherited *set* — is deferred to the first consumer that needs it (the first consumer, CD inheritance, overrides only scalars).
@@ -1702,6 +1703,42 @@ effective(node) = merge( effective(parent_via_b), node.statedFields )
 **Direction principle / reserved `B`.** Per §23's convention, lowercase `b` = child-claims-parent. Uppercase **`B`** is **reserved** (not assigned) for a future parent-claims-child / federation inverse — e.g. a parent recognizing a child as "the same community." Do not assign speculatively.
 
 See ADR 0027 for the full rationale, the rejected alternatives (folding into `IMPORT`; multi-char tags), and the deferred design questions.
+
+---
+
+## 26. Resolved Definition
+
+**The read-side of the `b` tag (§25).** Where `b` is the *write* primitive ("I defer to X"), the **resolved definition** is the *read* primitive: *what a node's definition actually resolves to after following its `b` deferences.* It is **general** — Alice's resolved definition of `dogs` versus Bob's is the same mechanism as a Community Declaration — so every consumer (the Communities Protocol included) reads *through* it. Established by ADR 0028, the read-side companion to ADR 0027.
+
+**The closure.** From a node, trace `b` / `INHERITS_FROM` transitively → the set of all nodes it defers to (a derived query, `MATCH (n)-[:INHERITS_FROM*0..]->(x)`; **not stored**). The closure is **not guaranteed acyclic** — dense mutual deference (Alice `b`→Bob, Bob `b`→Alice) creates cycles; the resolution rule's visited-set handles them.
+
+**Resolution rule** — the merge that produces the resolved definition:
+
+1. **The node's own stated fields win** (a child overrides its ancestors — carried from §25 / ADR 0027). Any conflict is settlable by stating the field yourself; conflicts only bite for fields you leave unstated.
+2. **For unstated conflicts among multiple `b` parents, first-listed `b` wins** — walk depth-first in the order the `b` tags are listed on the event; the first value to land sticks. Precedence is **author-controlled** (you order your `b` tags), deterministic, and **observer-independent** (a node's own definition does not change based on who resolves it).
+3. **A visited-set keyed on a-tag bounds cycles** (carried from ADR 0027). The walk always terminates and always yields *an* answer — never "ambiguous → undefined."
+
+```
+resolved(node):
+  visited = {}
+  return merge_walk(node, visited)
+
+merge_walk(node, visited):
+  if node.a-tag in visited: return {}            # cycle guard
+  visited.add(node.a-tag)
+  result = {}
+  for parent in node.b-tags (in listed order):   # ancestors; first-listed wins
+    result = fill_unset(result, merge_walk(resolve(parent), visited))
+  return overlay(result, node.statedFields)       # the node's own fields always win
+```
+
+**Live, read-time.** A resolved definition is computed **on read**, against ancestors' *current* state — so it tracks their future edits (§25's live-`b` semantics, "whatever Alice says"). The `INHERITS_FROM` edge is the only materialized artifact; the definition is never snapshotted into the node. (Caching is a consumer/performance concern, out of scope.)
+
+**What it settles.** This **defines the multi-parent resolution order that ADR 0027 deferred** (§25's multi-parent note now points here), and it **is the general `effectiveX`** that §25 forward-referenced as the Communities Protocol's `effectiveCD` — which is simply a *named instance* of Resolved Definition. §22's grapevine-resolution (which definition a web of trust converges on) selects among nodes' resolved definitions.
+
+**Scope (v1).** Field-level override only — a stated field replaces the inherited one wholesale. The **set-valued override algebra** (how a child adds/removes/replaces individual elements of an inherited *set*) **remains deferred** (ADR 0027), to the first consumer that needs it.
+
+See ADR 0028 for the rationale and the rejected alternative (WoT-weighted field resolution, which would make a node's own definition vary by observer).
 
 ---
 

--- a/engineering-team/decisions/community-reference/0028-resolved-definition.md
+++ b/engineering-team/decisions/community-reference/0028-resolved-definition.md
@@ -1,0 +1,107 @@
+# ADR 0028: Resolved Definition — the read-side of the `b` tag
+
+**Status:** Accepted
+**Date:** 2026-06-05
+**Story:** `engineering-team/stories/community-reference/32-resolved-definition-primitive.md`
+**Builds on:** ADR 0027 (the `b` / inherit-from tag — the *write* primitive). This ADR is its read-side companion.
+**Amends:** ADR 0027's deferral — 0027 left "multi-parent `b` resolution order" as a deferred "consumer concern" and assumed "the first consumers are single-parent." This ADR **resolves that order** and retires the single-parent assumption. It does not contradict any 0027 decision; it completes one.
+
+## Context
+
+ADR 0027 / BIBLE §25 established the **`b` tag**: the *write* primitive for definitional inheritance — a child event carries `["b", "<parent-a-tag>", "inherit"]` to declare "my definition is the parent's, unless I state otherwise," materializing a `(child)-[:INHERITS_FROM]->(parent)` edge. It deliberately left two loose ends:
+
+1. **Multi-parent resolution order was deferred.** §25 allows multiple `b` tags but says (BIBLE:1676) "resolution order is a consumer concern, deferred," and ADR 0027 assumed "the first consumers are single-parent."
+2. **A resolver was forward-referenced but never defined.** §25's live-resolution note points at the Communities Protocol's `effectiveCD` as the read pattern — but nothing defines it. Story #31's review flagged this as its one open (non-blocking) follow-up.
+
+The missing companion is the **read side**: *given a node and its `b` deferences, what does its definition actually resolve to?* That design was settled in this session's scoping (`docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` §2) — the **Resolved Definition** primitive. It is **general** (Alice's resolved definition of `dogs` vs Bob's is the same mechanism as a community), so it belongs in BIBLE core next to §25, with the Communities Protocol and any future consumer reading *through* it.
+
+**Constraints / grounding:** the Concept Graph API was unreachable all session — grounded in the BIBLE, exactly as ADR 0027 was (the subject is a protocol primitive whose deliverable is BIBLE prose, not a graph concept). BIBLE currently ends at **§25**, so **§26** is the next slot. **This story's deliverable is documentation only** (BIBLE prose + this ADR); no resolver code. No new lint/build tooling (CLAUDE.md).
+
+## Options considered
+
+### Option A — Closure-merge via override → first-listed → visited-set, resolved live at read time (chosen)
+
+A node's **resolved definition** = the merge of its **closure** — the transitive `b`/`INHERITS_FROM` ancestor-set (a derived query, `MATCH (n)-[:INHERITS_FROM*0..]->(x)`; not stored; **may contain cycles** — it is not a DAG). The merge rule:
+
+1. **The node's own stated fields win** (child overrides ancestors — already established by ADR 0027).
+2. **For unstated conflicts among multiple `b` parents, first-listed `b` wins** — depth-first in the order the `b` tags are listed on the event; the first value to land sticks. Author-controlled (you order your `b` tags), deterministic, **no PoV-dependence**.
+3. **A visited-set keyed on a-tag bounds cycles** (carried from ADR 0027). The walk always terminates and always yields *an* answer — never "ambiguous → undefined."
+
+Resolution is **live** (computed at read time against ancestors' current state); the `INHERITS_FROM` edge is the only materialized artifact.
+
+**Pros:** deterministic and total (always an answer); precedence is author-controlled and observer-independent (your own definition doesn't change based on who's looking); reuses ADR 0027's override + visited-set wholesale; fills the deferred multi-parent order; closes the §25 `effectiveCD` reference; **general** (any concept).
+**Cons:** first-listed-wins is a *heuristic*, not principled conflict arbitration; multi-parent authors must understand that `b`-tag order encodes precedence (rare in practice); live resolution has a per-read walk cost (bounded by a max-depth guard).
+
+### Option B — WoT-weighted field-level resolution (rejected)
+
+For each conflicting field, weight each parent's value by the parent-author's GrapeRank influence from the resolving PoV; take the weighted winner.
+
+**Why rejected:** it makes a node's *own* resolved definition **vary by observer** — "my definition of `dogs`" would change depending on who is looking, which is surprising and violates the intuition that a node authoritatively states its own meaning. It is also materially more complex. First-listed-wins keeps a node's definition observer-independent and cheap. Recorded as a deliberate v1 rejection; revisit only if a concrete consumer needs trust-weighted field arbitration.
+
+### Option C — Snapshot at materialization vs live read-time resolution (decided: live)
+
+Snapshot would freeze a node's resolved definition when its edge is created. **Rejected** because it contradicts §25's live-`b` semantics ("deference tracks future edits — *whatever Alice says*"). Live read-time resolution is the choice; the edge is materialized, the definition is computed on read. (Caching is a consumer/performance concern, out of scope.)
+
+## Decision
+
+Adopt **Option A.** Define **Resolved Definition** as the general read-side of the `b` tag:
+
+```
+resolved(node):
+  visited = {}
+  return merge_walk(node, visited)
+
+merge_walk(node, visited):
+  if node.a_tag in visited: return {}        # cycle guard (ADR 0027)
+  visited.add(node.a_tag)
+  result = {}
+  # ancestors first, in the node's b-tag listed order; nearer/earlier wins
+  for parent in node.b_tags (in listed order):
+    inherited = merge_walk(resolve(parent), visited)
+    result = fill_unset(result, inherited)   # first value to land sticks
+  result = overlay(result, node.statedFields) # the node's own fields always win
+  return result
+```
+
+- It is **general** — applies to any concept (a `dogs` concept, a Community Declaration, a Set). The Communities Protocol's `effectiveCD` becomes a **named instance** of Resolved Definition.
+- It **fills the multi-parent resolution order ADR 0027 deferred** and retires 0027's single-parent assumption.
+- It **defines the general resolver §25 forward-referenced as `effectiveCD`**, closing story #31's open follow-up.
+- **first-listed-wins** is the v1 heuristic; **WoT-weighted field resolution is rejected for v1** (Option B).
+- **Set-valued override algebra** (add/remove/replace over an inherited element *set*) **remains deferred** per ADR 0027 — Resolved Definition v1 is **field-level** (a stated field replaces the inherited one wholesale).
+
+## Consequences
+
+### Positive
+- The read side of `b` is defined once, generally; every consumer (Communities included) reads through one primitive.
+- Multi-parent resolution is settled and deterministic; cycles are safe.
+- Closes story #31's `effectiveCD` forward-reference — no more dangling BIBLE pointer.
+- Zero new mechanism: it's ADR 0027's override + visited-set, plus a listed-order tiebreak.
+
+### Negative / risk
+- **First-listed-wins is a heuristic.** Mitigation: a node can always settle any conflict by stating the field itself (its own fields win); and the rule is documented as "good enough for now," revisitable.
+- **Live read cost.** A per-read closure walk, bounded by a max-depth guard; caching is a deferred consumer concern.
+- **Author awareness for multi-parent.** Ordering `b` tags now carries meaning. Rare today (first consumers are mostly single-parent); documented in §26.
+
+### Neutral
+- Additive and read-only; no existing behavior changes. ADR 0027 / §25 stand, with §25's multi-parent note updated to point here.
+
+**Firmware reinstall required?** **No** — the deliverable is documentation (BIBLE prose) only; no concept definitions or schemas change. A future story that *implements* the resolver in code may touch firmware/graph-engine and should re-evaluate then.
+
+## Implementation notes
+
+**Phase 4 is documentation-only — edit `BIBLE.md`, no source.** Three edits:
+
+1. **New `BIBLE.md` §26 "Resolved Definition"** — append after §25 (The Inherit-From Tag); add to the Table of Contents; cross-link §25 and §22. Mirror `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` §2: the read-side framing (companion to §25's write primitive); the closure (transitive `b`/`INHERITS_FROM`, derived, may cycle — not a DAG); the resolution rule (own-fields-win → first-listed-`b`-wins → visited-set), with the short pseudocode above; **live** read-time resolution; **general** (any concept); the note that it fills ADR 0027's deferred multi-parent order and defines the general `effectiveX` that §25 called `effectiveCD`; and that **set-valued override remains deferred** (field-level only in v1). Do not duplicate this ADR's rationale verbatim — point here for the "why" (story #20 / #31 precedent).
+
+2. **`BIBLE.md` §25 multi-parent note (BIBLE:1676)** — replace "resolution order is a consumer concern, deferred" with a pointer: resolution order is **defined in §26 (Resolved Definition)**.
+
+3. **`BIBLE.md` §25 `effectiveCD` reference** — §25's live-resolution bullet mentions the Communities `effectiveCD` (grep `effectiveCD` in BIBLE; one hit, in §25). Update it to note `effectiveCD` is a **named instance of §26's Resolved Definition**, so the forward-reference resolves (this is the story #31 review follow-up being closed).
+
+No source files, tests, or firmware are touched by this ADR's story.
+
+## Out of scope (named, deferred)
+
+- **Resolver code** — any actual merge-walk implementation, Neo4j/query work, materialization, caching. A future implementation story.
+- **WoT-weighted field-level resolution** — rejected for v1 (Option B); revisit only on concrete need.
+- **Set-valued override algebra** (add/remove/replace over an inherited element set) — remains deferred per ADR 0027; Resolved Definition v1 is field-level.
+- **The Communities-specific consumer layer** — `effectiveCD`'s community semantics (roster, roles, membership) build *on* this primitive but are separate, and gated on the three-branch reconciliation (handoff §7).

--- a/engineering-team/reviews/community-reference/32-resolved-definition-primitive.md
+++ b/engineering-team/reviews/community-reference/32-resolved-definition-primitive.md
@@ -1,0 +1,65 @@
+# Review: Story 32 — Resolved Definition primitive (read-side of the `b` tag)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-06
+**Diff:** `git diff origin/staging` (commits `2407a8ac` story, `6efda988` adr, `db6a1219` impl)
+**Story:** `engineering-team/stories/community-reference/32-resolved-definition-primitive.md`
+**ADR:** `engineering-team/decisions/community-reference/0028-resolved-definition.md` (Accepted)
+**Test plan:** none — Test Design skipped (story resolved-Q2, docs-only). Verified by claim-accuracy/consistency audit + the test gate, per the story #20 / #31 precedent.
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **24/26 suites PASS**, independently re-run. **This change introduces zero regressions.** Two suites fail (`manual-task-retrigger-after-finish` 6/4, `task-queue-semaphore-protection-audit` 3/3) — **pre-existing and unrelated** (see Findings → Non-blocking #1; independently confirmed below). Every suite that could be affected by a BIBLE change is green.
+- [x] _Lint not configured — skipped._
+- [x] _Typecheck not configured — skipped._
+- [x] _Build not configured — skipped._
+- [x] **Diff scope:** `BIBLE.md` (the substantive change) + the ADR 0028 and story #32 artifacts. **No source/test/firmware files touched.** No new lint/typecheck/build tooling.
+
+## Spec adherence (story acceptance criteria)
+
+All 5 ACs satisfied:
+
+- [x] **AC1 — general read-side primitive.** §26 opens "the read-side of the `b` tag… It is **general** — Alice's resolved definition of `dogs` vs Bob's… not community-specific" (BIBLE:1709–1711).
+- [x] **AC2 — resolution rule.** §26 states the three-step rule (own-stated-fields-win → first-listed-`b`-wins → visited-set bounds cycles), with pseudocode, and "the closure is **not guaranteed acyclic**" (BIBLE:1713–1733). Always terminates / always yields an answer — stated.
+- [x] **AC3 — fills 0027's deferred order + defines the general `effectiveX`; §25 updated.** §26 "What it settles" (BIBLE:1737); §25 multi-parent note now "resolution order is **defined in §26**" (BIBLE:1677); §25's `effectiveCD` mention now "the general **Resolved Definition** primitive — see §26; … `effectiveCD` is a named instance" (BIBLE:1687).
+- [x] **AC4 — ADR records the decision.** ADR 0028 records the closure-merge + override→first-listed→visited-set rule; first-listed-wins flagged "good-enough heuristic"; WoT-weighted resolution recorded as the rejected alternative (Option B).
+- [x] **AC5 — no test regression / no new tooling.** Confirmed: zero regression (below); BIBLE-only; no tooling.
+
+## ADR adherence (fidelity to ADR 0028)
+
+- [x] **The three specified BIBLE edits are all present and match** ADR 0028 §Implementation notes: (1) new **§26** + TOC entry (anchor `#26-resolved-definition`) + cross-links to §25/§22; (2) §25 multi-parent note → §26; (3) §25 `effectiveCD` → named instance of §26.
+- [x] Pseudocode present (matches ADR 0028's). **Set-valued override** noted as still-deferred per ADR 0027 (BIBLE:1739). **WoT-weighted** resolution noted as out-of-scope/rejected (BIBLE:1741, "would make a node's own definition vary by observer").
+- [x] §26 attributes itself to ADR 0028 and the §25 lineage to ADR 0027 — no silent contradiction; it completes 0027's deferral as the ADR states.
+
+## Internal consistency / accuracy audit
+
+- [x] **§26 is consistent with §25 (the write side).** §25 describes the `b` write tag + a single-parent resolution sketch; §26 is the general/canonical read-side, and §25 now points to it for resolution order. No conflict; the pseudocode generalizes §25's `effective(node)` sketch to multi-parent.
+- [x] **Cross-references resolve.** TOC `#26-resolved-definition` (BIBLE:39) matches heading `## 26. Resolved Definition` (BIBLE:1709). §25↔§26 pointers are bidirectional and correct. The §22 grapevine-resolution link is accurate (it selects among resolved definitions).
+- [x] **Story #31's previously-dangling `effectiveCD` forward-reference now resolves** — it points to §26 (a real, present section). That non-blocking follow-up from the #31 review is **closed** by this change.
+- [x] Pseudocode matches the prose rule (cycle guard, listed-order parents, own-fields overlay). Accurate.
+
+## Concept-graph integrity
+- [x] **N/A — no concepts, handles, or schemas changed.** Documentation of a protocol primitive; no firmware concept definitions edited, no graph nodes created.
+- [x] **Firmware reinstall:** **not required** (ADR 0028 §Consequences correctly states "No — documentation only"). A future resolver-*implementation* story re-evaluates.
+- [x] Concept Graph API was unreachable all session; grounding in the BIBLE is correct here (the deliverable *is* BIBLE prose, the subject a new primitive) — the precedent set by ADR 0027 this session and the standing direction. Not a defect.
+
+## Things tests can't catch
+- [x] No secrets, no debug logging, no commented-out code (prose-only diff).
+- [x] No scope creep: `db6a1219` touches **only** `BIBLE.md`; the ADR/story are the harness artifacts. Set-valued override and the Communities consumer layer are correctly left out of scope.
+- [x] No silent AC drop; no behavior added beyond the story.
+
+## House rules check
+- [x] Concept Graph API authority respected (down → grounded in BIBLE, appropriate for a BIBLE-prose deliverable).
+- [x] No new lint/typecheck/build tooling.
+
+## Findings
+
+### Blocking
+_None._
+
+### Non-blocking
+1. **Test gate red due to a PRE-EXISTING, unrelated breakage (not this story).** `test/task-queue-semaphore-protection-audit.test.js:47` reads `engineering-team/decisions/0013-task-queue-neo4j-resource-class.md` (and the manual-retrigger suite reads ADR 0012 similarly) — **flat paths the #236 epic-folder reorg moved** into `decisions/task-queue-scheduler/`. Independently confirmed: `git cat-file -e origin/staging:engineering-team/decisions/0013-…` → **absent** — so the suites fail on the clean `staging` base itself, with or without this change. This BIBLE-only diff touches none of it; **zero regression**. A fix is already spawned (`task_00e94771`: update the test paths + audit `test/` for other stale flat-path refs). This is **not** a CHANGES_REQUESTED reason for story #32, but the team should land that fix to un-break staging's gate.
+2. *(Context, not a defect)* The branch-convention divergence surfaced during planning (Avi's `feat/communities` and Vinney's `feat/pubkey-tagging-target` haven't adopted the epic-folder scheme) is captured in `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` §7 for the three-branch reconciliation. Noted so it isn't lost.
+
+## Verdict
+**PASS** — the diff matches the story (5/5 ACs), conforms to ADR 0028 (all three edits, decision + rejected alternative recorded), is internally consistent and accurate against §25/§22, every cross-reference resolves (and story #31's dangling `effectiveCD` reference is now closed). Documentation-only; no source/test/firmware. The two failing suites are an **independently-confirmed pre-existing `staging` breakage** from the #236 reorg, demonstrably not caused by this change (separately tracked in `task_00e94771`); 24/24 unaffected suites pass.

--- a/engineering-team/stories/community-reference/32-resolved-definition-primitive.md
+++ b/engineering-team/stories/community-reference/32-resolved-definition-primitive.md
@@ -1,0 +1,57 @@
+# Story 32: Define the Resolved Definition primitive (read-side of the `b` tag)
+
+**Status:** Approved
+**Created:** 2026-06-05
+**Type:** Doc (protocol-definition — runs Planning → Architecture → Implementation → Review; **not** fast-tracked; carries a ratifiable design decision = an ADR. Sibling/continuation of `community-reference` #31 / ADR 0027.)
+
+## Background
+
+Story #31 / ADR 0027 / BIBLE §25 established the **`b` tag** — the *write* primitive for definitional inheritance ("I defer to X"). It deliberately left two loose ends: it **deferred the multi-parent resolution order** ("resolution order is a consumer concern"), and §25 **forward-references a resolver, `effectiveCD`, that nothing yet defines** (flagged as the one non-blocking follow-up in story #31's review).
+
+The missing companion is the **read side**: *what does a node's definition actually resolve to, after following its `b` deferences?* That design is now settled (written up in `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` §2): the **Resolved Definition** primitive. It is **general** — Alice's resolved definition of `dogs` versus Bob's is the same mechanism as a community — so it belongs in BIBLE core next to §25, with the Communities Protocol (and any future consumer) reading *through* it. Capturing it now fills ADR 0027's deferred resolution order and closes the §25 `effectiveCD` thread.
+
+## User-facing description
+
+**As an implementer or reviewer** reading the BIBLE, **I want** the read-side of the `b` tag — how a node's definition resolves after following its deferences — defined once and generally, **so that** I can compute a resolved definition without inferring it from a forward-reference.
+
+**As a protocol designer**, **I want** the multi-parent conflict-resolution rule (the thing ADR 0027 deferred) recorded in an ADR, **so that** consumers build on a settled, deterministic rule rather than guessing.
+
+## Acceptance criteria
+
+Externally checkable assertions on `BIBLE.md` and the ADR (exact placement is the Implementer's call).
+
+- [ ] The BIBLE defines **Resolved Definition** as the **general read-side of the `b` tag** (§25): a node's resolved definition = the merge of its `b`/`INHERITS_FROM` **closure**; explicitly general (any concept, e.g. `dogs`), **not** community-specific.
+- [ ] The BIBLE states the **resolution rule**: (1) the node's own stated fields win; (2) for unstated conflicts among multiple `b` parents, **first-listed `b` wins** (deterministic, author-controlled); (3) a **visited-set bounds cycles** (the closure is not guaranteed acyclic). It always terminates and yields an answer.
+- [ ] The BIBLE records that this **fills the multi-parent resolution order ADR 0027 deferred** and **defines the general resolver §25 forward-referenced as `effectiveCD`** — and §25's "multi-parent resolution deferred" note is updated to point to the new section.
+- [ ] An ADR (in the `community-reference` 0027 lineage) records the decision — closure-merge + the override → first-listed → visited-set rule — with first-listed-wins flagged as a good-enough heuristic and **WoT-weighted field resolution explicitly rejected for v1**.
+- [ ] Quality: no regression in the npm test suites (no source touched); no new lint/typecheck/build tooling.
+
+## Concepts touched
+
+Concept Graph API unreachable at planning — Architect to resolve any handles via `/api/concept-graph/summaries`.
+
+- **The `b` tag / `INHERITS_FROM`** — §25 / ADR 0027 (the write primitive this completes).
+- **Resolved Definition** — *new*; this story defines it.
+- *(Consumer)* the Communities Protocol's `effectiveCD` — becomes a named instance of the general Resolved Definition.
+
+## Out of scope
+
+- **Any code** — an actual resolver/merge-walk implementation, Neo4j/query work. Docs + decision only; implementation is a future story.
+- **WoT-weighted field-level resolution** — explicitly rejected for v1 (first-listed-wins is the rule).
+- **Set-valued override algebra** (add/remove/replace over an inherited element *set*) — remains deferred per ADR 0027 (the first consumer that needs it defines it); not this story.
+- **The Communities-specific resolution/consumer layer** — separate, and gated on the three-branch reconciliation (handoff doc §7).
+
+## Open questions
+
+**Resolved at planning (2026-06-05):**
+1. **Scope** → the general Resolved Definition primitive only: BIBLE §26 (next section after §25) + an ADR (0027 lineage) + a small §25 cross-reference amendment. Docs-only.
+2. **Phase path** → Planning → Architecture → Implementation → Review, with **Test Design skipped** (no executable behavior; doc-content sentinels covered in Review, per the #20 / #31 precedent).
+3. **Save location** → `engineering-team/stories/community-reference/` per the epic-folder convention on staging+main (confirmed 2026-06-05); branched off `staging`. Note: `feat/communities` and `feat/pubkey-tagging-target` have not adopted epic-folders — convention alignment is part of the three-branch reconciliation (handoff §7).
+
+**Forwarded to the Architect:**
+4. Exact ADR number (expected **0028**, `decisions/community-reference/`); whether the §25 amendment is specified in that ADR or folded into Implementation notes; confirm §26 is the right section slot.
+
+## Linked artifacts
+- ADR: _(filled in after Architecture — expected `0028`, community-reference epic)_
+- Test plan: _n/a — Test Design skipped (docs-only)._
+- Review: _(filled in after Review)_

--- a/engineering-team/stories/community-reference/32-resolved-definition-primitive.md
+++ b/engineering-team/stories/community-reference/32-resolved-definition-primitive.md
@@ -1,6 +1,6 @@
 # Story 32: Define the Resolved Definition primitive (read-side of the `b` tag)
 
-**Status:** Approved
+**Status:** In Progress
 **Created:** 2026-06-05
 **Type:** Doc (protocol-definition — runs Planning → Architecture → Implementation → Review; **not** fast-tracked; carries a ratifiable design decision = an ADR. Sibling/continuation of `community-reference` #31 / ADR 0027.)
 
@@ -52,6 +52,6 @@ Concept Graph API unreachable at planning — Architect to resolve any handles v
 4. Exact ADR number (expected **0028**, `decisions/community-reference/`); whether the §25 amendment is specified in that ADR or folded into Implementation notes; confirm §26 is the right section slot.
 
 ## Linked artifacts
-- ADR: _(filled in after Architecture — expected `0028`, community-reference epic)_
+- ADR: [../../decisions/community-reference/0028-resolved-definition.md](../../decisions/community-reference/0028-resolved-definition.md) — **Accepted** (2026-06-05).
 - Test plan: _n/a — Test Design skipped (docs-only)._
 - Review: _(filled in after Review)_

--- a/engineering-team/stories/community-reference/32-resolved-definition-primitive.md
+++ b/engineering-team/stories/community-reference/32-resolved-definition-primitive.md
@@ -54,4 +54,4 @@ Concept Graph API unreachable at planning — Architect to resolve any handles v
 ## Linked artifacts
 - ADR: [../../decisions/community-reference/0028-resolved-definition.md](../../decisions/community-reference/0028-resolved-definition.md) — **Accepted** (2026-06-05).
 - Test plan: _n/a — Test Design skipped (docs-only)._
-- Review: _(filled in after Review)_
+- Review: [../../reviews/community-reference/32-resolved-definition-primitive.md](../../reviews/community-reference/32-resolved-definition-primitive.md) — **PASS** (2026-06-06): 5/5 ACs, ADR 0028-conformant, BIBLE-only diff, story #31's `effectiveCD` ref now closed; 24/24 unaffected suites green (2 pre-existing #236-reorg failures separately tracked in `task_00e94771`).


### PR DESCRIPTION
## Summary

Adds **BIBLE §26 "Resolved Definition"** — the *read-side* of the `b` tag (§25). Where `b` writes "I defer to X," the resolved definition reads "what X means after following the deferences": the merge of a node's `b`/`INHERITS_FROM` closure via **own-fields-win → first-listed-`b`-wins → visited-set**, resolved live. General to any concept. Completes the inherit-from primitive (§25 write + §26 read). **Documentation-only.**

Story #32 / ADR 0028 (Accepted) / Review **PASS** (no blocking findings).

## Changes

- **`BIBLE.md` §26 (new)** — Resolved Definition: closure (may cycle), the resolution rule + pseudocode, live read-time, general; set-valued override noted as still-deferred, WoT-weighted noted as rejected. + Table of Contents entry; cross-links §25/§22.
- **`BIBLE.md` §25** — multi-parent note → "resolution order defined in §26"; `effectiveCD` mention → "named instance of §26." **Closes story #31's dangling `effectiveCD` forward-reference.**
- **engineering-team/** — ADR 0028, story #32, review (PASS), all under the `community-reference` epic.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs (docker build + SSH deploy; doesn't run the unit suite).
- [ ] Light health check on staging.brainstorm.world (docs-only — formality).
- [x] `npm test`: 24/26 pass; **zero regressions**. The 2 failing suites (`manual-task-retrigger-after-finish`, `task-queue-semaphore-protection-audit`) are **pre-existing** — #236's epic-folder reorg moved ADR 0012/0013; the tests read the old flat paths, which `origin/staging` already lacks. Tracked in `task_00e94771`; not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)