### PR TITLE
feat(profile): followers table page (#34)

### DIFF
--- a/engineering-team/decisions/profile/0030-profile-followers-list.md
+++ b/engineering-team/decisions/profile/0030-profile-followers-list.md
@@ -1,0 +1,71 @@
+# ADR 0030: Followers list on the primary profile page
+
+**Status:** Accepted
+**Date:** 2026-06-06
+**Story:** `engineering-team/stories/profile/34-profile-followers-list.md`
+
+## Context
+
+Story #34 adds `/user/:pubkey/followers` — a table of a profile's **verified** followers with the same columns/controls as the Follows page (#29 / ADR 0026), and turns the #33 "Verified Followers" count into a same-tab link to it. v1: **verified followers only**, **owner/House PoV only** (both deferrals mirror #29).
+
+This is a deliberate mirror of ADR 0026, so the design starts there. Verified facts on the current tree (branch off `staging`, which includes #33):
+
+- **Follows is an isolated, purpose-built endpoint** ([followsWithMetrics.js](src/api/grapevineInteractions/queries/followsWithMetrics.js)): `GET /api/get-grapevine-follows?observee=<pk>`, Cypher `MATCH (observee)-[:FOLLOWS]->(f:NostrUser) RETURN f.pubkey, f.influence, f.hops, f.verified{Follower,Muter,Reporter}Count`, owner-PoV from the `NostrUser` node, a `NEO4J_QUERY_TIMEOUT_MS` deadline → 504, non-owner `observer` → 400. Registered at [index.js:320](src/api/index.js:320) (import [:32](src/api/index.js:32)). ADR 0026 chose this **new endpoint specifically to isolate from shared/live code and accept traversal duplication as the price**.
+- **Frontend:** [BrainstormFollows.jsx](ui/src/pages/BrainstormFollows.jsx) (234 lines — DataTable + client sort/search/pagination + localStorage column prefs + ⓘ popover + back-link + row→profile nav), hook [useGrapevineFollows.js](ui/src/hooks/useGrapevineFollows.js) (raw `fetch` + AbortController), route [App.jsx:85-86](ui/src/App.jsx:85). Names/pics via batched `/api/profiles` (≤50/req — the #29 staging fix).
+- **The #33 count** ([BrainstormProfile.jsx:236](ui/src/pages/BrainstormProfile.jsx:236)) renders "Verified Followers" as a plain `<div className="bsp-count">` — *explicitly* "plain until the followers table ships."
+- **The verified cutoff** `VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF` is read via `getConfigFromFile` ([cypherQueries.js:10](src/api/grapevineInteractions/queries/cypherQueries.js:10)); reuse it (the 0.01/0.05/"score>2" inconsistency stays a separate intake item).
+
+**Two material deltas vs. #29:**
+1. **Direction + filter.** Follows lists *all* outbound follows (no filter); followers v1 lists *verified* inbound followers: `(follower)-[:FOLLOWS]->(observee) WHERE follower.influence > cutoff`.
+2. **Scale.** Follows sets are small (Jack follows 695). *Verified-follower* sets are large for popular accounts (Jack ≈ 26,711 — confirmed live on staging). #29's "fetch the whole set, sort/search/paginate client-side, batch every name via `/api/profiles`" does **not** scale to tens of thousands (≈534 profile batches for Jack; heavy inbound traversal → 504 risk).
+
+Constraints: no new build/lint tooling; honor the Neo4j deadline pattern; no concept-graph/firmware change (Concept Graph API `:8877` unreachable — concepts named in plain language; runtime Neo4j properties, not graph nodes).
+
+## Options considered
+
+### Option A — Mirror: new endpoint + new page + new hook *(chosen)*
+`GET /api/get-grapevine-followers?observee=<pk>` (a sibling of followsWithMetrics.js with reversed direction + verified filter); new `BrainstormFollowers.jsx` (copy of BrainstormFollows with the hook/labels/empty-state swapped); new `useGrapevineFollowers.js`; new route; count→link.
+- **Pros:** exactly mirrors ADR 0026's own Option-A rationale — **zero regression risk to the live, prod-shipped Follows feature**; isolated; ships parity fast; the verified filter + scale bound live cleanly in a dedicated query.
+- **Cons:** duplicates the ~234-line page and the endpoint/hook. (Addressed: file a DRY follow-up — see Consequences.)
+
+### Option B — Generalize the existing follows endpoint + page (direction/type param)
+- **Pros:** DRY.
+- **Cons:** edits the **live #29 page + endpoint** (regression risk on prod code); #29 explicitly deferred generalization; folds a verified-filter branch into the unfiltered follows path. Rejected for v1.
+
+### Option C — Extract a shared `<GrapevineList>` component + shared cypher builder
+- **Pros:** cleanest long-term DRY.
+- **Cons:** refactors the live #29 page (regression risk + scope creep well beyond "add followers"). Rejected for v1 — but it's the right **follow-up** once both pages are stable.
+
+### Scale sub-decision (within A): mirror Follows' client-side pagination *(user decision)*
+Per the user, the page **paginates in 50-row blocks exactly like the Follows page** — the endpoint returns the **whole verified set** and the page sorts/searches/**paginates client-side, 50 rows per page** (no server cap). This fully matches the story's "every verified follower / sort across the whole list" AC — **no deviation**.
+- **Scale watch-out (mega-accounts):** for a Jack-sized account the whole verified set is ≈26K rows, so first paint waits on (a) a heavy inbound traversal (millions of edges → the 504 deadline is the backstop) and (b) batched `/api/profiles` name lookups for the full set (~26K/50 ≈ 530 batches). This is the same client-side model as #29, just at larger scale; it can be **slow or 504 on the largest accounts**. If staging on a mega-account shows that, the **expected first fix is (b) lazy name-hydration** — fetch the whole verified set once (one traversal) but call `/api/profiles` only for the visible 50-row page, removing the ~530-request name storm (full metric sort + npub search stay whole-set; name search covers hydrated rows). **Server-side pagination is a larger, separate effort that does *not* reduce the traversal** (Neo4j must re-expand the dense node + re-order per page) and forces sort/search out of the client (names live outside the graph) — deferred. Both are follow-ons, not bundled here. *(User, 2026-06-06: ship (a); expects to at least do (b) after seeing real load.)*
+
+## Decision
+**Option A (mirror)**, owner/House PoV only, verified filter reusing `VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF`, the #33 count turned into a link, and **whole-set fetch with client-side 50-row pagination — exactly mirroring Follows** (the user's decision). This honors ADR 0026's isolation precedent (no risk to live Follows) and delivers full parity with the story's ACs. We accept page/endpoint duplication as the price (as ADR 0026 accepted traversal duplication) and file the DRY refactor as a follow-up. The mega-account scale cost is a documented watch-out with server-side pagination as the ready follow-on.
+
+## Consequences
+- **Enables:** native verified-followers exploration with Follows parity; isolated from the live Follows feature; bounded cost at scale.
+- **Duplication → follow-up.** `BrainstormFollowers.jsx` ≈ `BrainstormFollows.jsx` and the two endpoints share shape. File an intake: *"Extract a shared `<GrapevineList>` component + cypher builder (DRY follows/followers)"* — a deliberate refactor once both are stable (Option C), not bundled here.
+- **Count (Meili, precomputed) vs. list length (Neo4j, live) may diverge.** The #33 count comes from Meili `wot_*` (precomputed via kind-30382); this table is a live Neo4j query — and may use a different effective cutoff (the inconsistency intake). Like #29's "Following badge ≠ list length," UI copy + tests must **not** assume equality.
+- **Mega-account scale** — fetching + naming the whole verified set (≈26K for Jack) can be slow or 504 on the largest accounts (heavy inbound dense-node traversal + ~530 `/api/profiles` batches). Same client-side model as #29 at larger scale; graceful (504 guard). Expected first optimization if it bites: **(b) lazy name-hydration** (visible-page names only); server-side pagination is a larger, separate follow-on that does not reduce the traversal.
+- **Firmware reinstall required?** No (no concept/schema change).
+
+## Implementation notes
+**Backend** — new `src/api/grapevineInteractions/queries/followersWithMetrics.js` exporting `handleGetGrapevineFollowers(req, res)`, a near-copy of followsWithMetrics.js with:
+- Cypher: `MATCH (follower:NostrUser)-[:FOLLOWS]->(observee:NostrUser {pubkey:$observee}) WHERE follower.influence > $cutoff RETURN follower.pubkey AS pubkey, follower.influence AS influence, follower.hops AS hops, follower.verifiedFollowerCount AS verifiedFollowerCount, follower.verifiedMuterCount AS verifiedMuterCount, follower.verifiedReporterCount AS verifiedReporterCount`. Pass `$cutoff` from `getConfigFromFile('VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF', …)`. **No server-side ORDER BY/LIMIT** — return the whole verified set; the page pre-sorts by `verifiedFollowerCount` desc and paginates client-side 50/page, exactly like Follows (#29).
+- Same `observee` validation, owner-only `observer` 400, `NEO4J_QUERY_TIMEOUT_MS` deadline + 504, `toInt`/`toFloat` parsing, and `{ success, observer:'owner', observee, count, data }` response shape as followsWithMetrics.js.
+- Register in [src/api/index.js](src/api/index.js) next to the follows route (`app.get('/api/get-grapevine-followers', handleGetGrapevineFollowers)` + import).
+
+**Frontend** (`ui/src`, Vite — `npm run build` to reflect):
+- New `ui/src/hooks/useGrapevineFollowers.js` — mirror useGrapevineFollows.js, fetch `/api/get-grapevine-followers?observee=<pk>`.
+- New `ui/src/pages/BrainstormFollowers.jsx` — mirror BrainstormFollows.jsx (same DataTable, client sort/search/pagination, localStorage column prefs + reset, ⓘ "computed locally, not NIP-85" popover, "← Back to profile", row→`/user/<pubkey>`, name/rank/npub derivation, `/api/profiles` batching ≤50). Deltas only: the hook, the page title/labels ("Followers"), empty-state copy ("no verified followers"), and a distinct localStorage key (e.g. `bsp-followers-columns`). Default sort: pre-sort by `verifiedFollowerCount` desc (already the server order).
+- Route: add `{ path:'/user/:pubkey/followers', element:<BrainstormFollowers/> }` to [ui/src/App.jsx](ui/src/App.jsx:85) + import.
+- Count→link: in [BrainstormProfile.jsx:236](ui/src/pages/BrainstormProfile.jsx:236), change the plain Verified-Followers `<div className="bsp-count">` to `<Link to={`/user/${pubkey}/followers`} className="bsp-count bsp-count-link">`, keeping the `fmtCount(trustScores?.verifiedFollowerCount ?? trustScores?.followers)` value. (This is the one edit to a file #33 shipped; the Following link is the template.)
+- Styles: reuse existing `bsp-*` / `data-table` classes; no new tooling.
+
+## Out of scope
+- **All-followers (unverified) view**; **personalized/customer PoV** for this table — both deferred (story #34).
+- The **DRY `<GrapevineList>` refactor** (Option C) — follow-up intake.
+- **Scale optimizations** — deferred (v1 is client-side like #29). Expected order if mega-account load proves too slow: **(b) lazy name-hydration first**, then server-side sort/search/pagination (a larger redesign — names live outside the graph).
+- Other interaction types (mutes/muters/reports/reporters); the duplicate `TRUST_METRICS` rows; the cutoff inconsistency — existing intake items, untouched.
+- Changing the Follows page (#29), `get-grapevine-interaction`, or legacy pages.

--- a/engineering-team/reviews/profile/34-profile-followers-list.md
+++ b/engineering-team/reviews/profile/34-profile-followers-list.md
@@ -1,0 +1,54 @@
+# Review: Story 34 — Followers list on the primary profile page
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-06
+**Diff:** `git diff origin/staging...HEAD` — branch `feat/story-34-profile-followers-list`; impl `1e909eda` (story `085019cd`, adr `aeff8806`, tests `bf2c9620`)
+**Story:** `engineering-team/stories/profile/34-profile-followers-list.md`
+**ADR:** `engineering-team/decisions/profile/0030-profile-followers-list.md`
+**Test plan:** `engineering-team/stories/profile/34-profile-followers-list.test-plan.md`
+
+## Quality gates (run by reviewer, not trusted)
+- [x] **Node `profile-followers-list` — PASS 27/27** (standalone).
+- [x] **Node `profile-verified-followers-count` — PASS 6/6** (its T5 was inverted plain→link by this story; now green).
+- [x] `node --check` — `followersWithMetrics.js` + `index.js` OK.
+- [x] **Build** — Vite compiles; deployed to local `:7778`; **browser-verified** — the profile's "Verified Followers" count links and clicking it lands on `/user/<pk>/followers`, which renders (title, back-to-profile, search, Columns, ⓘ, empty state).
+- [x] **`npm run test:playwright` — deferred to staging.** Supplementary spec; a pre-existing `tests/global-setup.js` bug blocks local PW; real data is at staging.
+- Lint / Typecheck — not configured.
+- *(Full `npm test` not used as the signal — concept-graph suites need `:8877`, down by choice; the #34/#33 suites are stack-free and were run standalone.)*
+
+## Spec adherence — every AC has a passing test
+Entry point (count→link) → `T11` + #33 `T5` + browser; Return → `T12`; Direct load (owner-PoV verified) → `T1/T2/T6/T8/T9`; Row nav → `T13`; Listing + empty state → `T9` (browser-confirmed); **Verified scope** → `T3`; Default sort verifiedFollowerCount desc → `T20`; Re-sort/Search → `T18`; Pagination (client 50/page) → `T19`; Columns + default visibility → `T14`; Persistence + reset (distinct key) → `T21`; Name/Rank/npub → `T16/T15/T17`; Owner PoV (non-owner→400) → `T5`; Disclosure → `T22`; Parity → `T14/T18/T19/T23`. No criterion dropped; nothing added beyond the story.
+
+## ADR adherence (Option A — mirror, not generalize)
+- [x] New isolated endpoint `/api/get-grapevine-followers` ([followersWithMetrics.js:94-95](src/api/grapevineInteractions/queries/followersWithMetrics.js:94)) — **inbound** `(follower)-[:FOLLOWS]->(observee)` + `WHERE follower.influence > VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF` (reused, [:27](src/api/grapevineInteractions/queries/followersWithMetrics.js:27); no new constant); RETURNs the six fields; 504 deadline; non-owner `observer` → 400.
+- [x] **No ORDER BY/LIMIT** — whole verified set returned; the page pre-sorts by verifiedFollowerCount desc + paginates client-side 50/page (the user's decision). Confirmed absent in the cypher.
+- [x] **Live follows feature UNTOUCHED** — `git diff --name-only origin/staging...HEAD` does **not** include `followsWithMetrics.js` or `BrainstormFollows.jsx`; the `/api/get-grapevine-follows` route is intact (and still returns `success:true` on a live call). This is the entire point of Option A — confirmed (R1–R4 green).
+- [x] count→link: [BrainstormProfile.jsx:244](ui/src/pages/BrainstormProfile.jsx:244) — the #33 plain counter is now `<Link … className="bsp-count bsp-count-link">` to `/user/${pubkey}/followers`, value unchanged.
+- [x] Distinct localStorage key — `bsp-followers-columns` ([BrainstormFollowers.jsx:22](ui/src/pages/BrainstormFollowers.jsx:22)) vs `bsp-follows-columns` (follows page); no collision.
+- [x] No new dependencies / build tooling.
+
+## Concept-graph integrity
+- [x] N/A — no concept/schema change (runtime Neo4j node properties surfaced, not redefined). No firmware reinstall. Concept Graph API unreachable this session — non-load-bearing (no concepts touched).
+
+## Things tests can't catch
+- [x] No secrets, debug logging, or commented-out code in the diff.
+- [x] Edge cases: null influence → "—" rank; empty set → empty state (browser-confirmed); 504 on timeout (mega-account guard).
+- [x] **Cross-story consistency** — the #33 T5 inversion is correct and the #33 suite stays self-consistent (6/0). The count→link is the single edit to a #33-shipped file; the Following counter is unchanged (R4).
+- [x] Reuses `bsp-follows-*` CSS classes (no new CSS) — intentional, consistent styling.
+- [x] Security: no new input boundary beyond the validated `observee` (64-hex + nip19); owner-only.
+
+## House rules check
+- [x] Concept Graph authority respected. No new lint/typecheck/build tooling. `dist/` (gitignored) not committed.
+
+## Findings
+
+### Blocking
+None.
+
+### Non-blocking
+1. **Mega-account scale (staging watch-out).** The whole-set + client-pagination model (the user's "like Follows" decision) means a Jack-sized account fetches ~26k rows + ~530 `/api/profiles` batches up front, and the inbound dense-node traversal can be slow / 504. Documented in ADR 0030; **(b) lazy name-hydration** is the expected first optimization (server-side pagination the larger follow-on). Verify real load at `cycle-staging`.
+2. **Local verification was render + navigation only.** Local Neo4j has no FOLLOWS for Jack (count:0 → empty state) and local Meili has no House scores (count anchor "—"); the populated table + the Playwright spec verify at staging. Not a defect.
+3. **Duplication (filed follow-up).** `BrainstormFollowers.jsx` ≈ `BrainstormFollows.jsx` and the two endpoints share shape — the deliberate price of Option A's isolation. The "DRY `<GrapevineList>`" refactor is the documented follow-up.
+
+## Verdict
+**PASS** — the diff matches story #34, ADR 0030 (Option A, mirror), and the test plan; gates are clean (27/0 + 6/0, run by the reviewer); the live follows feature is provably untouched; scope is tight (deferred items not pulled in). The open items are non-blocking and staging-bound by design.

--- a/engineering-team/stories/profile/34-profile-followers-list.md
+++ b/engineering-team/stories/profile/34-profile-followers-list.md
@@ -83,5 +83,5 @@ None open.
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/profile/0030-profile-followers-list.md` (Accepted 2026-06-06)
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/profile/34-profile-followers-list.test-plan.md` (27 tests — 23 failing T + 4 regression sentinels; confirmed failing 2026-06-06; also inverts #33's T5 plain→link)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/profile/34-profile-followers-list.md
+++ b/engineering-team/stories/profile/34-profile-followers-list.md
@@ -1,6 +1,6 @@
 # Story 34: Followers list on the primary profile page
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-06
 **Type:** Feature
 **Epic:** profile
@@ -84,4 +84,4 @@ None open.
 ## Linked artifacts
 - ADR: `engineering-team/decisions/profile/0030-profile-followers-list.md` (Accepted 2026-06-06)
 - Test plan: `engineering-team/stories/profile/34-profile-followers-list.test-plan.md` (27 tests — 23 failing T + 4 regression sentinels; confirmed failing 2026-06-06; also inverts #33's T5 plain→link)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/profile/34-profile-followers-list.md` (PASS 2026-06-06)

--- a/engineering-team/stories/profile/34-profile-followers-list.md
+++ b/engineering-team/stories/profile/34-profile-followers-list.md
@@ -1,0 +1,87 @@
+# Story 34: Followers list on the primary profile page
+
+**Status:** Approved
+**Created:** 2026-06-06
+**Type:** Feature
+**Epic:** profile
+
+## Background
+Story #33 added a **"Verified Followers"** count to the primary profile (`/user/<pubkey>`), shipped as a plain (non-link) number *pending this follow-up*. This story makes that count actionable: clicking it opens a dedicated page to see and evaluate the accounts that follow this user — ranked by local trust signals — **mirroring the existing Follows page (#29)**. It is the inbound counterpart to Follows: Follows lists who a user *follows* (outbound); this lists who *follows* the user (inbound).
+
+Because a prominent account can have millions of raw followers, **v1 lists the *verified* followers** — those whose web-of-trust standing clears the instance's verification cutoff (the same set the count reflects). An "all followers" view is deferred. Affected: anyone viewing a profile (logged-in or logged-out).
+
+## User-facing description
+As someone viewing a profile, I want to open that person's verified followers as a list ranked by trust signals, so that I can explore and judge who follows them — without leaving the primary UI.
+
+## Acceptance criteria
+Testable from the outside. Each criterion gets at least one test.
+
+**Navigation & URL**
+- [ ] **Entry point.** Given a profile at `/user/<pubkey>`, when it renders, then the "Verified Followers" count is a link that navigates **in the same tab** to `/user/<pubkey>/followers`. *(This replaces the plain number shipped in #33.)*
+- [ ] **Return.** Given the followers page, when the user activates a "← Back to profile" control (and likewise the browser back button), then they return to `/user/<pubkey>`.
+- [ ] **Direct load.** Given `/user/<pubkey>/followers`, when loaded directly, then the page shows `<pubkey>`'s verified followers computed from the **instance owner's (House)** point of view.
+- [ ] **Row navigation.** Given a row (an account that follows `<pubkey>`), when the viewer activates it, then they navigate **in the same tab** to that account's own `/user/<that-pubkey>` profile.
+
+**The list**
+- [ ] **Listing.** Given the profile user has N verified followers, when the page loads, then each verified follower appears as one row. If N = 0, an empty-state message is shown.
+- [ ] **Verified scope.** The list contains **only** followers whose trust standing clears the instance's verification cutoff (the same definition behind the "Verified Followers" count); unverified / bot followers are excluded. *(An "all followers" view is deferred — see Out of scope.)*
+- [ ] **Default sort.** When the page loads, all N rows are ordered by **verified-followers count, descending**, across the whole list (not just a visible page).
+- [ ] **Re-sort.** Given the list, when the user sorts by any visible column, then the rows reorder accordingly; the default remains verified-followers descending.
+- [ ] **Search.** Given the list, when the user types in an in-page search, then rows are filtered by name / display name or npub.
+- [ ] **Pagination.** Given more rows than fit one page, then results are paginated; moving between pages preserves the current sort, search text, and column visibility.
+
+**Columns**
+- [ ] **Default visibility.** On first load with no saved preferences, the visible columns are **picture, name, rank**; the hidden columns are **npub, hops, verified followers, verified muters, verified reporters**.
+- [ ] **Toggle.** Every column can be shown or hidden by the user.
+- [ ] **Persistence.** A user's column show/hide choices persist across reloads and sessions; a "reset to defaults" control restores the default visibility above.
+- [ ] **Name fallback.** Each row's name column shows the display name; if absent, the name; if both absent, a shortened npub.
+- [ ] **Rank.** The rank column shows an integer **0–100**, equal to `round(influence × 100)` from the owner's point of view (not a raw decimal).
+
+**Point of view (v1: owner / House only)**
+- [ ] **Owner point of view.** All metrics (rank, hops, verified counts) are computed from the **instance owner's (House)** point of view, for every viewer (including logged-in customers and logged-out visitors). *(The point-of-view selector, customer-relative metrics, and `?observer=`/`?pov=` support are deferred — mirroring Follows #29.)*
+
+**Disclosure**
+- [ ] **Local-data disclosure.** The page provides a **tappable** ⓘ affordance revealing a note that all data here is computed **locally by this Tapestry instance and is not imported via NIP-85**; it works by tap on touch devices (not hover-only).
+
+**Parity**
+- [ ] **Follows-page parity.** The page matches the Follows page (`/user/<pubkey>/follows`) in layout, columns, controls, and behavior — differing only in direction (followers, inbound) and the verified-only scope.
+
+## Deferred to a follow-up
+- **All-followers view** (unverified included) — v1 is verified-only ("verified now, all later," per the planning decision).
+- **Customer-observer / personalized point of view** — the PoV selector, customer-relative metrics, and `?observer=`/`?pov=` support. (Note: the #33 *count* honors `?pov=`; this table does not yet — a known minor inconsistency to reconcile when personalized support lands.) Same deferral as Follows #29: customer metrics live on a different node type / query path (ADR 0026).
+
+## Concepts touched
+*(Concept Graph API at `:8877` unreachable during planning — named in plain language; the Architect should resolve handles via `/api/concept-graph/summaries`.)*
+- **Follower (inbound follows)** — an account that follows the profile user (the kind:3 relationship, inbound direction); distinct from "follows / following" (outbound).
+- **Verified follower** — a follower whose influence clears the instance's verification cutoff (the set this page lists).
+- **GrapeRank influence / rank** — per-account trust score (0–1), shown scaled to an integer 0–100 ("rank").
+- **Hops** — graph distance from the observer.
+- **Verified followers / muters / reporters** — per-row counts of accounts that follow / mute / report the row's account above the cutoff, from the owner's point of view.
+- **Observer / point of view (House / owner)** — the pubkey all scores are computed relative to (v1: owner).
+- **Profile** — picture / name / display_name for the picture and name columns.
+
+## Out of scope
+- **All-followers (unverified) view** — deferred.
+- **Personalized / customer point of view** for this table — deferred.
+- **Other interaction types** — mutes / muters / reports / reporters tables (in `_intake.md`); the duplicate "Verified Followers" rows in the profile trust-metrics grid; the verification-cutoff inconsistency. All untouched.
+- Changing the Follows page (#29) or the legacy pages.
+- Serving / importing these metrics over NIP-85 (local-only; the disclosure says so).
+
+## Open questions
+Resolved during planning:
+- **Table scope?** → **Verified followers only for v1**; all-followers deferred ("verified now, all later").
+- **Point of view?** → **Owner / House only for v1**, mirroring Follows #29; personalized deferred.
+- **Link target?** → `/user/<pubkey>/followers`.
+
+None open.
+
+## Notes for the Architect
+- **Mirror the Follows feature (#29 / ADR 0026).** Follows is `/user/:pubkey/follows` backed by an owner-PoV list endpoint that traverses the follow edge *outbound* from the profile user and returns, per row, rank (from influence) / hops / the three verified counts, read from the owner node. **Followers is the reverse direction** (the follow edge inbound), additionally **filtered to verified** (influence above the cutoff).
+- **Generalize-vs-mirror is your call:** extend the existing follows list endpoint/page to also serve followers (a direction/type parameter) vs. a parallel followers endpoint/page. Note: a *generic* interaction endpoint already supports a `verifiedFollowers` type but returns only pubkey/hops/influence — **not** the three verified counts this table's columns + default sort require, so it isn't sufficient as-is.
+- The default sort is **verified-followers descending across the entire set**, so those counts must be available to rank the whole list (not fetched lazily per visible row) — same constraint as #29.
+- Reuse the shared table component + #29's persistence / search / pagination patterns; the deltas are direction (inbound) + the verified-only filter. This is a **large story** (parity with #29's ~16 criteria); you may propose phasing the implementation (data path before UI) within one ADR.
+
+## Linked artifacts
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/profile/34-profile-followers-list.md
+++ b/engineering-team/stories/profile/34-profile-followers-list.md
@@ -82,6 +82,6 @@ None open.
 - Reuse the shared table component + #29's persistence / search / pagination patterns; the deltas are direction (inbound) + the verified-only filter. This is a **large story** (parity with #29's ~16 criteria); you may propose phasing the implementation (data path before UI) within one ADR.
 
 ## Linked artifacts
-- ADR: (filled in after Architecture phase)
+- ADR: `engineering-team/decisions/profile/0030-profile-followers-list.md` (Accepted 2026-06-06)
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/profile/34-profile-followers-list.test-plan.md
+++ b/engineering-team/stories/profile/34-profile-followers-list.test-plan.md
@@ -1,0 +1,78 @@
+# Test Plan: Story 34 — Followers list on the primary profile page
+
+**Story:** `engineering-team/stories/profile/34-profile-followers-list.md`
+**ADR:** `engineering-team/decisions/profile/0030-profile-followers-list.md`
+**Date:** 2026-06-06
+
+## Approach
+
+ADR 0030 chose **Option A (mirror, not generalize)**: a NEW isolated endpoint `GET /api/get-grapevine-followers` + a NEW page `BrainstormFollowers.jsx` + a NEW hook `useGrapevineFollowers.js` + route `/user/:pubkey/followers`, leaving the live Follows feature untouched; and the #33 "Verified Followers" count becomes a `<Link>` to the new page. v1: verified followers only (`WHERE follower.influence > VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF`), owner/House PoV, whole-set fetch + client-side 50-row pagination (faithful #29 parity).
+
+Tests are **source-regex sentinels**, mirroring the #29 suite (`test/profile-follows-list.test.js`) — this repo has no React render harness and CLAUDE.md forbids adding one. Browser behavior is covered by the supplementary, live Playwright spec.
+
+**Direction discipline:** `follows`/`following` = OUTBOUND `(observee)-[:FOLLOWS]->(x)`; `followers` = INBOUND `(x)-[:FOLLOWS]->(observee)`. The substrings differ (`follows` vs `follow*ers*`), so route/endpoint regexes don't cross-match.
+
+## Coverage map
+
+| Acceptance criterion | Test(s) | Level |
+|---|---|---|
+| Entry point — count → `/user/:pubkey/followers` link | `T11` + `PW1` (+ #33 `T5`, updated) | source + e2e |
+| Return — Back-to-profile | `T12` + `PW2` | source + e2e |
+| Direct load — owner-POV verified followers | `T1`,`T2`,`T6`,`T8`,`T9` | source |
+| Row navigation → `/user/<pubkey>` | `T13` | source |
+| Listing + empty state | `T9` | source |
+| **Verified scope** (influence > cutoff) | `T3` | source |
+| Default sort = verifiedFollowerCount desc (whole set) | `T20` | source |
+| Re-sort / Search | `T18` (DataTable) | source |
+| Pagination (client-side, 50/page) | `T19` | source |
+| Default visibility / Toggle | `T14` | source |
+| Persistence + reset (followers-specific key) | `T21` | source |
+| Name fallback / Rank / npub | `T16`,`T15`,`T17` | source |
+| Owner PoV only (non-owner → 400) | `T5` | source |
+| Local-data disclosure (NIP-85, tappable) | `T22` | source |
+| Follows-page parity (columns/controls) | `T14`,`T18`,`T19`,`T23` | source |
+| Backend contract (handler, validation, 504, response shape, registration) | `T1`,`T2`,`T4`,`T6`,`T7` | source |
+| Regression — live Follows feature untouched | `R1`–`R4` | source |
+
+Node suite: `test/profile-followers-list.test.js` (wired into `test/test.js`). Playwright: `tests/brainstorm/profile-followers-list.spec.js` (supplementary, live).
+
+## Cross-story update (#33)
+Story #34 **reverses** #33's "plain, non-link" decision. `test/profile-verified-followers-count.test.js` **T5** has been **updated** from "the counter is plain (1 bsp-count-link, no /followers link)" to "the counter **links** to `/user/${pubkey}/followers` (≥2 bsp-count-link)". This is an intended behavior change, not a regression — #33's T5 now fails until #34's count→link lands, then passes. #33's T1–T4 + R1 are unchanged.
+
+## Edge cases
+- [x] **Direction** — `T3` pins INBOUND `(follower)-[:FOLLOWS]->(observee)` (not the follows outbound) and the verified filter; `R1` guards the follows endpoint stays OUTBOUND + unfiltered.
+- [x] **Verified scope** — `T3` requires `influence > cutoff` reusing `VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF` (not all followers, not a new constant).
+- [x] **Key collision** — `T21` forbids reusing the follows localStorage key (`bsp-follows-columns`) so the two pages don't clobber each other's column prefs.
+- [x] **`/api/profiles` cap** — `T23` keeps `PROFILE_CHUNK ≤ 50` (matters more at followers scale).
+- [x] **Mirror, not generalize** — `R1`/`R2`/`R3` guard that the live follows endpoint/page/route are untouched (the ADR's whole isolation rationale).
+- [x] **Mega-account scale** (≈26k for Jack) — a documented watch-out (ADR 0030), to be observed at staging; not a unit-test concern.
+
+## Test infrastructure
+- **Node runner:** `npm test` (entry `test/test.js`); the `profile-followers-list` suite is wired in. Pure source-regex — **no Docker/Neo4j/Meili dependency**. Standalone (clean signal):
+  ```
+  node -e "require('./test/profile-followers-list.test.js').run().then(r=>{console.log(r);process.exit(0)})"
+  ```
+- **Playwright (supplementary, live):** `tests/brainstorm/profile-followers-list.spec.js` — needs a deployed instance (`BRAINSTORM_BASE_URL`, default `:7778`). **Not run pre-implementation.** A pre-existing harness bug (`tests/global-setup.js:16` reads `config.use`, undefined in the installed Playwright) blocks `npm run test:playwright` locally — verify at the staging smoke or via a Chrome MCP tab. *(That global-setup bug is intake-worthy, separate from this story.)*
+- No concept/firmware change → no `POST /api/firmware/install` precondition.
+
+## How to run
+```
+npm test                 # node suites (includes profile-followers-list)
+npm run test:playwright  # browser/e2e — staging only (see global-setup caveat)
+```
+
+## Verification
+Confirmed **failing for the right reasons** on 2026-06-06 (pre-implementation), run standalone:
+
+```
+profile-followers-list:  RESULT { pass: 4, fail: 23 }
+  ✓ R1–R4  (regression sentinels: live follows endpoint/page/route + Following count all untouched)
+  ✗ T1–T23 (each meaningful: "followersWithMetrics.js does not exist yet", "App.jsx must declare /user/:pubkey/followers",
+            "BrainstormFollowers.jsx does not exist yet", "must link the Verified Followers count to /user/${pubkey}/followers", …)
+
+profile-verified-followers-count (after the T5 update):  RESULT { pass: 5, fail: 1 }
+  ✓ T1–T4, R1
+  ✗ T5  — "the Verified Followers counter must link to /user/${pubkey}/followers" (fails until #34's count→link lands; intended)
+```
+`node --check test/test.js` passes. Playwright not run pre-implementation (tests deployed state).
+```

--- a/src/api/grapevineInteractions/queries/followersWithMetrics.js
+++ b/src/api/grapevineInteractions/queries/followersWithMetrics.js
@@ -1,0 +1,150 @@
+/**
+ * Story #34 / ADR 0030 — followers list with owner-POV metrics (verified only).
+ *
+ *   GET /api/get-grapevine-followers?observee=<pk>[&observer=owner]
+ *
+ * Lists the VERIFIED accounts that follow <observee> — inbound FOLLOWS edges whose
+ * follower clears the verification cutoff — with the owner's GrapeRank metrics read
+ * straight from each follower's NostrUser node: influence (→ rank), hops, and the
+ * three verified counts. v1 is OWNER POV ONLY; a non-owner `observer` is rejected 400
+ * (customer cards deferred, exactly like followsWithMetrics.js / ADR 0026).
+ *
+ * The inbound mirror of followsWithMetrics.js. ADR 0030 chose Option A — a NEW,
+ * isolated endpoint, leaving the follows endpoint untouched. The verified filter
+ * reuses VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF (the same cutoff the verified-* count
+ * algos write into the node properties). The whole verified set is returned; the page
+ * sorts/paginates client-side (50/page), like the follows page. Mirrors the per-query
+ * Neo4j deadline + 504 pattern (story #5 / ADRs 0024-0025).
+ */
+
+const neo4j = require('neo4j-driver');
+const { getConfigFromFile } = require('../../../utils/config');
+const { nip19 } = require('nostr-tools');
+
+// Verified cutoff — reused from the existing verified-* machinery (/etc/graperank.conf).
+// Read at module load; restart the brainstorm process to pick up changes. Default 0.05
+// matches the sibling cutoff usage in cypherQueries.js.
+const VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF = getConfigFromFile('VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF', '0.05');
+
+function toInt(v) {
+  if (v == null) return null;
+  if (typeof v.toNumber === 'function') return v.toNumber();
+  if (typeof v === 'object' && typeof v.low === 'number') return v.low;
+  const n = parseInt(v.toString(), 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+function toFloat(v) {
+  if (v == null) return null;
+  const n = parseFloat(v.toString());
+  return Number.isNaN(n) ? null : n;
+}
+
+function isValidHexPubkey(pk) {
+  return typeof pk === 'string' && /^[0-9a-f]{64}$/i.test(pk);
+}
+
+/**
+ * GET /api/get-grapevine-followers
+ */
+function handleGetGrapevineFollowers(req, res) {
+  try {
+    const observee = req.query.observee;
+    const observer = req.query.observer; // v1: owner only (see below)
+
+    // --- Validate observee: 64-char hex, cross-checked via nip19 (cf. followsWithMetrics.js).
+    if (!observee || !isValidHexPubkey(observee)) {
+      return res.status(400).json({
+        success: false,
+        message: 'Missing or invalid observee parameter (expected a 64-character hex pubkey)'
+      });
+    }
+    try {
+      const npub = nip19.npubEncode(observee);
+      if (!npub.startsWith('npub')) throw new Error('bad encode');
+    } catch {
+      return res.status(400).json({ success: false, message: 'Invalid observee parameter' });
+    }
+
+    // --- v1 is OWNER POV only. Customer observers are deferred (ADR 0030, mirroring
+    // ADR 0026): their metrics live on NostrUserWotMetricsCard, which this endpoint
+    // does not yet read.
+    const ownerPubkey = getConfigFromFile('BRAINSTORM_OWNER_PUBKEY', '');
+    if (observer && observer !== 'owner' && observer !== ownerPubkey) {
+      return res.status(400).json({
+        success: false,
+        message: 'customer observers not yet supported — this endpoint currently serves the owner point of view only'
+      });
+    }
+
+    // --- Neo4j with a driver-layer deadline (story #5 / ADR 0024-0025 pattern).
+    const neo4jUri = getConfigFromFile('NEO4J_URI', 'bolt://localhost:7687');
+    const neo4jUser = getConfigFromFile('NEO4J_USER', 'neo4j');
+    const neo4jPassword = getConfigFromFile('NEO4J_PASSWORD', 'neo4j');
+    const queryTimeoutMs = parseInt(getConfigFromFile('NEO4J_QUERY_TIMEOUT_MS', 15000), 10);
+
+    const driver = neo4j.driver(neo4jUri, neo4j.auth.basic(neo4jUser, neo4jPassword));
+    const session = driver.session();
+
+    // Followers = INBOUND FOLLOWS edges, filtered to VERIFIED (follower influence > cutoff).
+    // Owner POV: the metrics ARE the follower NostrUser node's own GrapeRank properties
+    // (no NostrUserWotMetricsCard join in v1). The whole verified set is returned; the
+    // page sorts by verifiedFollowerCount desc and paginates client-side, like follows.
+    const cypherQuery = `
+      MATCH (follower:NostrUser)-[:FOLLOWS]->(observee:NostrUser {pubkey: $observee})
+      WHERE follower.influence > ${VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF}
+      RETURN follower.pubkey AS pubkey,
+             follower.influence AS influence,
+             follower.hops AS hops,
+             follower.verifiedFollowerCount AS verifiedFollowerCount,
+             follower.verifiedMuterCount AS verifiedMuterCount,
+             follower.verifiedReporterCount AS verifiedReporterCount
+    `;
+
+    const queryStartMs = Date.now();
+    session.run(cypherQuery, { observee }, { timeout: queryTimeoutMs })
+      .then(result => {
+        const data = result.records
+          .map(r => ({
+            pubkey: r.get('pubkey') ?? null,
+            influence: toFloat(r.get('influence')),
+            hops: toInt(r.get('hops')),
+            verifiedFollowerCount: toInt(r.get('verifiedFollowerCount')),
+            verifiedMuterCount: toInt(r.get('verifiedMuterCount')),
+            verifiedReporterCount: toInt(r.get('verifiedReporterCount'))
+          }))
+          // Defensive: drop any null-pubkey row.
+          .filter(row => row.pubkey);
+
+        res.status(200).json({
+          success: true,
+          observer: 'owner',
+          observee,
+          count: data.length,
+          data
+        });
+      })
+      .catch(error => {
+        const elapsedMs = Date.now() - queryStartMs;
+        const isTimeout = error && typeof error.code === 'string' && /TransactionTimedOut/i.test(error.code);
+        if (isTimeout) {
+          console.error('Neo4j query timeout fetching grapevine followers:', { observee, elapsedMs, limitMs: queryTimeoutMs, code: error.code });
+          return res.status(504).json({
+            success: false,
+            message: `Neo4j query timeout after ${elapsedMs}ms (limit ${queryTimeoutMs}ms) fetching followers for ${observee}.`
+          });
+        }
+        console.error('Error fetching grapevine followers:', error);
+        res.status(500).json({ success: false, message: `Error fetching grapevine followers: ${error.message}` });
+      })
+      .finally(() => {
+        session.close();
+        driver.close();
+      });
+  } catch (error) {
+    console.error('Error in handleGetGrapevineFollowers:', error);
+    res.status(500).json({ success: false, message: `Server error: ${error.message}` });
+  }
+}
+
+module.exports = { handleGetGrapevineFollowers };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -30,6 +30,7 @@ const { handleSignUpNewCustomer } = require('./auth/signUpNewCustomer');
 const { handleGetOwnerInfo } = require('./owner/ownerInfo');
 const { handleGetGrapevineInteraction } = require('./grapevineInteractions/queries');
 const { handleGetGrapevineFollows } = require('./grapevineInteractions/queries/followsWithMetrics');
+const { handleGetGrapevineFollowers } = require('./grapevineInteractions/queries/followersWithMetrics');
 const { handleOldSearchProfiles, handleOldSearchProfilesStream } = require('./search/profiles');
 const { handleKeywordSearchProfiles } = require('./search/profiles/keyword');
 const { handlePrecomputeWhitelistMaps, handlePrecomputeWhitelistStatus } = require('./search/profiles/whitelistPrecompute');
@@ -318,6 +319,8 @@ async function register(app) {
     app.get('/api/get-grapevine-interaction', handleGetGrapevineInteraction);
     // Follows list with owner-POV metrics (story #29 / ADR 0026)
     app.get('/api/get-grapevine-follows', handleGetGrapevineFollows);
+    // Followers list (verified, owner-POV metrics) (story #34 / ADR 0030)
+    app.get('/api/get-grapevine-followers', handleGetGrapevineFollowers);
 
     // Search endpoint
     app.get('/api/search/profiles', handleOldSearchProfiles);

--- a/test/profile-followers-list.test.js
+++ b/test/profile-followers-list.test.js
@@ -1,0 +1,303 @@
+/**
+ * Story #34 / ADR 0030 — followers list on the primary profile page (v1: verified
+ * followers, owner POV). The inbound mirror of the follows list (#29 / ADR 0026).
+ * See engineering-team/stories/profile/34-profile-followers-list.test-plan.md
+ *
+ * ADR 0030 chose Option A (MIRROR, not generalize): a NEW isolated endpoint
+ * GET /api/get-grapevine-followers (reverse direction + verified filter) + a NEW
+ * page BrainstormFollowers.jsx + a NEW hook useGrapevineFollowers.js + route
+ * /user/:pubkey/followers — leaving the live follows feature untouched — and the
+ * #33 "Verified Followers" count becomes a <Link> to the new page. v1: verified
+ * followers only (WHERE follower.influence > VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF),
+ * owner/House POV, whole-set fetch + client-side 50-row pagination (#29 parity).
+ *
+ * Source-regex sentinels (the #29 profile-follows-list precedent — no React render
+ * harness in this repo). Browser behavior is in the supplementary Playwright spec
+ * tests/brainstorm/profile-followers-list.spec.js.
+ *
+ * Direction note: "follows"/"following" = OUTBOUND (observee)-[:FOLLOWS]->(x);
+ * "followers" = INBOUND (x)-[:FOLLOWS]->(observee). The substrings differ
+ * (`follows` vs `followers`), so route/endpoint regexes don't cross-match.
+ *
+ * T* must FAIL pre-implementation and PASS post-implementation.
+ * R* are regression sentinels — PASS before AND after (they guard the live #29
+ * follows feature, which ADR 0030 chose NOT to touch).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const FOLLOWERS_HANDLER = path.resolve(__dirname, '../src/api/grapevineInteractions/queries/followersWithMetrics.js');
+const FOLLOWS_HANDLER   = path.resolve(__dirname, '../src/api/grapevineInteractions/queries/followsWithMetrics.js');
+const API_INDEX         = path.resolve(__dirname, '../src/api/index.js');
+const APP_JSX           = path.resolve(__dirname, '../ui/src/App.jsx');
+const FOLLOWERS_PAGE    = path.resolve(__dirname, '../ui/src/pages/BrainstormFollowers.jsx');
+const FOLLOWS_PAGE      = path.resolve(__dirname, '../ui/src/pages/BrainstormFollows.jsx');
+const FOLLOWERS_HOOK    = path.resolve(__dirname, '../ui/src/hooks/useGrapevineFollowers.js');
+const PROFILE_PAGE      = path.resolve(__dirname, '../ui/src/pages/BrainstormProfile.jsx');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+function countOf(src, re) { return (src.match(re) || []).length; }
+
+// ===========================================================================
+// BACKEND — new endpoint GET /api/get-grapevine-followers (owner POV, verified)
+// ===========================================================================
+
+test('T1: followersWithMetrics.js exists and exports handleGetGrapevineFollowers (ADR 0030 §Impl)', () => {
+  const src = safeRead(FOLLOWERS_HANDLER);
+  assert(src.length > 0,
+    'src/api/grapevineInteractions/queries/followersWithMetrics.js does not exist yet — ADR 0030 (Option A) calls for a NEW endpoint handler mirroring followsWithMetrics.js.');
+  assert(/handleGetGrapevineFollowers/.test(src), 'followersWithMetrics.js must define handleGetGrapevineFollowers.');
+  assert(/module\.exports\s*=\s*\{[\s\S]*handleGetGrapevineFollowers/.test(src),
+    'followersWithMetrics.js must export handleGetGrapevineFollowers so src/api/index.js can register it.');
+});
+
+test('T2: handler requires + 64-hex-validates `observee`, returning 400 otherwise (AC: Direct load / input validation)', () => {
+  const src = safeRead(FOLLOWERS_HANDLER);
+  assert(src.length > 0, 'followersWithMetrics.js does not exist yet.');
+  assert(/req\.query\.observee/.test(src), 'handler must read the `observee` query param.');
+  assert(/\.status\(\s*400\s*\)/.test(src), 'handler must return HTTP 400 for a missing/invalid observee.');
+  assert(/[0-9a-f]\{64\}|\{\s*64\s*\}|npubEncode/i.test(src),
+    'handler must validate the pubkey shape (64-hex or nip19.npubEncode round-trip, like followsWithMetrics.js).');
+});
+
+test('T3: Cypher is INBOUND (follower)-[:FOLLOWS]->(observee), VERIFIED-filtered (influence > cutoff), returns all six fields (AC: Listing / Verified scope / Owner POV)', () => {
+  const src = safeRead(FOLLOWERS_HANDLER);
+  assert(src.length > 0, 'followersWithMetrics.js does not exist yet.');
+  // Inbound direction: the FOLLOWS edge must point TO observee (vs follows, which points to a followee).
+  assert(/:FOLLOWS\s*\]\s*->\s*\(\s*observee/.test(src),
+    'handler Cypher must traverse INBOUND: (follower)-[:FOLLOWS]->(observee). (Outbound (observee)-[:FOLLOWS]->(f) would be the follows query.)');
+  // Verified-only filter reusing the existing cutoff parameter.
+  assert(/influence\s*>/.test(src),
+    'handler must filter verified followers with a WHERE influence > cutoff clause (v1 lists only verified followers).');
+  assert(/VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF/.test(src),
+    'the verified cutoff must reuse VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF (getConfigFromFile) — do not invent a new constant (ADR 0030).');
+  for (const field of ['pubkey', 'influence', 'hops', 'verifiedFollowerCount', 'verifiedMuterCount', 'verifiedReporterCount']) {
+    assert(new RegExp('\\b' + field + '\\b').test(src),
+      `handler must surface \`${field}\` per row (same six fields as the follows endpoint, read from the follower's NostrUser node for owner POV).`);
+  }
+});
+
+test('T4: handler enforces the Neo4j deadline (NEO4J_QUERY_TIMEOUT_MS) with a 504 {success:false} branch (AC: graceful at scale; ADR §Impl)', () => {
+  const src = safeRead(FOLLOWERS_HANDLER);
+  assert(src.length > 0, 'followersWithMetrics.js does not exist yet.');
+  assert(/NEO4J_QUERY_TIMEOUT_MS/.test(src), 'handler must read NEO4J_QUERY_TIMEOUT_MS (same deadline pattern as followsWithMetrics.js).');
+  assert(/session\.(run|executeRead|readTransaction)\s*\([\s\S]{0,400}\btimeout\s*:/.test(src),
+    'handler must pass a driver-layer { timeout: ... } so the heavy inbound traversal fails fast.');
+  const win = src.match(/\.status\(\s*504\s*\)\s*\.json\(\s*\{[\s\S]{0,400}?\}/);
+  assert(win, 'handler must return HTTP 504 with a JSON body on timeout (mega-account watch-out, ADR 0030).');
+  assert(/success\s*:\s*false/.test(win[0]), 'the 504 JSON body must include success:false.');
+});
+
+test('T5: a non-owner `observer` is rejected with 400 (owner-only v1; customer POV deferred — story §Deferred)', () => {
+  const src = safeRead(FOLLOWERS_HANDLER);
+  assert(src.length > 0, 'followersWithMetrics.js does not exist yet.');
+  assert(/observer/.test(src), 'handler must look at the `observer` param to reject non-owner values in v1.');
+  assert(/\.status\(\s*400\s*\)[\s\S]{0,260}(customer|owner[\s-]?only|not\s*(yet\s*)?support)/i.test(src) ||
+         /(customer|owner[\s-]?only|not\s*(yet\s*)?support)[\s\S]{0,260}\.status\(\s*400\s*\)/i.test(src),
+    'a non-owner `observer` must return 400 (customer observers deferred, exactly like followsWithMetrics.js).');
+});
+
+test('T6: GET /api/get-grapevine-followers is registered in src/api/index.js → handleGetGrapevineFollowers (AC: Direct load)', () => {
+  const src = safeRead(API_INDEX);
+  assert(src.length > 0, 'src/api/index.js missing — unexpected.');
+  assert(/['"]\/api\/get-grapevine-followers['"]/.test(src),
+    "src/api/index.js must register '/api/get-grapevine-followers' (next to get-grapevine-follows).");
+  assert(/handleGetGrapevineFollowers/.test(src), 'src/api/index.js must wire the route to handleGetGrapevineFollowers.');
+});
+
+test('T7: success response carries success:true, observer, observee, count, data[] (ADR §Impl response shape)', () => {
+  const src = safeRead(FOLLOWERS_HANDLER);
+  assert(src.length > 0, 'followersWithMetrics.js does not exist yet.');
+  for (const key of ['success', 'observer', 'observee', 'count', 'data']) {
+    assert(new RegExp('\\b' + key + '\\b').test(src),
+      `the success response must include \`${key}\` (same shape as get-grapevine-follows).`);
+  }
+});
+
+// ===========================================================================
+// FRONTEND — route, page, hook, the count→link, and #29 table parity
+// ===========================================================================
+
+test('T8: ui/src/App.jsx registers the /user/:pubkey/followers route → BrainstormFollowers (AC: Direct load)', () => {
+  const src = safeRead(APP_JSX);
+  assert(src.length > 0, 'ui/src/App.jsx missing — unexpected.');
+  assert(/\/user\/:pubkey\/followers/.test(src), "App.jsx must declare a route with path '/user/:pubkey/followers'.");
+  assert(/BrainstormFollowers/.test(src), 'App.jsx must map the followers route to the BrainstormFollowers page.');
+});
+
+test('T9: ui/src/pages/BrainstormFollowers.jsx exists, reads :pubkey, loads followers, has an empty state (AC: Listing)', () => {
+  const src = safeRead(FOLLOWERS_PAGE);
+  assert(src.length > 0, 'BrainstormFollowers.jsx does not exist yet — the Implementer must create the followers page (mirror BrainstormFollows.jsx).');
+  assert(/useParams/.test(src), 'BrainstormFollowers.jsx must read the :pubkey route param via useParams.');
+  assert(/useGrapevineFollowers|get-grapevine-followers/.test(src),
+    'BrainstormFollowers.jsx must source rows from the followers endpoint (via useGrapevineFollowers or a direct fetch).');
+  assert(/empty|no verified followers|no followers|0 followers/i.test(src),
+    'BrainstormFollowers.jsx must render an empty-state message when N = 0 (AC: Listing).');
+});
+
+test('T10: ui/src/hooks/useGrapevineFollowers.js fetches /api/get-grapevine-followers (AC: Listing)', () => {
+  const src = safeRead(FOLLOWERS_HOOK);
+  assert(src.length > 0, 'useGrapevineFollowers.js does not exist yet — mirror useGrapevineFollows.js.');
+  assert(/get-grapevine-followers/.test(src), 'useGrapevineFollowers.js must call /api/get-grapevine-followers.');
+  assert(/fetch\s*\(/.test(src), 'useGrapevineFollowers.js must use fetch (useUserCounts/useGrapevineFollows convention).');
+});
+
+test('T11: the profile "Verified Followers" count links to /user/:pubkey/followers in the same tab (AC: Entry point; reverses #33)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/\/user\/\$\{pubkey\}\/followers/.test(src),
+    'BrainstormProfile.jsx must link the Verified Followers count to `/user/${pubkey}/followers` (it shipped plain in #33; #34 makes it a <Link>).');
+  // Both prominent counters are now links → Following (/follows) + Verified Followers (/followers).
+  assert(countOf(src, /bsp-count-link/g) >= 2,
+    'the Verified Followers counter must become a <Link className="...bsp-count-link"> (expected >=2 bsp-count-link: Following + Verified Followers).');
+});
+
+test('T12: the followers page has a "Back to profile" link to /user/:pubkey (AC: Return)', () => {
+  const src = safeRead(FOLLOWERS_PAGE);
+  assert(src.length > 0, 'BrainstormFollowers.jsx does not exist yet.');
+  assert(/back to profile/i.test(src), 'BrainstormFollowers.jsx must render a "Back to profile" control.');
+  assert(/\/user\/\$\{pubkey\}(?!\/follow)/.test(src) || /to=\{`\/user\/\$\{pubkey\}`\}/.test(src),
+    'the back control must navigate to `/user/${pubkey}` (the profile, not the followers/follows page).');
+});
+
+test('T13: each row navigates to that account\'s own /user/<pubkey> profile (AC: Row navigation)', () => {
+  const src = safeRead(FOLLOWERS_PAGE);
+  assert(src.length > 0, 'BrainstormFollowers.jsx does not exist yet.');
+  assert(/onRowClick|navigate\s*\(|to=\{`\/user\//.test(src) && /\/user\//.test(src),
+    'BrainstormFollowers.jsx rows must navigate to /user/<that-pubkey> (e.g. onRowClick → navigate(`/user/${row.pubkey}`)).');
+});
+
+test('T14: the page defines all columns incl. default visibility (pic/name/rank shown; npub/hops/verified* hidden) (AC: Default visibility)', () => {
+  const src = safeRead(FOLLOWERS_PAGE);
+  assert(src.length > 0, 'BrainstormFollowers.jsx does not exist yet.');
+  for (const key of ['name', 'rank', 'npub', 'hops', 'verifiedFollowerCount', 'verifiedMuterCount', 'verifiedReporterCount']) {
+    assert(new RegExp('\\b' + key + '\\b').test(src), `BrainstormFollowers.jsx must define the \`${key}\` column.`);
+  }
+  assert(/pic|picture|avatar/i.test(src), 'BrainstormFollowers.jsx must define the picture/avatar column.');
+  assert(/default/i.test(src) && /(hidden|visible|show|hide)/i.test(src),
+    'BrainstormFollowers.jsx must encode default column visibility (pic/name/rank shown; npub/hops/verified* hidden).');
+});
+
+test('T15: rank is round(influence*100) with a "—" fallback when influence is null (AC: Rank)', () => {
+  const src = safeRead(FOLLOWERS_PAGE);
+  assert(src.length > 0, 'BrainstormFollowers.jsx does not exist yet.');
+  assert(/Math\.round\(\s*[\w.?]+\s*\*\s*100\s*\)/.test(src), 'rank must be Math.round(influence * 100) — an integer 0–100.');
+  assert(/—/.test(src), 'rank must fall back to "—" when influence is null/absent.');
+});
+
+test('T16: the name column falls back display_name → name → shortened npub (AC: Name fallback)', () => {
+  const src = safeRead(FOLLOWERS_PAGE);
+  assert(src.length > 0, 'BrainstormFollowers.jsx does not exist yet.');
+  assert(/display_name\s*\|\|\s*[\w.?[\]'"()]*\bname\b/.test(src),
+    'the name cell must use the fallback chain display_name || name || <shortened npub>.');
+});
+
+test('T17: npub is derived via nip19.npubEncode (AC: Name fallback / npub column)', () => {
+  const src = safeRead(FOLLOWERS_PAGE);
+  assert(src.length > 0, 'BrainstormFollowers.jsx does not exist yet.');
+  assert(/npubEncode/.test(src), 'BrainstormFollowers.jsx must derive npub via nip19.npubEncode(pubkey).');
+});
+
+test('T18: the page reuses DataTable for sort + search/filter (AC: Re-sort, Search)', () => {
+  const src = safeRead(FOLLOWERS_PAGE);
+  assert(src.length > 0, 'BrainstormFollowers.jsx does not exist yet.');
+  assert(/DataTable/.test(src), 'BrainstormFollowers.jsx must reuse ui/src/components/DataTable.jsx (ADR §Impl).');
+});
+
+test('T19: the page implements pagination (AC: Pagination)', () => {
+  const src = safeRead(FOLLOWERS_PAGE);
+  assert(src.length > 0, 'BrainstormFollowers.jsx does not exist yet.');
+  assert(/page\s*size|pagesize|currentPage|setPage|pageIndex|\bpaginat/i.test(src),
+    'BrainstormFollowers.jsx must paginate results client-side (50-row blocks, like Follows).');
+});
+
+test('T20: default sort is verifiedFollowerCount descending across the whole set (AC: Default sort)', () => {
+  const src = safeRead(FOLLOWERS_PAGE);
+  assert(src.length > 0, 'BrainstormFollowers.jsx does not exist yet.');
+  assert(/verifiedFollowerCount/.test(src) && /sort\s*\(/.test(src),
+    'BrainstormFollowers.jsx must pre-sort the full data set by verifiedFollowerCount (descending) before render.');
+});
+
+test('T21: column show/hide choices persist via localStorage with a reset, under a followers-specific key (AC: Persistence)', () => {
+  const src = safeRead(FOLLOWERS_PAGE);
+  assert(src.length > 0, 'BrainstormFollowers.jsx does not exist yet.');
+  assert(/localStorage/.test(src), 'column visibility prefs must persist via localStorage (AC: Persistence).');
+  assert(/reset/i.test(src), 'the page must offer a "reset to defaults" control.');
+  assert(/followers/i.test(src) && !/['"`][^'"`]*bsp-follows-columns[^'"`]*['"`]/.test(src),
+    'use a FOLLOWERS-specific localStorage key (e.g. bsp-followers-columns) — must NOT reuse the follows key `bsp-follows-columns`, or the two pages would clobber each other.');
+});
+
+test('T22: the local-data ⓘ disclosure states data is computed locally and NOT via NIP-85, and opens on tap (AC: Local-data disclosure)', () => {
+  const src = safeRead(FOLLOWERS_PAGE);
+  assert(src.length > 0, 'BrainstormFollowers.jsx does not exist yet.');
+  assert(/NIP-?85/i.test(src), 'the disclosure must mention NIP-85 (data is NOT imported via NIP-85).');
+  assert(/comput(e|ed)\s+locally|locally by this|this Tapestry instance/i.test(src),
+    'the disclosure must state the data is computed locally by this Tapestry instance.');
+  assert(/onClick/.test(src), 'the ⓘ affordance must open on tap/click (mobile-friendly), not hover-only.');
+});
+
+test('T23: the /api/profiles batch size respects the server cap (PROFILE_CHUNK ≤ 50) — the #29 Name-column regression guard', () => {
+  const src = safeRead(FOLLOWERS_PAGE);
+  assert(src.length > 0, 'BrainstormFollowers.jsx does not exist yet.');
+  const m = src.match(/PROFILE_CHUNK\s*=\s*(\d+)/);
+  assert(m, 'BrainstormFollowers.jsx must define `PROFILE_CHUNK` (the /api/profiles batch size) — at followers scale this matters even more.');
+  const chunk = parseInt(m[1], 10);
+  assert(chunk >= 1 && chunk <= 50, `PROFILE_CHUNK=${chunk} must be 1..50 — /api/profiles 400s for >50 pubkeys (fetchProfiles.js).`);
+});
+
+// ===========================================================================
+// REGRESSION SENTINELS — guard the live #29 follows feature (ADR 0030 = mirror, not generalize)
+// ===========================================================================
+
+test('R1: the live follows endpoint (followsWithMetrics.js) is UNCHANGED — still OUTBOUND, still unfiltered (ADR chose mirror, not generalize)', () => {
+  const src = safeRead(FOLLOWS_HANDLER);
+  assert(src.length > 0, 'followsWithMetrics.js missing — unexpected.');
+  assert(/:FOLLOWS\s*\]\s*->\s*\(\s*f\b/.test(src),
+    'the follows endpoint must still traverse OUTBOUND (observee)-[:FOLLOWS]->(f). If this fails, the Implementer generalized it instead of adding a separate followers endpoint (Option B), regressing live Follows.');
+  assert(!/influence\s*>/.test(src),
+    'the follows endpoint must NOT gain a verified `influence > cutoff` filter — follows lists ALL follows; only the new followers endpoint filters to verified.');
+});
+
+test('R2: the live follows page (BrainstormFollows.jsx) is UNCHANGED — still uses the useGrapevineFollows hook', () => {
+  const src = safeRead(FOLLOWS_PAGE);
+  assert(src.length > 0, 'BrainstormFollows.jsx missing — unexpected.');
+  assert(/useGrapevineFollows\b/.test(src),
+    'BrainstormFollows.jsx must remain the follows page using the `useGrapevineFollows` hook — followers is a NEW parallel page (ADR 0030 = mirror, not generalize), so this page must not be repurposed to useGrapevineFollowers.');
+});
+
+test('R3: the existing /api/get-grapevine-follows route remains registered (live follows endpoint unregressed)', () => {
+  const src = safeRead(API_INDEX);
+  assert(src.length > 0, 'src/api/index.js missing — unexpected.');
+  assert(/['"]\/api\/get-grapevine-follows['"]/.test(src),
+    'the existing /api/get-grapevine-follows registration must remain.');
+});
+
+test('R4: BrainstormProfile still shows the Following count via useUserCounts + a <Link> to /follows (count area unregressed)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/useUserCounts/.test(src), 'BrainstormProfile.jsx must keep useUserCounts for the Following count.');
+  assert(/\/user\/\$\{pubkey\}\/follows/.test(src) && /bsp-count-label[^>]*>\s*Following/.test(src),
+    'the Following count must remain a <Link> to /user/${pubkey}/follows with its "Following" label (Verified Followers is added beside it, not replacing it).');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/profile-verified-followers-count.test.js
+++ b/test/profile-verified-followers-count.test.js
@@ -74,16 +74,19 @@ test('T4: the new counter formats its value via the existing fmtCount helper (AC
     'the new counter must format its value through the existing `fmtCount` helper (a 2nd `fmtCount(...)` call beside the Following one). fmtCount returns "—" for null/undefined (AC5) and "0" for 0 (AC6).');
 });
 
-// AC7 — the new counter is a PLAIN element, not a link; no premature followers-table link.
-test('T5: the "Verified Followers" counter is plain (not a <Link>); the followers table is deferred (AC7)', () => {
+// AC7 — UPDATED by story #34. #33 shipped this counter PLAIN ("plain until the followers
+// table ships"); story #34 ships that table (/user/:pubkey/followers), so the counter becomes
+// a same-tab <Link>. This assertion now tracks the current intended behavior — it fails until
+// #34's count→link lands, then passes. (See engineering-team/stories/profile/34-*.)
+test('T5: the "Verified Followers" counter links to /user/${pubkey}/followers (updated by story #34; was plain in #33)', () => {
   const src = safeRead(PROFILE_PAGE);
   assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
   assert(countOf(src, /bsp-count-value/g) >= 2,
-    'the new counter must exist (expected >=2 `bsp-count-value` spans; only "Following" has one pre-implementation).');
-  assert(countOf(src, /bsp-count-link/g) === 1,
-    'exactly ONE `bsp-count-link` must remain (the existing "Following" link). The new "Verified Followers" counter must be a PLAIN element (e.g. `<div className="bsp-count">`), NOT a <Link>/bsp-count-link — AC7, non-link until the followers table ships.');
-  assert(!/\/user\/\$\{pubkey\}\/followers/.test(src),
-    'the counter must NOT link to `/user/${pubkey}/followers` — that page is sub-feature 2 (deferred). The count is a plain number for now.');
+    'the Verified Followers counter must still exist beside Following (>=2 `bsp-count-value` spans).');
+  assert(/\/user\/\$\{pubkey\}\/followers/.test(src),
+    'story #34: the Verified Followers counter must link to `/user/${pubkey}/followers` (the followers table). It shipped plain in #33; #34 makes it a <Link>.');
+  assert(countOf(src, /bsp-count-link/g) >= 2,
+    'both prominent counters are now links: Following → /follows and Verified Followers → /followers (expected >=2 `bsp-count-link`).');
 });
 
 // Regression — the existing "Following" count is untouched (added beside, not replaced).

--- a/test/test.js
+++ b/test/test.js
@@ -50,6 +50,7 @@ const taskQueueSemaphoreProtectionAudit = require('./task-queue-semaphore-protec
 const profileFollowsList = require('./profile-follows-list.test.js');
 const profileWebsiteLink = require('./profile-website-link.test.js');
 const profileVerifiedFollowersCount = require('./profile-verified-followers-count.test.js');
+const profileFollowersList = require('./profile-followers-list.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -138,6 +139,9 @@ async function main() {
   console.log('\nprofile-verified-followers-count suite:');
   const profileVerifiedFollowersCountResult = await profileVerifiedFollowersCount.run();
 
+  console.log('\nprofile-followers-list suite:');
+  const profileFollowersListResult = await profileFollowersList.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -222,6 +226,9 @@ async function main() {
   console.log(
     `profile-verified-followers-count suite:          ${profileVerifiedFollowersCountResult.fail === 0 ? 'PASS' : 'FAIL'} (${profileVerifiedFollowersCountResult.pass} passed, ${profileVerifiedFollowersCountResult.fail} failed)`
   );
+  console.log(
+    `profile-followers-list suite:                    ${profileFollowersListResult.fail === 0 ? 'PASS' : 'FAIL'} (${profileFollowersListResult.pass} passed, ${profileFollowersListResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -251,7 +258,8 @@ async function main() {
     taskQueueSemaphoreProtectionAuditResult.fail === 0 &&
     profileFollowsListResult.fail === 0 &&
     profileWebsiteLinkResult.fail === 0 &&
-    profileVerifiedFollowersCountResult.fail === 0;
+    profileVerifiedFollowersCountResult.fail === 0 &&
+    profileFollowersListResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/tests/brainstorm/profile-followers-list.spec.js
+++ b/tests/brainstorm/profile-followers-list.spec.js
@@ -1,0 +1,44 @@
+/**
+ * Playwright behavioral check for story #34 / ADR 0030: the profile "Verified
+ * Followers" count links to /user/:pubkey/followers, which renders a table of
+ * verified followers (the inbound mirror of the follows page #29).
+ * See engineering-team/stories/profile/34-profile-followers-list.test-plan.md
+ *
+ * SUPPLEMENTARY + LIVE-DATA DEPENDENT (mirrors tests/brainstorm/profile-follows-list.spec.js).
+ * The deterministic coverage is the node suite test/profile-followers-list.test.js
+ * (no stack dependency). NOTE: a PRE-EXISTING harness bug (tests/global-setup.js
+ * reads config.use, undefined in the installed Playwright) currently blocks
+ * `npm run test:playwright` everywhere — unrelated to this story; run/verify at the
+ * staging smoke (or via a Chrome MCP tab), not as a local gate.
+ *
+ * Not run pre-implementation (the page/route/link don't exist yet); exercised at
+ * the staging smoke after the feature deploys.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = process.env.BRAINSTORM_BASE_URL || 'http://localhost:7778';
+// Jack Dorsey — a high-profile account with many verified followers (≈26.7k on staging).
+const PUBKEY = '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2';
+
+test.describe('Story 34 — followers list page', () => {
+  test('the profile "Verified Followers" count links to /user/<pk>/followers (Entry point)', async ({ page }) => {
+    await page.goto(`${BASE_URL}/user/${PUBKEY}`);
+    const link = page.getByRole('link', { name: /Verified Followers/i });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('href', new RegExp(`/user/${PUBKEY}/followers`));
+    await link.click();
+    await expect(page).toHaveURL(new RegExp(`/user/${PUBKEY}/followers$`));
+  });
+
+  test('the followers page renders the table and a Back-to-profile control', async ({ page }) => {
+    await page.goto(`${BASE_URL}/user/${PUBKEY}/followers`);
+    await expect(page.getByText(/back to profile/i)).toBeVisible();
+    // The verified-followers table renders (DataTable). Rows hydrate names/scores
+    // progressively; a visible table element is the load-bearing assertion here.
+    await expect(page.locator('table, .data-table, [class*="data-table"]').first()).toBeVisible();
+    // Back-to-profile returns to the profile.
+    await page.getByText(/back to profile/i).first().click();
+    await expect(page).toHaveURL(new RegExp(`/user/${PUBKEY}$`));
+  });
+});

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -66,6 +66,7 @@ import Dashboard from './pages/Dashboard';
 import BrainstormSearch from './pages/BrainstormSearch';
 import BrainstormProfile from './pages/BrainstormProfile';
 import BrainstormFollows from './pages/BrainstormFollows';
+import BrainstormFollowers from './pages/BrainstormFollowers';
 import BrainstormSettings from './pages/BrainstormSettings';
 import BrainstormPersonalization from './pages/BrainstormPersonalization';
 import BrainstormHowSearchWorks from './pages/BrainstormHowSearchWorks';
@@ -84,6 +85,10 @@ const router = createBrowserRouter([
   {
     path: '/user/:pubkey/follows',
     element: <BrainstormFollows />,
+  },
+  {
+    path: '/user/:pubkey/followers',
+    element: <BrainstormFollowers />,
   },
   {
     path: '/settings',

--- a/ui/src/hooks/useGrapevineFollowers.js
+++ b/ui/src/hooks/useGrapevineFollowers.js
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook: fetch the VERIFIED accounts that follow <observee>, with owner-POV GrapeRank
+ * metrics, from `/api/get-grapevine-followers`. Returns { data, loading, error }.
+ *
+ * v1 is owner POV only (ADR 0030), so `observer` is not sent — the endpoint defaults
+ * to the instance owner. The inbound mirror of useGrapevineFollows.js.
+ */
+export default function useGrapevineFollowers(observee) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!observee) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    fetch(`/api/get-grapevine-followers?observee=${observee}`, { signal: controller.signal })
+      .then(r => r.json())
+      .then(json => {
+        if (json?.success && Array.isArray(json.data)) {
+          setData(json.data);
+        } else {
+          setData(null);
+          setError(json?.message || json?.error || 'No data');
+        }
+      })
+      .catch(err => {
+        if (err.name === 'AbortError') return;
+        setError(err.message || 'Fetch failed');
+        setData(null);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [observee]);
+
+  return { data, loading, error };
+}

--- a/ui/src/pages/BrainstormFollowers.jsx
+++ b/ui/src/pages/BrainstormFollowers.jsx
@@ -1,0 +1,236 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { nip19 } from 'nostr-tools';
+import { useAuth } from '../context/AuthContext';
+import BrainstormUserMenu from '../components/BrainstormUserMenu';
+import DataTable from '../components/DataTable';
+import useGrapevineFollowers from '../hooks/useGrapevineFollowers';
+
+/* ── Helpers ──────────────────────────────────────────── */
+
+function safeNpub(pubkey) {
+  try { return nip19.npubEncode(pubkey); } catch { return pubkey; }
+}
+function shortNpub(npub) {
+  if (!npub) return '—';
+  return npub.length > 20 ? `${npub.slice(0, 12)}…${npub.slice(-6)}` : npub;
+}
+
+const PAGE_SIZE = 50;
+// Followers-specific localStorage key — distinct from the follows page key so the two
+// pages do not clobber each other's column-visibility prefs.
+const STORAGE_KEY = 'bsp-followers-columns';
+
+// Column definitions + default visibility (pic/name/rank shown; the rest hidden).
+const ALL_COLUMNS = [
+  { key: 'picture', label: '', sortable: false, render: (_v, row) => (
+    row.picture
+      ? <img src={row.picture} alt="" className="bsp-follows-avatar" onError={e => { e.target.style.display = 'none'; }} />
+      : <div className="bsp-follows-avatar bsp-follows-avatar-ph">{(row.name || '?')[0].toUpperCase()}</div>
+  ) },
+  { key: 'name', label: 'Name', render: v => v || '—' },
+  { key: 'rank', label: 'Rank', render: v => (v == null ? '—' : v) },
+  { key: 'npub', label: 'npub', render: v => <code className="bsp-follows-npub">{shortNpub(v)}</code> },
+  { key: 'hops', label: 'Hops', render: v => (v == null ? '—' : v) },
+  { key: 'verifiedFollowerCount', label: 'Verified Followers', render: v => (v == null ? '—' : v) },
+  { key: 'verifiedMuterCount', label: 'Verified Muters', render: v => (v == null ? '—' : v) },
+  { key: 'verifiedReporterCount', label: 'Verified Reporters', render: v => (v == null ? '—' : v) },
+];
+const DEFAULT_VISIBLE = {
+  picture: true, name: true, rank: true,
+  npub: false, hops: false,
+  verifiedFollowerCount: false, verifiedMuterCount: false, verifiedReporterCount: false,
+};
+
+function loadVisible() {
+  try {
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    if (saved && typeof saved === 'object') return { ...DEFAULT_VISIBLE, ...saved };
+  } catch { /* ignore */ }
+  return { ...DEFAULT_VISIBLE };
+}
+
+// /api/profiles caps at 50 pubkeys per request (src/api/profiles/fetchProfiles.js:148),
+// so profile lookups are batched at PROFILE_CHUNK and merged chunk-by-chunk as they arrive.
+const PROFILE_CHUNK = 50;
+
+/* ── Local-data disclosure popover (tap to open; mobile-friendly) ── */
+
+function InfoPopover({ open, onClose }) {
+  if (!open) return null;
+  return (
+    <div className="bsp-confirm-overlay" onClick={onClose}>
+      <div className="bsp-confirm-box bsp-follows-info" onClick={e => e.stopPropagation()}>
+        <h3 className="bsp-confirm-title">About this data</h3>
+        <p className="bsp-confirm-message">
+          All data on this page is computed locally by this Tapestry instance and is not imported via NIP-85.
+        </p>
+        <div className="bsp-confirm-buttons">
+          <button className="bsp-confirm-ok" onClick={onClose}>Got it</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Main component ──────────────────────────────────── */
+
+export default function BrainstormFollowers() {
+  const { pubkey } = useParams();
+  const navigate = useNavigate();
+  const { user, login, logout } = useAuth();
+
+  const { data: followers, loading, error } = useGrapevineFollowers(pubkey);
+
+  const [profiles, setProfiles] = useState({});
+  const [search, setSearch] = useState('');
+  const [visible, setVisible] = useState(loadVisible);
+  const [showCols, setShowCols] = useState(false);
+  const [showInfo, setShowInfo] = useState(false);
+
+  // Persist column show/hide choices across reloads/sessions.
+  useEffect(() => {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(visible)); } catch { /* ignore */ }
+  }, [visible]);
+
+  // Batch-load names/pics for the follower pubkeys. /api/profiles caps at 50 pubkeys/request,
+  // so chunk at PROFILE_CHUNK and merge each chunk as it returns (names fill in progressively;
+  // one slow/failed chunk no longer blocks the whole list).
+  useEffect(() => {
+    if (!followers || followers.length === 0) { setProfiles({}); return; }
+    let cancelled = false;
+    setProfiles({});
+    const pubkeys = followers.map(f => f.pubkey);
+    (async () => {
+      for (let i = 0; i < pubkeys.length && !cancelled; i += PROFILE_CHUNK) {
+        const batch = pubkeys.slice(i, i + PROFILE_CHUNK);
+        try {
+          const r = await fetch(`/api/profiles?pubkeys=${batch.join(',')}`);
+          const j = await r.json();
+          if (!cancelled && j?.profiles) setProfiles(prev => ({ ...prev, ...j.profiles }));
+        } catch { /* tolerate partial profile failures */ }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [followers]);
+
+  // Build rows: merge metrics + profile, derive rank/name/npub.
+  const rows = useMemo(() => {
+    const list = (followers || []).map(f => {
+      const p = profiles[f.pubkey] || {};
+      const npub = safeNpub(f.pubkey);
+      return {
+        pubkey: f.pubkey,
+        picture: p.picture || null,
+        name: p.display_name || p.name || shortNpub(npub),
+        npub,
+        rank: f.influence == null ? null : Math.round(f.influence * 100),
+        hops: f.hops,
+        verifiedFollowerCount: f.verifiedFollowerCount,
+        verifiedMuterCount: f.verifiedMuterCount,
+        verifiedReporterCount: f.verifiedReporterCount,
+      };
+    });
+    // Default sort: verified followers, descending, across the whole set.
+    list.sort((a, b) => (b.verifiedFollowerCount ?? -1) - (a.verifiedFollowerCount ?? -1));
+    return list;
+  }, [followers, profiles]);
+
+  // Page-level search — matches name / npub / pubkey even when those columns are hidden.
+  const searched = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter(r =>
+      (r.name && r.name.toLowerCase().includes(q)) ||
+      (r.npub && r.npub.toLowerCase().includes(q)) ||
+      r.pubkey.toLowerCase().includes(q)
+    );
+  }, [rows, search]);
+
+  const columns = useMemo(() => ALL_COLUMNS.filter(c => visible[c.key]), [visible]);
+
+  return (
+    <div className="bsp-page">
+      {/* Top bar */}
+      <div className="bsp-top-bar">
+        <a href="/" className="bsp-logo">
+          <img src="/brainstorm.svg" alt="" className="bsp-logo-img" />
+        </a>
+        <div className="bsp-auth">
+          <BrainstormUserMenu user={user} login={login} logout={logout} />
+        </div>
+      </div>
+
+      <div className="bsp-content">
+        {/* Header + back link */}
+        <div className="bsp-follows-header">
+          <Link to={`/user/${pubkey}`} className="bsp-back-link">← Back to profile</Link>
+          <h1 className="bsp-follows-title">Verified Followers</h1>
+          <button
+            type="button"
+            className="bsp-info-btn"
+            aria-label="About this data"
+            title="About this data"
+            onClick={() => setShowInfo(true)}
+          >ⓘ</button>
+        </div>
+
+        {/* Controls: search + columns toggle */}
+        <div className="bsp-follows-controls">
+          <input
+            type="search"
+            className="bsp-follows-search"
+            placeholder="Search by name or npub…"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+          <div className="bsp-follows-colmenu">
+            <button type="button" className="bsp-follows-colbtn" onClick={() => setShowCols(s => !s)}>
+              Columns ▾
+            </button>
+            {showCols && (
+              <div className="bsp-follows-colpanel" onMouseLeave={() => setShowCols(false)}>
+                {ALL_COLUMNS.map(c => (
+                  <label key={c.key} className="bsp-follows-colopt">
+                    <input
+                      type="checkbox"
+                      checked={!!visible[c.key]}
+                      onChange={() => setVisible(v => ({ ...v, [c.key]: !v[c.key] }))}
+                    />
+                    {c.label || 'Picture'}
+                  </label>
+                ))}
+                <button
+                  type="button"
+                  className="bsp-follows-colreset"
+                  onClick={() => setVisible({ ...DEFAULT_VISIBLE })}
+                >Reset to defaults</button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Body */}
+        {loading && <div className="bsp-loading">Loading followers…</div>}
+        {error && !loading && (
+          <div className="bsp-trust-unavailable"><span className="bsp-trust-icon">🔒</span><span>{error}</span></div>
+        )}
+        {!loading && !error && rows.length === 0 && (
+          <div className="bsp-empty">No verified followers found for this account.</div>
+        )}
+        {!loading && !error && rows.length > 0 && (
+          <DataTable
+            columns={columns}
+            data={searched}
+            pageSize={PAGE_SIZE}
+            showFilter={false}
+            onRowClick={row => navigate(`/user/${row.pubkey}`)}
+            emptyMessage="No matching accounts."
+          />
+        )}
+      </div>
+
+      <InfoPopover open={showInfo} onClose={() => setShowInfo(false)} />
+    </div>
+  );
+}

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -239,12 +239,12 @@ export default function BrainstormProfile() {
                 <span className="bsp-count-value">{fmtCount(followingCount)}</span>
                 <span className="bsp-count-label">Following</span>
               </Link>
-              {/* Verified Followers: plain (non-link) until the followers table ships (story #33, ADR 0029).
-                  Value rides the PoV-resolved trustScores; `??` keeps a genuine 0 from being dropped. */}
-              <div className="bsp-count">
+              {/* Verified Followers → followers table (story #34, ADR 0030). Value rides the
+                  PoV-resolved trustScores; `??` keeps a genuine 0 from being dropped. */}
+              <Link to={`/user/${pubkey}/followers`} className="bsp-count bsp-count-link">
                 <span className="bsp-count-value">{fmtCount(trustScores?.verifiedFollowerCount ?? trustScores?.followers)}</span>
                 <span className="bsp-count-label">Verified Followers</span>
-              </div>
+              </Link>
             </div>
 
             {/* Action buttons */}


### PR DESCRIPTION
## Summary

Adds `/user/:pubkey/followers` — a table of a profile's **verified** followers, mirroring the Follows page (#29) — and makes the #33 "Verified Followers" count a same-tab **link** to it. The inbound counterpart to Follows; v1 = verified followers only, owner/House PoV. Story profile #34, ADR 0030 (**Option A — a new isolated endpoint, leaving the live Follows feature untouched**).

## Changes

- **NEW** `src/api/grapevineInteractions/queries/followersWithMetrics.js` — `GET /api/get-grapevine-followers` (inbound `(follower)-[:FOLLOWS]->(observee)`, verified filter reusing `VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF`, owner PoV, 504 deadline); registered in `src/api/index.js`.
- **NEW** `ui/src/pages/BrainstormFollowers.jsx` + `ui/src/hooks/useGrapevineFollowers.js`; route `/user/:pubkey/followers` in `ui/src/App.jsx`.
- `ui/src/pages/BrainstormProfile.jsx` — the "Verified Followers" count is now a `<Link>` to the new page.
- Tests: `test/profile-followers-list.test.js` (27/0) + #33 T5 inverted (plain→link; 6/0); supplementary Playwright spec.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs green.
- [ ] Profile "Verified Followers" count links → `/user/<pk>/followers`.
- [ ] Followers table populates with **real data** (Jack ≈26.7k), paginated 50/page, default sort verified-followers desc; back-to-profile + row navigation.
- [ ] **Scale:** observe Jack's followers-page load time (mega-account: whole-set fetch + ~530 `/api/profiles` batches). If slow, schedule (b) lazy name-hydration (ADR 0030). Confirm a small account is snappy.
- [ ] Regression: Following count + `/follows` page unaffected (mirror, not generalize).
- [ ] Known: Playwright blocked by a pre-existing `global-setup.js` bug → manual/Chrome check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)