### PR TITLE
feat(profile): Verified Followers count on profile page

### DIFF
--- a/engineering-team/decisions/profile/0029-profile-verified-followers-count.md
+++ b/engineering-team/decisions/profile/0029-profile-verified-followers-count.md
@@ -1,0 +1,75 @@
+# ADR 0029: Verified-followers count on the profile page
+
+**Status:** Accepted
+**Date:** 2026-06-06
+**Story:** `engineering-team/stories/profile/33-profile-verified-followers-count.md`
+
+## Context
+
+Story 33 asks for a **"Verified Followers"** plain (non-link) count in the prominent counter block beside the existing "Following" count on the profile page — House PoV by default, personalized PoV when selected, reusing the existing verified-followers influence cutoff. Scope is the count display only (the followers table is sub-feature 2, deferred).
+
+Acceptance criteria (quoted to confirm): (1) a count labeled "Verified Followers" appears in the prominent counter area beside "Following"; (2) it reflects only verified followers, not the raw total; (3) no PoV specified → House PoV; (4) personalized PoV selected & available → reflect it, else fall back to House; (5) no data → neutral placeholder (not error, not misleading "0"); (6) zero verified followers → "0"; (7) displayed as a plain, non-link number.
+
+**Key finding — the data is already on the page, PoV-aware.** Tracing the current tree:
+
+- The prominent counter block (`bsp-counts`) at [BrainstormProfile.jsx:236-242](ui/src/pages/BrainstormProfile.jsx:236) renders "Following" only, via `useUserCounts` → `GET /api/get-user-counts` (strfry kind-3 `p`-tag count — not applicable to followers).
+- The **Reputation** section already fetches `GET /api/search/profiles/meili/document/<pubkey>` ([BrainstormProfile.jsx:141](ui/src/pages/BrainstormProfile.jsx:141)) and extracts `wot_<metric>_<povSuffix>` fields into a `trustScores` object ([:149-182](ui/src/pages/BrainstormProfile.jsx:149)). `povSuffix` = `?pov=` else the House `delegatedPubkey` suffix ([:130-139](ui/src/pages/BrainstormProfile.jsx:130)).
+- `TRUST_METRICS` ([:34-46](ui/src/pages/BrainstormProfile.jsx:34)) already maps both `verifiedFollowerCount` ([:43](ui/src/pages/BrainstormProfile.jsx:43)) and `followers` ([:36](ui/src/pages/BrainstormProfile.jsx:36)) — both already render in the Reputation grid today.
+- Pipeline producing the field: `calculateVerifiedFollowerCounts.sh` sets `NostrUser.verifiedFollowerCount` (House) and `NostrUserWotMetricsCard.verifiedFollowerCount` (personalized, per enrolled PoV); [publish_kind30382.js:154,161](src/algos/customers/nip85/publish_kind30382.js:154) emits both `["followers", N]` and `["verifiedFollowerCount", N]` tags; [loadScoresIntoMeilisearch.js:93](src/algos/nip85/loadScoresIntoMeilisearch.js:93) writes `wot_<tag>_<povSuffix>` for every non-structural tag → Meili docs carry `wot_verifiedFollowerCount_<suffix>` and `wot_followers_<suffix>`.
+
+So `trustScores.verifiedFollowerCount` (and `.followers`, same value) is **already available client-side, already PoV-namespaced**, identical to what the Reputation grid consumes.
+
+**Constraints:** JS-without-build (no new tooling); minimize new surface; staging≈prod scale (~32M FOLLOWS) so avoid heavy per-request graph queries; the verified cutoff is applied upstream in the `calculate*` step (this story consumes the result — cutoff reused implicitly). Concept Graph API at `:8877` was unreachable; this change introduces/alters **no concepts**, so concept-graph orientation is not load-bearing here.
+
+## Options considered
+
+### Option A — Reuse the client-side `trustScores` value (chosen)
+Render the already-fetched `trustScores.verifiedFollowerCount` in the `bsp-counts` block as a plain counter. No backend change.
+- **Pros:** zero new backend/endpoint/Neo4j surface; PoV resolution already done by the page; same source & freshness as the rest of the Reputation section (UI consistency); no new query on the prod-scale graph; smallest possible diff and test surface.
+- **Cons:** value rides the Reputation Meili fetch's cadence (staleness — but identical to what the grid already shows) and its loading/error lifecycle (`trustLoading`/`trustError`), which is separate from the Following count's `useUserCounts` lifecycle; the rare "personalized PoV selected but not indexed" case degrades to the placeholder rather than substituting House (see Consequences).
+
+### Option B — Server-side via `get-user-data` (Neo4j, observer-aware)
+`handleGetUserData` returns `verifiedFollowerCount` from `NostrUser`/`NostrUserWotMetricsCard` ([userdata.js:154](src/api/export/users/queries/userdata.js:154), PoV via `observerPubkey`). The page would call it for the counter.
+- **Pros:** reads the Neo4j property one pipeline hop fresher than Meili.
+- **Cons:** that handler runs a large social-graph query (frens/groupies/idols/recommendations/mutuals) — heavyweight + 504 timeout risk on the prod-scale graph for a single number; the page doesn't call it today (new fetch + new loading/error handling); its PoV model (`observerPubkey`) differs from the page's `povSuffix` approach. Overkill for a page-load count.
+
+### Option C — Extend `get-user-counts` (the "hybrid" the docstring anticipates)
+Add a Neo4j `verifiedFollowerCount` branch to `/api/get-user-counts` (today strfry-only, `followingCount` only — [userdata.js:315](src/api/export/users/queries/userdata.js:315)), plus PoV handling it currently lacks.
+- **Pros:** co-locates with `followingCount`; one clean "counts" endpoint; decouples the counter from the Reputation fetch.
+- **Cons:** new query + new PoV plumbing for no fresher data (same upstream pipeline); duplicates data already in hand client-side; more code and test surface. A reasonable *future* consolidation, unnecessary now.
+
+*(A live per-request count cypher over inbound FOLLOWS with an influence filter was rejected outright — too heavy at prod scale for a page-load number, and unnecessary given precomputed counts exist.)*
+
+## Decision
+**Option A.** The verified-follower count is already client-side, already PoV-aware, and already the source the Reputation section uses. The feature is a small, self-contained front-end change with no backend, endpoint, Neo4j, or concept surface, and no new prod-scale query. It is also the most *consistent* choice — the prominent counter and the Reputation grid will show the same number from the same source.
+
+**Contingency:** if, at implementation time against a live stack, Meili unexpectedly does **not** carry `wot_verifiedFollowerCount_<suffix>` / `wot_followers_<suffix>`, fall back to **Option C** (extend `get-user-counts`). The Tester/Implementer will confirm against a live Meili document early.
+
+## Consequences
+- **Enables:** the prominent "Verified Followers" counter with House-default + personalized PoV, reusing existing infrastructure; near-zero risk; no firmware/concept changes.
+- **Constrains:** the counter shares the Reputation section's data source and refresh cadence (Meili, refreshed by the scheduled score-load). Staleness is bounded by that cadence — acceptable and consistent with the existing grid.
+- **Loading states:** the counter's value derives from the `trustScores` fetch (`trustLoading`/`trustError`), which is *separate* from the Following count's `useUserCounts` (`userCountsLoading`). The two counters in `bsp-counts` will resolve independently; the Implementer handles the verified-followers value with the existing `fmtCount` helper so it shows "—" until `trustScores` resolves.
+- **PoV fallback edge (flag for Tester + user):** the page resolves one active PoV (`?pov=` else House). House is the default → satisfies AC#3 and the common-case intent of AC#4 ("default to House when no personalized PoV is in play"). For a *selected personalized PoV that has no scores indexed*, the existing fetch reports "no trust scores" for the whole Reputation section, so the counter shows the placeholder (AC#5) rather than silently substituting House. This matches the user's stated intent for the dominant no-personalized case; strict per-lookup House substitution in the rare partial case is a small possible follow-up (read the House-suffix value as an explicit fallback) — **recommend deferring**.
+- **Duplicate-field note:** `wot_verifiedFollowerCount_<suffix>` and `wot_followers_<suffix>` carry the same value. The counter reads `verifiedFollowerCount` with `followers` as a defensive fallback. (The duplicate `TRUST_METRICS` *grid* rows remain a separate intake cleanup — untouched here.)
+- **Cutoff:** reused implicitly — the count reflects whatever `VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF` the upstream `calculate*` step applied. No cutoff logic enters this change. (The 0.01 / 0.05 / "score > 2" inconsistency remains an intake item.)
+- **Firmware reinstall required?** No (no concept/schema changes).
+
+## Implementation notes
+Single file. No backend changes.
+
+- **File: [ui/src/pages/BrainstormProfile.jsx](ui/src/pages/BrainstormProfile.jsx)**
+  - In the `bsp-counts` block (currently [:236-242](ui/src/pages/BrainstormProfile.jsx:236)), add a second count element beside the existing Following `<Link>`.
+  - **Value:** `trustScores?.verifiedFollowerCount ?? trustScores?.followers`. Format with the existing `fmtCount` helper ([:97](ui/src/pages/BrainstormProfile.jsx:97)) — `fmtCount(null)` → `"—"` (AC#5), `fmtCount(0)` → `"0"` (AC#6).
+  - **Render as a plain element** (e.g. `<div className="bsp-count">` with `bsp-count-value` + `bsp-count-label`), **not** a `<Link>`, and without `bsp-count-link` (AC#7 — non-link until the followers table ships). Leave the existing Following `<Link>` exactly as-is.
+  - **Label:** `"Verified Followers"` (AC#1).
+  - **PoV:** no new logic — the value rides the existing `povSuffix` resolution ([:130-139](ui/src/pages/BrainstormProfile.jsx:130)) and `trustScores` fetch ([:141-182](ui/src/pages/BrainstormProfile.jsx:141)). House by default (AC#3); `?pov=` honored (AC#4).
+  - **Do NOT touch:** the Following count; the Reputation grid; the `TRUST_METRICS` array (duplicate-row cleanup is out of scope); any backend file.
+  - **Styling:** reuse the existing `bsp-count` / `bsp-count-value` / `bsp-count-label` classes; a small CSS tweak for the non-link variant (if needed) belongs in the existing profile stylesheet — no new build step.
+
+## Out of scope
+- The followers table page (`/user/:pubkey/followers`) — sub-feature 2.
+- Reconciling the duplicate "Verified Followers" rows in `TRUST_METRICS` — intake.
+- Reconciling the cutoff inconsistency (0.01 / 0.05 / "score > 2") — intake.
+- Any change to how `verifiedFollowerCount` is computed/published/loaded (`calculate*`, `publish_kind30382`, `loadScoresIntoMeilisearch`).
+- Strict per-lookup personalized→House substitution (recommend defer).
+- Changing `get-user-counts` / `get-user-data`.

--- a/engineering-team/reviews/profile/33-profile-verified-followers-count.md
+++ b/engineering-team/reviews/profile/33-profile-verified-followers-count.md
@@ -1,0 +1,59 @@
+# Review: Story 33 — Verified-followers count on the profile page
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-06
+**Diff:** `git diff origin/staging...HEAD` — branch `feat/story-33-verified-followers-count`; impl commit `c8d59993` (story `70dd05b7`, adr `30c0aae8`, tests `3a38cfa4`)
+**Story:** `engineering-team/stories/profile/33-profile-verified-followers-count.md`
+**ADR:** `engineering-team/decisions/profile/0029-profile-verified-followers-count.md`
+**Test plan:** `engineering-team/stories/profile/33-profile-verified-followers-count.test-plan.md`
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] **Node suite (story #33) — PASS, 6/6** (run standalone by the reviewer): T1–T5 + R1 all green; `RESULT {pass:6, fail:0}`.
+  - The full `npm test` was *not* used as the signal: it also runs concept-graph suites that require the local stack at `:8877` (down by the user's choice this session). The #33 suite is pure source-regex with no stack dependency, so it was run standalone for a clean result: `node -e "require('./test/profile-verified-followers-count.test.js').run()…"`.
+- [x] **`npm run test:playwright` — deferred to staging (not run).** `tests/brainstorm/profile-verified-followers-count.spec.js` is supplementary + live-data dependent; locally the harness can't start (pre-existing `tests/global-setup.js:16` reads `config.use`, undefined in the installed Playwright version) and local Meili has no House scores. Runs at `cycle-staging` against real data. *(Non-blocking — see Findings #1.)*
+- [x] **Build** — Vite build compiles cleanly (~47s; only the pre-existing chunk-size warning). Deployed into the running container; `:7778`/`:80` serve 200.
+- [x] Lint / Typecheck — not configured (skipped).
+
+## Spec adherence
+- [x] Every acceptance criterion has a passing test:
+  - **AC1** (label "Verified Followers" in the counter area, beside Following) → **T1**
+  - **AC2** (verified score, not the raw total) → **T2** (reads `trustScores.verifiedFollowerCount`)
+  - **AC3** (no PoV → House) → **T2** (value from the PoV-resolved `trustScores`) + staging visual
+  - **AC4** (personalized when available, else House; partial-personalized → placeholder, accepted) → **T2** + **T4** + staging visual
+  - **AC5** (no data → "—") → **T4** (`fmtCount(null/undefined)`→"—"); observed live locally (counter shows "—" with no House scores)
+  - **AC6** (zero → "0") → **T3** (`??` preserves 0) + **T4** (`fmtCount(0)`→"0")
+  - **AC7** (plain, non-link) → **T5**
+- [x] No criterion silently dropped; no behavior added beyond the story.
+
+## ADR adherence
+- [x] Matches ADR 0029 §Implementation notes exactly. Diff ([BrainstormProfile.jsx:236-250](ui/src/pages/BrainstormProfile.jsx:236)): a plain `<div className="bsp-count">` (not `<Link>`, no `bsp-count-link`) with `bsp-count-value`=`fmtCount(trustScores?.verifiedFollowerCount ?? trustScores?.followers)` and label `Verified Followers`, placed after the **unchanged** Following `<Link>`.
+- [x] **Option A honored — no backend change.** `git diff --name-only origin/staging...HEAD | grep '^src/'` → none. `get-user-counts` / `get-user-data` / `cypherQueries` / algos all untouched.
+- [x] No CSS change — the shared `.bsp-count` base styling ([styles.css:3393](ui/src/styles.css:3393)) suffices; `.bsp-count-link` only added link affordance, correctly absent here.
+- [x] No new dependencies; no new build/lint tooling.
+
+## Concept-graph integrity
+- [x] N/A — no concepts added or changed; the change surfaces an existing precomputed metric. No firmware reinstall required. (Concept Graph API was unreachable this session; correctly treated as non-load-bearing since the feature defines no concepts.)
+
+## Things tests can't catch
+- [x] No secrets, no leftover `console.log`/`debugger`, no `TODO`/`FIXME` in the added lines (grep of `^\+` lines: none).
+- [x] The two added comments are explanatory rationale (non-link + `??`), appropriate — not commented-out code.
+- [x] Edge cases handled: null/undefined `trustScores` → "—" (optional chaining + `fmtCount`); a genuine 0 preserved via `??` (a `||` here would drop it — pinned by T3).
+- [x] No concurrency concern (pure render of already-fetched state); no new input boundary or injection vector (renders a server-derived number).
+
+## House rules check
+- [x] Concept Graph API authority respected (no concept work).
+- [x] No new lint/typecheck/build tooling.
+- [x] `dist/` (gitignored, line 97) not committed; only the source file, the two test files, the runner wiring, and the harness docs.
+
+## Findings
+
+### Blocking
+None.
+
+### Non-blocking
+1. **Live numeric + PoV visual deferred to staging.** Local Meili has no House WoT scores (verified against `/api/search/profiles/meili/document` for Jack + 3 well-known pubkeys → no `wot_*` fields), so the counter renders "—" locally. AC2/AC3/AC4's *numeric* behavior and the personalized `?pov=` path are therefore not visually exercised locally. This is a **data gap, not a code defect** — the read logic is unit-pinned and the data pipeline was traced in ADR 0029 §Context. Close it at `cycle-staging` via the Playwright spec + a manual check on a scored profile.
+2. **Deferred follow-ups (correctly NOT in this diff), already in `_intake.md`:** the followers *table* page (sub-feature 2); the duplicate "Verified Followers" rows in `TRUST_METRICS` ([BrainstormProfile.jsx:36](ui/src/pages/BrainstormProfile.jsx:36) & [:43](ui/src/pages/BrainstormProfile.jsx:43)); the verified-cutoff inconsistency (graperank.conf `0.01` vs cypherQueries.js fallback `0.05` vs UI "score > 2"). Confirmed untouched.
+
+## Verdict
+**PASS** — the diff matches the story, ADR 0029 (Option A, front-end only), and the test plan; the node gate is clean (6/6, run by the reviewer); scope is tight (one source file, no backend, deferred items untouched). The only open item is live numeric/PoV verification, which is staging-bound by design and recorded as a non-blocking note.

--- a/engineering-team/stories/profile/33-profile-verified-followers-count.md
+++ b/engineering-team/stories/profile/33-profile-verified-followers-count.md
@@ -49,6 +49,6 @@ None outstanding. Resolved during planning:
 - **Label** → **"Verified Followers"** (not bare "Followers"), so the deliberately verified-only figure is not misread as a raw follower total.
 
 ## Linked artifacts
-- ADR: (filled in after Architecture phase)
+- ADR: `engineering-team/decisions/profile/0029-profile-verified-followers-count.md` (Accepted 2026-06-06)
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/profile/33-profile-verified-followers-count.md
+++ b/engineering-team/stories/profile/33-profile-verified-followers-count.md
@@ -1,6 +1,6 @@
 # Story 33: Verified-followers count on the profile page
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-06
 **Type:** Feature
 **Epic:** profile
@@ -51,4 +51,4 @@ None outstanding. Resolved during planning:
 ## Linked artifacts
 - ADR: `engineering-team/decisions/profile/0029-profile-verified-followers-count.md` (Accepted 2026-06-06)
 - Test plan: `engineering-team/stories/profile/33-profile-verified-followers-count.test-plan.md` (5 failing T-tests + 1 regression sentinel; confirmed failing 2026-06-06)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/profile/33-profile-verified-followers-count.md` (PASS 2026-06-06)

--- a/engineering-team/stories/profile/33-profile-verified-followers-count.md
+++ b/engineering-team/stories/profile/33-profile-verified-followers-count.md
@@ -1,0 +1,54 @@
+# Story 33: Verified-followers count on the profile page
+
+**Status:** Approved
+**Created:** 2026-06-06
+**Type:** Feature
+**Epic:** profile
+
+## Background
+The main user profile page shows a prominent **"Following"** count — how many accounts a user follows — beside the identity and action buttons. There is no equivalent count for *followers*.
+
+For followers, a raw total is actively misleading: a prominent account may be followed by large numbers of bots and spam accounts, so the raw number says little about real standing. What's meaningful is the count of **verified** followers — accounts whose standing in the web of trust clears the system's existing verification threshold. The system already computes this count; this story surfaces it on the profile page.
+
+Affected: anyone viewing a profile (logged-in or anonymous). This is **sub-feature 1** of two; the followers *table* (a browsable list of those followers) is sub-feature 2 and is deferred.
+
+## User-facing description
+As a visitor to a user's profile page, I want to see how many *verified* followers that user has — shown prominently alongside the existing "Following" count — so that I can gauge their real standing in the trust network without being misled by bot or spam followers.
+
+## Acceptance criteria
+Testable from the outside.
+
+- [ ] Given any user's profile page, when it finishes loading, then a count labeled **"Verified Followers"** appears in the same prominent counter area as the existing "Following" count.
+- [ ] Given the displayed count, then it reflects only *verified* followers (followers whose web-of-trust standing clears the system's existing verification threshold) — not the user's raw/total follower count.
+- [ ] Given no point-of-view is specified, when the profile loads, then the count is computed from the default (**House**) point of view.
+- [ ] Given a personalized point-of-view is selected (e.g., via the page address) and verified-follower data for it is available, when the profile loads, then the count reflects that point of view; if it is unavailable, then it falls back to the House point of view.
+- [ ] Given a user for whom no verified-follower data exists (e.g., a profile not yet scored), when the profile loads, then a neutral placeholder is shown (consistent with how the "Following" count handles missing data) — not an error and not a misleading "0".
+- [ ] Given a user with zero verified followers, when the profile loads, then the count shows "0".
+- [ ] Given the "Verified Followers" count, then it is displayed as a plain (non-interactive) number — not a link — in this story. (It is intended to become a link to the followers list once sub-feature 2 ships.)
+
+## Concepts touched
+*(Concept Graph API at `:8877` was unreachable during planning — named in plain language; Architect to resolve handles via `/api/concept-graph/summaries`.)*
+
+- **Verified follower** — a follower whose influence / web-of-trust score clears the verification threshold. The displayed metric.
+- **Influence / GrapeRank score** — the per-account web-of-trust score the verification threshold is applied to.
+- **Verified-followers influence cutoff** — the existing, configurable threshold parameter that defines "verified." This story *reuses* it; it does not define a new one.
+- **Point of view (PoV) / House PoV** — whose web of trust the score is computed from. Default is the House PoV; a personalized PoV may be selected.
+- **Follower (inbound follows)** — an account that follows this user (the inbound direction of the follows relationship).
+
+## Out of scope
+- The followers **table/list page** (a browsable list of the verified followers) — sub-feature 2, deferred. The count is a plain number until that ships.
+- Generalizing the followers view to other relationship types (mutes / muters / reports / reporters).
+- Changing, reconciling, or re-defining the verification threshold value or the meaning of "verified" — this story consumes the existing parameter as-is. *(The cross-tree inconsistency between the configured value, the code fallback, and the UI's "Verification Score > 2" description is logged separately in intake as a cleanup.)*
+- The duplicate "Verified Followers" entries already present in the profile's trust-metrics grid — reconciliation logged separately in intake.
+- Computing or recomputing verified-follower counts for personalized PoVs — the story consumes whatever the system already produces; it does not build the per-PoV computation pipeline.
+- Any change to the existing "Following" count's behavior.
+
+## Open questions
+None outstanding. Resolved during planning:
+- **Link target** → the count is a **plain (non-link) number** for now; it becomes a link when the followers table (sub-feature 2) ships.
+- **Label** → **"Verified Followers"** (not bare "Followers"), so the deliberately verified-only figure is not misread as a raw follower total.
+
+## Linked artifacts
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/profile/33-profile-verified-followers-count.md
+++ b/engineering-team/stories/profile/33-profile-verified-followers-count.md
@@ -50,5 +50,5 @@ None outstanding. Resolved during planning:
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/profile/0029-profile-verified-followers-count.md` (Accepted 2026-06-06)
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/profile/33-profile-verified-followers-count.test-plan.md` (5 failing T-tests + 1 regression sentinel; confirmed failing 2026-06-06)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/profile/33-profile-verified-followers-count.test-plan.md
+++ b/engineering-team/stories/profile/33-profile-verified-followers-count.test-plan.md
@@ -1,0 +1,74 @@
+# Test Plan: Story 33 — Verified-followers count on the profile page
+
+**Story:** `engineering-team/stories/profile/33-profile-verified-followers-count.md`
+**ADR:** `engineering-team/decisions/profile/0029-profile-verified-followers-count.md`
+**Date:** 2026-06-06
+
+## Approach
+
+ADR 0029 chose **Option A** — a pure front-end change to one file (`ui/src/pages/BrainstormProfile.jsx`): render the already-fetched, PoV-aware `trustScores.verifiedFollowerCount` (fallback `.followers`) as a **plain (non-link)** "Verified Followers" counter in the `bsp-counts` block, beside the existing "Following" `<Link>`, formatted with the existing `fmtCount` helper.
+
+Tests are **source-regex sentinels**, following the **story #29 (profile-follows-list)** precedent: a single-file profile-UI change in a repo with **no React render harness** (no vitest/jest; `ui/` has no test runner) and a house rule against adding test tooling. *(Story #30 used a pure importable helper only because its logic was shared across two files; here the logic lives in one file, so #29's source-sentinel style fits.)* Browser-rendered behavior — the element is not an `<a>`, PoV via `?pov=` — is covered by a **supplementary, live-data** Playwright spec.
+
+**False-positive note:** `BrainstormProfile.jsx` already contains the strings `"Verified Followers"`, `verifiedFollowerCount`, and `followers` inside the `TRUST_METRICS` array (the Reputation grid). Every sentinel therefore targets the **new** counter specifically — a *2nd* `bsp-count-*` span, a direct `trustScores.verifiedFollowerCount` read, a *2nd* `fmtCount(...)` call — none of which exist pre-implementation. Verified by the pre-impl baseline counts (all 1) below.
+
+## Coverage map
+
+| Acceptance criterion | Test(s) | File | Level |
+|---|---|---|---|
+| AC1 — "Verified Followers" count in the prominent counter area, beside "Following" | `T1` + `PW1` | node + spec | source + e2e |
+| AC2 — reflects the **verified** score, not the raw total | `T2` | node | source |
+| AC3 — no PoV → **House** | `T2` (value from PoV-resolved `trustScores`) + `PW3` (manual) | node + e2e | source + e2e |
+| AC4 — personalized PoV when available, else House (partial-personalized → placeholder, **accepted edge**) | `T2` + `T4` + `PW3` (manual) | node + e2e | source + e2e |
+| AC5 — no data → neutral placeholder "—" | `T4` (value via `fmtCount`; `fmtCount(null)→"—"`) | node | source |
+| AC6 — zero → "0" | `T3` (`??` preserves 0) + `T4` (`fmtCount(0)→"0"`) | node | source |
+| AC7 — plain, **non-link** number | `T5` + `PW2` | node + spec | source + e2e |
+| Regression — existing "Following" count unchanged | `R1` + `PW2` | node + spec | source + e2e |
+
+Node suite: `test/profile-verified-followers-count.test.js` (wired into `test/test.js`).
+Playwright: `tests/brainstorm/profile-verified-followers-count.spec.js` (supplementary, live-data dependent).
+
+## Edge cases
+- [x] **0 vs. null (the key trap):** `T3` pins nullish-coalescing (`verifiedFollowerCount ?? followers`) and forbids `||`, so a genuine `0` renders "0" (AC6) rather than being treated as falsy and dropped to "—" or the `.followers` value.
+- [x] **Missing data:** `T4` ties the value to `fmtCount`, which renders "—" for null/undefined (AC5).
+- [x] **Partial personalized PoV (accepted edge, per ADR 0029 + user):** when a personalized `?pov=` is selected but that account has no indexed score, the existing Reputation fetch yields no value → the counter shows the placeholder "—" (NOT a silent House substitute). Covered by `T4`'s placeholder path; *not* a strict per-lookup House fallback (deferred by decision).
+- [x] **False positives from pre-existing TRUST_METRICS tokens:** every sentinel uses count thresholds (`≥2`) or new-only patterns (`trustScores.verifiedFollowerCount`, `verifiedFollowerCount ??`) — confirmed failing pre-impl.
+
+## Test infrastructure
+- **Node runner:** `npm test` (entry `test/test.js`); the `profile-verified-followers-count` suite is wired in. The suite is **pure source-regex — no Docker/Neo4j/Concept-Graph/Meili dependency**, so it runs anywhere. Standalone (clean signal, independent of other suites):
+  ```
+  node -e "require('./test/profile-verified-followers-count.test.js').run().then(r=>{console.log(r);process.exit(0)})"
+  ```
+  *(The full `npm test` also runs other suites, some of which expect the live stack at `localhost:8877`; the local stack is currently down by choice, so the standalone command above is the clean way to verify just this suite.)*
+- **Playwright (supplementary, live):** `tests/brainstorm/profile-verified-followers-count.spec.js` — needs a deployed instance (`BRAINSTORM_BASE_URL`, default `:7778`) with House-PoV WoT scores loaded into Meilisearch and the target account (Jack Dorsey, `82341f88…e6a2`) having verified followers indexed. **Not run pre-implementation;** exercised at the staging smoke after deploy. Fragile to live data (flagged in-file).
+- No concept/firmware change → no `POST /api/firmware/install` precondition.
+
+## How to run
+```
+npm test                 # node suites (includes profile-verified-followers-count)
+npm run test:playwright  # browser/e2e (needs a deployed instance with House scores loaded)
+```
+
+## Verification
+Node suite confirmed **failing for the right reason** on 2026-06-06 (pre-implementation), run standalone against commit `30c0aae8`:
+
+```
+✗ T1: BrainstormProfile.jsx renders a "Verified Followers" count in the bsp-counts block (AC1)
+      a SECOND counter must be added to the bsp-counts block (expected >=2 `bsp-count-label` spans; …).
+✗ T2: the new counter sources its value from trustScores.verifiedFollowerCount (verified score, PoV-resolved) (AC2; AC3/AC4 source)
+      the counter must read `verifiedFollowerCount` directly off the PoV-resolved `trustScores` object …
+✗ T3: the verifiedFollowerCount->followers fallback uses ?? (not ||) so a real 0 is preserved (AC6)
+      the count must fall back with nullish-coalescing: `trustScores?.verifiedFollowerCount ?? trustScores?.followers` …
+✗ T4: the new counter formats its value via the existing fmtCount helper (AC5 placeholder, AC6 zero)
+      the new counter must format its value through the existing `fmtCount` helper (a 2nd `fmtCount(...)` call …).
+✗ T5: the "Verified Followers" counter is plain (not a <Link>); the followers table is deferred (AC7)
+      the new counter must exist (expected >=2 `bsp-count-value` spans; only "Following" has one …).
+✓ R1: the existing "Following" count is unchanged — useUserCounts + <Link> to /follows (regression)
+
+RESULT: 1 passed, 5 failed
+```
+
+Pre-impl baseline counts in `BrainstormProfile.jsx` (each must be `1`, confirming the `≥2`/`===1` thresholds gate correctly): `bsp-count-label=1`, `bsp-count-value=1`, `bsp-count-link=1`, `fmtCount(=1`. `test/test.js` passes `node --check`.
+
+Playwright spec: not run pre-implementation (it tests deployed state); exercised against staging after the feature deploys.
+```

--- a/test/profile-verified-followers-count.test.js
+++ b/test/profile-verified-followers-count.test.js
@@ -1,0 +1,117 @@
+/**
+ * Story #33: Verified-followers count on the profile page.
+ * ADR 0029. See engineering-team/stories/profile/33-profile-verified-followers-count.test-plan.md
+ *
+ * ADR 0029 chose Option A (pure front-end): render the already-fetched,
+ * PoV-aware client-side value `trustScores.verifiedFollowerCount` (fallback
+ * `.followers`) as a PLAIN (non-link) "Verified Followers" counter in the
+ * profile's `bsp-counts` block, beside the existing "Following" <Link>.
+ * No backend change.
+ *
+ * Tests are source-regex sentinels — the #29 profile-follows-list precedent
+ * (a single-file profile UI change with no React render harness; #30's pure
+ * helper was justified only because its logic was shared across two files).
+ * Browser-level behavior (the element is not an <a>; ?pov= reflects the PoV)
+ * is covered by the supplementary, live-data Playwright spec
+ * tests/brainstorm/profile-verified-followers-count.spec.js.
+ *
+ * FALSE-POSITIVE AVOIDANCE: BrainstormProfile.jsx ALREADY contains the strings
+ * "Verified Followers", "verifiedFollowerCount" and "followers" inside the
+ * TRUST_METRICS array (the Reputation grid, rendered as bsp-trust-card-*).
+ * Each sentinel below therefore targets the NEW bsp-counts-block counter
+ * specifically — a 2nd bsp-count-* span, a direct trustScores.verifiedFollowerCount
+ * read, a 2nd fmtCount(...) call — none of which exist pre-implementation.
+ *
+ * T1–T5 must FAIL pre-implementation and PASS post-implementation.
+ * R1 is a regression sentinel — it must PASS both before and after (it guards
+ * the existing "Following" count, which is added-beside, not replaced).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PROFILE_PAGE = path.resolve(__dirname, '../ui/src/pages/BrainstormProfile.jsx');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+function countOf(src, re) { return (src.match(re) || []).length; }
+
+// AC1 — a "Verified Followers" count renders in the bsp-counts block, beside Following.
+test('T1: BrainstormProfile.jsx renders a "Verified Followers" count in the bsp-counts block (AC1)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(countOf(src, /bsp-count-label/g) >= 2,
+    'a SECOND counter must be added to the bsp-counts block (expected >=2 `bsp-count-label` spans; only the existing "Following" counter has one pre-implementation).');
+  assert(/bsp-count-label[^>]*>\s*Verified Followers/.test(src),
+    'the new counter must be labeled "Verified Followers" via a `bsp-count-label` span. (The existing "Verified Followers" strings are TRUST_METRICS labels rendered as bsp-trust-card-label in the Reputation grid, not the prominent counter.)');
+});
+
+// AC2 (+ AC3/AC4 at source level) — value from the verified score on the PoV-resolved trustScores.
+test('T2: the new counter sources its value from trustScores.verifiedFollowerCount (verified score, PoV-resolved) (AC2; AC3/AC4 source)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/trustScores\s*\??\.\s*verifiedFollowerCount/.test(src),
+    'the counter must read `verifiedFollowerCount` directly off the PoV-resolved `trustScores` object (e.g. `trustScores?.verifiedFollowerCount`). Pre-implementation trustScores is only read as `trustScores[metric.tag]` in the Reputation grid. Reading trustScores ties the count to the existing House-default / ?pov= resolution (AC3/AC4) and to the VERIFIED score, not the raw follower total (AC2).');
+});
+
+// AC6 + zero-preservation — nullish-coalescing fallback so a genuine 0 shows "0".
+test('T3: the verifiedFollowerCount->followers fallback uses ?? (not ||) so a real 0 is preserved (AC6)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/verifiedFollowerCount\s*\?\?/.test(src),
+    'the count must fall back with nullish-coalescing: `trustScores?.verifiedFollowerCount ?? trustScores?.followers`. (Pre-implementation `verifiedFollowerCount` only appears as a TRUST_METRICS tag string, never followed by `??`.)');
+  assert(!/verifiedFollowerCount\s*\|\|/.test(src),
+    'do NOT use `||` for the fallback — `verifiedFollowerCount || followers` treats a genuine 0 as falsy and drops it (showing the followers value or "—" instead of "0"). Use `??`.');
+});
+
+// AC5/AC6 display — the value is formatted through the existing fmtCount helper (null -> "—", 0 -> "0").
+test('T4: the new counter formats its value via the existing fmtCount helper (AC5 placeholder, AC6 zero)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(countOf(src, /fmtCount\s*\(/g) >= 2,
+    'the new counter must format its value through the existing `fmtCount` helper (a 2nd `fmtCount(...)` call beside the Following one). fmtCount returns "—" for null/undefined (AC5) and "0" for 0 (AC6).');
+});
+
+// AC7 — the new counter is a PLAIN element, not a link; no premature followers-table link.
+test('T5: the "Verified Followers" counter is plain (not a <Link>); the followers table is deferred (AC7)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(countOf(src, /bsp-count-value/g) >= 2,
+    'the new counter must exist (expected >=2 `bsp-count-value` spans; only "Following" has one pre-implementation).');
+  assert(countOf(src, /bsp-count-link/g) === 1,
+    'exactly ONE `bsp-count-link` must remain (the existing "Following" link). The new "Verified Followers" counter must be a PLAIN element (e.g. `<div className="bsp-count">`), NOT a <Link>/bsp-count-link — AC7, non-link until the followers table ships.');
+  assert(!/\/user\/\$\{pubkey\}\/followers/.test(src),
+    'the counter must NOT link to `/user/${pubkey}/followers` — that page is sub-feature 2 (deferred). The count is a plain number for now.');
+});
+
+// Regression — the existing "Following" count is untouched (added beside, not replaced).
+test('R1: the existing "Following" count is unchanged — useUserCounts + <Link> to /follows (regression)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/useUserCounts/.test(src),
+    'BrainstormProfile.jsx must keep using useUserCounts for the Following count.');
+  assert(/\/user\/\$\{pubkey\}\/follows/.test(src) && /bsp-count-link/.test(src),
+    'the Following count must remain a <Link> (bsp-count-link) to `/user/${pubkey}/follows`.');
+  assert(/bsp-count-label[^>]*>\s*Following/.test(src),
+    'the "Following" label must remain (the new counter is added beside it, not in place of it).');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -49,6 +49,7 @@ const killTimeoutOrphansByDefault = require('./kill-timeout-orphans-by-default.t
 const taskQueueSemaphoreProtectionAudit = require('./task-queue-semaphore-protection-audit.test.js');
 const profileFollowsList = require('./profile-follows-list.test.js');
 const profileWebsiteLink = require('./profile-website-link.test.js');
+const profileVerifiedFollowersCount = require('./profile-verified-followers-count.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -134,6 +135,9 @@ async function main() {
   console.log('\nprofile-website-link suite:');
   const profileWebsiteLinkResult = await profileWebsiteLink.run();
 
+  console.log('\nprofile-verified-followers-count suite:');
+  const profileVerifiedFollowersCountResult = await profileVerifiedFollowersCount.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -215,6 +219,9 @@ async function main() {
   console.log(
     `profile-website-link suite:                      ${profileWebsiteLinkResult.fail === 0 ? 'PASS' : 'FAIL'} (${profileWebsiteLinkResult.pass} passed, ${profileWebsiteLinkResult.fail} failed)`
   );
+  console.log(
+    `profile-verified-followers-count suite:          ${profileVerifiedFollowersCountResult.fail === 0 ? 'PASS' : 'FAIL'} (${profileVerifiedFollowersCountResult.pass} passed, ${profileVerifiedFollowersCountResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -243,7 +250,8 @@ async function main() {
     killTimeoutOrphansByDefaultResult.fail === 0 &&
     taskQueueSemaphoreProtectionAuditResult.fail === 0 &&
     profileFollowsListResult.fail === 0 &&
-    profileWebsiteLinkResult.fail === 0;
+    profileWebsiteLinkResult.fail === 0 &&
+    profileVerifiedFollowersCountResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/tests/brainstorm/profile-verified-followers-count.spec.js
+++ b/tests/brainstorm/profile-verified-followers-count.spec.js
@@ -1,0 +1,58 @@
+/**
+ * Playwright behavioral check for story #33 / ADR 0029: the profile page shows a
+ * "Verified Followers" count beside "Following", as a PLAIN (non-link) number.
+ * See engineering-team/stories/profile/33-profile-verified-followers-count.test-plan.md
+ *
+ * SUPPLEMENTARY + LIVE-DATA DEPENDENT (mirrors the story #30 spec). The
+ * deterministic coverage is the node suite test/profile-verified-followers-count.test.js
+ * (no stack dependency). This spec additionally verifies the browser-rendered
+ * result and the not-an-anchor behavior that source-regex can only approximate.
+ *
+ * Preconditions / fragility:
+ *   - A reachable Brainstorm instance (BRAINSTORM_BASE_URL or http://localhost:7778)
+ *     with the change deployed AND House-PoV WoT scores loaded into Meilisearch
+ *     (the count comes from wot_verifiedFollowerCount_<houseSuffix>).
+ *   - Relies on LIVE DATA: the account below (Jack Dorsey) is expected to have
+ *     verified followers indexed under the House PoV. If scores aren't loaded the
+ *     Reputation section reports "no scores" and the counter shows "—".
+ *
+ * Not run pre-implementation (current code has no such counter); exercised at the
+ * staging smoke after the feature deploys.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = process.env.BRAINSTORM_BASE_URL || 'http://localhost:7778';
+// Jack Dorsey — a high-profile account expected to have verified followers indexed.
+const PUBKEY = '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2';
+
+test.describe('Story 33 — verified-followers count on the profile page', () => {
+  test('a "Verified Followers" count is shown beside "Following"', async ({ page }) => {
+    await page.goto(`${BASE_URL}/user/${PUBKEY}`);
+
+    // Both prominent counters present.
+    await expect(page.getByText('Following', { exact: true })).toBeVisible();
+    await expect(page.getByText('Verified Followers', { exact: true })).toBeVisible();
+  });
+
+  test('the "Verified Followers" count is a plain element, not a link; "Following" remains a link', async ({ page }) => {
+    await page.goto(`${BASE_URL}/user/${PUBKEY}`);
+
+    // AC7: the verified-followers counter is NOT a link.
+    await expect(page.getByText('Verified Followers', { exact: true })).toBeVisible();
+    expect(
+      await page.getByRole('link', { name: /Verified Followers/i }).count(),
+      'the Verified Followers counter must be plain text, not a <Link> (the followers table is deferred)'
+    ).toBe(0);
+
+    // Regression: the Following counter is still a same-tab link to /follows.
+    const followingLink = page.getByRole('link', { name: /Following/i });
+    await expect(followingLink).toBeVisible();
+    await expect(followingLink).toHaveAttribute('href', new RegExp(`/user/${PUBKEY}/follows`));
+  });
+
+  // PoV (AC3/AC4) is exercisable manually here by appending ?pov=<8hex> to the URL
+  // (e.g. ?pov=a1420e44) and confirming the count reflects that PoV when its scores
+  // are indexed, falling back to House (default, no ?pov) otherwise. Left as a manual
+  // check — asserting a specific PoV-dependent number needs a fixed fixture instance.
+});

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -233,12 +233,18 @@ export default function BrainstormProfile() {
               </div>
             </div>
 
-            {/* Following count */}
+            {/* Following + Verified Followers counts */}
             <div className={`bsp-counts ${userCountsLoading ? 'bsp-counts-loading' : ''}`}>
               <Link to={`/user/${pubkey}/follows`} className="bsp-count bsp-count-link">
                 <span className="bsp-count-value">{fmtCount(followingCount)}</span>
                 <span className="bsp-count-label">Following</span>
               </Link>
+              {/* Verified Followers: plain (non-link) until the followers table ships (story #33, ADR 0029).
+                  Value rides the PoV-resolved trustScores; `??` keeps a genuine 0 from being dropped. */}
+              <div className="bsp-count">
+                <span className="bsp-count-value">{fmtCount(trustScores?.verifiedFollowerCount ?? trustScores?.followers)}</span>
+                <span className="bsp-count-label">Verified Followers</span>
+              </div>
             </div>
 
             {/* Action buttons */}


### PR DESCRIPTION
## Summary

Adds a **"Verified Followers"** count to the main profile page, beside the existing "Following" count — surfacing the number of followers whose web-of-trust standing clears the verification threshold (not the raw, bot-inflatable total). Front-end only; it reuses the already-fetched, PoV-resolved trust scores the Reputation section already loads. Story profile #33, ADR 0029 (Option A).

## Changes

- `ui/src/pages/BrainstormProfile.jsx` — a plain (non-link) "Verified Followers" counter in the `bsp-counts` block; value `fmtCount(trustScores?.verifiedFollowerCount ?? trustScores?.followers)`; House PoV by default, `?pov=` honored; `??` preserves a genuine 0. Following counter untouched. No backend/CSS change.
- `test/profile-verified-followers-count.test.js` (+ `test/test.js` wiring) — 6 source-sentinel tests (T1–T5 + R1 regression), 6/6.
- `tests/brainstorm/profile-verified-followers-count.spec.js` — supplementary live Playwright spec.
- `engineering-team/{stories,decisions,reviews}/profile/33-…` — story, ADR 0029, test plan, PASS review.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs green.
- [ ] Smoke on staging: `/user/82341f88…e6a2` shows a **"Verified Followers" number** (not "—") beside "Following", as a plain non-link element.
- [ ] `?pov=a1420e44` reflects the personalized PoV (or falls back to House).
- [ ] Regression: "Following" still links to `/user/<pubkey>/follows`.
- [ ] Known caveat: the Playwright spec may be blocked by a pre-existing `tests/global-setup.js` (`config.use` undefined) bug — fall back to a manual Chrome check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)