### PR TITLE
fix(test): repair stale flat doc paths from #236 reorg (npm test → green)

### DIFF
--- a/test/manual-task-retrigger-after-finish.test.js
+++ b/test/manual-task-retrigger-after-finish.test.js
@@ -34,7 +34,7 @@ const ROOT = path.resolve(__dirname, '..');
 
 const QUEUE_MODULE     = path.join(ROOT, 'src/manage/taskQueue/queue/index.js');
 const SCHEDULER_MODULE = path.join(ROOT, 'src/manage/taskQueue/queue/scheduler.js');
-const ADR_0012         = path.join(ROOT, 'engineering-team/decisions/0012-task-queue-phase-1-bullmq.md');
+const ADR_0012         = path.join(ROOT, 'engineering-team/decisions/task-queue-scheduler/0012-task-queue-phase-1-bullmq.md');
 const PROBE_SCRIPT     = path.join(ROOT, 'test/probe-bullmq-removeOnComplete-immediate.js');
 
 function readSafe(p) {

--- a/test/profile-follows-list.test.js
+++ b/test/profile-follows-list.test.js
@@ -1,6 +1,6 @@
 /**
  * Story #29: Follows list on the primary profile page (v1 — owner POV only).
- * ADR 0026. See engineering-team/stories/29-profile-follows-list.test-plan.md
+ * ADR 0026. See engineering-team/stories/profile/29-profile-follows-list.test-plan.md
  *
  * v1 ships a standalone /user/:pubkey/follows React page backed by a NEW
  * endpoint GET /api/get-grapevine-follows that lists who <observee> follows

--- a/test/profile-website-link.test.js
+++ b/test/profile-website-link.test.js
@@ -1,6 +1,6 @@
 /**
  * Story #30: profile "Website" link broken for scheme-less URLs.
- * See engineering-team/stories/30-profile-website-link-scheme.test-plan.md
+ * See engineering-team/stories/profile/30-profile-website-link-scheme.test-plan.md
  *
  * Bug: ui/src/pages/BrainstormProfile.jsx and ui/src/pages/users/UserDetail.jsx
  * render `<a href={profile.website}>` from the RAW kind-0 website value, so a

--- a/test/scheduled-search-and-house-scores-refresh.test.js
+++ b/test/scheduled-search-and-house-scores-refresh.test.js
@@ -1,6 +1,6 @@
 /**
  * Failing tests for story #4: scheduled task to refresh Meilisearch profiles + House PoV WoT scores.
- * See engineering-team/stories/4-scheduled-search-and-house-scores-refresh.test-plan.md
+ * See engineering-team/stories/search-and-router/4-scheduled-search-and-house-scores-refresh.test-plan.md
  *
  * Each test maps to one or more acceptance criteria. Tests fail on the pre-implementation
  * tree and pass once the Implementer lands the changes described in ADR 0003 (Option A).

--- a/test/task-queue-semaphore-protection-audit.test.js
+++ b/test/task-queue-semaphore-protection-audit.test.js
@@ -44,7 +44,7 @@ const path = require('path');
 const ROOT = path.resolve(__dirname, '..');
 
 const TASK_REGISTRY = path.join(ROOT, 'src/manage/taskQueue/taskRegistry.json');
-const ADR_0013      = path.join(ROOT, 'engineering-team/decisions/0013-task-queue-neo4j-resource-class.md');
+const ADR_0013      = path.join(ROOT, 'engineering-team/decisions/task-queue-scheduler/0013-task-queue-neo4j-resource-class.md');
 const BIBLE_MD      = path.join(ROOT, 'BIBLE.md');
 
 function readSafe(p) {

--- a/test/treasure-maps-router-preset.test.js
+++ b/test/treasure-maps-router-preset.test.js
@@ -1,6 +1,6 @@
 /**
  * Failing tests for story #2: treasureMaps router preset + 10040 to Negentropy Sync.
- * See engineering-team/stories/2-treasure-maps-router-preset.test-plan.md
+ * See engineering-team/stories/search-and-router/2-treasure-maps-router-preset.test-plan.md
  *
  * Each test maps to one or more acceptance criteria. Tests are designed to fail
  * on the pre-implementation tree and pass once the Implementer lands the changes


### PR DESCRIPTION
## Summary

The #236 epic-folder reorg moved `engineering-team/` docs into per-epic subfolders but left **6 test files** referencing the old flat paths. Two suites have been **failing on staging** since (they `fs`-read the moved ADRs); the other four had stale header-comment references. This restores `npm test` to **26/26 PASS**.

## Changes (pure path updates, flat → epic; no test logic)

- `task-queue-semaphore-protection-audit.test.js` — ADR 0013 → `decisions/task-queue-scheduler/`
- `manual-task-retrigger-after-finish.test.js` — ADR 0012 → `decisions/task-queue-scheduler/`
- `profile-follows-list` / `profile-website-link` — test-plan refs → `stories/profile/`
- `scheduled-search-and-house-scores-refresh` / `treasure-maps-router-preset` — test-plan refs → `stories/search-and-router/`

## Test plan

- [x] `npm test` — **26/26 PASS** (was 24/26; the two task-queue suites are green again).
- [ ] After merge: `deploy-staging.yml` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)