### PR TITLE
Verified Reporters: profile count + list page (+ membership API)

### DIFF
--- a/engineering-team/audits/verified-reporters/audit.md
+++ b/engineering-team/audits/verified-reporters/audit.md
@@ -1,0 +1,69 @@
+# Build Audit: Verified Reporters
+
+**Book:** `engineering-team/audits/verified-reporters/book.md`
+**Date:** 2026-06-07
+**Branch / commit range:** `staging` (15e7a1d9) .. `feat/verified-reporters` (dbd1c34d)
+**Provenance:** PRD-backed (`product-team/prd/verified-reporters.md` §8.1)
+**Confidence:** high (anchored at kickoff; every shipped file traces to a story + ADR)
+
+> As-built record — what the product *is* now. Source-linked, audience-neutral. Proposes nothing; the PRD addendum carries the product feedback.
+
+## 1. What shipped
+- A **Verified Reporters count** on the profile, in the counts row beside Following and Verified Followers — a negative-signal link when > 0, neutral "0" / "—" otherwise — `stories/verified-reporters/1-verified-reporters-count.md`.
+- A **verified-reporters membership capability** — `GET /api/get-grapevine-reporters?observee=<pk>` returning the verified users who reported an account under the House PoV — `stories/verified-reporters/2-verified-reporters-membership-data.md`.
+- A **Verified Reporters list page** at `/user/:pubkey/reporters` — who reported the account, Rank-descending, with PoV attribution and designed empty/loading/error states — `stories/verified-reporters/3-verified-reporters-list-page.md`.
+
+Together: profile count → list page → membership endpoint. The credible negative trust signal, end to end.
+
+## 2. Epics & stories rolled up
+
+### Epic: `verified-reporters`
+| Story | Delivered | Status | Review |
+|---|---|---|---|
+| #1 verified-reporters-count | PoV-filtered count in the profile counts row; negative-signal link >0, neutral 0, "—" unavailable, dimmed loading; ADR 0001 | Done | `reviews/verified-reporters/1-verified-reporters-count.md` (PASS) |
+| #2 verified-reporters-membership-data | `GET /api/get-grapevine-reporters` — inverse-`REPORTS` query, verified filter, `count===data.length`; ADR 0002 | Done | `reviews/verified-reporters/2-verified-reporters-membership-data.md` (PASS) |
+| #3 verified-reporters-list-page | `/user/:pubkey/reporters` page mirroring the followers list; Rank-desc; PoV line + popover; skeleton + retry; ADR 0003 | Done | `reviews/verified-reporters/3-verified-reporters-list-page.md` (PASS) |
+
+## 3. As-built inventory
+Derived from the diff (13 files, +1276/−2):
+
+- **User-facing:**
+  - Profile counts row gains a third counter — `ui/src/pages/BrainstormProfile.jsx` (count value from `trustScores.verifiedReporterCount`; links to `/user/:pubkey/reporters` when > 0).
+  - New page `ui/src/pages/BrainstormReporters.jsx` + route `/user/:pubkey/reporters` in `ui/src/App.jsx`.
+  - New data hook `ui/src/hooks/useGrapevineReporters.js` (returns `{data, loading, error, refetch}`).
+  - Styles: `ui/src/styles.css` — `.bsp-count-value-negative`, `.bsp-count-loading`, `.bsp-skeleton-row` + `@keyframes bsp-shimmer`, `.bsp-follows-subtitle`, `.bsp-follows-pov`.
+- **Data & contracts:**
+  - New route `GET /api/get-grapevine-reporters?observee=<pk>` → `src/api/grapevineInteractions/queries/reportersWithMetrics.js` (`handleGetGrapevineReporters`), registered in `src/api/index.js`. Response `{ success, observer:'owner', observee, count, data:[{pubkey, influence, hops, verifiedFollowerCount, verifiedMuterCount, verifiedReporterCount}] }`, `count === data.length`; `observee` validated (400), owner-only `observer` (400), `NEO4J_QUERY_TIMEOUT_MS` → 504.
+  - Cypher: `MATCH (observee:NostrUser {pubkey:$observee})<-[:REPORTS]-(reporter:NostrUser) WHERE reporter.influence > $cutoff` — the inverse of `calculateVerifiedReporterCounts.sh`, reusing `VERIFIED_REPORTERS_INFLUENCE_CUTOFF`.
+- **Domain:** no concept-graph or schema change; no firmware reinstall. Uses the existing `[:REPORTS]` Neo4j edge and the `NostrUser.influence` / `verified*Count` runtime properties. Concepts referenced (unchanged): `nostr-user`, `web-of-trust`, `graperank`; a NIP-56 report is a `nostr-event` of kind 1984.
+- **Tests:** `test/profile-verified-reporters-count.test.js` (11), `test/verified-reporters-membership-data.test.js` (12), `test/verified-reporters-list-page.test.js` (17), wired into `test/test.js`; supplementary Playwright `tests/brainstorm/profile-verified-reporters-{count,list}.spec.js` (live-data, run at staging smoke).
+
+## 4. Deviations from intent
+Harvested from the ADRs' Consequences, the stories' Deviations/Out-of-scope/Open-questions, and the reviews; reconciled against the diff.
+
+| # | Specified (PRD anchor) | Built | Type | Rationale (source) | Product impact | Carry-forward |
+|---|---|---|---|---|---|---|
+| 1 | §5.2/§6/§7 — count & list "relative to who is looking," effective PoV personal-else-House | The **count** is per-PoV (Meili `wot_verifiedReporterCount_<povSuffix>`); the **list membership** is **House/owner PoV only** | deferred | Per-PoV membership = the per-customer `NostrUserWotMetricsCard` traversal that follows (ADR 0026) and followers (ADR 0030) explicitly deferred (ADR 0002 §Context/Decision) | A personalized-PoV viewer sees a personal count but a House-PoV list; they can differ | Personalized-PoV membership → next phase |
+| 2 | §8.1 — "whose PoV is in effect is attributed" on the count | No per-count / counts-row PoV marker shipped; attribution lives on the **list page** (PoV line + popover) | deferred | The fallback applies to all three counts at once; a per-count chip triples clutter — deferred to a shared cross-cutting session (PRD §8.3 / §11 decision 5) | Glance-only House-fallback viewer sees an unlabeled count; attributed one tap away on the list | Shared counts-row PoV indicator → Phase 4 |
+| 3 | §10 metric 1 — count = list length | Holds *within the capability* (`count === data.length`) and at House PoV vs the count algo; **not** a hard real-time guarantee vs the precomputed Meili profile badge | constraint-discovered | Profile count = precomputed Meili; list = live Neo4j → refresh skew (ADR 0002/0003, mirrors ADR 0030) | Count badge and list length can differ transiently; list page shows its own live count | Note in any future copy/tests; no fix needed |
+| 4 | §5.2 — designed loading & error states | List loading uses a **skeleton**; error has a **"Try again" retry** (hook gained a backward-compatible `refetch`) | intentional-change | AC7 + design guide; improves on the followers precedent's text loader / no-retry (ADR 0003) | Strictly better UX than the sibling pages | Fold into the DRY refactor so follows/followers gain parity |
+| 5 | §5.1 — count behavior (4 display states) | Implemented as a 2-branch ternary (link >0 / else span), `fmtCount(null)`→"—" unifying loading+unavailable | interpretation | Same observable behavior, less branching (story #1 `## Deviations`) | None (identical UX) | — |
+
+**Undocumented work:** none. Every file in the diff traces to a story + ADR (verified by walking `git diff --stat`).
+
+## 5. Quality state at close
+- **Test gate:** `npm test` → **Overall PASS** at close (2026-06-07). Verified-reporters suites: count 11/11, membership-data 12/12, list-page 17/17; no other suite regressed.
+- **Known, accepted (non-blocking, from reviews):**
+  - `reportersWithMetrics.js` — a harmless `.filter(row => row.pubkey)` carryover from the follows copy (no OPTIONAL MATCH here, so it never fires).
+  - Per-request Neo4j driver creation — pre-existing pattern inherited from `followsWithMetrics.js`, not introduced here.
+  - `BrainstormReporters.jsx` — "Try again" reuses `.bsp-follows-colbtn`; possible initial-mount empty-state flash inherited from the follows/followers pages.
+- **Debt logged by ADRs:** the DRY `<GrapevineList>` + shared-cypher refactor (now 3 near-duplicate pages/endpoints — ADR 0030's standing follow-up); the verified-influence-cutoff inconsistency (existing intake item, inherited not fixed).
+
+## 6. Carry-forward register
+- [ ] **Personalized / customer PoV membership** for the list + endpoint (the `NostrUserWotMetricsCard` traversal) — realizes the PRD's full per-viewer vision (§4 #1; ADR 0002).
+- [ ] **Shared counts-row PoV indicator** across Following / Verified Followers / Verified Reporters — tap-friendly, single, for the whole row (§4 #2; PRD §8.3).
+- [ ] **DRY refactor:** extract a shared `<GrapevineList>` component + cypher builder for follows/followers/reporters; carry the skeleton + retry to all three (§5 debt; ADR 0030 follow-up).
+- [ ] **Report-type breakdown** (split by NIP-56 type) — PRD Phase 2.
+- [ ] **Pile-on resistance** (tag/discount pile-on-prone reporters) — PRD Phase 3.
+- [ ] **Self-view retaliation/privacy controls** — PRD Phase 4 (note: reports are public NIP-56 events; bounded risk).
+- [ ] **Verified-influence-cutoff inconsistency** (0.01/0.05/"score>2") — existing intake item.

--- a/engineering-team/audits/verified-reporters/book.md
+++ b/engineering-team/audits/verified-reporters/book.md
@@ -1,0 +1,22 @@
+# Book of Work: Verified Reporters
+
+**Slug:** verified-reporters
+**Status:** Open
+**Opened:** 2026-06-07
+**Closed:** —
+
+## Intent anchor
+**PRD-backed** — `product-team/prd/verified-reporters.md` §8.1 (In Scope / MVP). Completion is *computed*: every story tracing to these sections is `Done` and the `verified-reporters` epic is closed.
+
+The feature: a point-of-view-filtered "Verified Reporters" count on the user profile (parallel to Following / Verified Followers), linking to a list page at `/user/:pubkey/reporters` that shows which verified users have NIP-56-reported the observed account. Companion guides: `product-team/guides/verified-reporters-design-guide.md`, `verified-reporters-style-guide.md`.
+
+## Epics in this book
+- `verified-reporters` — the count, the membership data, and the list page.
+
+## Provenance
+- **Mode:** PRD-backed
+- **Confidence at close:** (to be set at close)
+
+## Close artifacts *(filled by `/close-book`)*
+- Build audit: `engineering-team/audits/verified-reporters/audit.md`
+- Product feedback: `engineering-team/audits/verified-reporters/prd-addendum.md`

--- a/engineering-team/audits/verified-reporters/book.md
+++ b/engineering-team/audits/verified-reporters/book.md
@@ -1,9 +1,9 @@
 # Book of Work: Verified Reporters
 
 **Slug:** verified-reporters
-**Status:** Open
+**Status:** Closed
 **Opened:** 2026-06-07
-**Closed:** —
+**Closed:** 2026-06-07
 
 ## Intent anchor
 **PRD-backed** — `product-team/prd/verified-reporters.md` §8.1 (In Scope / MVP). Completion is *computed*: every story tracing to these sections is `Done` and the `verified-reporters` epic is closed.
@@ -15,7 +15,7 @@ The feature: a point-of-view-filtered "Verified Reporters" count on the user pro
 
 ## Provenance
 - **Mode:** PRD-backed
-- **Confidence at close:** (to be set at close)
+- **Confidence at close:** high — anchored to the PRD at kickoff; all three stories Done with PASS reviews; every shipped file traces to a story + ADR.
 
 ## Close artifacts *(filled by `/close-book`)*
 - Build audit: `engineering-team/audits/verified-reporters/audit.md`

--- a/engineering-team/audits/verified-reporters/prd-addendum.md
+++ b/engineering-team/audits/verified-reporters/prd-addendum.md
@@ -1,0 +1,47 @@
+# PRD Addendum: verified-reporters — Verified Reporters MVP
+
+**Reconciles:** `product-team/prd/verified-reporters.md` *(immutable — never edited)*
+**Build audit:** `engineering-team/audits/verified-reporters/audit.md`
+**Date:** 2026-06-07
+**Authored by:** engineering (Reviewer at book scope)
+
+> Stands beside the PRD; never edits it. Records where the built product diverged from the plan, why, and what the next product cycle should pick up. The product team reads this to scope the next phase, then issues a superseding `prd/verified-reporters-v2.md`.
+
+## 1. Summary
+The PRD set out the credible negative trust signal: a PoV-filtered Verified Reporters count on the profile, linking to a list of *which* verified users reported the account. All of §8.1 (the MVP) shipped and is reviewed-PASS: the count (parallel to Following/Verified Followers, negative-signal, designed zero/loading/unavailable states), the membership endpoint, and the list page. The headline divergence is about **point of view**: the *count* is per-viewer (as planned), but the *list membership* shipped **House/owner PoV only** — full per-viewer membership is the same customer-observer machinery the follows/followers features already deferred, and it is the main carry-forward. Two PoV-attribution and granularity items were deferred as the PRD itself anticipated.
+
+## 2. Deviations from the PRD
+
+### 2.1 Intentional changes
+- **List loading + error UX exceed the precedent.** The list page uses a skeleton loader and an error "Try again" retry (the hook gained a backward-compatible `refetch`), where the sibling follows/followers pages use a text loader and no retry. (PRD §5.2 asked for designed loading/error states; we went a step better.) Recommend the product model treat skeleton + retry as the standard for these list pages.
+- **PoV attribution line is honest about House.** Because list membership is House-only in v1 (see 2.4), the list's PoV line always reads as the House view rather than "your web of trust." This keeps the no-global-view principle truthful rather than cosmetic.
+
+### 2.2 Deferred (cut to a later phase)
+- **Personalized / customer PoV for the list membership** → next phase. The list and its endpoint resolve the House/owner PoV only. (The count remains per-PoV.) This is the biggest gap vs the PRD's "relative to who is looking" for the *list*.
+- **Counts-row PoV indicator** (the shared, tap-friendly marker for Following / Verified Followers / Verified Reporters) → **Phase 4**. No per-count PoV chip shipped; attribution lives on the list page only. (Already PRD §8.3 / §11 decision 5.)
+- **Report-type breakdown** → **Phase 2**; **pile-on resistance** → **Phase 3**; **self-view privacy controls** → **Phase 4** — all per the existing PRD roadmap, unchanged.
+
+### 2.3 Added beyond the PRD
+- None product-visible. (Internally, the data hook gained a `refetch` to serve the retry — an implementation detail, not a new product capability.)
+
+### 2.4 Constraints discovered
+- **"Effective PoV (personal-else-House)" is cheap for the count but expensive for the list.** The count is read from a precomputed, per-PoV Meili field; the *list* must be computed live from the graph, and a per-viewer verified set requires the per-customer trust-metrics traversal that the platform has repeatedly deferred. So the PRD's implicit assumption that the list is per-viewer the same way the count is does not hold in v1 — the list is House-PoV. **Implication for the product model:** treat per-viewer *membership* as its own scoped phase, distinct from the already-shipped per-viewer *count*.
+- **Count = list length is a steady-state/House guarantee, not real-time.** The profile count (precomputed Meili) and the list length (live graph) can differ transiently across a refresh. The list page shows its own live count to stay internally consistent. The PRD's success metric (count = list length) should be read as "consistent in steady state at House PoV," not "byte-identical to the profile badge at every instant."
+
+## 3. Impact on the product model
+- **Scope / roadmap:** add an explicit phase for **personalized-PoV membership** (the list/endpoint reading per-viewer trust), separate from the shipped per-viewer count. Keep the counts-row PoV indicator (Phase 4) and report-type/pile-on phases as planned.
+- **Domain model:** make explicit that the verified-reporter *count* and the verified-reporter *membership* come from two surfaces — a precomputed per-PoV metric vs a live House-PoV graph query — and that personalized membership depends on the customer trust-metrics structure.
+- **Design rules:** the PoV line should state House when the data is House (no false "your network" attribution); skeleton + retry are the list-page standard.
+- **Personas / journeys:** unchanged. The Cautious Newcomer's House-fallback experience is honored; the Vetting Observer with a *personal* network gets a personal count but a House list until the deferred phase ships — worth naming in the next journey pass.
+
+## 4. Recommended scope for the next phase
+Engineering's read — input, not decision:
+1. **Personalized-PoV membership** for `/reporters` (and, in parallel, followers) — the cleanest single step toward the PRD's full per-viewer vision (audit carry-forward #1).
+2. **Shared counts-row PoV indicator** across all three counts — small, cross-cutting, removes the one known glance-level attribution gap (#2).
+3. **DRY `<GrapevineList>` refactor** before piling on more list variants — three near-duplicate pages/endpoints now exist; consolidating also lets follows/followers inherit the skeleton + retry (#3).
+4. Then the planned **report-type breakdown** (Phase 2) and **pile-on resistance** (Phase 3).
+
+## 5. Open questions for product
+1. **Personalized-PoV membership priority:** is per-viewer list membership the next phase, or do report-type breakdown / pile-on resistance come first? — options: PoV-first / granularity-first.
+2. **House-view labeling:** is "Relative to the House (default) web of trust…" the right standing copy for logged-in users with a personal network (until personalized membership ships), or should the page suppress the list for them rather than show a House view? — options: show House + label / gate behind personalized PoV.
+3. **Count vs list-length expectation:** ratify "consistent in steady state at House PoV" (not real-time-identical to the profile badge) as the product's stated guarantee. — options: ratify / require real-time parity (would force the count off Meili onto a live query).

--- a/engineering-team/decisions/verified-reporters/0001-verified-reporters-count.md
+++ b/engineering-team/decisions/verified-reporters/0001-verified-reporters-count.md
@@ -1,0 +1,89 @@
+# ADR 0001: Verified Reporters count on the profile
+
+**Status:** Accepted
+**Date:** 2026-06-07
+**Story:** `engineering-team/stories/verified-reporters/1-verified-reporters-count.md`
+**Epic:** `verified-reporters`
+
+## Context
+
+Story 1 elevates the existing per-point-of-view verified-reporter count into a clickable, negative-signal count in the profile counts row, parallel to Following and Verified Followers, linking to `/user/:pubkey/reporters`.
+
+Acceptance criteria (quoted to confirm):
+1. A count labelled "Verified Reporters" appears in the counts row alongside Following and Verified Followers, computed under the viewer's effective point of view.
+2. When `> 0`, the value reads as a negative signal and the whole count links to `/user/:pubkey/reporters`.
+3. When exactly `0`, the value is neutral and is not a link.
+4. When unavailable / not computed, a placeholder ("—") is shown, not a link, distinct from a real zero.
+5. When loading, a dimmed/placeholder value is shown (no bare spinner).
+6. The count's accessible name states the number and that it opens the list.
+
+**What already exists (verified on `feat/verified-reporters`, off `staging`):**
+- `ui/src/pages/BrainstormProfile.jsx:236-248` — the `.bsp-counts` row already renders **Following** and **Verified Followers** as `.bsp-count.bsp-count-link` entries. Verified Followers links to `/user/:pubkey/followers` and its value rides `trustScores?.verifiedFollowerCount ?? trustScores?.followers`. **This resolves PRD §11 decision 1: Verified Reporters is a third count-link in this row.**
+- `BrainstormProfile.jsx:121-189` — a `useEffect` resolves the point of view (`?pov=` param, else the house `delegatedPubkey` prefix) and loads `/api/search/profiles/meili/document/:pubkey`, stripping `wot_` and the PoV suffix into a `trustScores` map. `verifiedReporterCount` is already one of those keys (it is in `TRUST_METRICS` at line 45 and renders today as a 🚩 "Reporters" trust card in the Reputation grid).
+- `BrainstormProfile.jsx:97` — `fmtCount(n)` returns `—` for `null`/`undefined`, else a localized number.
+- `ui/src/styles.css` — `--red: #f85149` (line 18); `.bsp-count-value` (3398, weight 600); `.bsp-counts-loading .bsp-count-value { opacity: .4 }` (3405); `.bsp-count-link` + hover underline (4150-4151).
+- Tests are **Playwright e2e** (`tests/brainstorm/profile-verified-followers-count.spec.js` is the direct precedent), selected by user-facing vocabulary, run against the Vite-built UI (`npm run build` in `ui/`).
+
+**Constraints:** JS-without-build (no new lint/typecheck). Design tokens only — no hex/px literals in components (use `--red`). Copy must come verbatim from `product-team/guides/verified-reporters-style-guide.md`. No concept-graph or schema change → **no firmware reinstall**.
+
+**No concept changes.** This story displays an existing data field. The concepts it relates to (`nostr-user`, `web-of-trust`, `graperank`; NIP-56 report = `nostr-event` kind 1984) are unchanged; the count value is read from the already-published Meili document, not computed here.
+
+## Options considered
+
+### Option A — Inline conditional count-link in `.bsp-counts`, value from `trustScores.verifiedReporterCount`
+Add a third entry to the existing counts row, mirroring the Following/Verified Followers pattern, but with state-dependent rendering (link only when `> 0`). Read the value from the already-fetched, PoV-resolved `trustScores`. Add two small token-based CSS modifiers (negative color; per-count loading dim).
+
+- **Pros:** Mirrors the established pattern in the same file; reuses data already fetched (no new network call, no new PoV resolution); smallest diff; tests slot directly alongside `profile-verified-followers-count.spec.js`; no route work bleeds into this story.
+- **Cons:** The reporters count renders differently from its always-link siblings (conditional link/neutral/placeholder), a slight asymmetry in the row.
+
+### Option B — Extract a shared `<ProfileCount>` component for all three counts
+Componentize the counts row, encapsulating the state logic and DRYing Following/Verified Followers/Verified Reporters.
+
+- **Pros:** Reusable; isolates the state machine; tidier long-term.
+- **Cons:** A refactor that touches the *working* Following and Verified Followers counts — regression risk for no functional gain in this story. The project has no component unit-test harness (tests are Playwright e2e), so the isolation/testability benefit is largely theoretical. Inconsistent with the current inline pattern. Out of proportion to a single-count story.
+
+### Option C — Source the value from a dedicated fetch / `useUserCounts`
+Drive the reporters value from `useUserCounts` (the `/api/get-user-counts` hook) or a new endpoint instead of `trustScores`.
+
+- **Cons:** `useUserCounts` is **owner-POV node properties** (its own docstring), not point-of-view-aware. The verified-reporter count is intrinsically per-PoV (namespaced `wot_verifiedReporterCount_<povSuffix>` in the Meili document). Sourcing it from `useUserCounts` would break AC1 (effective PoV) and contradict the whole premise. Reject — and this is precisely why `trustScores` is the correct source.
+
+## Decision
+
+We chose **Option A**. It reuses the exact pattern and the already-PoV-resolved data in `BrainstormProfile.jsx`, keeps the diff minimal and the regression surface near zero, and lands the tests right next to the Verified Followers precedent. Option B's refactor is deferred; Option C is wrong for a per-PoV metric.
+
+**Resolved story-internal tension (AC6 vs AC3):** AC6 ("accessible name states the number *and that it opens the list*") only applies to the actionable `> 0` state, because AC3 makes `0` a non-link. The `> 0` link carries `aria-label="{n} verified reporters. View list."`; the non-link states (`0`, `—`, loading) are self-describing through their visible text (value + "Verified Reporters" label), which a screen reader reads as e.g. "0 Verified Reporters". No "View list" is claimed where nothing opens.
+
+## Consequences
+
+- **Enables** Story 3's entry point and gives the primary persona the at-a-glance negative signal using data that already exists (no added network cost).
+- **Constrains:** introduces conditional rendering distinct from the always-link siblings; adds two small CSS modifiers.
+- **Deliberate non-change:** the existing `verifiedReporterCount` 🚩 trust card in the Reputation grid stays (Verified Followers already appears in both the count row and a trust card; removing trust cards is a separate cleanup, out of scope here).
+- **Known interim state:** the `/user/:pubkey/reporters` link target does not exist until Story 3; the link will 404 until then. Accepted per the story.
+- **Follow-ups:** the shared counts-row PoV indicator (deferred Phase 4); optional future componentization of the counts row (Option B).
+- **Firmware reinstall required?** No (no concept/schema change).
+
+## Implementation notes
+
+- **File: `ui/src/pages/BrainstormProfile.jsx`** — in the `.bsp-counts` block, after the Verified Followers `<Link>` (~line 247), add the Verified Reporters count. Derive the value where `trustScores` is in scope:
+  ```js
+  const verifiedReporterCount = trustScores?.verifiedReporterCount ?? null;
+  ```
+  Render by state (value source `trustScores`, governed by `trustLoading`/`trustError` — NOT `userCountsLoading`):
+  - `trustLoading` → non-link `<span className="bsp-count bsp-count-loading">` with value `—`, label `Verified Reporters`.
+  - else `trustError || verifiedReporterCount == null` → non-link `<span className="bsp-count">` with value `—` (via `fmtCount(null)`).
+  - else `verifiedReporterCount === 0` → non-link `<span className="bsp-count">` with neutral value `0`, label `Verified Reporters`.
+  - else (`> 0`) → `<Link to={`/user/${pubkey}/reporters`} className="bsp-count bsp-count-link" aria-label={`${verifiedReporterCount} verified reporters. View list.`}>` with `<span className="bsp-count-value bsp-count-value-negative">{fmtCount(verifiedReporterCount)}</span><span className="bsp-count-label">Verified Reporters</span>`.
+- **File: `ui/src/styles.css`** — add next to the existing count styles:
+  ```css
+  .bsp-count-value-negative { color: var(--red); }
+  .bsp-count-loading .bsp-count-value { opacity: 0.4; }
+  ```
+- **Copy (verbatim from the style guide):** label `Verified Reporters`; link `aria-label` `{n} verified reporters. View list.`.
+- **Do NOT** register the `/user/:pubkey/reporters` route or build the page (Story 3). **Do NOT** remove the existing Reporters trust card (out of scope).
+- **Build/test seam (for the Tester):** mirror `tests/brainstorm/profile-verified-followers-count.spec.js`. Selectors by vocabulary: link `role=link name=/verified reporters/i`, `href` matching `/\/user\/[0-9a-f]{64}\/reporters$/`, and `not target=_blank`. The count is PoV-dependent, so pin a `?pov=` (or rely on the house fallback) to get deterministic fixtures: a pubkey with `> 0` verified reporters (link + negative color), one with `0` (text "0", no link), one with no scores (`—`). UI must be built (`npm run build` in `ui/`) before the specs run.
+
+## Out of scope
+- The `/user/:pubkey/reporters` route and list page (Story 3).
+- The membership data behind the list (Story 2).
+- Any counts-row point-of-view indicator (deferred Phase 4).
+- Removing or restyling the existing trust cards; changing Following or Verified Followers.

--- a/engineering-team/decisions/verified-reporters/0002-verified-reporters-membership-data.md
+++ b/engineering-team/decisions/verified-reporters/0002-verified-reporters-membership-data.md
@@ -1,0 +1,80 @@
+# ADR 0002: Verified reporters membership data
+
+**Status:** Accepted
+**Date:** 2026-06-07
+**Story:** `engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.md`
+**Epic:** `verified-reporters`
+
+## Context
+
+Story 2 needs the *membership* behind the verified-reporter count: given an account and a point of view, the verified users who NIP-56-reported it, each with enough identity to display and weigh (AC1, AC2). The load-bearing requirement is **AC3 — the returned set size must equal the count shown for that account under the same point of view** (count = list length). AC4: no calculated PoV → House fallback. AC5: empty set on none. AC6: reject a bad account identifier.
+
+**How the count is actually computed (verified on this branch):**
+`src/algos/follows-mutes-reports/calculateVerifiedReporterCounts.sh:13-18`:
+```cypher
+MATCH (n:NostrUser)<-[f:REPORTS]-(m:NostrUser)
+WHERE m.influence > ${VERIFIED_REPORTERS_INFLUENCE_CUTOFF:-0.05}
+WITH n, count(f) AS verifiedReporterCount
+SET n.verifiedReporterCount = verifiedReporterCount
+```
+So a "verified report" is the Neo4j edge **`(reporter:NostrUser)-[:REPORTS]->(reported:NostrUser)`** where the **reporter's `influence` > `VERIFIED_REPORTERS_INFLUENCE_CUTOFF`** (House/owner GrapeRank, default 0.05). The result is written to `reported.verifiedReporterCount`, published to Meilisearch via kind-30382, and read by Story 1 as `wot_verifiedReporterCount_<povSuffix>` (`BrainstormProfile.jsx:155-166`).
+
+**The membership is the literal inverse of that count query** — return `m` (the reporters) instead of `count(f)`. Same edge, same cutoff, same `influence` source ⇒ `count(rows) === reported.verifiedReporterCount` at House PoV, by construction.
+
+**The PoV dimension (the deferral that this whole feature area already made):**
+- The House count uses `m.influence` (one GrapeRank per node).
+- A **personalized/customer** count (`src/algos/customers/calculateVerifiedReporterCounts.sh`) traverses a per-customer `NostrUserWotMetricsCard` with a per-customer `VERIFIED_REPORTERS_INFLUENCE_CUTOFF`. This is the same `NostrUserWotMetricsCard` / `?observer=<customer>` machinery that **ADR 0026 (follows) and ADR 0030 (followers) explicitly deferred** ("owner/House PoV only" for v1).
+
+**The count-vs-list reality (ADR 0030 already found this):** the profile count comes from **Meili** (precomputed, refreshed periodically via kind-30382); a membership endpoint is a **live Neo4j** query. Even at House PoV with the identical cutoff, the two are different *snapshots*, so they match in steady state but can transiently diverge across a refresh. ADR 0030 §Consequences documents exactly this for followers and told tests not to assume real-time equality.
+
+**Precedent to mirror:** follows = `GET /api/get-grapevine-follows` (`src/api/grapevineInteractions/queries/followsWithMetrics.js`, `handleGetGrapevineFollows`); followers = `GET /api/get-grapevine-followers` (ADR 0030) — an isolated, purpose-built endpoint with `isValidHexPubkey(observee)` → 400, a `NEO4J_QUERY_TIMEOUT_MS` deadline → 504, owner-only `observer` → 400, response `{ success, observer:'owner', observee, count, data }`, consumed by a `useGrapevine*` hook.
+
+Constraints: JS-without-build (no new lint/typecheck); honor the Neo4j deadline pattern; no concept-graph/firmware change (Concept Graph API not consulted for runtime Neo4j properties — these are node properties, not graph-concept nodes).
+
+## Scope decision to ratify (PoV): House/owner PoV for v1
+Story 2's AC1/AC3 say "under the viewer's point of view." The honest, precedent-consistent v1 is **House/owner PoV only**, deferring personalized/customer PoV exactly as follows/followers did. Under that scope: **AC4 (House fallback) is the v1 path and is fully met; AC1/AC3 hold at House PoV** (membership = inverse of the House count, count = list length in steady state). For a *personalized-PoV* viewer, Story 1's profile count (which can be a customer-PoV Meili value) and this House-PoV list can differ — a documented v1 limitation, the same divergence ADR 0030 accepted. This is flagged for the user to ratify at the gate (it scopes AC1/AC3); personalized-PoV membership is a named follow-up.
+
+## Options considered
+
+### Option A — New isolated endpoint, inverse-REPORTS traversal, House PoV *(chosen)*
+`GET /api/get-grapevine-reporters?observee=<pk>` — a sibling of `followsWithMetrics.js` / `followersWithMetrics.js`. Cypher: `MATCH (observee)<-[:REPORTS]-(reporter:NostrUser) WHERE reporter.influence > $cutoff RETURN reporter.{pubkey,influence,hops,verified*Count}`, `$cutoff` from `VERIFIED_REPORTERS_INFLUENCE_CUTOFF` (the **same** var the count algo uses). Whole verified set, no server ORDER BY/LIMIT; `{ success, observer:'owner', observee, count, data }` with `count === data.length`. New `useGrapevineReporters` hook for Story 3.
+- **Pros:** membership is the literal inverse of the count computation → AC3 holds at House PoV by construction (and the endpoint's own `count` always equals `data.length`); zero regression risk to live follows/followers (ADR 0026/0030 isolation precedent); same validation/deadline/shape as its siblings; verified-reporter sets are *small* (being reported by trusted users is rare — the feature's whole premise), so ADR 0030's mega-account scale worry barely applies.
+- **Cons:** a third near-duplicate endpoint/hook. Addressed: the DRY follow-up ADR 0030 already filed (`<GrapevineList>` + shared cypher builder) should absorb reporters too.
+
+### Option B — Generalize the follows/followers endpoint with an interaction-type param
+One endpoint serving follows / followers / reporters.
+- **Pros:** DRY now.
+- **Cons:** edits live, prod-shipped code (follows is on prod) — regression risk; ADR 0026/0030 deliberately rejected this for v1. Rejected for the same reason here; fold into the planned DRY refactor later, not now.
+
+### Option C — Personalized/customer per-PoV membership now
+Reproduce the per-customer `NostrUserWotMetricsCard` traversal so the list matches Story 1's PoV-namespaced count for *every* PoV.
+- **Pros:** AC3 would hold for personalized PoV too.
+- **Cons:** this is exactly the customer-observer complexity follows/followers deferred; high scope/risk, a `?observer=<customer>` selector and metrics-card traversal. Rejected for v1; named as the personalized-PoV follow-up.
+
+## Decision
+**Option A**, **House/owner PoV only for v1** (pending user ratification of the PoV scoping above). The membership endpoint is the inverse of the existing House count query, reusing `VERIFIED_REPORTERS_INFLUENCE_CUTOFF`, so `count = list length` holds at House PoV in steady state and the endpoint's own `count` equals `data.length` exactly. Personalized-PoV membership and the DRY refactor are follow-ups.
+
+## Consequences
+- **Enables** Story 3 (the list page) with data whose count matches the House-PoV count by construction.
+- **AC3 is exact within the capability** (`count === data.length`) and holds at House PoV vs the count algo (same edge + cutoff). **It is not a hard real-time guarantee vs Story 1's profile count**, which is precomputed in Meili: transient refresh-skew and personalized-PoV differences are possible — Story 3 should display *its own* (live) count as the list header so the page is internally consistent, and copy/tests must not assert real-time equality with the profile badge (mirrors ADR 0030).
+- **Personalized/customer PoV deferred** — for such viewers the profile count (personal) and this list (House) can differ. Named follow-up.
+- **Duplication → the existing DRY follow-up** (ADR 0030's `<GrapevineList>` + shared cypher builder) should later absorb follows/followers/reporters.
+- **Cutoff inconsistency** (the existing intake item: 0.01 vs 0.05 vs "score>2") is inherited, not fixed here — but using the *same* `VERIFIED_REPORTERS_INFLUENCE_CUTOFF` as the count algo is what makes count = list length hold.
+- **Firmware reinstall required?** No (no concept/schema change; runtime Neo4j properties only).
+
+## Implementation notes
+**Backend** — new `src/api/grapevineInteractions/queries/reportersWithMetrics.js` exporting `handleGetGrapevineReporters(req, res)`, a near-copy of `followsWithMetrics.js` with:
+- Cypher: `MATCH (observee:NostrUser {pubkey:$observee})<-[:REPORTS]-(reporter:NostrUser) WHERE reporter.influence > $cutoff RETURN reporter.pubkey AS pubkey, reporter.influence AS influence, reporter.hops AS hops, reporter.verifiedFollowerCount AS verifiedFollowerCount, reporter.verifiedMuterCount AS verifiedMuterCount, reporter.verifiedReporterCount AS verifiedReporterCount`. **No server ORDER BY/LIMIT** — return the whole verified set (Story 3 sorts/paginates client-side, like follows).
+- `$cutoff` from `getConfigFromFile('VERIFIED_REPORTERS_INFLUENCE_CUTOFF', 0.05)` — the **same** variable `calculateVerifiedReporterCounts.sh` uses (NOT the followers cutoff). This is the AC3 invariant; call it out in code.
+- Same `isValidHexPubkey(observee)` → 400 (AC6), owner-only `observer` → 400, `NEO4J_QUERY_TIMEOUT_MS` deadline → 504 with `{success:false}`, `toInt`/`toFloat` parsing, and `{ success:true, observer:'owner', observee, count, data }` response shape (`count === data.length`, AC3/AC5; empty `data:[]` is a normal 200, not an error).
+- Register in `src/api/index.js` next to the follows/followers routes: `app.get('/api/get-grapevine-reporters', handleGetGrapevineReporters)` + import.
+
+**Frontend** — new `ui/src/hooks/useGrapevineReporters.js`, mirroring `useGrapevineFollows.js` (raw `fetch` + AbortController) against `/api/get-grapevine-reporters?observee=<pk>`. (The page that consumes it is Story 3 — not built here.)
+
+## Out of scope
+- The list page UI/route `/user/:pubkey/reporters` and the count→behavior — Story 3 / Story 1 (done).
+- **Personalized / customer PoV** membership (the `NostrUserWotMetricsCard` traversal) — deferred, named follow-up (mirrors ADR 0026/0030).
+- Splitting by NIP-56 report type (Phase 2); pile-on discounting (Phase 3).
+- The DRY `<GrapevineList>` / shared-cypher refactor — the existing ADR 0030 follow-up, later.
+- Fixing the verified-influence-cutoff inconsistency — existing intake item, untouched.
+- Changing follows/followers endpoints or the `[:REPORTS]` ingestion.

--- a/engineering-team/decisions/verified-reporters/0003-verified-reporters-list-page.md
+++ b/engineering-team/decisions/verified-reporters/0003-verified-reporters-list-page.md
@@ -1,0 +1,66 @@
+# ADR 0003: Verified Reporters list page
+
+**Status:** Accepted
+**Date:** 2026-06-07
+**Story:** `engineering-team/stories/verified-reporters/3-verified-reporters-list-page.md`
+**Epic:** `verified-reporters`
+
+## Context
+
+Story 3 (final) adds `/user/:pubkey/reporters` — a table of an account's verified reporters, the link target of Story 1's count and the consumer of Story 2's data. ACs: title "Verified Reporters" + back link + description; columns picture/name/Rank sorted by Rank desc; row → reporter profile; row count == the count under the same (House) PoV; a visible PoV line + "About this data" popover; designed empty/loading(skeleton)/error(+retry) states.
+
+**This is a deliberate mirror of an existing, shipped page.** Verified facts on this branch (off `staging`):
+- `ui/src/pages/BrainstormFollowers.jsx` (237 lines) is the closest precedent — the "verified <relationship>" list (ADR 0030): `DataTable` + client sort/search/pagination, `loadVisible()`/localStorage column prefs (`STORAGE_KEY = 'bsp-followers-columns'`), the `InfoPopover` ("computed locally … not NIP-85"), `← Back to profile`, row→`/user/${row.pubkey}`, name/rank/npub derivation (`rank = Math.round(f.influence*100)`), `/api/profiles` batching at `PROFILE_CHUNK = 50`. It sorts by `verifiedFollowerCount` desc and uses a text loader (`Loading followers…`) and an error block with no retry.
+- The data hook `ui/src/hooks/useGrapevineReporters.js` already exists (Story 2) and returns `{ data, loading, error }` from `GET /api/get-grapevine-reporters?observee=<pk>`.
+- Routes live in `ui/src/App.jsx:86-91` (`/user/:pubkey/follows` → `BrainstormFollows`, `/user/:pubkey/followers` → `BrainstormFollowers`).
+- Story 1 already links the profile count to `/user/${pubkey}/reporters` (`BrainstormProfile.jsx`); the route is currently unbuilt (404) until this story.
+- Copy is fixed by `product-team/guides/verified-reporters-style-guide.md` (canonical table).
+
+Constraints: JS-without-build (no new lint/typecheck); tokens only; no concept-graph/firmware change. House/owner PoV only for v1 (ADR 0002).
+
+## Options considered
+
+### Option A — Mirror BrainstormFollowers.jsx → a new BrainstormReporters.jsx *(chosen)*
+A near-copy with bounded deltas (below), reusing `DataTable`, `InfoPopover`, and the `bsp-*` classes; new route; consume the existing `useGrapevineReporters` hook.
+- **Pros:** exactly mirrors the ADR 0026/0030 isolation precedent — zero regression risk to the live follows/followers pages; ships parity fast; the new copy/states live in one isolated file.
+- **Cons:** a third near-duplicate page (follows/followers/reporters). Addressed: this is now the strongest argument for the already-filed DRY follow-up (a shared `<GrapevineList>` + cypher builder, ADR 0030) — but that refactor stays a follow-up, not bundled here.
+
+### Option B — Extract a shared `<GrapevineList>` component now (DRY all three)
+- **Pros:** cleanest long-term DRY.
+- **Cons:** refactors the live follows/followers pages (regression risk + scope creep well beyond "add the reporters page"). Rejected for v1 — exactly as ADR 0026/0030 rejected it; it's the right follow-up once all three pages are stable.
+
+### Option C — Generalize an existing page with an interaction-type param
+- **Cons:** edits live, prod-adjacent pages; rejected for the same reason as Option B.
+
+## Decision
+**Option A** — a new isolated `BrainstormReporters.jsx`, mirroring `BrainstormFollowers.jsx`, with the deltas listed below, House/owner PoV only for v1. Deferred: the DRY refactor (now clearly warranted — note it) and personalized PoV.
+
+## Consequences
+- **Completes the feature end to end** — the count (Story 1) now links to a real page backed by real data (Story 2).
+- **Honest House-PoV attribution.** Because membership is House-only in v1 (ADR 0002), the list a viewer sees is always the House view. So the PoV line is the **House line, always** — showing "Relative to your web of trust" would misattribute a House-PoV list. The personal-PoV line ships with personalized membership (deferred). This keeps the no-global-view principle truthful rather than cosmetic.
+- **count = list length** is the page's own live row count (from the hook), never the precomputed Meili profile badge — so no real-time-equality coupling (per ADR 0002/0030).
+- **Third near-duplicate page** → strengthens the DRY follow-up (ADR 0030's `<GrapevineList>`); still deferred.
+- **Scale:** verified-reporter sets are expected small (being reported by trusted users is rare — the feature's premise), so ADR 0030's mega-account whole-set-fetch concern barely applies; the same Neo4j 504 guard is inherited via the Story-2 endpoint. No special handling.
+- **Firmware reinstall required?** No.
+
+## Implementation notes
+**New file `ui/src/pages/BrainstormReporters.jsx`** — copy `BrainstormFollowers.jsx`, then apply these deltas (everything else identical):
+1. **Hook:** import and use `useGrapevineReporters(pubkey)` (not followers).
+2. **localStorage key:** `STORAGE_KEY = 'bsp-reporters-columns'` (distinct, so it doesn't clobber follows/followers prefs).
+3. **Title:** `Verified Reporters`.
+4. **Description line (new):** under the title, render `Verified users who have reported this account.` (style guide). Followers has no description — this is added.
+5. **PoV line (new):** a visible line below the description. **v1: always the House line** — `Relative to the House (default) web of trust. Sign in and build your network to see your own view.` (style guide). (The personal line `Relative to your web of trust.` is reserved for when personalized membership ships.)
+6. **"About this data" popover (extended):** keep the existing local/NIP-85 sentence and add the style guide's second paragraph: `Counts are personal to each viewer's web of trust. There is no single global number. When you have no calculated web of trust, the House (default) view is shown.`
+7. **Default sort:** by **`rank` descending** (`(b.rank ?? -1) - (a.rank ?? -1)`), where `rank = Math.round(influence*100)` — deliberately different from followers' `verifiedFollowerCount` sort (most credible reporters first).
+8. **Empty state:** `No verified reporters. No one in this web of trust has reported this account.` (style guide).
+9. **Loading (skeleton, not text):** replace the `Loading followers…` text with a skeleton — a few placeholder rows. Add minimal token-based CSS to `ui/src/styles.css` (e.g. `.bsp-skeleton-row { height: 2.25rem; border-radius: 6px; background: linear-gradient(90deg, rgba(255,255,255,.04), rgba(255,255,255,.09), rgba(255,255,255,.04)); background-size: 200% 100%; animation: bsp-shimmer 1.2s infinite; }` + `@keyframes bsp-shimmer`). This honors AC7 / the design guide (the precedent's text loader is the one place we intentionally improve).
+10. **Error (+ retry):** show the style guide error copy `Couldn't load reporters. Trust scores may still be computing for this view. Try again in a moment.` with a `Try again` button (reuse the existing `.bsp-trust-unavailable` 🔒 block; add a retry button). Wire retry by a **backward-compatible addition to `ui/src/hooks/useGrapevineReporters.js`**: return a `refetch` (e.g. a `reload()` that bumps an internal nonce in the effect dep) alongside `{ data, loading, error }`; the button calls it. (Additive — does not change the existing return contract; the only edit to a Story-2 file, in-scope for the retry AC.)
+11. **Columns / rows / search / `/api/profiles` batching / row→profile nav:** unchanged from `BrainstormFollowers.jsx` (same `ALL_COLUMNS`, `DEFAULT_VISIBLE`, `PROFILE_CHUNK = 50`, `onRowClick → navigate('/user/'+row.pubkey)`). The page's live count is `rows.length` (never the Meili badge).
+
+**Route:** add to `ui/src/App.jsx` after the followers route (`:90-91`): `{ path: '/user/:pubkey/reporters', element: <BrainstormReporters /> }` + the import. (Vite build — `npm run build` in `ui/` to reflect.)
+
+## Out of scope
+- The profile count + link (Story 1) and the endpoint/data (Story 2) — consumed, not rebuilt.
+- **Personalized/customer PoV** and the personal-PoV line — deferred (ADR 0002).
+- The DRY `<GrapevineList>` refactor — the existing ADR 0030 follow-up.
+- Report-type split (Phase 2); pile-on (Phase 3); changing follows/followers pages or the profile counts.

--- a/engineering-team/epics/verified-reporters.md
+++ b/engineering-team/epics/verified-reporters.md
@@ -1,0 +1,25 @@
+# Epic: Verified Reporters
+
+**Status:** Active
+**Book:** `engineering-team/audits/verified-reporters/book.md` (PRD-backed)
+**Source PRD:** `product-team/prd/verified-reporters.md`
+**Guides:** `product-team/guides/verified-reporters-design-guide.md`, `verified-reporters-style-guide.md` (+ `verified-reporters-wireframes.html`)
+
+## What this is
+The credible negative trust signal on the profile: a point-of-view-filtered count of the *verified* users (inside the viewer's web of trust) who have NIP-56-reported the observed account, plus a list of exactly who they are. The mirror of Verified Followers, swapping the follow relationship for the report relationship. Point of view is intrinsic: the number differs per viewer, with a House (default) fallback when the viewer has no calculated web of trust.
+
+## Stories
+`stories/verified-reporters/` — dependency-ordered (see `product-team/stories-queue.md`):
+
+1. **verified-reporters-count** — elevate the existing per-PoV count into a clickable, negative-signal count in the profile counts row, linking to the list. *(this story; uses data that already exists)*
+2. **verified-reporters-membership-data** — the net-new data capability: the identities of the verified reporters under the viewer's PoV (so the list and count agree). *(queued)*
+3. **verified-reporters-list-page** — the `/user/:pubkey/reporters` page, mirroring the follows list, sorted by Rank desc, with PoV attribution. *(queued; depends on #2)*
+
+## ADRs
+`decisions/verified-reporters/` — none yet.
+
+## Related
+- The `profile` epic (story 29, `profile-follows-list`) established the follows list + `DataTable` + "About this data" pattern this epic mirrors for the reporters list.
+
+## Deferred (later phases, not this epic)
+Report-type breakdown (Phase 2); pile-on resistance (Phase 3); self-view privacy controls, web-of-trust education, and the shared counts-row PoV indicator (Phase 4); moderator / transaction-vetting surfaces (Phase 5).

--- a/engineering-team/reviews/verified-reporters/1-verified-reporters-count.md
+++ b/engineering-team/reviews/verified-reporters/1-verified-reporters-count.md
@@ -1,0 +1,66 @@
+# Review: Story verified-reporters #1 — Verified Reporters count on the profile
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-07
+**Diff:** `git diff staging...HEAD` — implementation commit `c3a0c8cb` (ui/src/pages/BrainstormProfile.jsx, ui/src/styles.css)
+**Story:** `engineering-team/stories/verified-reporters/1-verified-reporters-count.md`
+**ADR:** `engineering-team/decisions/verified-reporters/0001-verified-reporters-count.md`
+**Test plan:** `engineering-team/stories/verified-reporters/1-verified-reporters-count.test-plan.md`
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **PASS.** The `profile-verified-reporters-count` suite reports PASS (11 passed, 0 failed): T1–T8 (one per AC) green, R1–R3 (regression sentinels) green. Overall runner: **PASS** (no other suite regressed).
+- [x] `npm run test:playwright` — **not run in review (by design).** `tests/brainstorm/profile-verified-reporters-count.spec.js` is supplementary and live-data-dependent; its own header marks it "not run pre-implementation … exercised at the staging smoke." The deterministic gate is the node suite above. Browser/visual verification (the `>0` red-link state) is the staging smoke, matching the Verified Followers precedent.
+- [x] Vite build — UI compiles (`npm run build` in `ui/`, confirmed at implementation; the source-regex suite cannot catch a JSX syntax error, the build can).
+- [x] _Lint not configured — skipped._
+- [x] _Typecheck not configured — skipped._
+
+## Spec adherence
+- [x] Every acceptance criterion has a passing test.
+  - AC1 (label, parity, effective PoV) → T1 (3rd `bsp-count-label` reading "Verified Reporters"), T2 (`trustScores?.verifiedReporterCount`); `BrainstormProfile.jsx:97,248-269`.
+  - AC2 (`>0` → negative signal + link) → T3 (`/user/${pubkey}/reporters` + 3rd `bsp-count-link`), T4 (`bsp-count-value-negative` + `--red`); `BrainstormProfile.jsx:253-261`, `styles.css:3409-3411`.
+  - AC3 (`0` → neutral, not a link) → T5; the else-branch renders a `<span>` (not a `<Link>`), `fmtCount(0)`→"0"; `BrainstormProfile.jsx:262-267`.
+  - AC4 (unavailable → "—", not a link) → T6; `verifiedReporterCount` null ⇒ else-branch ⇒ `fmtCount(null)`→"—".
+  - AC5 (loading → dimmed placeholder) → T7; `bsp-count-loading` on the span when `trustLoading`, `styles.css:3413-3415` opacity 0.4.
+  - AC6 (accessible name) → T8; `aria-label={\`${verifiedReporterCount} verified reporters. View list.\`}`, `BrainstormProfile.jsx:256`.
+- [x] No criterion silently dropped.
+- [x] No behavior added beyond the story.
+
+## ADR adherence
+- [x] Files changed match ADR 0001 implementation notes exactly (BrainstormProfile.jsx + styles.css; value from `trustScores`; two token-based CSS modifiers).
+- [x] Option A honored — reuses the already-fetched, PoV-resolved `trustScores`; no new fetch, no new component, no `useUserCounts` (the ADR's rejected Option C).
+- [x] **Deliberate non-changes all honored:**
+  - `/user/:pubkey/reporters` route NOT registered (diff touches only the two files; App.jsx untouched) — correct, that's story #3.
+  - Existing `verifiedReporterCount` 🚩 "Reporters" trust card retained (R3 green; `TRUST_METRICS` intact).
+  - Following and Verified Followers counts untouched (R1/R2 green; only the section comment changed).
+- [x] No new dependencies. Tokens only — `var(--red)`, no hardcoded hex/px.
+- [x] **Logged deviation reviewed and accepted:** the ADR's four display states are implemented as a 2-branch ternary (`>0 ? <Link> : <span>`), with `fmtCount(null)`→"—" covering loading+unavailable and the `bsp-count-loading` dim added only when `trustLoading`. Observable behavior is identical to the ADR's four states; the simplification is faithful and is logged under the story's `## Deviations`.
+
+## Concept-graph integrity
+- [x] N/A — no concept/schema change (a pure front-end display of an existing data field). No firmware reinstall required (matches ADR). No BIBLE.md re-derivation.
+
+## Things tests can't catch
+- [x] No secrets in committed files.
+- [x] No leftover debug logging / `console.log`; comments are explanatory and appropriate.
+- [x] No commented-out code.
+- [x] Edge cases handled: `null > 0` is false → falls to the neutral/unavailable branch; on `trustError`, `trustScores` is null so the counter renders a plain "—" non-link (the ADR's error state, reached cleanly without an explicit `trustError` reference); loading "—" is dimmed while unavailable "—" is not — the two are visually distinct as AC4/AC5 require.
+- [x] No concurrency concerns (render-only, derived from existing state).
+- [x] Security: no new input boundary; the value is read-only display of already-fetched data; `pubkey` interpolated into the route is the same already-validated param used by the sibling count-links.
+- [x] No scope creep — only the two files, exactly the story.
+
+## House rules check
+- [x] Concept Graph API authority respected (no concept work).
+- [x] No new lint/typecheck/build tooling.
+- [x] Style-guide copy verbatim: label "Verified Reporters"; aria-label "{n} verified reporters. View list." No banned phrases; the count surface carries no emoji (the glyph ruling applies to the trust card, untouched here).
+
+## Findings
+
+### Blocking
+None.
+
+### Non-blocking
+1. **`ui/src/pages/BrainstormProfile.jsx:237,262-267`** — during the window where `userCounts` has loaded but `trustScores` is still loading, the row-level dim (`bsp-counts-loading`) is gated on `userCountsLoading`, so Following renders normal, Verified Followers renders a plain "—" (it has no loading treatment), and Verified Reporters renders a *dimmed* "—". The slight inconsistency between the two trust-sourced counts is pre-existing (Verified Followers shipped without a loading state) and the Reporters loading dim is exactly what AC5 mandated. Optional future harmonization belongs with the deferred shared-counts-row work (PRD §8.3), not this story.
+2. **`ui/src/pages/BrainstormProfile.jsx:252`** — `verifiedReporterCount > 0` relies on the value being numeric; if the Meili document ever returned it as a string, JS coercion would still behave correctly and `fmtCount` coerces too. This mirrors the existing Verified Followers counter's assumption, so it is consistent with the codebase, not a new risk.
+
+## Verdict
+**PASS** — the diff matches the story's six acceptance criteria, conforms to ADR 0001 (including every deliberate non-change), the logged deviation is faithful, the deterministic gate is green (11/11), and there are no blocking issues. Browser/visual confirmation of the `>0` state is the staging smoke (the supplementary Playwright spec), per the established two-tier convention.

--- a/engineering-team/reviews/verified-reporters/2-verified-reporters-membership-data.md
+++ b/engineering-team/reviews/verified-reporters/2-verified-reporters-membership-data.md
@@ -1,0 +1,57 @@
+# Review: Story verified-reporters #2 — Verified reporters membership data
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-07
+**Diff:** `git diff staging...HEAD` — implementation commit `94c62a48` (src/api/grapevineInteractions/queries/reportersWithMetrics.js [new], src/api/index.js, ui/src/hooks/useGrapevineReporters.js [new])
+**Story:** `engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.md`
+**ADR:** `engineering-team/decisions/verified-reporters/0002-verified-reporters-membership-data.md`
+**Test plan:** `engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.test-plan.md`
+
+## Quality gates (run by reviewer, not trusted)
+- [x] `npm test` — **PASS.** `verified-reporters-membership-data` suite: PASS (12 passed, 0 failed) — T1–T10 (ACs + endpoint contract) green, R1–R2 (follows untouched) green. Overall runner: **PASS** (no other suite regressed).
+- [x] Vite build — `ui/` compiles (the new hook), confirmed at implementation.
+- [x] Live endpoint smoke — **not run in review (by design).** A meaningful count=list-length / verified-filter check needs the Docker stack with real `[:REPORTS]` data and an account with verified reporters; that is the staging smoke / Story 3 page exercise. The in-capability invariant (`count === data.length`) is enforced in code and asserted by T4.
+- [x] _Lint / typecheck / build gates not configured — skipped._
+
+## Spec adherence
+- [x] AC1 (verified reporters under PoV; unverified excluded) — `reportersWithMetrics.js:88-90` `MATCH (observee)<-[:REPORTS]-(reporter) WHERE reporter.influence > $cutoff`. T3/T6.
+- [x] AC2 (identifier + Rank/credibility per reporter) — RETURN `pubkey, influence, hops, verified{Follower,Muter,Reporter}Count` (`:91-96`); mapped at `:100-107`. T5.
+- [x] AC3 (set size == count under same PoV) — cutoff is `VERIFIED_REPORTERS_INFLUENCE_CUTOFF` (`:78`), the **same** var the count algo uses; response `count: data.length` (`:114`). T4 (and its copy-paste guard against the followers cutoff). Holds at House PoV / within the capability; transient divergence vs the Meili profile badge is documented and acceptable (ADR 0002 / ADR 0030).
+- [x] AC4 (no PoV → House fallback) — owner/House is the only/default path; non-owner `observer` → 400 (`:65-70`). T6.
+- [x] AC5 (no reporters → empty set, not error) — `MATCH … WHERE` yields zero rows → `data:[]`, `count:0`, HTTP 200 (`:98-116`). T7.
+- [x] AC6 (bad account id → clear error) — `isValidHexPubkey` + `nip19.npubEncode` round-trip → 400 (`:49-60`). T2.
+- [x] No criterion silently dropped; no behavior beyond the story.
+
+## ADR adherence
+- [x] Option A — a new isolated endpoint (`reportersWithMetrics.js`), new route, new hook. No generalization of live code (Option B) and no customer-PoV traversal (Option C).
+- [x] Inverse-REPORTS Cypher with the verified filter, reusing the reporters cutoff via `getConfigFromFile` — exactly as ADR §Impl specified.
+- [x] Response shape `{ success, observer:'owner', observee, count, data }` (`:110-116`); `observer:'owner'` literal (`:112`).
+- [x] `NEO4J_QUERY_TIMEOUT_MS` driver deadline → 504 `{success:false}` (`:76, 96, 120-127`).
+- [x] **Deliberate non-changes honored:** `followsWithMetrics.js` and `followersWithMetrics.js` not edited (diff: `index.js` only adds one import + one `app.get`); `/user/:pubkey/reporters` route NOT registered and no list page built (those are Story 3).
+- [x] No new dependencies (`neo4j-driver`, `nostr-tools`, `getConfigFromFile` all pre-existing).
+
+## Concept-graph integrity
+- [x] N/A — runtime Neo4j node properties + the `[:REPORTS]` edge, not graph-concept nodes. No schema/concept change. No firmware reinstall (matches ADR).
+
+## Things tests can't catch
+- [x] Security: `observee` is validated (64-hex + npub round-trip) before any query; the Cypher is fully parameterized (`$observee`, `$cutoff`) — no injection vector. `observer` is checked against an allowlist (`'owner'` / owner pubkey).
+- [x] Resource cleanup: `session.close()` + `driver.close()` in `finally` (`:131-134`).
+- [x] No secrets; the `console.error` calls are legitimate error logging (mirroring the follows handler), not debug cruft. No commented-out code.
+- [x] Edge: empty result is a normal 200 (verified above). Timeout → 504. Other errors → 500.
+- [x] No scope creep — exactly the three files.
+
+## House rules check
+- [x] Concept Graph API authority respected (no concept work).
+- [x] No new lint/typecheck/build tooling.
+
+## Findings
+
+### Blocking
+None.
+
+### Non-blocking
+1. **`reportersWithMetrics.js:108` — `.filter(row => row.pubkey)` is a harmless carryover.** In `followsWithMetrics.js` this filter drops the single null-pubkey row that an `OPTIONAL MATCH` emits when the observee follows no one. This handler uses a plain `MATCH … WHERE` (no `OPTIONAL`), so every row already has a reporter with a pubkey and the filter never removes anything. It's defensive and harmless — optional cleanup, not a bug.
+2. **`reportersWithMetrics.js:80` — a Neo4j driver is created per request** (then closed in `finally`). This is the *existing* pattern inherited verbatim from `followsWithMetrics.js`, not introduced by this story; flagging only for awareness. A shared long-lived driver is a repo-wide optimization that belongs with the eventual DRY `<GrapevineList>`/endpoint refactor (ADR 0030 follow-up), not here.
+
+## Verdict
+**PASS** — the diff satisfies all six acceptance criteria, conforms to ADR 0002 (Option A, the inverse-REPORTS query, the reporters cutoff, the response shape, the deadline, and every deliberate non-change), the deterministic gate is green (12/12), and there are no blocking issues. The two non-blocking notes are a harmless carryover and a pre-existing pattern. Live count=list-length verification is the staging smoke / Story 3, as designed.

--- a/engineering-team/reviews/verified-reporters/3-verified-reporters-list-page.md
+++ b/engineering-team/reviews/verified-reporters/3-verified-reporters-list-page.md
@@ -1,0 +1,58 @@
+# Review: Story verified-reporters #3 — Verified Reporters list page
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-07
+**Diff:** `git diff staging...HEAD` — implementation commit `37c9cf78` (ui/src/pages/BrainstormReporters.jsx [new], ui/src/hooks/useGrapevineReporters.js, ui/src/styles.css, ui/src/App.jsx)
+**Story:** `engineering-team/stories/verified-reporters/3-verified-reporters-list-page.md`
+**ADR:** `engineering-team/decisions/verified-reporters/0003-verified-reporters-list-page.md`
+**Test plan:** `engineering-team/stories/verified-reporters/3-verified-reporters-list-page.test-plan.md`
+
+## Quality gates (run by reviewer, not trusted)
+- [x] `npm test` — **PASS.** `verified-reporters-list-page` suite: PASS (17 passed, 0 failed) — T1–T14 (ACs + deltas) green, R1–R3 (follows/followers intact) green. Overall runner: **PASS** (no other suite regressed).
+- [x] Vite build — `ui/` compiles, confirmed at implementation.
+- [x] `npm run test:playwright` — not run in review (supplementary, live-data; staging smoke). The deterministic gate is the node suite.
+- [x] _Lint / typecheck / build gates not configured — skipped._
+
+## Spec adherence
+- [x] AC1 — route `/user/:pubkey/reporters` → `BrainstormReporters` (`App.jsx`); page title "Verified Reporters", back link to `/user/${pubkey}`, description "Verified users who have reported this account." (`BrainstormReporters.jsx` header + `bsp-follows-subtitle`). T1–T3.
+- [x] AC2 — columns picture/name/Rank default; `rank = Math.round(influence*100)`; **default sort Rank desc** `(b.rank ?? -1) - (a.rank ?? -1)` (not verifiedFollowerCount). T4/T5.
+- [x] AC3 — `onRowClick={row => navigate(\`/user/${row.pubkey}\`)}`. T6.
+- [x] AC4 — rows come from `useGrapevineReporters`; the page's count is its own live `rows.length`, never the Meili profile badge (per ADR 0002/0003). T3.
+- [x] AC5 — House PoV line `Relative to the House (default) web of trust. …` (honest: v1 membership is House-only); "About this data" popover extended with "There is no single global number." T7/T8.
+- [x] AC6 — empty state "No verified reporters. No one in this web of trust has reported this account." T9.
+- [x] AC7 — loading renders a skeleton (`bsp-skeleton-row` ×4 with `aria-label="Loading reporters"`, `@keyframes bsp-shimmer`), not a bare spinner; error shows the style-guide copy + a "Try again" button wired to the hook's new `refetch`. T10–T12.
+- [x] No criterion dropped; no behavior beyond the story.
+
+## ADR adherence
+- [x] Option A — new `BrainstormReporters.jsx` mirroring `BrainstormFollowers.jsx`; reuses `DataTable`, `InfoPopover`, `bsp-*` classes, client sort/search/pagination, localStorage prefs (distinct key `bsp-reporters-columns`), `/api/profiles` batching at `PROFILE_CHUNK = 50`. T13/T14.
+- [x] `refetch` added to `useGrapevineReporters` as a **backward-compatible** change: still returns `{data, loading, error}` plus `refetch`; `reloadNonce` added to the effect deps (verified in the hook diff). No other consumer exists yet, so no breakage.
+- [x] Skeleton + subtitle/pov CSS added to `styles.css` (token/rem/opacity conventions consistent with the file); no hardcoded hex.
+- [x] **Deliberate non-changes honored:** `BrainstormFollowers.jsx` and `BrainstormFollows.jsx` are untouched by the entire branch (confirmed via `git diff --name-only`); R1 (follows/followers routes intact), R2/R3 (followers page + its verifiedFollowerCount sort intact) all green.
+- [x] No new dependencies. House/owner PoV only (v1); personalized PoV + the DRY refactor deferred per the ADR.
+
+## Concept-graph integrity
+- [x] N/A — front-end page over the Story-2 endpoint; no concept/schema change, no firmware reinstall.
+
+## Things tests can't catch
+- [x] State branches are mutually exclusive and correctly ordered (loading → skeleton; error&&!loading → error; !loading&&!error&&empty → empty; else → table). No double-render.
+- [x] A11y: the skeleton carries `aria-label="Loading reporters"` (not a contentless spinner); the ⓘ button has an aria-label; the back link and rows are keyboard-navigable (inherited).
+- [x] Security: `pubkey` comes from `useParams`; the endpoint validates `observee`; no new injection surface. No secrets, no `console.log`, no commented-out code.
+- [x] count=list-length is the page's own live `rows.length` — not coupled to the precomputed Meili badge (transient divergence acceptable, ADR 0002/0030).
+- [x] Scope: exactly the 4 files; nothing else touched.
+
+## House rules check
+- [x] Concept Graph API authority respected (no concept work).
+- [x] No new lint/typecheck/build tooling.
+- [x] Style-guide copy used verbatim (title, description, PoV line, empty, error, popover); no banned phrases; glyphs (🔒 ⓘ) are inherited iconography.
+
+## Findings
+
+### Blocking
+None.
+
+### Non-blocking
+1. **`BrainstormReporters.jsx` — the "Try again" button reuses `className="bsp-follows-colbtn"`** (the Columns-toggle button style) rather than a dedicated retry class. Harmless visual reuse with zero new CSS; an optional future polish (a `.bsp-retry-btn`), not required.
+2. **Initial-mount empty-state flash (inherited pattern).** Before the hook's effect sets `loading=true`, there is a render with `loading=false / reporters=null`; React batches the effect so it should not visibly flash, and this is identical to the shipped `BrainstormFollowers`/`BrainstormFollows` pages — not introduced here. Noted for awareness; belongs to the eventual shared-`<GrapevineList>` refactor if ever addressed.
+
+## Verdict
+**PASS** — the diff satisfies all seven acceptance criteria, conforms to ADR 0003 (mirror, Rank-desc sort, verbatim copy, skeleton, error+retry via a backward-compatible `refetch`, House-PoV honesty, own-live-count), keeps the follows/followers pages untouched, and the gate is green (17/17). The two non-blocking notes are a harmless class reuse and an inherited pattern. This completes the verified-reporters MVP end to end.

--- a/engineering-team/stories/verified-reporters/1-verified-reporters-count.md
+++ b/engineering-team/stories/verified-reporters/1-verified-reporters-count.md
@@ -43,6 +43,6 @@ Testable from the outside. Each gets at least one test.
 
 ## Linked artifacts
 - PRD: `product-team/prd/verified-reporters.md` (§5.1, §5.3, §11); design guide `product-team/guides/verified-reporters-design-guide.md`; style guide `product-team/guides/verified-reporters-style-guide.md` (canonical copy — use the count label and accessible-name strings verbatim).
-- ADR: (filled in after Architecture phase)
+- ADR: `engineering-team/decisions/verified-reporters/0001-verified-reporters-count.md` (Accepted)
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/verified-reporters/1-verified-reporters-count.md
+++ b/engineering-team/stories/verified-reporters/1-verified-reporters-count.md
@@ -1,6 +1,6 @@
 # Story 1: Verified Reporters count on the profile
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-07
 **Type:** Feature
 **Epic:** `verified-reporters` · **Book:** `engineering-team/audits/verified-reporters/book.md`
@@ -48,4 +48,4 @@ Testable from the outside. Each gets at least one test.
 - PRD: `product-team/prd/verified-reporters.md` (§5.1, §5.3, §11); design guide `product-team/guides/verified-reporters-design-guide.md`; style guide `product-team/guides/verified-reporters-style-guide.md` (canonical copy — use the count label and accessible-name strings verbatim).
 - ADR: `engineering-team/decisions/verified-reporters/0001-verified-reporters-count.md` (Accepted)
 - Test plan: `engineering-team/stories/verified-reporters/1-verified-reporters-count.test-plan.md` (suite `test/profile-verified-reporters-count.test.js` + Playwright `tests/brainstorm/profile-verified-reporters-count.spec.js`)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/verified-reporters/1-verified-reporters-count.md` — **PASS** (2026-06-07)

--- a/engineering-team/stories/verified-reporters/1-verified-reporters-count.md
+++ b/engineering-team/stories/verified-reporters/1-verified-reporters-count.md
@@ -1,0 +1,48 @@
+# Story 1: Verified Reporters count on the profile
+
+**Status:** Approved
+**Created:** 2026-06-07
+**Type:** Feature
+**Epic:** `verified-reporters` · **Book:** `engineering-team/audits/verified-reporters/book.md`
+
+## Background
+A profile already shows positive trust signals (Following, Verified Followers). It shows no credible negative one. The data needed for the negative signal already exists: a per-point-of-view count of verified users who have NIP-56-reported the account is already computed and is shown today as a non-interactive figure on the profile. This story elevates that figure into a first-class, point-of-view-filtered count placed alongside the other counts, marked as a negative signal, and acting as the entry point to a list of *who* reported (built in later stories).
+
+Source: `product-team/prd/verified-reporters.md` §5.1, §5.3, §11. Affects the primary persona (the Vetting Observer, deciding whether to engage a stranger) and the secondary persona (the Cautious Newcomer, who lands on the House fallback).
+
+## User-facing description
+As someone viewing a profile, I want to see — at a glance, alongside Following and Verified Followers — how many people inside my web of trust have reported this account, so that I have a credible warning signal before I engage, and a way to go look at who they are.
+
+## Acceptance criteria
+Testable from the outside. Each gets at least one test.
+
+- [ ] Given a profile, when it loads, then a count labelled "Verified Reporters" appears in the counts row alongside Following and Verified Followers, computed under the viewer's effective point of view (their personal web of trust if available, otherwise the House default — the same point of view the other counts use).
+- [ ] Given the count is greater than zero, then its value is shown as a negative signal (visually distinct from the positive/neutral counts) and the whole count is a link to `/user/:pubkey/reporters`.
+- [ ] Given the count is exactly zero, then the value is shown neutrally (not as a warning) and is not a link.
+- [ ] Given the count is unavailable or not yet computed, then a placeholder ("—") is shown, not a link, and is visually distinguishable from a real zero.
+- [ ] Given the count is still loading, then a dimmed/placeholder value is shown (no bare spinner).
+- [ ] Given any state, then the count's accessible name states the number and that it opens the list (for example, "3 verified reporters. View list.").
+
+*(Six criteria, but a single cohesive surface — one count and its display states. Not split, because splitting one component's states across stories would fragment a unit that must be built and tested together.)*
+
+## Concepts touched
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-user` — nostr user (the observed user, the observer, and the reporters are all this concept in different roles).
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:web-of-trust` — web of trust (the viewer's point of view that filters the count).
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:graperank` — graperank (defines "verified": the same threshold Verified Followers uses).
+- NIP-56 report — a nostr-event of kind 1984 (the underlying report behind the count). `nostr-event` / `nostr-kind` handles apply.
+
+## Out of scope
+- The list page itself (`/user/:pubkey/reporters`) — that is story 3 of this epic. Until it ships, the link target may be an unbuilt/empty page; that is acceptable within the epic sequence.
+- The membership data behind the list (the reporter identities) — story 2.
+- Any per-count or counts-row point-of-view indicator (e.g. a "House" marker). Deferred to a cross-cutting Phase 4 session that handles all three counts together (PRD §8.3 / §11 decision 5). The count carries no PoV chrome in this story.
+- Splitting the count by NIP-56 report type (Phase 2); pile-on discounting (Phase 3); self-view privacy handling (Phase 4).
+- Changing Following or Verified Followers themselves.
+
+## Open questions
+- **Placement parity (for the Architect, PRD §11 decision 1 — does not block approval):** the count must match Verified Followers' treatment *as it exists on this branch*. The decision is to match the staging reference (a count-link in the counts row). The Architect should confirm against the actual profile component on `feat/verified-reporters` (off `staging`) whether Verified Followers is currently a count-link or a trust card, and place Verified Reporters to match — elevating Verified Followers itself is out of scope.
+
+## Linked artifacts
+- PRD: `product-team/prd/verified-reporters.md` (§5.1, §5.3, §11); design guide `product-team/guides/verified-reporters-design-guide.md`; style guide `product-team/guides/verified-reporters-style-guide.md` (canonical copy — use the count label and accessible-name strings verbatim).
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/verified-reporters/1-verified-reporters-count.md
+++ b/engineering-team/stories/verified-reporters/1-verified-reporters-count.md
@@ -44,5 +44,5 @@ Testable from the outside. Each gets at least one test.
 ## Linked artifacts
 - PRD: `product-team/prd/verified-reporters.md` (§5.1, §5.3, §11); design guide `product-team/guides/verified-reporters-design-guide.md`; style guide `product-team/guides/verified-reporters-style-guide.md` (canonical copy — use the count label and accessible-name strings verbatim).
 - ADR: `engineering-team/decisions/verified-reporters/0001-verified-reporters-count.md` (Accepted)
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/verified-reporters/1-verified-reporters-count.test-plan.md` (suite `test/profile-verified-reporters-count.test.js` + Playwright `tests/brainstorm/profile-verified-reporters-count.spec.js`)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/verified-reporters/1-verified-reporters-count.md
+++ b/engineering-team/stories/verified-reporters/1-verified-reporters-count.md
@@ -41,6 +41,9 @@ Testable from the outside. Each gets at least one test.
 ## Open questions
 - **Placement parity (for the Architect, PRD §11 decision 1 — does not block approval):** the count must match Verified Followers' treatment *as it exists on this branch*. The decision is to match the staging reference (a count-link in the counts row). The Architect should confirm against the actual profile component on `feat/verified-reporters` (off `staging`) whether Verified Followers is currently a count-link or a trust card, and place Verified Reporters to match — elevating Verified Followers itself is out of scope.
 
+## Deviations
+- ADR 0001 enumerated four display states (loading / unavailable / zero / >0) as distinct branches. Implemented as a single `verifiedReporterCount > 0 ? <Link…> : <span…>` ternary: the non-link `<span>` covers loading, unavailable, and zero, because `fmtCount(verifiedReporterCount)` already renders `—` for null (loading/unavailable) and `0` for zero, and the `bsp-count-loading` dim is added to that span only when `trustLoading`. Same observable behavior as the ADR's four states, with less branching. ([ui/src/pages/BrainstormProfile.jsx](../../../ui/src/pages/BrainstormProfile.jsx))
+
 ## Linked artifacts
 - PRD: `product-team/prd/verified-reporters.md` (§5.1, §5.3, §11); design guide `product-team/guides/verified-reporters-design-guide.md`; style guide `product-team/guides/verified-reporters-style-guide.md` (canonical copy — use the count label and accessible-name strings verbatim).
 - ADR: `engineering-team/decisions/verified-reporters/0001-verified-reporters-count.md` (Accepted)

--- a/engineering-team/stories/verified-reporters/1-verified-reporters-count.test-plan.md
+++ b/engineering-team/stories/verified-reporters/1-verified-reporters-count.test-plan.md
@@ -1,0 +1,69 @@
+# Test Plan: Story verified-reporters #1 — Verified Reporters count on the profile
+
+**Story:** `engineering-team/stories/verified-reporters/1-verified-reporters-count.md`
+**ADR:** `engineering-team/decisions/verified-reporters/0001-verified-reporters-count.md`
+**Date:** 2026-06-07
+
+## Approach
+Two tiers, matching the Verified Followers precedent (story #33 / ADR 0029):
+
+1. **Deterministic source-regex node suite** — `test/profile-verified-reporters-count.test.js`, run by `npm test`. No stack, no build, no live data. These are the **pre-implementation failing tests**: T1–T8 fail now and pass once the counter is built; R1–R3 are regression sentinels that pass before *and* after.
+2. **Supplementary Playwright spec** — `tests/brainstorm/profile-verified-reporters-count.spec.js`. Browser-level behavior (the 0/unavailable states are not anchors; the sibling links survive). **Live-data dependent and NOT run pre-implementation** — exercised at the staging smoke after deploy. The `> 0` link (href, `--red`, aria-label) and PoV are documented manual/fixture checks, mirroring how the VF spec left PoV manual.
+
+Why source-regex for the deterministic tier: the change is a single-file React/JSX edit and the repo has no React render harness; this matches the `profile-verified-followers-count` / `profile-follows-list` precedents. The **false-positive trap** (the file already contains `verifiedReporterCount` and `Reporters` in `TRUST_METRICS`) is handled by targeting the *new bsp-counts-block counter* specifically — see each sentinel's message.
+
+## Coverage map
+| Criterion | Test(s) | File | Level |
+|---|---|---|---|
+| AC1 — "Verified Reporters" count in the counts row, parallel, effective PoV | `T1` (3rd `bsp-count-label` + "Verified Reporters"), `T2` (`trustScores?.verifiedReporterCount`) ; `P1` (visible beside siblings) | node suite ; Playwright | source-regex ; e2e |
+| AC2 — `>0` → negative signal + link to `/reporters` | `T3` (link + 3rd `bsp-count-link`), `T4` (`bsp-count-value-negative` + `--red`) ; `>0` manual check | node suite ; Playwright | source-regex ; e2e/manual |
+| AC3 — `0` → neutral, NOT a link | `T5` (numeric-zero branch) ; `P2` (0-account → no `verified reporters` link) | node suite ; Playwright | source-regex ; e2e |
+| AC4 — unavailable → `—`, not a link, distinct from 0 | `T6` (3rd `fmtCount`, null→`—`) ; `P2` (covers the no-link case) | node suite ; Playwright | source-regex ; e2e |
+| AC5 — loading → dimmed placeholder, no bare spinner | `T7` (`bsp-count-loading` + `opacity`) | node suite | source-regex |
+| AC6 — accessible name states number + opens list | `T8` (`{n} verified reporters. View list.`) ; `>0` manual check | node suite ; Playwright | source-regex ; manual |
+| Regression — Following unchanged | `R1` | node suite | source-regex |
+| Regression — Verified Followers unchanged | `R2` ; `P2` (sibling links survive) | node suite ; Playwright | source-regex ; e2e |
+| Regression — Reporters trust card retained (ADR deliberate non-change) | `R3` | node suite | source-regex |
+
+## Edge cases
+- [x] Zero vs unavailable distinguished — `0` (neutral, no link) vs `—` (no scores). `T5`/`T6` + `P2`.
+- [x] Loading state is a dimmed placeholder, not a spinner — `T7`.
+- [x] False positive from the existing `TRUST_METRICS` Reporters card — every sentinel targets the new counter; `R3` guards the card stays.
+- [x] Link target `/reporters` does not 404-regress the page — the link is inert markup until story #3 builds the route (out of scope here; noted in the story).
+- [ ] `>0` red color + aria-label in the browser — fixture-dependent; documented manual check in the spec.
+- [ ] PoV (`?pov=`) reflected in the number — fixture-dependent; documented manual check in the spec.
+
+## Test infrastructure
+- Framework: Node built-in runner (`node test/test.js`) for the deterministic suite; Playwright (`npm run test:playwright`) for the supplementary spec.
+- Wiring: `test/profile-verified-reporters-count.test.js` is registered in `test/test.js` (require + run + results line + `overallOk`).
+- Concept Graph API: not required (no concept/graph change in this story).
+- Live stack: only the Playwright spec needs a running instance with the UI **built** (`npm run build` in `ui/`) and House-PoV WoT scores indexed in Meilisearch. Base URL `BRAINSTORM_BASE_URL` or `http://localhost:7778`.
+- Fixtures: Playwright uses Jack Dorsey (`82341f88…be6a2`) as a scores-loaded, 0-verified-reporters account for the not-a-link case. A `>0` account is needed at smoke time for the link/red/aria-label check.
+
+## How to run
+```
+npm test                       # deterministic node suites (incl. this one)
+npm run test:playwright        # supplementary browser spec (needs a built, running instance)
+```
+
+## Verification
+The new node suite fails with the current code (T1–T8 fail — one per acceptance criterion; R1–R3 pass — existing behavior intact). Confirmed via `npm test` on 2026-06-07:
+
+```
+profile-verified-reporters-count suite:
+  ✗ T1: BrainstormProfile.jsx renders a "Verified Reporters" count in the bsp-counts block (AC1)
+  ✗ T2: the new counter sources its value from trustScores.verifiedReporterCount (PoV-resolved) (AC1)
+  ✗ T3: the counter links to /user/${pubkey}/reporters (AC2)
+  ✗ T4: the >0 value uses a negative-signal modifier backed by the --red token (AC2)
+  ✗ T5: the counter branches on the count so 0 is rendered neutrally, not as a link (AC3)
+  ✗ T6: the new counter formats its value via the existing fmtCount helper (AC4 placeholder, AC6 number)
+  ✗ T7: a per-count loading dim exists for the reporters counter (AC5)
+  ✗ T8: the >0 link carries the canonical accessible name "{n} verified reporters. View list." (AC6)
+  ✓ R1: the existing "Following" count is unchanged — useUserCounts + <Link> to /follows (regression)
+  ✓ R2: the existing "Verified Followers" count is unchanged — <Link> to /followers (regression)
+  ✓ R3: the existing Reporters trust card is retained in TRUST_METRICS (ADR 0001 deliberate non-change)
+
+profile-verified-reporters-count suite:          FAIL (3 passed, 8 failed)
+```
+
+Each `✗` fails because the feature is unimplemented (the targeted markup/strings are absent), not from a typo or import error — verified by reading the failure messages. All other suites remain PASS (the runner wiring did not regress them).

--- a/engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.md
+++ b/engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.md
@@ -37,12 +37,13 @@ Testable from the outside (input → expected behavior).
 - Splitting or filtering by NIP-56 report type — all types counted/listed together (Phase 2).
 - Pile-on detection / discounting of pile-on-prone reporters (Phase 3).
 - Arbitrary third-party observer selection beyond the viewer's own point of view or the House fallback (mirrors the follows v1 deferral).
+- **Personalized / customer point-of-view membership (deferred to v2, per ADR 0002, ratified 2026-06-07).** v1 is **House/owner PoV only** — the same deferral follows (ADR 0026) and followers (ADR 0030) made. AC1/AC3 are therefore scoped to the House PoV for v1; AC4 (House fallback) is the v1 path. For a personalized-PoV viewer, Story 1's profile count (a possibly customer-PoV Meili value) and this House-PoV list may differ — accepted v1 limitation.
 
 ## Open questions
-- **Count = list-length invariant (for the Architect):** the membership must be derived from the **same** "verified within this point of view" definition that already produces the verified-reporter *count* shown in Story 1, so the two cannot disagree. The Architect should confirm the membership query and the existing count come from one source of truth (same threshold, same point-of-view resolution), and call out if they cannot, since AC3 depends on it.
+- **Count = list-length invariant — RESOLVED (2026-06-07, ADR 0002).** The membership is the literal inverse of the count computation (`(reporter)-[:REPORTS]->(reported)` with `reporter.influence > VERIFIED_REPORTERS_INFLUENCE_CUTOFF`), so `count === data.length` exactly within the capability, and it equals the House-PoV count algo in steady state. It is **not** a hard real-time guarantee against Story 1's *precomputed Meili* profile badge (refresh skew) — Story 3 displays its own live count as the list header, and tests must not assert real-time equality with the profile badge.
 
 ## Linked artifacts
 - PRD: `product-team/prd/verified-reporters.md` (§5.2, §6, §7)
-- ADR: (filled in after Architecture phase)
+- ADR: `engineering-team/decisions/verified-reporters/0002-verified-reporters-membership-data.md` (Accepted)
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.md
+++ b/engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.md
@@ -1,0 +1,48 @@
+# Story 2: Verified reporters membership data
+
+**Status:** Approved
+**Created:** 2026-06-07
+**Type:** Feature
+**Epic:** `verified-reporters` · **Book:** `engineering-team/audits/verified-reporters/book.md`
+
+## Background
+Story 1 shipped the Verified Reporters *count* on the profile, reusing a per-point-of-view count that already exists in the data layer. But the *membership* behind that count — *which* verified users reported the account — does not exist yet. Without it, the list page (Story 3) has nothing to render, and there is no way to prove the count equals what a viewer would actually see.
+
+This story provides that membership: given an account and a viewer's point of view, the set of verified users who have filed a NIP-56 report against that account. It is the net-new data need identified in the PRD (§7): the count exists; the identities do not.
+
+Source: `product-team/prd/verified-reporters.md` §5.2, §6, §7; `product-team/stories-queue.md` (Story 2). Serves the Vetting Observer (who needs to weigh *who* reported). Unblocks Story 3 (the list page).
+
+## User-facing description
+As someone inspecting an account's verified reporters, I want the list of *which* trusted users reported it — each with enough identity to judge their credibility — so that the count I saw on the profile becomes an inspectable, weighable list rather than a bare number.
+
+## Acceptance criteria
+Testable from the outside (input → expected behavior).
+
+- [ ] Given an account and a point of view, the capability returns the set of users who have filed a NIP-56 report against that account **and** are verified within that point of view; users who are not verified within that point of view (unverified / sybil reporters) are excluded.
+- [ ] Each returned reporter includes enough identity to display and weigh them: a stable identifier and the reporter's credibility (Rank) metric.
+- [ ] The size of the returned set equals the verified-reporter count shown for that account under the **same** point of view (the list length and the count agree).
+- [ ] When the viewer has no calculated point of view, the set is resolved under the House (default) point of view.
+- [ ] When the account has no verified reporters under the point of view, the result is an empty set — a normal, successful empty result, not an error.
+- [ ] A missing or malformed account identifier is rejected with a clear error response, not a crash and not a silent empty success.
+
+## Concepts touched
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-user` — nostr user (the reported account and each reporter).
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:web-of-trust` — web of trust (the point of view that filters reporters to "verified").
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:graperank` — graperank (defines "verified" and supplies the Rank/credibility metric).
+- NIP-56 report — a `nostr-event` of kind 1984 (the report linking a reporter to the reported account). The Architect resolves how reports are read.
+
+## Out of scope
+- The list page UI and route (`/user/:pubkey/reporters`) — that is Story 3.
+- The profile count surface — shipped in Story 1.
+- Splitting or filtering by NIP-56 report type — all types counted/listed together (Phase 2).
+- Pile-on detection / discounting of pile-on-prone reporters (Phase 3).
+- Arbitrary third-party observer selection beyond the viewer's own point of view or the House fallback (mirrors the follows v1 deferral).
+
+## Open questions
+- **Count = list-length invariant (for the Architect):** the membership must be derived from the **same** "verified within this point of view" definition that already produces the verified-reporter *count* shown in Story 1, so the two cannot disagree. The Architect should confirm the membership query and the existing count come from one source of truth (same threshold, same point-of-view resolution), and call out if they cannot, since AC3 depends on it.
+
+## Linked artifacts
+- PRD: `product-team/prd/verified-reporters.md` (§5.2, §6, §7)
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.md
+++ b/engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.md
@@ -1,6 +1,6 @@
 # Story 2: Verified reporters membership data
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-07
 **Type:** Feature
 **Epic:** `verified-reporters` · **Book:** `engineering-team/audits/verified-reporters/book.md`
@@ -46,4 +46,4 @@ Testable from the outside (input → expected behavior).
 - PRD: `product-team/prd/verified-reporters.md` (§5.2, §6, §7)
 - ADR: `engineering-team/decisions/verified-reporters/0002-verified-reporters-membership-data.md` (Accepted)
 - Test plan: `engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.test-plan.md` (suite `test/verified-reporters-membership-data.test.js`)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/verified-reporters/2-verified-reporters-membership-data.md` — **PASS** (2026-06-07)

--- a/engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.md
+++ b/engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.md
@@ -45,5 +45,5 @@ Testable from the outside (input → expected behavior).
 ## Linked artifacts
 - PRD: `product-team/prd/verified-reporters.md` (§5.2, §6, §7)
 - ADR: `engineering-team/decisions/verified-reporters/0002-verified-reporters-membership-data.md` (Accepted)
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.test-plan.md` (suite `test/verified-reporters-membership-data.test.js`)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.test-plan.md
+++ b/engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.test-plan.md
@@ -1,0 +1,65 @@
+# Test Plan: Story verified-reporters #2 — Verified reporters membership data
+
+**Story:** `engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.md`
+**ADR:** `engineering-team/decisions/verified-reporters/0002-verified-reporters-membership-data.md`
+**Date:** 2026-06-07
+
+## Approach
+Deterministic **source-regex node suite** — `test/verified-reporters-membership-data.test.js`, run by `npm test`, wired into `test/test.js`. This mirrors the `profile-follows-list` precedent, which pinned a new backend endpoint at source (handler + `index.js` registration + hook) without prescribing the exact wiring. The handler, route, and hook do not exist pre-implementation, so **T1–T10 are the failing tests**; **R1–R2** are regression sentinels (the untouched follows endpoint/route) that pass before and after.
+
+No live integration test in `npm test`: the endpoint is Neo4j-backed and needs the stack plus `[:REPORTS]` edges and a known-reported account, which is live-data dependent and flaky. The **count = list length** guarantee is enforced *by construction* (`count: data.length`, asserted by T4) and against the count algo by reusing `VERIFIED_REPORTERS_INFLUENCE_CUTOFF` (T4). Live end-to-end exercise happens at Story 3 (the list page Playwright spec) and at the staging smoke.
+
+**False-positive trap handled:** `src/api/index.js` and `followsWithMetrics.js` already contain `REPORTS` / `verifiedReporterCount` (the follows RETURN surfaces the reporter *count* per row). Every sentinel targets the NEW handler/route/hook (`handleGetGrapevineReporters`, `/api/get-grapevine-reporters`, the `[:REPORTS]` edge + `VERIFIED_REPORTERS_INFLUENCE_CUTOFF` filter in the new file) — absent pre-implementation.
+
+## Coverage map
+| Criterion | Test(s) | Level |
+|---|---|---|
+| AC1 — verified reporters under the (House v1) PoV; unverified excluded | T3 (`[:REPORTS]` edge + `influence >` filter), T6 (owner/House POV only) | source-regex |
+| AC2 — identifier + Rank/credibility per reporter | T5 (pubkey, influence, hops, verified*Count) | source-regex |
+| AC3 — set size == count under same PoV | T4 (`VERIFIED_REPORTERS_INFLUENCE_CUTOFF`, not the followers cutoff; `count: data.length`) | source-regex |
+| AC4 — no PoV → House fallback | T6 (owner/House is the v1 default path; non-owner observer → 400) | source-regex |
+| AC5 — no reporters → empty set, not an error | T7 (`data` from `result.records.map`; `{success,observer,observee,count,data}` shape) | source-regex |
+| AC6 — bad account id → clear error | T2 (`observee` validation → 400) | source-regex |
+| Endpoint reachable / handler exists | T1 (handler + export), T9 (route registered), T10 (hook fetches it), T8 (deadline → 504) | source-regex |
+| Regression — follows endpoint untouched | R1 (handler + `:FOLLOWS` edge), R2 (`/api/get-grapevine-follows` route) | source-regex |
+
+## Edge cases
+- [x] Empty result is a successful 200 with `data:[] count:0` (the filtered MATCH yields zero rows) — T7.
+- [x] Wrong cutoff (copy-paste from followers) would silently break count=list-length — T4 guards both presence of `VERIFIED_REPORTERS_INFLUENCE_CUTOFF` and absence of `VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF`.
+- [x] Runaway inbound traversal on a heavily-reported account → 504 deadline — T8 (though verified-reporter sets are expected small).
+- [x] Personalized/customer PoV — deferred (ADR 0002); non-owner observer rejected (T6), not silently coerced.
+- [ ] Live count = list-length against a real account — deferred to Story 3 page smoke / staging (guaranteed by construction here).
+
+## Test infrastructure
+- Framework: Node built-in runner (`node test/test.js`). Wired in `test/test.js` (require + run + results line + `overallOk`).
+- Concept Graph API: not required (runtime Neo4j node properties, not graph-concept nodes; no firmware change).
+- Live stack: not needed for this suite (source-regex). Story 3 / staging exercise the endpoint against Neo4j.
+- Fixtures: none (source-regex).
+
+## How to run
+```
+npm test
+```
+
+## Verification
+The new suite fails with the current code (T1–T10 fail — handler/route/hook absent; R1–R2 pass — follows untouched). Confirmed via `npm test` on 2026-06-07:
+
+```
+verified-reporters-membership-data suite:
+  ✗ T1: reportersWithMetrics.js exists and exports handleGetGrapevineReporters (ADR 0002 §Impl)
+  ✗ T2: handler requires + 64-hex-validates `observee`, returning 400 otherwise (AC6)
+  ✗ T3: handler Cypher traverses the inbound :REPORTS edge with a verified-influence filter (AC1)
+  ✗ T4: the verified filter uses VERIFIED_REPORTERS_INFLUENCE_CUTOFF (not the followers cutoff) and the response count is data.length (AC3)
+  ✗ T5: success rows carry identity + credibility metric per reporter (AC2)
+  ✗ T6: a non-owner `observer` is rejected with 400 — owner/House POV only in v1 (AC1/AC4; personalized POV deferred)
+  ✗ T7: success response shape is {success, observer:'owner', observee, count, data} (AC3/AC5)
+  ✗ T8: handler enforces the Neo4j deadline (NEO4J_QUERY_TIMEOUT_MS) with a 504 {success:false} branch
+  ✗ T9: GET /api/get-grapevine-reporters is registered in src/api/index.js → handleGetGrapevineReporters
+  ✗ T10: ui/src/hooks/useGrapevineReporters.js fetches /api/get-grapevine-reporters
+  ✓ R1: the follows endpoint is untouched — followsWithMetrics.js still exports handleGetGrapevineFollows over the :FOLLOWS edge
+  ✓ R2: the existing /api/get-grapevine-follows route remains registered
+
+verified-reporters-membership-data suite:        FAIL (2 passed, 10 failed)
+```
+
+Each `✗` fails because the feature is unimplemented (the new handler/route/hook are absent), not from a typo or import error. All other suites remain PASS.

--- a/engineering-team/stories/verified-reporters/3-verified-reporters-list-page.md
+++ b/engineering-team/stories/verified-reporters/3-verified-reporters-list-page.md
@@ -1,0 +1,45 @@
+# Story 3: Verified Reporters list page
+
+**Status:** Approved
+**Created:** 2026-06-07
+**Type:** Feature
+**Epic:** `verified-reporters` · **Book:** `engineering-team/audits/verified-reporters/book.md`
+
+## Background
+Story 1 shipped the Verified Reporters count on the profile (a link when > 0). Story 2 shipped the data — the verified users who reported an account, under the House point of view. This story is the surface that ties them together: a dedicated page that lists *who* those reporters are, so the observer can weigh them. It is the link target of the count and the consumer of the membership data. With it, the feature is complete end to end.
+
+Source: `product-team/prd/verified-reporters.md` §5.2, §5.3; `product-team/stories-queue.md` (Story 3). Serves the Vetting Observer (inspect and weigh the reporters) and the Cautious Newcomer (the point-of-view attribution lives here). It is a deliberate mirror of the existing Followers list.
+
+## User-facing description
+As someone who saw that trusted people reported an account, I want a page that shows exactly which verified users reported it — most credible first, each clickable through to their profile — and that tells me plainly whose web of trust the list reflects, so I can judge how much weight the warning deserves.
+
+## Acceptance criteria
+Testable from the outside (input → expected behavior).
+
+- [ ] Visiting `/user/:pubkey/reporters` shows a page titled "Verified Reporters", a back link to the profile (`/user/:pubkey`), and the description "Verified users who have reported this account."
+- [ ] The page lists the verified reporters of that account, defaulting to the columns picture, name, and Rank, sorted by Rank descending (most credible first).
+- [ ] Selecting a reporter navigates to that reporter's own profile.
+- [ ] The number of rows equals the verified-reporter count for that account under the same (House) point of view.
+- [ ] The page states whose point of view is in effect — "Relative to your web of trust." (personal) or the House line — and an "About this data" control explains the data is computed locally by this instance and that counts are personal, with no single global number.
+- [ ] When the account has no verified reporters, the page shows the empty state "No verified reporters. No one in this web of trust has reported this account." — not a blank screen and not an error.
+- [ ] While loading, a skeleton placeholder is shown (no bare spinner); on failure, a helpful message with a retry control is shown (never "Something went wrong").
+
+## Concepts touched
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-user` — nostr user (the reported account and each reporter row).
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:web-of-trust` — web of trust (the point of view the list and its attribution reflect).
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:graperank` — graperank (the Rank/credibility shown per reporter).
+
+## Out of scope
+- The profile count and its link (Story 1, done) and the membership data/endpoint (Story 2, done) — this story consumes them; it does not re-build them.
+- Personalized / customer point-of-view (deferred, consistent with ADR 0002 and the follows/followers precedent). v1 is House/owner point of view; the personal point-of-view line is shown when applicable but personalized membership is not computed here.
+- Splitting the list by NIP-56 report type (Phase 2); pile-on discounting (Phase 3).
+- Any change to the profile count, the Following/Verified Followers counts, or the follows/followers pages.
+
+## Open questions
+- **count = list length, restated (resolved by ADR 0002):** the page's row count should equal the count the membership endpoint reports (which equals `data.length`). It is *not* a hard real-time guarantee against the precomputed Meili count shown on the profile badge — so the page should present its own (live) count as the header and copy/tests must not assert real-time equality with the profile badge. The Architect carries this into the page design.
+
+## Linked artifacts
+- PRD: `product-team/prd/verified-reporters.md` (§5.2, §5.3); design guide `product-team/guides/verified-reporters-design-guide.md`; style guide `product-team/guides/verified-reporters-style-guide.md` (use the title, description, point-of-view lines, empty-state, error, and "About this data" copy verbatim).
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/verified-reporters/3-verified-reporters-list-page.md
+++ b/engineering-team/stories/verified-reporters/3-verified-reporters-list-page.md
@@ -41,5 +41,5 @@ Testable from the outside (input → expected behavior).
 ## Linked artifacts
 - PRD: `product-team/prd/verified-reporters.md` (§5.2, §5.3); design guide `product-team/guides/verified-reporters-design-guide.md`; style guide `product-team/guides/verified-reporters-style-guide.md` (use the title, description, point-of-view lines, empty-state, error, and "About this data" copy verbatim).
 - ADR: `engineering-team/decisions/verified-reporters/0003-verified-reporters-list-page.md` (Accepted)
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/verified-reporters/3-verified-reporters-list-page.test-plan.md` (suite `test/verified-reporters-list-page.test.js` + Playwright `tests/brainstorm/profile-verified-reporters-list.spec.js`)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/verified-reporters/3-verified-reporters-list-page.md
+++ b/engineering-team/stories/verified-reporters/3-verified-reporters-list-page.md
@@ -40,6 +40,6 @@ Testable from the outside (input → expected behavior).
 
 ## Linked artifacts
 - PRD: `product-team/prd/verified-reporters.md` (§5.2, §5.3); design guide `product-team/guides/verified-reporters-design-guide.md`; style guide `product-team/guides/verified-reporters-style-guide.md` (use the title, description, point-of-view lines, empty-state, error, and "About this data" copy verbatim).
-- ADR: (filled in after Architecture phase)
+- ADR: `engineering-team/decisions/verified-reporters/0003-verified-reporters-list-page.md` (Accepted)
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/verified-reporters/3-verified-reporters-list-page.md
+++ b/engineering-team/stories/verified-reporters/3-verified-reporters-list-page.md
@@ -1,6 +1,6 @@
 # Story 3: Verified Reporters list page
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-07
 **Type:** Feature
 **Epic:** `verified-reporters` · **Book:** `engineering-team/audits/verified-reporters/book.md`
@@ -42,4 +42,4 @@ Testable from the outside (input → expected behavior).
 - PRD: `product-team/prd/verified-reporters.md` (§5.2, §5.3); design guide `product-team/guides/verified-reporters-design-guide.md`; style guide `product-team/guides/verified-reporters-style-guide.md` (use the title, description, point-of-view lines, empty-state, error, and "About this data" copy verbatim).
 - ADR: `engineering-team/decisions/verified-reporters/0003-verified-reporters-list-page.md` (Accepted)
 - Test plan: `engineering-team/stories/verified-reporters/3-verified-reporters-list-page.test-plan.md` (suite `test/verified-reporters-list-page.test.js` + Playwright `tests/brainstorm/profile-verified-reporters-list.spec.js`)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/verified-reporters/3-verified-reporters-list-page.md` — **PASS** (2026-06-07)

--- a/engineering-team/stories/verified-reporters/3-verified-reporters-list-page.test-plan.md
+++ b/engineering-team/stories/verified-reporters/3-verified-reporters-list-page.test-plan.md
@@ -1,0 +1,76 @@
+# Test Plan: Story verified-reporters #3 — Verified Reporters list page
+
+**Story:** `engineering-team/stories/verified-reporters/3-verified-reporters-list-page.md`
+**ADR:** `engineering-team/decisions/verified-reporters/0003-verified-reporters-list-page.md`
+**Date:** 2026-06-07
+
+## Approach
+Two tiers, matching the follows/followers precedent:
+
+1. **Deterministic source-regex node suite** — `test/verified-reporters-list-page.test.js`, run by `npm test`, wired into `test/test.js`. The page (`BrainstormReporters.jsx`) and its route do not exist pre-implementation, so **T1–T14 are the failing tests**; **R1–R3** are regression sentinels (the follows/followers routes and the untouched followers page) that pass before and after.
+2. **Supplementary Playwright spec** — `tests/brainstorm/profile-verified-reporters-list.spec.js`. Live-data dependent, **not run pre-implementation** — exercised at the staging smoke. It covers the page shell, the empty state (most accounts have 0 verified reporters), and the PoV line; the populated path (Rank-desc rows, row→profile, count parity) is a documented manual/fixture check.
+
+**False-positive trap handled:** `App.jsx` and `BrainstormFollowers.jsx` already contain `reporters` / `Verified Reporters` / `verifiedReporterCount` (the followers page has a "Verified Reporters" *column*). Every sentinel targets the NEW page/route/key/copy — `BrainstormReporters`, `/user/:pubkey/reporters`, `bsp-reporters-columns`, the reporters-specific strings.
+
+## Coverage map
+| Criterion | Test(s) | Level |
+|---|---|---|
+| AC1 — route + title + back link + description | T1 (route), T2 (page, title, back, description), T3 (hook) | source-regex |
+| AC2 — columns picture/name/Rank, sorted Rank desc | T4 (Rank col + DataTable), T5 (rank-desc sort, not verifiedFollowerCount) | source-regex |
+| AC3 — row → reporter profile | T6 (`onRowClick → navigate('/user/'+pubkey)`) | source-regex |
+| AC4 — row count == count under same PoV | T3 (rows from the hook; page count is live `rows.length`, not the Meili badge); endpoint count=data.length is Story 2 | source-regex |
+| AC5 — PoV line + "About this data" popover | T7 (House PoV line), T8 (local/NIP-85 + "no single global number") | source-regex |
+| AC6 — empty state, verbatim | T9 | source-regex |
+| AC7 — skeleton loader; error + retry | T10 (`bsp-skeleton-row` + `@keyframes bsp-shimmer`), T11 (error copy + "Try again"), T12 (hook `refetch` + page wires it) | source-regex |
+| Delta — distinct storage key | T13 (`bsp-reporters-columns`) | source-regex |
+| Regression guard inherited — /api/profiles cap | T14 (`PROFILE_CHUNK ≤ 50`) | source-regex |
+| Regression — follows/followers routes intact | R1 | source-regex |
+| Regression — followers page untouched | R2 (hook + storage key), R3 (verifiedFollowerCount sort) | source-regex |
+
+## Edge cases
+- [x] Empty (0 verified reporters) → designed empty state, not blank/error — T9 (+ Playwright on a real 0-account).
+- [x] Loading → skeleton, not a text loader / bare spinner — T10.
+- [x] Error → style-guide copy + retry (not a raw error / "Something went wrong") — T11; retry needs the hook `refetch` — T12.
+- [x] Copy-paste-from-followers mistakes: wrong default sort (T5 guards), wrong storage key (T13), editing the followers file instead (R2/R3).
+- [x] Honest PoV: v1 membership is House-only, so the House PoV line is asserted (T7) — not the personal line.
+- [ ] Populated path (Rank-desc rows, row click, count parity) live — Playwright manual/fixture + staging smoke (needs an account with verified reporters).
+
+## Test infrastructure
+- Framework: Node built-in runner (`node test/test.js`) for the deterministic suite (wired in `test/test.js`); Playwright (`npm run test:playwright`) for the supplementary spec.
+- Concept Graph API: not required (no concept/graph change).
+- Live stack: only the Playwright spec needs a running instance with the UI **built** (`npm run build` in `ui/`) and the reporters endpoint live. Base URL `BRAINSTORM_BASE_URL` or `http://localhost:7778`.
+- Fixtures: Playwright uses Jack Dorsey (`82341f88…be6a2`) as a scores-loaded, 0-verified-reporters account for the empty-state path.
+
+## How to run
+```
+npm test                       # deterministic node suites (incl. this one)
+npm run test:playwright        # supplementary browser spec (needs a built, running instance)
+```
+
+## Verification
+The new node suite fails with the current code (T1–T14 fail — page/route/skeleton/refetch absent; R1–R3 pass — follows/followers intact). Confirmed via `npm test` on 2026-06-07:
+
+```
+verified-reporters-list-page suite:
+  ✗ T1: ui/src/App.jsx registers /user/:pubkey/reporters → BrainstormReporters (AC1)
+  ✗ T2: BrainstormReporters.jsx exists, reads :pubkey, shows the title, back link, and description (AC1)
+  ✗ T3: the page sources its rows from the useGrapevineReporters hook (AC1/AC4)
+  ✗ T4: columns include Rank (round(influence*100)) and the page reuses DataTable (AC2)
+  ✗ T5: default sort is by RANK descending, not by verifiedFollowerCount (AC2)
+  ✗ T6: selecting a reporter row navigates to that reporter's /user/<pubkey> profile (AC3)
+  ✗ T7: the page shows the House point-of-view line (AC5)
+  ✗ T8: the "About this data" popover states local computation AND the no-global-view sentence (AC5)
+  ✗ T9: the empty state uses the style-guide copy (AC6)
+  ✗ T10: loading shows a skeleton placeholder (a .bsp-skeleton-row + shimmer keyframes), not a bare spinner (AC7)
+  ✗ T11: the error state shows the style-guide copy and a "Try again" retry control (AC7)
+  ✗ T12: useGrapevineReporters exposes a refetch/reload, and the page wires the retry to it (AC7)
+  ✗ T13: the page uses a distinct localStorage key bsp-reporters-columns (delta)
+  ✗ T14: the page batches /api/profiles at PROFILE_CHUNK ≤ 50 (regression guard inherited)
+  ✓ R1: App.jsx still registers the follows and followers routes (regression)
+  ✓ R2: BrainstormFollowers.jsx is untouched — still uses useGrapevineFollowers + its own storage key (regression)
+  ✓ R3: BrainstormFollowers default sort remains verifiedFollowerCount desc (the reporters page must not have changed it)
+
+verified-reporters-list-page suite:              FAIL (3 passed, 14 failed)
+```
+
+Each `✗` fails because the feature is unimplemented (the new page/route/skeleton CSS/hook refetch are absent), not from a typo or import error. All other suites remain PASS.

--- a/product-team/discoveries/verified-reporters.md
+++ b/product-team/discoveries/verified-reporters.md
@@ -1,0 +1,42 @@
+# Discovery Brief: Verified Reporters
+
+**Slug:** verified-reporters
+**Date:** 2026-06-07
+**Strategist phase:** Discovery (Phase 1)
+
+## Problem statement
+When an observer lands on a user's profile, they can already read two trust signals — who that user follows, and who *within the observer's web of trust* follows them back (Verified Followers). What's missing is the credible **negative** signal: whether trustworthy people have formally flagged this account. NIP-56 report data already exists on the network, but in raw form it is worthless and effectively invisible — a bad actor can manufacture an unlimited number of reports, drowning any honest flag in noise. The observer most in need of this signal is **someone deciding whether to follow or engage a stranger**, who today has no at-a-glance way to learn "N people I'd actually trust have reported this account." (Moderation, transaction-vetting, and other observer roles inherit the same signal later, but the stranger-engagement case is the anchor.)
+
+## User landscape
+The types of people affected. For each: how they cope today, and what they hate about it.
+
+- **The engaging observer (anchor)** — someone deciding whether to follow, reply to, or engage a stranger. Today they eyeball follower counts, profile content, and gut feel; credible warnings that *do* exist in the report data are buried beneath bad-actor noise, so they can't be used. The pain: getting burned by accounts that trusted people had already flagged, with no way to have seen it.
+- **The moderator / community steward (later)** — needs to triage accounts at scale. Inherits the same signal; out of anchor scope but should not be designed against.
+- **The transactor (later)** — vetting a counterparty before value changes hands. Same signal, higher stakes; also later.
+
+## Competitive landscape
+What exists today and the **structural** reason it fails.
+
+- **Raw NIP-56 report counts (other Nostr clients)** — some clients can tally reports against an account, but the count is global and unfiltered. Structural failure: with no identity cost and no trust filter, reports are infinitely sybil-able, so the number carries no information and is rightly ignored or hidden. The metric is broken at the root, not in its presentation.
+- **Centralized platform "report" / trust-and-safety systems** — a platform aggregates reports and acts on them opaquely behind the scenes. Structural failure: the observer never sees the signal and cannot apply their *own* standard of whose judgment to trust; the platform's PoV is imposed as a single global truth. (General characterization of centralized moderation; specific competitor behaviors not individually verified.)
+- **Tapestry's own Verified Followers** — proves the positive-signal pattern works (a count filtered to the observer's web of trust, linking to a list). The gap is simply that no negative-signal counterpart exists yet.
+
+## Opportunity
+The web of trust is exactly the filter that converts an ungameable-in-raw-form metric into a credible one. A report only counts if the reporter is a **verified** user — inside the observer's calculated web of trust — so manufactured pile-ons from bad actors stay invisible no matter how many reports they file. The count is therefore **relative to who is looking** (`pov`): there is deliberately no global "verified reporters" number, in keeping with the principle that for most WoT measures *there is no such thing as a global view*. When the viewer has no calculated WoT yet, the House PoV is the fallback — used as sparingly as possible, as the closest thing to a shared baseline. Why now: the positive-signal pattern (Verified Followers) is already shipped and proven, so the negative-signal counterpart is a natural, legible extension. Why this team: only a system that already computes per-observer webs of trust can produce this metric at all.
+
+## Constraints
+The operating envelope.
+
+- **Budget:** Not specified; treat as a focused incremental feature, parallel to existing profile counts.
+- **Timeline:** Not specified.
+- **Team:** Tapestry / Brainstorm engineering team (downstream of this product flow).
+- **Technical:** Built on Tapestry / Nostr. Reuses the existing web-of-trust / "verified" notion (per-observer `pov`, House PoV fallback) and NIP-56 report data. Parallel in placement and behavior to the existing Following and Verified Followers counts on the profile.
+- **Regulatory:** None identified. Note the social/abuse dimension below.
+
+## Open questions
+Anything unresolved that later phases need to know. Numbered.
+
+1. **Report-type aggregation:** All NIP-56 report types are lumped into a single count for now. Separating by type (spam, impersonation, illegal, etc.) is explicitly deferred to a future phase — but the domain model should not foreclose it.
+2. **Pile-on by verified users:** Even verified users can pile on; this is human nature. The roadmap remedy — tagging pile-on-prone users and discounting their reports — is explicitly **out of scope now** but is a known future direction the design should not contradict.
+3. **House PoV fallback semantics:** Confirm in domain/scope phases exactly when the fallback engages (viewer has no calculated WoT available) and how it is signaled to the observer, so the "no global view" principle stays legible rather than silently defaulting.
+4. **Self-view and edge cases:** Behavior when the observer views their own profile, when the count is zero, and when WoT is still computing — to be settled downstream.

--- a/product-team/domain/verified-reporters.md
+++ b/product-team/domain/verified-reporters.md
@@ -1,0 +1,89 @@
+# Domain Model: Verified Reporters
+
+**Slug:** verified-reporters
+**Date:** 2026-06-07
+**Modeler phase:** Domain Modeling (Phase 4)
+
+> Conceptual model only — what the product knows about, not how it stores it. No tables, columns, foreign keys, or indexes.
+
+**Orientation note (concept graph @ `localhost:7778`, TA `e00ed090…df36`):** This feature reuses existing concepts wherever possible. `nostr-user`, `web-of-trust`, `graperank`, `nostr-event`, and `nostr-kind` already exist in the graph. The NIP-56 Report (as a domain noun) and the Point of View lens are application-level concepts not currently represented as concept-graph nodes. "Observer," "observed user," and "verified reporter" are **roles** a `Nostr User` plays, not separate entities.
+
+## Entities
+
+### Nostr User
+- **Description:** An account on the network, identified by its public key, that can follow, report, and be observed.
+- **Concept mapping:** `39998:e00ed090…df36:nostr-user` (existing)
+- **Roles in this feature (not separate entities):** *observed user* (the profile being viewed), *observer* (whoever is viewing, whose PoV the count reflects), *reporter* (a user who has filed a report).
+- **Attributes:**
+  | Attribute | Type | Required | Notes |
+  |---|---|---|---|
+  | public key | text | yes | Stable identity. |
+  | display name | text | no | For showing reporters in the list. |
+  | (other profile details) | — | — | Out of scope; owned by the existing profile, not this feature. |
+
+### NIP-56 Report
+- **Description:** A published flag in which one Nostr User formally reports another, per NIP-56.
+- **Concept mapping:** new as a domain noun. *Is a* `nostr-event` (existing) of `nostr-kind` 1984 (existing concept; kind 1984 is the report kind).
+- **Attributes:**
+  | Attribute | Type | Required | Notes |
+  |---|---|---|---|
+  | reporter | ref:Nostr User | yes | The author of the report. |
+  | subject | ref:Nostr User | yes | The user being reported (the observed user, in this feature). |
+  | report type | text | no | The NIP-56 category (spam, impersonation, illegal, etc.). **Captured but not surfaced or split in the MVP** — all types are counted in one pot. Present so Phase 2 can split without remodeling. |
+  | created at | date | yes | When the report was published. |
+  | source event | ref:nostr-event | yes | The underlying signed event the report is read from. |
+
+### Point of View (PoV)
+- **Description:** The trust lens through which "verified" is judged — whose web of trust is being applied when counting reporters.
+- **Concept mapping:** new as an explicit lens; *resolves to* a `web-of-trust` (existing) scored by `graperank` (existing). Not currently a concept-graph node.
+- **Attributes:**
+  | Attribute | Type | Required | Notes |
+  |---|---|---|---|
+  | kind | text | yes | `personal` or `house`. |
+  | owner | ref:Nostr User | no | The observer whose WoT this is. Absent when kind is `house`. |
+- **Note:** The **House PoV** is the platform's default observer lens, used only when the viewer has no calculated personal WoT available. It is the closest thing to a shared baseline — used sparingly, never presented as a global truth.
+
+### GrapeRank Score
+- **Description:** The personalized trust score of one Nostr User as computed within a given PoV; it is what makes a reporter "verified."
+- **Concept mapping:** `39998:e00ed090…df36:graperank` (existing)
+- **Attributes:**
+  | Attribute | Type | Required | Notes |
+  |---|---|---|---|
+  | subject | ref:Nostr User | yes | The user being scored. |
+  | pov | ref:Point of View | yes | Whose lens produced the score. |
+  | score value | number | yes | The trust score. |
+  | is verified | (derived) boolean | yes | True when the score meets the platform's verification criterion — the **same "verified" threshold already used by Verified Followers**. Not re-derived here. |
+
+## Relationships
+Named and directional.
+
+- Nostr User (reporter) **files** NIP-56 Report.
+- NIP-56 Report **targets** Nostr User (subject).
+- Point of View **belongs to** Nostr User (observer) — or is the House PoV when none is available.
+- GrapeRank Score **scores** Nostr User **within** Point of View.
+- Nostr User **is verified within** Point of View — derived: the user's GrapeRank Score in that PoV meets the verification criterion.
+
+## Derived view — the feature itself
+Not stored; computed on demand. Stated here because it is the heart of the product's world.
+
+- **Verified Reporters of an observed user, relative to a PoV** = the set of Nostr Users who (a) **file** a NIP-56 Report **targeting** that observed user, and (b) **are verified within** that PoV.
+- **Verified Reporters count** = the size of that set. By construction, **count = list length** under one PoV.
+- This is the exact negative-signal parallel of **Verified Followers** (verified users who *follow* the observed user) — same shape, swapping the "follow" relationship for the "report" relationship.
+
+## States and lifecycle
+
+- **PoV resolution (per observer, per view):** `personal WoT available → use personal PoV` → otherwise → `House PoV fallback`. This single transition is what the Cautious Newcomer experiences and what must be made legible.
+- **Verified status is dynamic, not fixed:** a reporter can move `unverified ↔ verified` as the observer's web of trust is recomputed (degrees of separation shift). The count is therefore a function of *both* the report set and the live WoT — not a stored tally.
+- **NIP-56 Report:** effectively immutable once published (it is a signed event); conceptually `present` or `absent` (a report may later be deleted/retracted via standard nostr deletion). No richer state machine in the MVP.
+
+## New vs. existing (Tapestry products)
+- **Maps to existing concepts:** Nostr User (`nostr-user`), Web of Trust (`web-of-trust`), GrapeRank Score (`graperank`); the NIP-56 Report *is a* Nostr Event (`nostr-event`) of a Nostr Kind (`nostr-kind`, kind 1984).
+- **Genuinely new (application-level, not currently concept-graph nodes):** the **NIP-56 Report** as a domain noun, the **Point of View** lens with its House fallback, and the **derived Verified Reporters view** (count + list). Whether any of these become concept-graph nodes is an engineering decision, not a domain one.
+
+## Named-but-not-modeled (deferred per scope)
+These are intentionally *not* modeled — named only so later phases know where they live.
+
+- **Report-type breakdown** (the `report type` attribute, split and surfaced) → Phase 2.
+- **Reporter quality / pile-on tag** on a Nostr User → Phase 3.
+- **Reporter-visibility / privacy controls** (self-view retaliation mitigation) → Phase 4.
+- **Inheritor surfaces** (moderator, transactor) → Phase 5.

--- a/product-team/guides/verified-reporters-design-guide.md
+++ b/product-team/guides/verified-reporters-design-guide.md
@@ -1,0 +1,108 @@
+# Design Guide: Verified Reporters
+
+**Slug:** verified-reporters
+**Date:** 2026-06-07
+
+> Visual rules, design tokens, component patterns, and wireframe references. Binding during engineering review. Honors `product-team/guardrails/design.md`.
+> Wireframes: [`verified-reporters-wireframes.html`](./verified-reporters-wireframes.html)
+
+## Grounding — mirror, don't invent
+This feature is a deliberate parallel to the existing **Following** / **Verified Followers** counts and the **Following list** page. It reuses, and must not diverge from, the live components in the `ui/` React app:
+
+- Profile counts row: `.bsp-counts` → `.bsp-count.bsp-count-link` → `.bsp-count-value` + `.bsp-count-label` ([BrainstormProfile.jsx](../../ui/src/pages/BrainstormProfile.jsx)).
+- List page shell: `.bsp-page` / `.bsp-top-bar` / `.bsp-content`, `.bsp-follows-header` (back-link + title + ⓘ info button), search + Columns toggle, `DataTable`, and the **"About this data" popover** ([BrainstormFollows.jsx](../../ui/src/pages/BrainstormFollows.jsx)).
+- Route pattern: `/user/:pubkey/follows` → **new sibling route `/user/:pubkey/reporters`** ([App.jsx](../../ui/src/App.jsx)).
+- The `verifiedReporterCount` metric **already exists** (per-PoV, namespaced `wot_verifiedReporterCount_<povSuffix>`) and already renders as a 🚩 "Reporters" trust card. The new work is (a) elevating it to a clickable count and (b) a list of *who* reported.
+
+**Design-time assumption (flag for the architect):** the reference profile on staging shows Following *and* Verified Followers as parallel count-links. On the `feat/communities` branch, Verified Followers currently renders as a trust *card*. Verified Reporters should match **Verified Followers' treatment, whatever it is at implementation time** — placed parallel to it. Elevating Verified Followers itself is out of scope here.
+
+## Design principles
+Non-negotiable; enforced in engineering review.
+
+1. **Parallel, not novel.** The Verified Reporters count and list reuse the exact components, classes, spacing, and route shape of Following / Verified Followers. A reviewer should not be able to tell the two features were built at different times.
+2. **Negative signal by color, meaning by word.** The count is marked negative with the existing **`--red`** semantic (the app already encodes "report" as red). Color never carries the meaning *alone* — the label word "Reporters" carries it; red reinforces. (Accessibility + the warning reading both hold.)
+3. **No silent global numbers.** Every surface that shows the count states whose PoV produced it. Personal PoV is the default and needs no shouting; **House fallback is always labeled**, never silent.
+4. **Zero is reassurance, not a warning.** A real "0" renders neutral (not red) and is visually distinct from "—" (not computed / unavailable). Three distinct states: `> 0` (red, linked), `0` (neutral, not linked), `unavailable` (`—`, muted).
+5. **Every state is designed.** Empty, loading (skeleton, not a bare spinner), and error (helpful, with a retry) are first-class for both the count and the list.
+6. **Tokens only.** No hex or px literals in components — reference the CSS custom properties below. (Note: the existing Report button hardcodes `#ef4444`; the count should use the `--red` token instead.)
+7. **No icon libraries.** Indicators are typography, the existing unicode glyphs the app already uses (🚩 ⓘ 🔒), colored shapes, or hand-crafted SVG. No Tabler/Lucide/etc.
+
+## Visual identity
+Inherits the app's GitHub-dark identity verbatim — this feature introduces **no new identity**, only a semantic application of the existing one.
+
+- **Color palette:** one accent `--accent` `#58a6ff` for all interactive elements (the count *link* affordance). Semantic colors are the only exception: `--green` success, `--orange` warning, `--red` error/negative. The Verified Reporters value uses **`--red`** as a negative/danger semantic — consistent with the existing Report action.
+- **Typography:** inherits the app body font. Count value: 0.9rem, weight 600. Count label: 0.9rem, opacity 0.6. List title: 1.4rem. No new families.
+- **Spacing:** the counts row uses `gap: 0.6rem`, `margin: 0.5rem 0 0.25rem` (existing `.bsp-counts`). List page inherits `.bsp-content` rhythm.
+- **Elevation:** flat, as the app is. Cards/popovers use the existing subtle `rgba(255,255,255,0.03–0.06)` surfaces and the `.bsp-confirm-overlay` modal layer for the popover.
+
+## Design tokens
+Existing app tokens (from `ui/src/styles.css :root`). Components reference these — never a raw value.
+
+```css
+:root {
+  /* color */
+  --accent: #58a6ff;          /* all interactive elements (link affordance) */
+  --accent-hover: #79c0ff;
+  --bg: #0d1117;
+  --surface: #161b22;          /* --bg-secondary */
+  --surface-2: #21262d;        /* --bg-tertiary */
+  --border: #30363d;
+  --text: #e6edf3;
+  --text-muted: #8b949e;
+  --green: #3fb950;            /* success */
+  --orange: #d29922;           /* warning */
+  --red: #f85149;             /* error / negative — the Verified Reporters signal */
+  /* radius */
+  --radius: 8px;               /* matches .bsp-trust-card */
+}
+```
+
+This feature adds **no new tokens**. If a negative-surface tint is ever needed, derive it as `rgba(248,81,73,0.1)` (token-driven), mirroring the Report button's `rgba(239,68,68,0.1)`.
+
+## Component patterns
+
+### Verified Reporters count (on the profile)
+- **Visual:** a `.bsp-count` inside the existing `.bsp-counts` row, placed parallel to Following / Verified Followers. Structure: `<value> <label>`. Label: **"Verified Reporters"**. When `> 0`, the value uses `--red` and the whole item is a `.bsp-count-link` (`<Link>` to `/user/:pubkey/reporters`); hover underlines the value (existing rule).
+- **Behavior:** clicking navigates to the Verified Reporters list. Accessible name conveys PoV, e.g. `title`/`aria-label`: *"3 verified reporters in your web of trust — view list"* (personal) or *"…in the House (default) web of trust…"* (fallback).
+- **PoV attribution (lightweight):** when the **House fallback** is active, append a small muted **"House"** qualifier chip to the label so the fallback is never silent even at a glance. Personal PoV shows no chip (it is the expected default). Full attribution lives on the list page.
+- **States:**
+  - **`> 0`:** red value, linked. (`3 Verified Reporters`)
+  - **Zero:** neutral value (inherits `--text`), **not** a link — there is nothing to inspect. (`0 Verified Reporters`) This *is* the count's empty state.
+  - **Loading:** reuse `.bsp-counts-loading` (value at opacity 0.4).
+  - **Unavailable / not computed:** render `—` (existing `fmtCount(null)`), muted, not a link.
+
+### Verified Reporters list page (`/user/:pubkey/reporters`)
+- **Visual:** clone of the Following page. `.bsp-follows-header` with `← Back to profile`, title **"Verified Reporters"**, and the ⓘ info button. A one-line muted **subtitle**: *"Verified users who have reported this account."* Below it, the **PoV attribution line** (see below). Then the existing controls (search + Columns toggle) and the `DataTable`.
+- **Columns:** reuse the existing column set. **Default visible:** Picture, Name, **Rank**. Optional (hidden) : npub, Hops, Verified Followers/Muters/Reporters. **Rank is the credibility weight** — it is what lets the Vetting Observer judge *whose* report this is.
+- **Default sort:** **Rank (influence) descending** — most credible reporters first, so "is this flagged by people who matter?" is answerable at a glance. (Deliberately differs from Following's sort, which is by verified-follower count.)
+- **Row behavior:** clicking a row navigates to that reporter's profile (`/user/:pubkey`) so the observer can vet the reporter.
+- **PoV attribution (primary home):** a visible line under the subtitle:
+  - Personal: *"Relative to your web of trust."*
+  - House fallback: *"Relative to the House (default) web of trust. Sign in and build your network to see your own view."* — styled muted, but always present.
+  - The ⓘ **"About this data" popover** is extended to explain: data is computed locally (existing copy) **plus** "Counts are personal to each viewer's web of trust — there is no single global number."
+- **States:**
+  - **Empty (zero reporters):** designed `.bsp-empty`: *"No verified reporters. No one in this web of trust has reported this account."* Never blank.
+  - **Loading:** a **skeleton table** (3–5 shimmer rows matching column layout), not the bare "Loading…" text — upgrades the guardrail bar over the existing text loader.
+  - **Error:** `.bsp-trust-unavailable` with 🔒 and a *helpful* message + retry: *"Couldn't load reporters — {reason}. Try again."* Never "Something went wrong."
+
+### About-this-data popover
+- **Visual/behavior:** reuse `InfoPopover` (`.bsp-confirm-overlay` / `.bsp-confirm-box`) verbatim. Tap ⓘ to open, tap outside or "Got it" to close (mobile-friendly). Content extended with the PoV / no-global-view sentence.
+
+## Screen inventory
+| Screen | Purpose | Wireframe |
+|---|---|---|
+| Profile — counts row (with Verified Reporters) | Surface the PoV-filtered count parallel to Following/Verified Followers; entry to the list | [verified-reporters-wireframes.html](./verified-reporters-wireframes.html) §A |
+| Verified Reporters list (`/user/:pubkey/reporters`) | Inspect *which* verified users reported the account, weigh them by Rank | [verified-reporters-wireframes.html](./verified-reporters-wireframes.html) §B |
+| List — empty / loading / error / House-PoV | Designed non-happy states | [verified-reporters-wireframes.html](./verified-reporters-wireframes.html) §B |
+
+## Responsive behavior
+- **Mobile (≤ 600px):** counts row wraps (existing `flex-wrap: wrap`); the new count never truncates — it wraps to its own line if needed. List page shows only Picture/Name/Rank (the defaults), search goes full-width, the Columns menu remains reachable. Count link and table rows are ≥ 44px touch targets.
+- **Tablet (601–960px):** counts inline; list table as-is with default columns.
+- **Desktop (> 960px):** unchanged from the existing pages; optional columns available via the toggle.
+
+## Accessibility baseline
+- **Contrast:** red value `--red` `#f85149` on `--bg` `#0d1117` ≈ **5.4:1** — passes AA for the 600-weight value. Muted label (opacity 0.6) must resolve to ≥ 4.5:1; matches the existing Following label.
+- **Color is never the only signal:** the label word "Verified Reporters" and the numeric value carry meaning independent of red; the House qualifier is a word, not a color.
+- **Keyboard:** the count is a real `<Link>` (focusable, Enter-activates); the ⓘ button and rows are keyboard-operable (existing behavior).
+- **Touch targets:** ≥ 44×44px for the count link, the ⓘ button, and table rows.
+- **Screen readers:** the count's `aria-label` states the number *and* the PoV; the PoV line is real text in the DOM, not an icon.

--- a/product-team/guides/verified-reporters-design-guide.md
+++ b/product-team/guides/verified-reporters-design-guide.md
@@ -21,7 +21,7 @@ Non-negotiable; enforced in engineering review.
 
 1. **Parallel, not novel.** The Verified Reporters count and list reuse the exact components, classes, spacing, and route shape of Following / Verified Followers. A reviewer should not be able to tell the two features were built at different times.
 2. **Negative signal by color, meaning by word.** The count is marked negative with the existing **`--red`** semantic (the app already encodes "report" as red). Color never carries the meaning *alone* — the label word "Reporters" carries it; red reinforces. (Accessibility + the warning reading both hold.)
-3. **No silent global numbers.** Every surface that shows the count states whose PoV produced it. Personal PoV is the default and needs no shouting; **House fallback is always labeled**, never silent.
+3. **No silent global numbers — at the investigation surface.** The Verified Reporters *list* always states whose PoV produced it (personal or House). The *count* carries no per-count PoV marker: the House fallback applies to all three counts (Following, Verified Followers, Verified Reporters) at once, so a single counts-row-level indicator is the right home — deferred to a cross-cutting session rather than stamped three times here. The principle holds where it is load-bearing (the list, where a viewer could be misled); the glance-only count defers to it one tap away.
 4. **Zero is reassurance, not a warning.** A real "0" renders neutral (not red) and is visually distinct from "—" (not computed / unavailable). Three distinct states: `> 0` (red, linked), `0` (neutral, not linked), `unavailable` (`—`, muted).
 5. **Every state is designed.** Empty, loading (skeleton, not a bare spinner), and error (helpful, with a retry) are first-class for both the count and the list.
 6. **Tokens only.** No hex or px literals in components — reference the CSS custom properties below. (Note: the existing Report button hardcodes `#ef4444`; the count should use the `--red` token instead.)
@@ -63,8 +63,8 @@ This feature adds **no new tokens**. If a negative-surface tint is ever needed, 
 
 ### Verified Reporters count (on the profile)
 - **Visual:** a `.bsp-count` inside the existing `.bsp-counts` row, placed parallel to Following / Verified Followers. Structure: `<value> <label>`. Label: **"Verified Reporters"**. When `> 0`, the value uses `--red` and the whole item is a `.bsp-count-link` (`<Link>` to `/user/:pubkey/reporters`); hover underlines the value (existing rule).
-- **Behavior:** clicking navigates to the Verified Reporters list. Accessible name conveys PoV, e.g. `title`/`aria-label`: *"3 verified reporters in your web of trust — view list"* (personal) or *"…in the House (default) web of trust…"* (fallback).
-- **PoV attribution (lightweight):** when the **House fallback** is active, append a small muted **"House"** qualifier chip to the label so the fallback is never silent even at a glance. Personal PoV shows no chip (it is the expected default). Full attribution lives on the list page.
+- **Behavior:** clicking navigates to the Verified Reporters list. Accessible name states the number and the destination, e.g. `aria-label`: *"3 verified reporters. View list."* PoV is conveyed on the list page, not duplicated per count.
+- **PoV attribution:** none at the count level in this release — no per-count "House" chip. Whose view produced the number is stated on the list page (one tap away). A single counts-row-level indicator covering all three counts is deferred to a cross-cutting session (see Grounding note and PRD §8.3 / §11 decision 5). Rationale: the fallback applies to Following, Verified Followers, and Verified Reporters together; three chips crowd the row, and a hover-only tooltip fails on touch devices. Accepted tradeoff: a glance-only viewer on the House fallback sees an unlabeled count, attributed fully on the list.
 - **States:**
   - **`> 0`:** red value, linked. (`3 Verified Reporters`)
   - **Zero:** neutral value (inherits `--text`), **not** a link — there is nothing to inspect. (`0 Verified Reporters`) This *is* the count's empty state.
@@ -105,4 +105,4 @@ This feature adds **no new tokens**. If a negative-surface tint is ever needed, 
 - **Color is never the only signal:** the label word "Verified Reporters" and the numeric value carry meaning independent of red; the House qualifier is a word, not a color.
 - **Keyboard:** the count is a real `<Link>` (focusable, Enter-activates); the ⓘ button and rows are keyboard-operable (existing behavior).
 - **Touch targets:** ≥ 44×44px for the count link, the ⓘ button, and table rows.
-- **Screen readers:** the count's `aria-label` states the number *and* the PoV; the PoV line is real text in the DOM, not an icon.
+- **Screen readers:** the count's `aria-label` states the number and the destination; the PoV is conveyed as real DOM text on the list page (the point-of-view line), not as an icon and not duplicated per count.

--- a/product-team/guides/verified-reporters-style-guide.md
+++ b/product-team/guides/verified-reporters-style-guide.md
@@ -1,0 +1,60 @@
+# Style Guide: Verified Reporters
+
+**Slug:** verified-reporters
+**Date:** 2026-06-07
+
+> Governs all user-facing text in this feature. Binding during engineering review. Built from `product-team/guardrails/language.md` plus this product's voice. Inherits, and never relaxes, the base guardrails.
+
+## Voice
+
+Plain, exact, and trust-aware. This feature deals in reputation and warnings, so the copy is calm and factual — it states what is true and whose view it reflects, and lets the reader judge. It never editorializes about the reported account ("dangerous," "bad actor") and never reassures falsely. It is precise about point of view: every number belongs to someone's web of trust, and the copy says so.
+
+Sounds like a careful colleague stating facts, not a platform issuing verdicts.
+
+## Language rules
+Base guardrails apply in full. Emphasized for this feature:
+
+- **Active voice.** "3 verified users reported this account," not "this account was reported."
+- **Concrete over vague.** State the number and the point of view. "Relative to your web of trust," not "personalized."
+- **No verdicts about the subject.** The copy describes the *signal*, never the *person*. Never "this account is untrustworthy."
+- **Whose view, always.** Any surface showing the count or list names the point of view (personal or House) in words.
+- **No em-dash sentence joins** as a default connective. Use a period or restructure. (Two copy strings from the design draft were rewritten for this; see canonical copy below.)
+- **No marketing tone, no superlatives, no false intimacy, no exclamation marks** in UI copy.
+
+## Iconography ruling (resolves a guardrail tension)
+
+The base guardrail bans "emoji in product copy." This feature reuses the app's existing unicode glyphs — flag (reporter motif), information (ⓘ), and lock (unavailable) — as **iconography**, the app's established visual indicator system, not as copy. They are permitted on that basis (the design guardrail allows "typography, colored shapes, brand marks, or hand-crafted SVG," and the existing Reporters metric already uses the flag glyph). They must never appear *inside a sentence* the user reads. This is open question #3 in the PRD; the recommended resolution is to keep them as iconography. If reversed, replace with hand-crafted SVG — do not substitute different emoji.
+
+## UI copy patterns
+
+- **Labels:** noun phrase, title-less. Count label: "Verified Reporters". Column: "Rank".
+- **Point-of-view lines:** state the lens plainly and, for the fallback, what to do about it.
+- **Empty states:** say there is nothing and why, in the viewer's terms.
+- **Error messages:** what happened and what to do; offer a retry. Never "Something went wrong."
+- **Links/navigation:** describe the destination ("Back to profile").
+
+## Canonical copy (use verbatim)
+
+| Surface | Copy |
+|---|---|
+| Count label | `Verified Reporters` |
+| Count accessible name | `{n} verified reporters. View list.` |
+| List title | `Verified Reporters` |
+| List description | `Verified users who have reported this account.` |
+| Point-of-view line (personal) | `Relative to your web of trust.` |
+| Point-of-view line (House) | `Relative to the House (default) web of trust. Sign in and build your network to see your own view.` |
+| Back link | `Back to profile` |
+| Empty state | `No verified reporters. No one in this web of trust has reported this account.` |
+| Error state | `Couldn't load reporters. Trust scores may still be computing for this view. Try again in a moment.` |
+| Retry button | `Try again` |
+| "About this data" popover | `All data on this page is computed locally by this Tapestry instance and is not imported via NIP-85.` / `Counts are personal to each viewer's web of trust. There is no single global number. When you have no calculated web of trust, the House (default) view is shown.` |
+
+> The error and popover strings above are the corrected, guardrail-compliant versions of the design-guide drafts (em-dash joins removed).
+
+## Forbidden phrases
+Base list from `product-team/guardrails/language.md`, plus feature-specific:
+
+- Any verdict about the reported account: "untrustworthy," "dangerous," "scammer," "bad actor," "flagged for removal."
+- Any framing that implies a global truth: "the number of reporters," "total reports," "globally reported." Always bind to a point of view.
+- "Reported by the community" (implies a single undifferentiated public; the signal is point-of-view-relative).
+- Superlatives about the signal: "highly reported," "most-reported." State the number.

--- a/product-team/guides/verified-reporters-wireframes.html
+++ b/product-team/guides/verified-reporters-wireframes.html
@@ -1,0 +1,232 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Verified Reporters — Wireframes</title>
+<style>
+  /* ── Real app tokens (ui/src/styles.css :root) ── */
+  :root{
+    --bg:#0d1117; --bg-secondary:#161b22; --bg-tertiary:#21262d;
+    --border:#30363d; --text:#e6edf3; --text-muted:#8b949e;
+    --accent:#58a6ff; --accent-hover:#79c0ff;
+    --green:#3fb950; --orange:#d29922; --red:#f85149; --radius:8px;
+    --font:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:#05070a;color:var(--text);font-family:var(--font);line-height:1.5;padding:32px}
+  h2.section{font-size:1.1rem;letter-spacing:.04em;text-transform:uppercase;color:var(--accent);
+    border-bottom:1px solid var(--border);padding-bottom:8px;margin:48px 0 8px}
+  h2.section:first-of-type{margin-top:0}
+  .note{color:var(--text-muted);font-size:.85rem;margin:0 0 20px;max-width:760px}
+  .frame-label{color:var(--text-muted);font-size:.72rem;text-transform:uppercase;letter-spacing:.06em;margin:24px 0 6px}
+  .device{background:var(--bg);border:1px solid var(--border);border-radius:12px;padding:20px;max-width:760px;margin-bottom:8px}
+  .device.mobile{max-width:380px}
+
+  /* ── Profile shell bits ── */
+  .bsp-header{display:flex;gap:14px;align-items:center;margin-bottom:6px}
+  .bsp-avatar{width:56px;height:56px;border-radius:50%;background:var(--bg-tertiary);
+    display:flex;align-items:center;justify-content:center;font-size:1.4rem;color:var(--text-muted)}
+  .bsp-name{font-size:1.3rem;margin:0}
+  .bsp-nip05{color:var(--text-muted);font-size:.85rem}
+
+  /* ── Counts row (mirrors .bsp-counts / .bsp-count) ── */
+  .bsp-counts{display:flex;align-items:baseline;flex-wrap:wrap;gap:.9rem;margin:.5rem 0 .25rem;font-size:.9rem}
+  .bsp-count{display:inline-flex;align-items:baseline;gap:.35rem;text-decoration:none;color:inherit}
+  .bsp-count-value{font-weight:600;color:var(--text)}
+  .bsp-count-label{opacity:.6}
+  a.bsp-count-link{cursor:pointer}
+  a.bsp-count-link:hover .bsp-count-value{text-decoration:underline}
+  /* negative-signal variant */
+  .bsp-count-value.neg{color:var(--red)}
+  .pov-chip{font-size:.62rem;font-weight:600;letter-spacing:.03em;color:var(--orange);
+    border:1px solid var(--orange);border-radius:999px;padding:0 .4em;opacity:.9;margin-left:.15rem}
+  .loading .bsp-count-value{opacity:.4}
+  .cap{color:var(--text-muted);font-size:.72rem;margin-top:6px}
+
+  /* ── List page (mirrors .bsp-follows-*) ── */
+  .bsp-follows-header{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:4px}
+  .bsp-back-link{font-size:.85rem;opacity:.75;text-decoration:none;color:var(--text)}
+  .bsp-back-link:hover{opacity:1;text-decoration:underline}
+  .bsp-follows-title{margin:0;font-size:1.4rem}
+  .bsp-info-btn{width:22px;height:22px;border-radius:50%;border:1px solid var(--border);
+    background:transparent;color:var(--text-muted);cursor:pointer;font-size:.75rem;line-height:1}
+  .subtitle{color:var(--text-muted);font-size:.9rem;margin:2px 0 0}
+  .pov-line{font-size:.82rem;margin:6px 0 0;color:var(--text-muted)}
+  .pov-line.house{color:var(--orange)}
+  .controls{display:flex;gap:10px;margin:16px 0 12px;flex-wrap:wrap}
+  .search{flex:1;min-width:160px;background:var(--bg-tertiary);border:1px solid var(--border);
+    color:var(--text);border-radius:6px;padding:8px 10px;font-size:.9rem}
+  .colbtn{background:var(--bg-tertiary);border:1px solid var(--border);color:var(--text);
+    border-radius:6px;padding:8px 12px;font-size:.9rem;cursor:pointer}
+
+  table{width:100%;border-collapse:collapse;font-size:.9rem}
+  th{text-align:left;color:var(--text-muted);font-weight:600;font-size:.78rem;text-transform:uppercase;
+    letter-spacing:.04em;padding:8px 10px;border-bottom:1px solid var(--border)}
+  td{padding:10px;border-bottom:1px solid rgba(255,255,255,.06)}
+  tr.row{cursor:pointer}
+  tr.row:hover td{background:rgba(255,255,255,.03)}
+  .av{width:30px;height:30px;border-radius:50%;background:var(--bg-tertiary);display:inline-flex;
+    align-items:center;justify-content:center;color:var(--text-muted);font-size:.8rem}
+  .rank{font-weight:600}
+  .rank.hi{color:var(--green)}
+  code{color:var(--text-muted);font-size:.8rem}
+
+  /* states */
+  .bsp-empty{padding:2rem;text-align:center;opacity:.7}
+  .bsp-empty .big{font-size:1.6rem;display:block;margin-bottom:.4rem}
+  .bsp-unavailable{display:flex;gap:.5rem;align-items:center;padding:1rem;background:rgba(248,81,73,.08);
+    border:1px solid rgba(248,81,73,.25);border-radius:var(--radius);color:#fca5a5}
+  .retry{margin-left:auto;background:transparent;border:1px solid var(--red);color:#fca5a5;
+    border-radius:6px;padding:4px 10px;cursor:pointer;font-size:.82rem}
+  .sk{height:30px;border-radius:6px;background:linear-gradient(90deg,rgba(255,255,255,.04),rgba(255,255,255,.09),rgba(255,255,255,.04));
+    background-size:200% 100%;animation:sh 1.2s infinite}
+  .sk.av{width:30px;height:30px;border-radius:50%}
+  @keyframes sh{0%{background-position:200% 0}100%{background-position:-200% 0}}
+
+  /* popover */
+  .pop{background:var(--bg-secondary);border:1px solid var(--border);border-radius:var(--radius);
+    padding:18px;max-width:420px;margin-top:8px}
+  .pop h3{margin:0 0 8px;font-size:1rem}
+  .pop p{margin:0 0 10px;color:var(--text-muted);font-size:.88rem}
+  .pop .ok{background:var(--accent);border:none;color:#06121f;border-radius:6px;padding:6px 14px;cursor:pointer;font-weight:600}
+  .legend{max-width:760px;color:var(--text-muted);font-size:.82rem;border-left:2px solid var(--accent);padding-left:12px;margin:6px 0 0}
+</style>
+</head>
+<body>
+
+<h2 class="section">§A · Profile — counts row</h2>
+<p class="note">The new <strong>Verified Reporters</strong> count sits in the existing <code>.bsp-counts</code> row, parallel to Following and Verified Followers. Value uses <code>--red</code> only when &gt; 0. Three numeric states: <strong>&gt;0</strong> (red, linked) · <strong>0</strong> (neutral, not linked) · <strong>unavailable</strong> (—).</p>
+
+<div class="frame-label">A1 · Personal PoV, count &gt; 0 (default happy path)</div>
+<div class="device">
+  <div class="bsp-header"><div class="bsp-avatar">A</div>
+    <div><h1 class="bsp-name">alice</h1><div class="bsp-nip05">✅ alice@example.com</div></div></div>
+  <div class="bsp-counts">
+    <a class="bsp-count bsp-count-link" href="#"><span class="bsp-count-value">1,204</span><span class="bsp-count-label">Following</span></a>
+    <a class="bsp-count bsp-count-link" href="#"><span class="bsp-count-value">312</span><span class="bsp-count-label">Verified Followers</span></a>
+    <a class="bsp-count bsp-count-link" href="#" title="3 verified reporters in your web of trust — view list">
+      <span class="bsp-count-value neg">3</span><span class="bsp-count-label">Verified Reporters</span></a>
+  </div>
+  <div class="cap">↑ red value + linked. aria-label states number <em>and</em> PoV.</div>
+</div>
+
+<div class="frame-label">A2 · Zero (reassurance, not warning — neutral, NOT a link)</div>
+<div class="device">
+  <div class="bsp-counts">
+    <a class="bsp-count bsp-count-link" href="#"><span class="bsp-count-value">1,204</span><span class="bsp-count-label">Following</span></a>
+    <a class="bsp-count bsp-count-link" href="#"><span class="bsp-count-value">312</span><span class="bsp-count-label">Verified Followers</span></a>
+    <span class="bsp-count" title="No verified reporters in your web of trust">
+      <span class="bsp-count-value">0</span><span class="bsp-count-label">Verified Reporters</span></span>
+  </div>
+  <div class="cap">↑ "0" is neutral (not red), not clickable — this is the count's empty state.</div>
+</div>
+
+<div class="frame-label">A3 · House PoV fallback (never silent — "House" chip + tooltip)</div>
+<div class="device">
+  <div class="bsp-counts">
+    <a class="bsp-count bsp-count-link" href="#"><span class="bsp-count-value">1,204</span><span class="bsp-count-label">Following</span></a>
+    <a class="bsp-count bsp-count-link" href="#"><span class="bsp-count-value">312</span><span class="bsp-count-label">Verified Followers</span></a>
+    <a class="bsp-count bsp-count-link" href="#" title="2 verified reporters in the House (default) web of trust — view list">
+      <span class="bsp-count-value neg">2</span><span class="bsp-count-label">Verified Reporters</span><span class="pov-chip">House</span></a>
+  </div>
+  <div class="cap">↑ logged-out / no personal WoT → "House" qualifier so the fallback is visible at a glance.</div>
+</div>
+
+<div class="frame-label">A4 · Loading · A5 · Unavailable</div>
+<div class="device">
+  <div class="bsp-counts loading" style="margin-bottom:14px">
+    <span class="bsp-count"><span class="bsp-count-value">312</span><span class="bsp-count-label">Verified Followers</span></span>
+    <span class="bsp-count"><span class="bsp-count-value">8</span><span class="bsp-count-label">Verified Reporters</span></span>
+  </div>
+  <div class="bsp-counts">
+    <span class="bsp-count"><span class="bsp-count-value">312</span><span class="bsp-count-label">Verified Followers</span></span>
+    <span class="bsp-count"><span class="bsp-count-value">—</span><span class="bsp-count-label">Verified Reporters</span></span>
+  </div>
+  <div class="cap">↑ loading: value dimmed (.bsp-counts-loading). unavailable/not-computed: "—", muted, not a link.</div>
+</div>
+
+<h2 class="section">§B · Verified Reporters list — <code>/user/:pubkey/reporters</code></h2>
+<p class="note">Clone of the Following page. Default sort = <strong>Rank ↓</strong> (most credible reporters first — answers "is this flagged by people who matter?"). Rows link to the reporter's profile so the observer can vet them. PoV attribution is the primary job of this page.</p>
+
+<div class="frame-label">B1 · Populated · Personal PoV</div>
+<div class="device">
+  <div class="bsp-follows-header">
+    <a class="bsp-back-link" href="#">← Back to profile</a>
+    <h1 class="bsp-follows-title">Verified Reporters</h1>
+    <button class="bsp-info-btn" aria-label="About this data">ⓘ</button>
+  </div>
+  <p class="subtitle">Verified users who have reported this account.</p>
+  <p class="pov-line">Relative to your web of trust.</p>
+  <div class="controls"><input class="search" placeholder="Search by name or npub…" /><button class="colbtn">Columns ▾</button></div>
+  <table>
+    <thead><tr><th></th><th>Name</th><th>Rank ▾</th></tr></thead>
+    <tbody>
+      <tr class="row"><td><span class="av">D</span></td><td>dan.well-known</td><td><span class="rank hi">94</span></td></tr>
+      <tr class="row"><td><span class="av">E</span></td><td>erin</td><td><span class="rank hi">81</span></td></tr>
+      <tr class="row"><td><span class="av">F</span></td><td>finn</td><td><span class="rank">63</span></td></tr>
+      <tr class="row"><td><span class="av">G</span></td><td>gwen</td><td><span class="rank">40</span></td></tr>
+    </tbody>
+  </table>
+  <div class="cap">Default cols: Picture · Name · Rank. Hidden (Columns ▾): npub · Hops · Verified Followers/Muters/Reporters.</div>
+</div>
+
+<div class="frame-label">B2 · House PoV fallback (attribution always present)</div>
+<div class="device">
+  <div class="bsp-follows-header">
+    <a class="bsp-back-link" href="#">← Back to profile</a>
+    <h1 class="bsp-follows-title">Verified Reporters</h1>
+    <button class="bsp-info-btn" aria-label="About this data">ⓘ</button>
+  </div>
+  <p class="subtitle">Verified users who have reported this account.</p>
+  <p class="pov-line house">Relative to the House (default) web of trust. Sign in and build your network to see your own view.</p>
+  <div class="cap">↑ same page, House variant of the PoV line (amber, never hidden).</div>
+</div>
+
+<div class="frame-label">B3 · "About this data" popover (extended with the no-global-view sentence)</div>
+<div class="pop">
+  <h3>About this data</h3>
+  <p>All data on this page is computed locally by this Tapestry instance and is not imported via NIP-85.</p>
+  <p><strong>Counts are personal to each viewer's web of trust — there is no single global number.</strong> When you have no calculated web of trust, the House (default) view is shown.</p>
+  <button class="ok">Got it</button>
+</div>
+
+<div class="frame-label">B4 · Empty (zero reporters)</div>
+<div class="device">
+  <div class="bsp-follows-header"><a class="bsp-back-link" href="#">← Back to profile</a><h1 class="bsp-follows-title">Verified Reporters</h1><button class="bsp-info-btn" aria-label="About this data">ⓘ</button></div>
+  <p class="pov-line">Relative to your web of trust.</p>
+  <div class="bsp-empty"><span class="big">🚩</span>No verified reporters.<br/>No one in this web of trust has reported this account.</div>
+</div>
+
+<div class="frame-label">B5 · Loading (skeleton, not a bare spinner)</div>
+<div class="device">
+  <div class="bsp-follows-header"><a class="bsp-back-link" href="#">← Back to profile</a><h1 class="bsp-follows-title">Verified Reporters</h1></div>
+  <p class="pov-line">Relative to your web of trust.</p>
+  <table style="margin-top:12px"><thead><tr><th></th><th>Name</th><th>Rank</th></tr></thead><tbody>
+    <tr><td><div class="sk av"></div></td><td><div class="sk" style="width:60%"></div></td><td><div class="sk" style="width:30px"></div></td></tr>
+    <tr><td><div class="sk av"></div></td><td><div class="sk" style="width:45%"></div></td><td><div class="sk" style="width:30px"></div></td></tr>
+    <tr><td><div class="sk av"></div></td><td><div class="sk" style="width:70%"></div></td><td><div class="sk" style="width:30px"></div></td></tr>
+  </tbody></table>
+</div>
+
+<div class="frame-label">B6 · Error (helpful + retry — never "Something went wrong")</div>
+<div class="device">
+  <div class="bsp-follows-header"><a class="bsp-back-link" href="#">← Back to profile</a><h1 class="bsp-follows-title">Verified Reporters</h1></div>
+  <div class="bsp-unavailable" style="margin-top:14px"><span>🔒</span><span>Couldn't load reporters — trust scores are still computing for this view. Try again in a moment.</span><button class="retry">Try again</button></div>
+</div>
+
+<div class="frame-label">B7 · Mobile (≤600px) — defaults keep it narrow, row ≥44px touch target</div>
+<div class="device mobile">
+  <div class="bsp-follows-header"><a class="bsp-back-link" href="#">← Back</a><h1 class="bsp-follows-title" style="font-size:1.2rem">Verified Reporters</h1></div>
+  <p class="pov-line">Relative to your web of trust.</p>
+  <input class="search" style="width:100%;margin:12px 0" placeholder="Search by name or npub…" />
+  <table><thead><tr><th></th><th>Name</th><th>Rank</th></tr></thead><tbody>
+    <tr class="row"><td><span class="av">D</span></td><td>dan.well-known</td><td><span class="rank hi">94</span></td></tr>
+    <tr class="row"><td><span class="av">E</span></td><td>erin</td><td><span class="rank hi">81</span></td></tr>
+  </tbody></table>
+</div>
+
+<p class="legend">Tokens, classes, and the route shape are taken verbatim from <code>ui/src/pages/BrainstormProfile.jsx</code>, <code>ui/src/pages/BrainstormFollows.jsx</code>, and <code>ui/src/styles.css</code>. This wireframe introduces no new visual identity — only the negative-signal application of <code>--red</code> and the PoV attribution surfaces.</p>
+
+</body>
+</html>

--- a/product-team/guides/verified-reporters-wireframes.html
+++ b/product-team/guides/verified-reporters-wireframes.html
@@ -39,8 +39,6 @@
   a.bsp-count-link:hover .bsp-count-value{text-decoration:underline}
   /* negative-signal variant */
   .bsp-count-value.neg{color:var(--red)}
-  .pov-chip{font-size:.62rem;font-weight:600;letter-spacing:.03em;color:var(--orange);
-    border:1px solid var(--orange);border-radius:999px;padding:0 .4em;opacity:.9;margin-left:.15rem}
   .loading .bsp-count-value{opacity:.4}
   .cap{color:var(--text-muted);font-size:.72rem;margin-top:6px}
 
@@ -122,15 +120,15 @@
   <div class="cap">↑ "0" is neutral (not red), not clickable — this is the count's empty state.</div>
 </div>
 
-<div class="frame-label">A3 · House PoV fallback (never silent — "House" chip + tooltip)</div>
+<div class="frame-label">A3 · House PoV fallback (no per-count marker — count is identical to A1; PoV attributed on the list)</div>
 <div class="device">
   <div class="bsp-counts">
     <a class="bsp-count bsp-count-link" href="#"><span class="bsp-count-value">1,204</span><span class="bsp-count-label">Following</span></a>
     <a class="bsp-count bsp-count-link" href="#"><span class="bsp-count-value">312</span><span class="bsp-count-label">Verified Followers</span></a>
-    <a class="bsp-count bsp-count-link" href="#" title="2 verified reporters in the House (default) web of trust — view list">
-      <span class="bsp-count-value neg">2</span><span class="bsp-count-label">Verified Reporters</span><span class="pov-chip">House</span></a>
+    <a class="bsp-count bsp-count-link" href="#" title="2 verified reporters. View list.">
+      <span class="bsp-count-value neg">2</span><span class="bsp-count-label">Verified Reporters</span></a>
   </div>
-  <div class="cap">↑ logged-out / no personal WoT → "House" qualifier so the fallback is visible at a glance.</div>
+  <div class="cap">↑ Under the House fallback the count is visually identical to A1. The fallback applies to all three counts at once, so a per-count "House" chip is intentionally omitted. PoV is attributed on the list page (§B2). <strong>Deferred (PRD §8.3):</strong> a single, tap-friendly row-level PoV indicator for Following + Verified Followers + Verified Reporters together.</div>
 </div>
 
 <div class="frame-label">A4 · Loading · A5 · Unavailable</div>

--- a/product-team/journeys/verified-reporters-cautious-newcomer.md
+++ b/product-team/journeys/verified-reporters-cautious-newcomer.md
@@ -1,0 +1,41 @@
+# Journey: The Cautious Newcomer
+
+**Slug:** verified-reporters-cautious-newcomer
+**Persona:** `product-team/personas/verified-reporters-cautious-newcomer.md`
+**Date:** 2026-06-07
+
+From first encounter to engaged user. This journey carries the first-visit / no-account experience and the House PoV fallback path.
+
+## Steps
+
+### 1. Arrive
+- **Trigger:** follows a shared link to a profile, with no account and no calculated WoT.
+- **Action:** view the profile.
+- **Expected experience:** trust signals render; the Verified Reporters count uses the House PoV fallback rather than failing or showing nothing.
+- **Emotional state:** curious, slightly wary.
+
+### 2. Read with uncertainty
+- **Trigger:** sees a count but has no network of their own.
+- **Action:** tries to interpret what the number means.
+- **Expected experience:** the UI signals that this is the House (default) view, not their personal network.
+- **Emotional state:** needs clarity / reassurance.
+
+### 3. Understand the model
+- **Trigger:** notices the count is labeled as a default rather than personal.
+- **Action:** accepts it provisionally as a baseline.
+- **Expected experience:** learns implicitly that the "real" number is personal and earned by building a network — there is no single global truth.
+- **Emotional state:** oriented, not misled.
+
+### 4. Graduate
+- **Trigger:** builds a web of trust over time.
+- **Action:** returns to profiles and now reads a PoV-filtered count of their own.
+- **Expected experience:** the number becomes theirs; they enter the Vetting Observer's loop.
+- **Emotional state:** invested.
+
+## First-visit experience
+This entire journey *is* the first-visit experience. A brand-new or logged-out viewer must still get a credible, clearly-labeled signal via the House PoV fallback. Value does not require an account — but the fallback must be presented as a default baseline, never as a personal or global truth.
+
+## Friction points
+- **Silent global default:** showing the House number without labeling it would contradict the no-global-view ethos and quietly mis-teach the model.
+- **Account wall:** requiring an account before showing *any* value would break the first-visit experience.
+- **Unexplained gap:** if the House view and a personal view differ later with no explanation, the newcomer feels the product is inconsistent rather than personalized.

--- a/product-team/journeys/verified-reporters-vetting-observer.md
+++ b/product-team/journeys/verified-reporters-vetting-observer.md
@@ -1,0 +1,48 @@
+# Journey: The Vetting Observer
+
+**Slug:** verified-reporters-vetting-observer
+**Persona:** `product-team/personas/verified-reporters-vetting-observer.md`
+**Date:** 2026-06-07
+
+From first encounter to engaged user. Includes the first-visit experience — the first time this user ever sees the Verified Reporters count.
+
+## Steps
+
+### 1. Encounter
+- **Trigger:** a stranger appears — a mention, a feed item, a search result.
+- **Action:** open the stranger's profile.
+- **Expected experience:** the profile loads with the trust-signals row, including a Verified Reporters count filtered to the observer's PoV, parallel to Following and Verified Followers.
+- **Emotional state:** routine, scanning.
+
+### 2. Notice the signal
+- **Trigger:** the Verified Reporters count is non-zero.
+- **Action:** pause and read the number.
+- **Expected experience:** the count is clearly attributed to their own PoV and is visually parallel to Verified Followers but legible as a *negative* signal — not blended into the positive ones.
+- **Emotional state:** alert, cautious.
+
+### 3. Investigate
+- **Trigger:** the count is high enough to be consequential.
+- **Action:** click the count to open the list of verified reporters.
+- **Expected experience:** the list shows *which* verified users reported this account, so the observer can weigh credibility — do I respect these reporters?
+- **Emotional state:** discerning.
+
+### 4. Decide
+- **Trigger:** enough information to judge.
+- **Action:** follow, ignore, or avoid.
+- **Expected experience:** a snap judgment supported by evidence rather than vibes.
+- **Emotional state:** confident.
+
+### 5. Recalibrate
+- **Trigger:** repeated encounters over time.
+- **Action:** continue vetting strangers with the signal in hand.
+- **Expected experience:** the signal sharpens their instincts and proves reliable.
+- **Emotional state:** trusts the system.
+
+## First-visit experience
+The first time this user ever sees the Verified Reporters count, it must be self-explanatory — a clear label plus PoV attribution — so it is never mistaken for a global number. No onboarding step should be required to make the signal legible.
+
+## Friction points
+- **Zero-state ambiguity:** is "0" a clean record, or simply not computed? The two must be distinguishable.
+- **Unweighable singletons:** a "1" from a possible pile-on-er presented with no way to weigh the reporter (discounting is a future feature; for now the list must at least be inspectable).
+- **Self-view retaliation:** seeing exactly who reported you enables retaliation; the self-view case needs deliberate handling.
+- **Count-vs-list mismatch:** if the count and the list apply filters differently, the numbers won't agree and trust in the signal erodes.

--- a/product-team/personas/verified-reporters-cautious-newcomer.md
+++ b/product-team/personas/verified-reporters-cautious-newcomer.md
@@ -1,0 +1,22 @@
+# Persona: The Cautious Newcomer
+
+**Slug:** verified-reporters-cautious-newcomer
+**Priority:** Secondary
+**Date:** 2026-06-07
+
+## Who they are
+New to Tapestry, or not logged in, with **no calculated web of trust yet**. They want to avoid bad actors but have no personal network to filter through. They are exploratory and a little wary, and they do not yet understand web-of-trust mechanics.
+
+## What they want
+Some credible signal about whether a stranger is widely flagged, despite having no network of their own to filter through.
+
+## Their core loop
+Land on a profile (often via a shared link, before having an account) → look for trust signals → hit the **House PoV fallback** for Verified Reporters → understand this is a shared default, not their own view → use it provisionally → build their own web of trust over time and graduate into the Vetting Observer's loop.
+
+## What they won't tolerate
+- Being silently shown a "global" number that contradicts the no-global-view principle.
+- Confusion about why their number differs from what an established user sees.
+- A dead end that requires an account before showing any value.
+
+## Notes
+This persona exists to force the design to handle the House PoV fallback explicitly and legibly (discovery open question #3). The first-visit / no-account experience lives here. Per discovery, the House PoV fallback should let even a no-WoT viewer see *something*, so first-visit value is achievable without an account — but the fallback must be labeled as a default, never passed off as a personal or global truth.

--- a/product-team/personas/verified-reporters-vetting-observer.md
+++ b/product-team/personas/verified-reporters-vetting-observer.md
@@ -1,0 +1,27 @@
+# Persona: The Vetting Observer
+
+**Slug:** verified-reporters-vetting-observer
+**Priority:** Primary
+**Date:** 2026-06-07
+
+## Who they are
+An established Tapestry user with a calculated web of trust. They habitually check a stranger's profile before following, replying to, or amplifying them. They read trust signals fluently and already use Following and Verified Followers as part of a snap judgment. They are constitutionally skeptical of raw counts and trust only signals filtered through their own network. They act on evidence, not vibes.
+
+## What they want
+To know at a glance whether people *they* trust have flagged this stranger, before deciding to engage.
+
+## Their core loop
+Encounter a stranger (mention, feed, search) → open their profile → scan the trust signals, including Verified Reporters → if the count is non-zero, drill into the list to weigh *who* reported and whether they respect those reporters → decide to engage, ignore, or avoid → sharper instincts on the next encounter.
+
+## What they won't tolerate
+- A count they can't trust — global or unfiltered noise carries no information.
+- A number with no way to see who is behind it.
+- Ambiguity about *whose* PoV the number reflects.
+- Latency that breaks the snap judgment.
+
+## Notes
+This is the anchor persona; every core design decision should serve it. Moderators and transactors are deferred inheritors of the same signal — at MVP scope they would see and want exactly what this persona does, so they are intentionally not modeled separately.
+
+Open edge cases for downstream phases:
+- **Self-view:** when this user views their *own* profile, do they see their own count and who reported them? This carries retaliation risk.
+- **Zero-state:** "0" must read as "no verified reports," never as "feature missing" or "not computed."

--- a/product-team/prd/verified-reporters.md
+++ b/product-team/prd/verified-reporters.md
@@ -1,0 +1,208 @@
+# Verified Reporters — Product Requirements Document
+
+**Slug:** verified-reporters
+**Date:** 2026-06-07
+**Status:** Draft
+**Companion guides:** `guides/verified-reporters-style-guide.md`, `guides/verified-reporters-design-guide.md`
+
+> Self-contained. A reader understands the product without opening the phase artifacts.
+
+## 1. Product Vision
+
+A person's Tapestry profile already shows positive trust signals: who they follow, and who within the viewer's trusted network follows them back (Verified Followers). It shows no credible **negative** signal. NIP-56 report data exists on the network, but in raw form it is worthless: a bad actor can manufacture an unlimited number of reports, burying any honest flag in noise. So a meaningful warning that *does* exist in the data is effectively invisible.
+
+**Verified Reporters** closes that gap. It is a count, shown on the profile parallel to Following and Verified Followers, of the verified users — people inside the viewer's own web of trust — who have filed a NIP-56 report against the account being viewed. The count links to a list of exactly who those reporters are, so the viewer can weigh them.
+
+The web of trust is what makes the metric credible. Because only *verified* reporters count, a pile-on of manufactured accounts stays invisible no matter how many reports it files. The number is therefore **relative to who is looking** — there is deliberately no global "verified reporters" figure. When a viewer has no calculated web of trust yet, a House (default) view is shown as a clearly-labeled fallback.
+
+## 2. Positioning & Competitive Context
+
+- **Raw NIP-56 report counts (other Nostr clients).** Some clients tally reports against an account, but the count is global and unfiltered. Structural failure: with no identity cost and no trust filter, reports are infinitely sybil-able, so the number carries no information and is rightly ignored or hidden. The metric is broken at the root, not in its presentation.
+- **Centralized trust-and-safety systems.** A platform aggregates reports and acts on them opaquely. Structural failure: the viewer never sees the signal and cannot apply their own standard of whose judgment to trust; the platform's single point of view is imposed as global truth. (General characterization of centralized moderation, not a verified claim about a specific competitor.)
+- **Tapestry's own Verified Followers.** Proves the pattern works: a count filtered to the viewer's web of trust, linking to a list. Verified Reporters is its missing negative counterpart.
+
+**Structural advantage:** only a system that already computes a personalized web of trust for each viewer can produce this metric at all. Tapestry already computes it (the per-viewer verified-reporter count exists in the data layer today); this feature surfaces it credibly.
+
+## 3. User Personas
+
+### The Vetting Observer (Primary)
+- **Who:** An established user with a calculated web of trust who habitually checks a stranger's profile before following, replying, or amplifying. Reads trust signals fluently. Skeptical of raw counts; trusts only signals filtered through their own network.
+- **Goal:** Know at a glance whether people *they* trust have flagged this stranger, before engaging.
+- **Core loop:** Encounter a stranger → open profile → scan trust signals including Verified Reporters → if non-zero, open the list and weigh *who* reported → decide to engage, ignore, or avoid → sharper instincts next time.
+- **Friction (won't tolerate):** A count they can't trust (global noise); a number with no way to see who is behind it; ambiguity about whose point of view the number reflects; latency that breaks the snap judgment.
+
+### The Cautious Newcomer (Secondary)
+- **Who:** New or logged-out, with no calculated web of trust yet. Wants to avoid bad actors but has no personal network to filter through. Exploratory and wary; does not yet understand web-of-trust mechanics.
+- **Goal:** Get some credible signal about whether a stranger is widely flagged, despite having no network of their own.
+- **Core loop:** Land on a profile (often via a shared link) → look for trust signals → see the House (default) view → understand it is a default, not a personal or global truth → use it provisionally → build a network over time and graduate into the Vetting Observer's loop.
+- **Friction (won't tolerate):** A silent "global" number that contradicts the no-global-view principle; confusion about why their number differs from an established user's; a dead end that requires an account before showing any value.
+
+*Moderators and transactors are deferred inheritors of the same signal (see §9). At this scope they would want exactly what the Vetting Observer wants, so they are not modeled separately.*
+
+## 4. User Journeys
+
+### Vetting Observer
+1. **Encounter.** A stranger appears (mention, feed, search); the observer opens the profile. The trust-signals row loads, including a Verified Reporters count filtered to the observer's point of view. *Routine, scanning.*
+2. **Notice the signal.** The count is non-zero. It reads clearly as a negative signal, attributed to the observer's own point of view. *Alert, cautious.*
+3. **Investigate.** The observer opens the list and sees *which* verified users reported the account, ordered so the most credible reporters surface first. *Discerning.*
+4. **Decide.** Follow, ignore, or avoid — a judgment supported by evidence. *Confident.*
+5. **Recalibrate.** Over repeated encounters the signal sharpens the observer's instincts. *Trusts the system.*
+
+*First-visit note:* the first time the count is seen it must be self-explanatory — a clear label plus point-of-view attribution — so it is never mistaken for a global number.
+
+### Cautious Newcomer
+1. **Arrive.** Follows a shared link with no account and no calculated web of trust. The Verified Reporters count shows via the House (default) view rather than failing or showing nothing. *Curious, wary.*
+2. **Read with uncertainty.** The viewer sees a count but has no network of their own. The interface states this is the House (default) view, not a personal network. *Needs clarity.*
+3. **Understand the model.** The viewer learns the real number is personal and earned by building a network; there is no single global truth. *Oriented, not misled.*
+4. **Graduate.** Over time the viewer builds a web of trust, returns, and reads a count of their own. *Invested.*
+
+## 5. Feature Specification
+
+### 5.1 Profile — Verified Reporters count
+- **Purpose:** Surface the point-of-view-filtered count of verified users who reported this account, parallel to Following and Verified Followers, as the entry point to the list.
+- **Content:** A numeric value and the label "Verified Reporters", placed in the existing counts row next to Following and Verified Followers.
+- **Behavior:**
+  - When the count is greater than zero, the value is shown as a **negative signal** (distinct from the neutral/positive counts) and the whole item links to the Verified Reporters list for this account.
+  - When the count is zero, the value is shown **neutrally** (not as a warning) and is **not** a link — there is nothing to inspect. This is the count's own empty state.
+  - When the count is not available or not yet computed, a placeholder ("—") is shown, not a link, visually distinct from a real zero.
+  - While loading, the value is shown in a dimmed/placeholder state, never a bare spinner.
+  - **Point-of-view attribution:** the count carries no per-count point-of-view marker. Whose view produced the number is stated on the Verified Reporters list (§5.2), one tap away. A shared, counts-row-level indicator covering Following, Verified Followers, and Verified Reporters together is deferred to a cross-cutting session (§8.3): the House fallback applies to all three counts at once, so marking it three times would crowd the row. Accepted tradeoff: a glance-only viewer on the House fallback sees an unlabeled number at the count level; the list one tap away attributes it fully.
+  - The accessible name of the count states the number and that it opens the list (for example, "{n} verified reporters. View list.").
+- **Actions (logged-in users):** none beyond navigation; this is a read surface. (The existing Report action elsewhere on the profile is unchanged and out of this feature's scope.)
+
+### 5.2 Verified Reporters list (`/user/:pubkey/reporters`)
+- **Purpose:** Show *which* verified users reported the account, so the observer can weigh their credibility, and make the point of view explicit.
+- **Content:**
+  - A header with a back link to the profile, the title "Verified Reporters", and an information control.
+  - A one-line description: "Verified users who have reported this account."
+  - A **point-of-view line**, always present: under a personal view, "Relative to your web of trust."; under the House fallback, "Relative to the House (default) web of trust. Sign in and build your network to see your own view."
+  - A table of reporters. Default columns: picture, name, and **Rank** (the reporter's trust/credibility score). Additional columns (point-of-view-relative metrics such as degrees of separation) are available through a column toggle, hidden by default.
+  - A search field to filter the list by name or identifier.
+  - An information popover ("About this data") explaining that the data is computed locally by this instance and that counts are personal to each viewer's web of trust, with no single global number.
+- **Behavior:**
+  - The list contains exactly the verified reporters counted on the profile, under the same point of view, so **the count equals the list length**.
+  - Default sort is by **Rank, descending** — the most credible reporters first, so "is this flagged by people who matter?" is answerable at a glance.
+  - Selecting a reporter opens that reporter's profile, so the observer can vet the reporter.
+  - **Empty state** (zero verified reporters): "No verified reporters. No one in this web of trust has reported this account." Never blank, never an error.
+  - **Loading state:** a skeleton of the table (placeholder rows), not a bare spinner.
+  - **Error state:** a helpful message and a retry control — what went wrong and what to do — never "Something went wrong."
+- **Actions (logged-in users):** search, toggle columns, open a reporter's profile.
+
+### 5.3 Traceability
+Every shippable element maps to a persona and a journey step.
+
+| Element | Persona | Journey step |
+|---|---|---|
+| Count on profile, point-of-view-filtered | Vetting Observer | Encounter (1), Notice (2) |
+| Negative-signal treatment of the count | Vetting Observer | Notice (2) |
+| Count links to the list | Vetting Observer | Investigate (3) |
+| List of *which* reporters, ordered by Rank | Vetting Observer | Investigate (3), Decide (4) |
+| Reporter rows link to reporter profiles | Vetting Observer | Investigate (3) |
+| Point-of-view line + "About this data" popover (on the list) | Cautious Newcomer | Arrive (1), Read with uncertainty (2), Understand (3) |
+| Zero-state (neutral count / designed empty list) | Vetting Observer | Notice (2) |
+
+## 6. Data Model
+
+Conceptual only — what the product knows about, not how it is stored.
+
+**Entities**
+- **Nostr User** — an account identified by its public key. Plays three *roles* in this feature, not three entity types: the *observed user* (profile being viewed), the *observer* (viewer, whose point of view the count reflects), and the *reporter* (a user who filed a report). Attributes used here: public key (required), display name (optional).
+- **NIP-56 Report** — a published flag in which one Nostr User formally reports another. Attributes: reporter (the author), subject (the user reported), report type (the NIP-56 category — captured but **not surfaced or split** in this release; all types are counted together), time created, and the underlying source event. A report is effectively immutable once published.
+- **Point of View** — the trust lens through which "verified" is judged. Has a kind (personal or House) and, when personal, an owner (the observer). The House view is the platform's default lens, used only when the viewer has no calculated web of trust.
+- **GrapeRank Score** — the personalized trust score of a Nostr User within a given point of view. Whether a reporter is "verified" derives from this score meeting the **same threshold already used by Verified Followers**; it is not redefined here.
+
+**Relationships**
+- A Nostr User (reporter) **files** a NIP-56 Report.
+- A NIP-56 Report **targets** a Nostr User (subject).
+- A Point of View **belongs to** a Nostr User (observer), or is the House view when none is available.
+- A GrapeRank Score **scores** a Nostr User **within** a Point of View.
+- A Nostr User **is verified within** a Point of View when their score meets the verification threshold.
+
+**Derived view (the feature itself)** — *Verified Reporters of an observed user, relative to a point of view* = the set of Nostr Users who both **file** a report **targeting** that user and **are verified within** that point of view. The count is the size of that set; by construction, count equals list length under one point of view.
+
+**Lifecycle that matters**
+- **Point-of-view resolution:** personal web of trust if available, otherwise House fallback. This single branch is the Cautious Newcomer's experience and must be made legible.
+- **Verified status is dynamic:** a reporter moves between verified and unverified as the observer's web of trust is recomputed. The count is a live function of (reports × web of trust), never a stored tally.
+
+## 7. Trust Model & Concept Mapping
+
+Architecturally significant points, stated at capability level (no implementation prescription).
+
+- **Personalization is intrinsic.** The count and the membership of the list are both functions of the viewer's point of view. The same profile yields different numbers to different viewers. This is by design, not a bug, and is the core of the product's credibility.
+- **Concept mapping (Tapestry).** Nostr User, Web of Trust, and GrapeRank Score map to existing concept handles (`nostr-user`, `web-of-trust`, `graperank`). A NIP-56 Report is a Nostr Event (`nostr-event`) of the report kind (`nostr-kind`, kind 1984). The Point of View lens and the derived Verified Reporters view are application-level notions, not concept-graph nodes.
+- **Existing vs. new capability.** The per-viewer verified-reporter **count** already exists in the data layer (it is already shown elsewhere on the profile as a non-interactive figure). The genuinely new capability this release requires is the **membership** behind that count — the identities of the verified reporters, resolved under the viewer's point of view — surfaced as a list. The count surface is an elevation of existing data; the list is the net-new data need.
+- **Abuse posture.** Manufactured pile-ons by non-verified accounts are already invisible because only verified reporters count. Pile-ons by *verified* users remain possible; discounting them is explicitly deferred (see §9). Reporter identities are already public NIP-56 events, so showing them creates no new disclosure.
+
+## 8. Scope Boundaries
+
+### 8.1 In Scope (must ship)
+- Verified Reporters count on the profile, point-of-view-filtered, parallel to Following / Verified Followers.
+- Count computed under the viewer's effective point of view: personal web of trust if available, else House fallback (reusing the platform's existing fallback, not a new one).
+- Point-of-view attribution on the list: the list always states whose view is in effect (personal or House), via the point-of-view line and the "About this data" popover. The count carries no per-count marker (the shared counts-row indicator is deferred; see §8.3).
+- Count links to a dedicated Verified Reporters list page; the list shows which verified users reported the account, with enough identity to weigh them.
+- Count equals list length under the same point of view.
+- Explicit zero-state (neutral count; designed empty list), distinct from "not computed".
+- All NIP-56 report types counted together (single pot).
+- Self-view shows the same count and list as any viewer using that point of view (no special-casing).
+- Designed loading and error states for both surfaces.
+
+### 8.2 Stretch
+- A reporter's report timestamp as an optional, hidden-by-default column on the list.
+
+### 8.3 Out of Scope (Phase 2+)
+- Splitting or breaking down the count by NIP-56 report type (Phase 2).
+- Pile-on resistance: detecting, tagging, and discounting pile-on-prone verified reporters (Phase 3).
+- Self-view retaliation mitigation and reporter-identity visibility controls (Phase 4).
+- Onboarding/education about the web of trust beyond the minimal point-of-view label and popover (Phase 4).
+- Moderator and transaction-vetting surfaces that consume the same signal (Phase 5).
+- A counts-row point-of-view indicator shared across Following, Verified Followers, and Verified Reporters (Phase 4). A single, tap-friendly (not hover-only, which fails on touch devices) indicator for the whole counts row. Deferred because the House fallback applies to all three counts together and is better solved once for the shared row than stamped three times by this feature.
+
+## 9. Phase Roadmap
+- **MVP — Credible negative signal.** The point-of-view-filtered Verified Reporters count and its inspectable list. *(This PRD.)*
+- **Phase 2 — Report-type granularity.** Break the single pot into NIP-56 types (filter and breakdown).
+- **Phase 3 — Reporter quality weighting.** Detect, tag, and discount pile-on-prone reporters.
+- **Phase 4 — Abuse & privacy controls.** Self-view retaliation mitigation, reporter-identity visibility, web-of-trust education.
+- **Phase 5 — Inheritor surfaces.** Moderator triage and transaction-vetting consumers of the signal.
+
+## 10. Success Metrics
+Observable by inspection of the live product; no instrumentation that does not yet exist.
+
+1. For 20 sampled profiles known to have reporters, the displayed count equals the number of verified reporters under the viewer's point of view **and** equals the list length, in 100% of cases.
+2. A logged-out / no-web-of-trust viewer who opens the Verified Reporters list sees the House point-of-view line on every sampled profile; the list never presents an unlabeled number, in 100% of sampled profiles. (Count-level point-of-view indication is deferred; see §8.3.)
+3. The count appears in the same trust-signals row as Following / Verified Followers, links out, and shares their point-of-view and fallback behavior, verified by inspection on 100% of sampled profiles.
+4. No load-time regression: the profile renders the count within the same latency envelope as the existing counts (no perceptible added delay on sampled profiles).
+5. A zero-report profile renders the explicit zero-state (neutral count; designed empty list), not a blank or an error, in 100% of sampled cases.
+
+*Engagement metrics (click-through, behavior change after viewing) require instrumentation not yet present and are deferred, not MVP criteria.*
+
+## 11. Decisions & Open Questions
+Each names a decision and its options. Items 1–5 are resolved (decisions recorded inline, 2026-06-07); they remain documented so engineering sees both the choice and the reasoning.
+
+1. **Placement parity with Verified Followers.** The live staging profile shows Verified Followers as a count-link in the counts row; the current `feat/communities` branch renders it as a non-interactive trust card. Where does the Verified Reporters count sit?
+   - (a) Place it as a count-link in the counts row regardless, matching the staging reference. *(Recommended — matches the approved design and the primary persona's expectation.)*
+   - (b) Match the branch's current Verified Followers treatment (trust card).
+   - (c) Elevate both Verified Followers and Verified Reporters to count-links (scope expansion beyond this feature).
+   *Resolution owner: Architect, against the build-time state of the profile.*
+   - **Decision: (a)** — match the staging reference (count-link in the counts row).
+
+2. **List route name.** `/user/:pubkey/reporters` vs `/user/:pubkey/verified-reporters`.
+   - (a) `/user/:pubkey/reporters` — short, parallel to the existing `/follows`. *(Recommended.)*
+   - (b) `/user/:pubkey/verified-reporters` — explicit, matches the feature name.
+   - **Decision: (a)** — `/user/:pubkey/reporters`, parallel to `/follows`.
+
+3. **Unicode glyphs vs. language guardrail.** The approved design reuses the app's existing unicode glyphs (flag, information, lock) as iconography. The language guardrail bans "emoji in product copy."
+   - (a) Treat these glyphs as inherited UI **iconography**, not copy, and permit them (they match the app's established icon language; the Report metric already uses the flag glyph). *(Recommended.)*
+   - (b) Replace them with hand-crafted SVG to satisfy a strict reading.
+   - (c) Drop them entirely.
+   - **Decision: (a)** — treat the glyphs as inherited UI iconography (permitted); not copy.
+
+4. **"Rank" label.** The reporter list shows the credibility score as "Rank" (matching the existing follows table), while the profile calls the same family of score "Verification Score." This naming inconsistency predates this feature.
+   - (a) Use "Rank" on the list for consistency with the existing table. *(Recommended for this release; harmonizing the vocabulary is a separate cleanup.)*
+   - (b) Use "Verification Score" on the list to match the profile.
+   - **Decision: (a)** — use "Rank" for consistency with the existing table; harmonizing the vocabulary is a separate cleanup.
+
+5. **Counts-row point-of-view indicator.** Whether to indicate the active point of view (personal vs House) at the counts-row level in this feature.
+   - (a) Add a per-count "House" qualifier on Verified Reporters. *(Rejected — the fallback applies to all three counts at once; three qualifiers crowd the row.)*
+   - (b) Add a single, tap-friendly row-level indicator for all three counts now. *(Rejected for this feature — it restyles the shared counts row that Following and Verified Followers occupy; cross-cutting, better designed once.)*
+   - (c) Attribute point of view on the list page only, and defer a shared counts-row indicator to a cross-cutting session.
+   - **Decision: (c)** — list-page attribution ships now; the shared counts-row indicator is deferred to Phase 4 (see §8.3). Accepted tradeoff: a glance-only viewer on the House fallback sees an unlabeled count, fully attributed one tap away on the list.

--- a/product-team/scope/verified-reporters.md
+++ b/product-team/scope/verified-reporters.md
@@ -31,7 +31,7 @@ The minimum feature set that delivers core value to the primary persona (the Vet
 - [ ] A **Verified Reporters count** on the profile, placed parallel to Following / Verified Followers.
 - [ ] Count is **PoV-filtered** — only verified reporters (inside the observer's WoT) are counted.
 - [ ] Count is computed against the observer's **effective PoV**: personal WoT if available, else **House PoV fallback** (the platform's standard fallback — reused, not reinvented).
-- [ ] **Whose PoV is in effect is attributed** (personal vs House), reusing the existing pattern from Verified Followers — so the number is never read as a global truth.
+- [ ] **Whose PoV is in effect is attributed on the list page** (personal vs House) — so the number is never read as a global truth. (Count-level / counts-row PoV indication is deferred; see below.)
 - [ ] Count is **clickable → a dedicated Verified Reporters list page** (the primary persona will not tolerate a number with no way to see who is behind it — the list is core, not optional).
 - [ ] The list shows the **verified users who reported** the observed user, with enough identity to judge credibility.
 - [ ] **Count = list length** under the same PoV/filter (internal consistency).
@@ -47,6 +47,7 @@ Each deferred item names its phase. No item is deferred without a phase.
 - Self-view retaliation mitigation and reporter-identity visibility controls → **Phase 4**
 - Inheritor surfaces (moderator bulk triage, transaction-vetting consumers) → **Phase 5**
 - Richer fallback education/onboarding beyond the minimal PoV label → **Phase 4**
+- Counts-row PoV indicator shared across Following / Verified Followers / Verified Reporters (a single, tap-friendly indicator for the whole row) → **Phase 4** (cross-cutting session; the House fallback applies to all three counts at once, so it is solved once for the shared row, not three times here)
 
 ## Phase roadmap
 Each phase has a theme.

--- a/product-team/scope/verified-reporters.md
+++ b/product-team/scope/verified-reporters.md
@@ -1,0 +1,77 @@
+# Scope: Verified Reporters
+
+**Slug:** verified-reporters
+**Date:** 2026-06-07
+**Manager phase:** Scope & Prioritization (Phase 3)
+
+## Features extracted
+Every feature implied by the journeys, listed flat.
+
+- A Verified Reporters count shown on the profile, in the trust-signals row alongside Following and Verified Followers.
+- The count is filtered to the observer's web of trust (only *verified* reporters count).
+- The count is computed against the observer's **effective PoV** — their personal WoT if available, else the House PoV fallback.
+- The count is visually legible as a *negative* / warning signal, distinct from the positive counts.
+- The count links to a dedicated Verified Reporters list page.
+- The list shows *which* verified users reported the observed user, with enough identity to judge credibility.
+- The count and the list agree (same PoV and filter → count equals list length).
+- Whose PoV is in effect (personal vs House) is attributed, so the number is never mistaken for a global truth.
+- A House PoV fallback for viewers with no calculated WoT, labeled as the default view.
+- First-visit / logged-out value (no account wall before the signal is visible).
+- Zero-state: "no verified reporters" renders explicitly, distinguishable from "not computed."
+- Self-view behavior (viewing one's own profile).
+- All NIP-56 report types counted together in a single pot.
+- Split / breakdown by NIP-56 report type.
+- Pile-on resistance: detect and tag pile-on-prone verified reporters and discount/ignore their reports.
+- Inheritor surfaces: moderator triage and transaction-vetting consumers of the same signal.
+
+## MVP boundary
+The minimum feature set that delivers core value to the primary persona (the Vetting Observer): *a credible, PoV-filtered count of who-I-trust has flagged this account, with a way to see who.*
+
+### In scope (must ship)
+- [ ] A **Verified Reporters count** on the profile, placed parallel to Following / Verified Followers.
+- [ ] Count is **PoV-filtered** — only verified reporters (inside the observer's WoT) are counted.
+- [ ] Count is computed against the observer's **effective PoV**: personal WoT if available, else **House PoV fallback** (the platform's standard fallback — reused, not reinvented).
+- [ ] **Whose PoV is in effect is attributed** (personal vs House), reusing the existing pattern from Verified Followers — so the number is never read as a global truth.
+- [ ] Count is **clickable → a dedicated Verified Reporters list page** (the primary persona will not tolerate a number with no way to see who is behind it — the list is core, not optional).
+- [ ] The list shows the **verified users who reported** the observed user, with enough identity to judge credibility.
+- [ ] **Count = list length** under the same PoV/filter (internal consistency).
+- [ ] **Zero-state** renders as an explicit "no verified reporters," distinguishable from an uncomputed/error state.
+- [ ] **All NIP-56 report types counted together** (single pot).
+- [ ] **Self-view shows the same count/list** as any observer using that PoV — no special-casing (reports are public NIP-56 events; reporter identity is already discoverable network-wide).
+
+### Out of scope (deferred)
+Each deferred item names its phase. No item is deferred without a phase.
+
+- Split / breakdown by NIP-56 report type → **Phase 2**
+- Pile-on resistance: tag pile-on-prone verified reporters and discount/ignore their reports → **Phase 3**
+- Self-view retaliation mitigation and reporter-identity visibility controls → **Phase 4**
+- Inheritor surfaces (moderator bulk triage, transaction-vetting consumers) → **Phase 5**
+- Richer fallback education/onboarding beyond the minimal PoV label → **Phase 4**
+
+## Phase roadmap
+Each phase has a theme.
+
+- **MVP:** Credible negative signal — the PoV-filtered Verified Reporters count and its inspectable list.
+- **Phase 2:** Report-type granularity — break the single pot into NIP-56 types (filter/breakdown).
+- **Phase 3:** Reporter quality weighting — pile-on resistance: detect, tag, and discount pile-on-prone reporters.
+- **Phase 4:** Abuse & privacy controls — self-view retaliation mitigation, reporter-identity visibility, fallback education.
+- **Phase 5:** Inheritor surfaces — moderator triage and transaction-vetting consumers of the signal.
+
+## Success metrics
+Concrete and observable without instrumentation that doesn't yet exist (verifiable by inspection of the live page).
+
+- For **20 sampled profiles** known to have reporters, the displayed count equals the number of verified reporters under the observer's PoV **and** equals the list length, in **100%** of cases.
+- A **logged-out / no-WoT viewer** sees a House-PoV-labeled count on every sampled profile (fallback never blank, never unlabeled) — **100%** of sampled profiles.
+- The Verified Reporters count appears in the **same trust-signals row** as Following / Verified Followers and links out, matching their placement and PoV/fallback semantics — verified by inspection on **100%** of sampled profiles.
+- **No load-time regression:** the profile page renders the new count within the same latency envelope as the existing counts (no perceptible added delay on sampled profiles).
+- Zero-state renders as explicit "no verified reporters" (not a blank, not an error) on **100%** of sampled zero-report profiles.
+
+> Engagement metrics (click-through on the count, behavior change after viewing) require click instrumentation not yet present and are therefore deferred, not MVP success criteria.
+
+## Tradeoffs
+What we gain by cutting what we cut.
+
+- **Lumping all report types** → we ship the credible signal and prove the pattern now; we lose granularity (a "5" doesn't say 5-spam vs 5-impersonation), but the primary persona can still inspect the list. Gain: speed and the core trust judgment.
+- **Deferring pile-on resistance** → we accept that even verified users can pile on, but the worst case (bad-actor sybil pile-ons) is *already* invisible because only verified reporters count. Gain: ship without building reputation-weighting machinery.
+- **Minimal PoV label instead of a fallback-education flow** → we keep the no-global-view ethos legible without building onboarding. Gain: the principle holds; the teaching is deferred.
+- **No self-view special-casing** → we ship one consistent model and accept bounded retaliation risk now, because NIP-56 reports are already public events (the information isn't secret). Gain: simplicity; deferral is safe, not reckless.

--- a/product-team/stories-queue.md
+++ b/product-team/stories-queue.md
@@ -1,0 +1,97 @@
+# Stories Queue: Verified Reporters
+
+**Slug:** verified-reporters
+**Date:** 2026-06-07
+**Source PRD:** `product-team/prd/verified-reporters.md`
+**Companion guides:** `product-team/guides/verified-reporters-design-guide.md`, `product-team/guides/verified-reporters-style-guide.md` (+ `verified-reporters-wireframes.html`)
+
+3 stories across 1 block, in dependency order. Engineering should be able to demo the count after Story 1, and the full investigation path after Story 3.
+
+**Handoff note (for the engineering Product Owner):** create one epic umbrella `engineering-team/epics/verified-reporters.md` and a folder `engineering-team/stories/verified-reporters/`, then promote each story below via `/plan-feature`, referencing the PRD and guides. The queue order is the pickup order. User-facing copy must use the style guide's canonical copy table verbatim.
+
+---
+
+## Block 1 — Verified Reporters
+*Suggested epic-slug: `verified-reporters`*
+
+The credible negative trust signal: a point-of-view-filtered count of verified users who reported the observed account, and a list of exactly who they are.
+
+---
+
+## Story 1: Verified Reporters count on the profile
+
+**PRD section(s):** §5.1, §5.3
+**Persona(s):** The Vetting Observer (primary); The Cautious Newcomer (House fallback behavior)
+**Block:** Verified Reporters
+**Suggested epic-slug:** `verified-reporters`
+
+**Description:** Surface the point-of-view-filtered Verified Reporters count in the profile's counts row, parallel to Following / Verified Followers, as a negative-signal entry point to the reporters list.
+
+**Acceptance criteria:**
+- [ ] On a profile with one or more verified reporters under the active point of view, the counts row shows a value labelled "Verified Reporters", placed parallel to Following and Verified Followers.
+- [ ] When the count is greater than zero, the value reads as a negative signal (visually distinct from the positive/neutral counts) and the whole count links to `/user/:pubkey/reporters`.
+- [ ] When the count is zero, the value is shown neutrally (not as a warning) and is not a link.
+- [ ] When the count is unavailable / not yet computed, a placeholder ("—") is shown, not a link, and is visually distinct from a real zero.
+- [ ] While the count is loading, a dimmed/placeholder value is shown (no bare spinner).
+- [ ] The count's accessible name states the number and that it opens the list (for example, "3 verified reporters. View list.").
+- [ ] The count is computed under the viewer's effective point of view (personal if available, else House), the same point of view used by the other counts on the page.
+
+**Dependencies:** None — uses the verified-reporter count that already exists in the data layer. (The link target page is delivered in Story 3; until then the link may resolve to an unbuilt/empty page. Acceptable within the epic sequence.)
+
+**Notes for engineering:** The per-point-of-view count already exists (it is read today as `verifiedReporterCount`, point-of-view-namespaced, and already rendered as a trust card in `ui/src/pages/BrainstormProfile.jsx`). This story *elevates* it to a count-link in the existing `.bsp-counts` row, mirroring the Following count-link pattern. Negative signal = the existing `--red` token (the app already encodes "report" as red, e.g. the Report action button). Place it to match Verified Followers' treatment **as it exists at build time** (PRD §11 decision 1: match the staging reference, a count-link). No per-count point-of-view marker — that is deferred (PRD §8.3 / §11 decision 5). Route target is `/user/:pubkey/reporters` (PRD §11 decision 2).
+
+---
+
+## Story 2: Verified reporters membership data
+
+**PRD section(s):** §5.2, §6, §7
+**Persona(s):** The Vetting Observer
+**Block:** Verified Reporters
+**Suggested epic-slug:** `verified-reporters`
+
+**Description:** Provide the set of verified users who reported a given account, resolved under the viewer's point of view, so the list and count agree.
+
+**Acceptance criteria:**
+- [ ] Given an account and a point of view, the capability returns the set of users who filed a NIP-56 report against that account and are verified within that point of view.
+- [ ] Reporters who are not verified within the point of view are excluded (unverified / sybil reporters do not appear).
+- [ ] Each returned reporter includes enough identity to display and weigh them: an identifier and the credibility (Rank) metric.
+- [ ] The size of the returned set equals the verified-reporter count shown for that account under the same point of view.
+- [ ] When the viewer has no calculated point of view, the set is resolved under the House (default) point of view.
+- [ ] When the account has no verified reporters under the point of view, an empty set is returned (not an error).
+
+**Dependencies:** None strictly (it is the data capability), but it must ship before Story 3, which consumes it.
+
+**Notes for engineering:** This is the net-new data need identified in PRD §7 — the *count* exists already, but the *membership* (the identities behind it) does not yet. It must use the **same** verified / point-of-view definition that produces the existing count, so count equals list length (AC4 and PRD success metric 1). Mirror how the follows / verified data is computed and exposed (see `src/api/grapevineInteractions/` and the `useGrapevineFollows` hook the follows list uses). All NIP-56 report types are counted together (single pot — no type filtering this release). Reporter identities are public NIP-56 events; no privacy special-casing (PRD §7).
+
+---
+
+## Story 3: Verified Reporters list page
+
+**PRD section(s):** §5.2, §5.3
+**Persona(s):** The Vetting Observer (primary); The Cautious Newcomer (point-of-view attribution)
+**Block:** Verified Reporters
+**Suggested epic-slug:** `verified-reporters`
+
+**Description:** A dedicated page at `/user/:pubkey/reporters` listing which verified users reported the account, ordered by credibility, with explicit point-of-view attribution.
+
+**Acceptance criteria:**
+- [ ] Navigating to `/user/:pubkey/reporters` shows a page titled "Verified Reporters", with a back link to the profile and the description "Verified users who have reported this account."
+- [ ] The page lists the verified reporters for that account under the viewer's point of view, with default columns picture, name, and Rank, sorted by Rank descending.
+- [ ] Selecting a reporter navigates to that reporter's profile.
+- [ ] The list length equals the count shown on the profile for the same account and point of view.
+- [ ] The page always states whose point of view is in effect — "Relative to your web of trust." (personal) or the House line (fallback) — and an "About this data" control explains the data is computed locally and that counts are personal, with no single global number.
+- [ ] When there are no verified reporters, the page shows the designed empty state ("No verified reporters. No one in this web of trust has reported this account."), not a blank and not an error.
+- [ ] While loading, a skeleton of the table is shown; on failure, a helpful message with a retry control is shown (never "Something went wrong").
+
+**Dependencies:** Story 2 must ship first — the page renders the membership data that Story 2 provides. Pairs with Story 1 (the count links here), but does not require Story 1 to function.
+
+**Notes for engineering:** Mirror `ui/src/pages/BrainstormFollows.jsx` (the `DataTable`, the search field, the Columns toggle, the `InfoPopover`). Register the route in `ui/src/App.jsx` parallel to `/user/:pubkey/follows` (PRD §11 decision 2: `/reporters`). **Default sort is Rank descending** — deliberately different from the follows list's sort — so the most credible reporters surface first. Search by name / npub. Optional hidden-by-default columns may include npub and Hops. Use the "Rank" label (PRD §11 decision 4). All user-facing strings come **verbatim** from the style guide's canonical copy table. The flag / information / lock glyphs are inherited UI iconography, not copy (PRD §11 decision 3). Extend the "About this data" popover with the no-global-view sentence. *Stretch (PRD §8.2):* a reporter's report timestamp as an optional, hidden-by-default column — only if cheap; not required.
+
+---
+
+## Sequence summary
+1. **Story 1 — Verified Reporters count** (independent; demoable immediately on existing data).
+2. **Story 2 — Membership data** (the net-new data capability; unblocks Story 3).
+3. **Story 3 — List page** (consumes Story 2; completes the investigation path and the count's link target).
+
+**Deferred to later phases (not in this queue):** report-type breakdown (Phase 2); pile-on resistance (Phase 3); self-view privacy controls, web-of-trust education, and the shared counts-row point-of-view indicator (Phase 4); moderator / transaction-vetting surfaces (Phase 5).

--- a/src/api/grapevineInteractions/queries/reportersWithMetrics.js
+++ b/src/api/grapevineInteractions/queries/reportersWithMetrics.js
@@ -1,0 +1,150 @@
+/**
+ * Story verified-reporters #2 / ADR 0002 — verified reporters membership.
+ *
+ *   GET /api/get-grapevine-reporters?observee=<pk>[&observer=owner]
+ *
+ * Lists the VERIFIED users who NIP-56-reported <observee>, with the owner's
+ * GrapeRank metrics read straight from each reporter's NostrUser node: influence
+ * (→ rank), hops, and the three verified counts. v1 is OWNER/HOUSE POV ONLY.
+ * Customer observers are deferred: their scores live on NostrUserWotMetricsCard
+ * (see ADR 0026 §Decision and userdata.js:40-85), so a non-owner `observer` is 400.
+ *
+ * This is the LITERAL INVERSE of the verified-reporter COUNT query
+ * (src/algos/follows-mutes-reports/calculateVerifiedReporterCounts.sh): same
+ * `(reporter)-[:REPORTS]->(reported)` edge, same `reporter.influence >
+ * VERIFIED_REPORTERS_INFLUENCE_CUTOFF` filter — returning the reporters instead of
+ * count(). Reusing that exact cutoff is what makes count = list length hold (AC3).
+ *
+ * Mirrors the per-query Neo4j deadline + 504 pattern of followsWithMetrics.js
+ * (story #29 / ADR 0026) and followersWithMetrics.js (story #34 / ADR 0030); those
+ * endpoints are intentionally left untouched (ADR 0002 Option A — a new endpoint).
+ */
+
+const neo4j = require('neo4j-driver');
+const { getConfigFromFile } = require('../../../utils/config');
+const { nip19 } = require('nostr-tools');
+
+function toInt(v) {
+  if (v == null) return null;
+  if (typeof v.toNumber === 'function') return v.toNumber();
+  if (typeof v === 'object' && typeof v.low === 'number') return v.low;
+  const n = parseInt(v.toString(), 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+function toFloat(v) {
+  if (v == null) return null;
+  const n = parseFloat(v.toString());
+  return Number.isNaN(n) ? null : n;
+}
+
+function isValidHexPubkey(pk) {
+  return typeof pk === 'string' && /^[0-9a-f]{64}$/i.test(pk);
+}
+
+/**
+ * GET /api/get-grapevine-reporters
+ */
+function handleGetGrapevineReporters(req, res) {
+  try {
+    const observee = req.query.observee;
+    const observer = req.query.observer; // v1: owner only (see below)
+
+    // --- Validate observee: 64-char hex, cross-checked via nip19 (cf. followsWithMetrics.js:48-60).
+    if (!observee || !isValidHexPubkey(observee)) {
+      return res.status(400).json({
+        success: false,
+        message: 'Missing or invalid observee parameter (expected a 64-character hex pubkey)'
+      });
+    }
+    try {
+      const npub = nip19.npubEncode(observee);
+      if (!npub.startsWith('npub')) throw new Error('bad encode');
+    } catch {
+      return res.status(400).json({ success: false, message: 'Invalid observee parameter' });
+    }
+
+    // --- v1 is OWNER/HOUSE POV only. Customer observers are deferred (ADR 0002): their
+    // metrics live on NostrUserWotMetricsCard, which this endpoint does not yet read.
+    const ownerPubkey = getConfigFromFile('BRAINSTORM_OWNER_PUBKEY', '');
+    if (observer && observer !== 'owner' && observer !== ownerPubkey) {
+      return res.status(400).json({
+        success: false,
+        message: 'customer observers not yet supported — this endpoint currently serves the owner point of view only'
+      });
+    }
+
+    // --- Neo4j with a driver-layer deadline (story #5 / ADR 0024-0025 pattern).
+    const neo4jUri = getConfigFromFile('NEO4J_URI', 'bolt://localhost:7687');
+    const neo4jUser = getConfigFromFile('NEO4J_USER', 'neo4j');
+    const neo4jPassword = getConfigFromFile('NEO4J_PASSWORD', 'neo4j');
+    const queryTimeoutMs = parseInt(getConfigFromFile('NEO4J_QUERY_TIMEOUT_MS', 15000), 10);
+
+    // The verified cutoff MUST be the reporters cutoff — the same config var the count
+    // algo uses (calculateVerifiedReporterCounts.sh). This is the count = list length
+    // invariant (AC3): same edge + same cutoff ⇒ list length == verifiedReporterCount.
+    const cutoff = parseFloat(getConfigFromFile('VERIFIED_REPORTERS_INFLUENCE_CUTOFF', 0.05));
+
+    const driver = neo4j.driver(neo4jUri, neo4j.auth.basic(neo4jUser, neo4jPassword));
+    const session = driver.session();
+
+    // Owner/House POV: the metrics ARE each reporter's own NostrUser node GrapeRank
+    // properties. Only VERIFIED reporters (influence above the cutoff) are returned —
+    // the inverse of the count query. No NostrUserWotMetricsCard join in v1.
+    const cypherQuery = `
+      MATCH (observee:NostrUser {pubkey: $observee})<-[:REPORTS]-(reporter:NostrUser)
+      WHERE reporter.influence > $cutoff
+      RETURN reporter.pubkey AS pubkey,
+             reporter.influence AS influence,
+             reporter.hops AS hops,
+             reporter.verifiedFollowerCount AS verifiedFollowerCount,
+             reporter.verifiedMuterCount AS verifiedMuterCount,
+             reporter.verifiedReporterCount AS verifiedReporterCount
+    `;
+
+    const queryStartMs = Date.now();
+    session.run(cypherQuery, { observee, cutoff }, { timeout: queryTimeoutMs })
+      .then(result => {
+        const data = result.records
+          .map(r => ({
+            pubkey: r.get('pubkey') ?? null,
+            influence: toFloat(r.get('influence')),
+            hops: toInt(r.get('hops')),
+            verifiedFollowerCount: toInt(r.get('verifiedFollowerCount')),
+            verifiedMuterCount: toInt(r.get('verifiedMuterCount')),
+            verifiedReporterCount: toInt(r.get('verifiedReporterCount'))
+          }))
+          .filter(row => row.pubkey);
+
+        res.status(200).json({
+          success: true,
+          observer: 'owner',
+          observee,
+          count: data.length,
+          data
+        });
+      })
+      .catch(error => {
+        const elapsedMs = Date.now() - queryStartMs;
+        const isTimeout = error && typeof error.code === 'string' && /TransactionTimedOut/i.test(error.code);
+        if (isTimeout) {
+          console.error('Neo4j query timeout fetching grapevine reporters:', { observee, elapsedMs, limitMs: queryTimeoutMs, code: error.code });
+          return res.status(504).json({
+            success: false,
+            message: `Neo4j query timeout after ${elapsedMs}ms (limit ${queryTimeoutMs}ms) fetching reporters for ${observee}.`
+          });
+        }
+        console.error('Error fetching grapevine reporters:', error);
+        res.status(500).json({ success: false, message: `Error fetching grapevine reporters: ${error.message}` });
+      })
+      .finally(() => {
+        session.close();
+        driver.close();
+      });
+  } catch (error) {
+    console.error('Error in handleGetGrapevineReporters:', error);
+    res.status(500).json({ success: false, message: `Server error: ${error.message}` });
+  }
+}
+
+module.exports = { handleGetGrapevineReporters };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -31,6 +31,7 @@ const { handleGetOwnerInfo } = require('./owner/ownerInfo');
 const { handleGetGrapevineInteraction } = require('./grapevineInteractions/queries');
 const { handleGetGrapevineFollows } = require('./grapevineInteractions/queries/followsWithMetrics');
 const { handleGetGrapevineFollowers } = require('./grapevineInteractions/queries/followersWithMetrics');
+const { handleGetGrapevineReporters } = require('./grapevineInteractions/queries/reportersWithMetrics');
 const { handleOldSearchProfiles, handleOldSearchProfilesStream } = require('./search/profiles');
 const { handleKeywordSearchProfiles } = require('./search/profiles/keyword');
 const { handlePrecomputeWhitelistMaps, handlePrecomputeWhitelistStatus } = require('./search/profiles/whitelistPrecompute');
@@ -321,6 +322,8 @@ async function register(app) {
     app.get('/api/get-grapevine-follows', handleGetGrapevineFollows);
     // Followers list (verified, owner-POV metrics) (story #34 / ADR 0030)
     app.get('/api/get-grapevine-followers', handleGetGrapevineFollowers);
+    // Verified reporters list (owner/House-POV metrics) (verified-reporters #2 / ADR 0002)
+    app.get('/api/get-grapevine-reporters', handleGetGrapevineReporters);
 
     // Search endpoint
     app.get('/api/search/profiles', handleOldSearchProfiles);

--- a/test/profile-verified-reporters-count.test.js
+++ b/test/profile-verified-reporters-count.test.js
@@ -1,0 +1,179 @@
+/**
+ * Story verified-reporters #1: Verified Reporters count on the profile page.
+ * ADR 0001 (verified-reporters). See
+ * engineering-team/stories/verified-reporters/1-verified-reporters-count.test-plan.md
+ *
+ * ADR 0001 chose Option A (pure front-end): render the already-fetched,
+ * PoV-resolved client-side value `trustScores.verifiedReporterCount` as a THIRD
+ * counter in the profile's `bsp-counts` block, beside "Following" and "Verified
+ * Followers". Unlike its always-link siblings it renders by state:
+ *   >0          → negative-signal value + <Link> to /user/:pubkey/reporters
+ *   0           → neutral value, NOT a link
+ *   unavailable → "—", NOT a link
+ *   loading     → dimmed "—"
+ * No backend change.
+ *
+ * Tests are source-regex sentinels — the profile-verified-followers-count /
+ * profile-follows-list precedents (a single-file profile UI change with no React
+ * render harness). Browser-level behavior (the 0/unavailable states are not <a>;
+ * the >0 link's red color and aria-label; ?pov= reflects the PoV) is covered by the
+ * supplementary, live-data Playwright spec
+ * tests/brainstorm/profile-verified-reporters-count.spec.js.
+ *
+ * FALSE-POSITIVE AVOIDANCE: BrainstormProfile.jsx ALREADY contains the strings
+ * "verifiedReporterCount" and "Reporters" inside the TRUST_METRICS array (the
+ * Reputation grid, rendered as bsp-trust-card-*). Each sentinel below therefore
+ * targets the NEW bsp-counts-block counter specifically — a 3rd bsp-count-label
+ * span reading "Verified Reporters", a direct `trustScores?.verifiedReporterCount`
+ * read, a /user/${pubkey}/reporters link, a `bsp-count-value-negative` class, a
+ * 3rd fmtCount(...) call, a `bsp-count-loading` dim, and the exact aria-label —
+ * none of which exist pre-implementation.
+ *
+ * T1–T8 must FAIL pre-implementation and PASS post-implementation.
+ * R1–R3 are regression sentinels — they must PASS both before and after (they
+ * guard the existing Following + Verified Followers counters and the deliberately
+ * retained Reporters trust card).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PROFILE_PAGE = path.resolve(__dirname, '../ui/src/pages/BrainstormProfile.jsx');
+const STYLES       = path.resolve(__dirname, '../ui/src/styles.css');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+function countOf(src, re) { return (src.match(re) || []).length; }
+
+// AC1 — a "Verified Reporters" count renders in the bsp-counts block, beside the other two.
+test('T1: BrainstormProfile.jsx renders a "Verified Reporters" count in the bsp-counts block (AC1)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(countOf(src, /bsp-count-label/g) >= 3,
+    'a THIRD counter must be added to the bsp-counts block (expected >=3 `bsp-count-label` spans; pre-implementation only "Following" and "Verified Followers" have one).');
+  assert(/bsp-count-label[^>]*>\s*Verified Reporters/.test(src),
+    'the new counter must be labeled "Verified Reporters" via a `bsp-count-label` span. (Pre-implementation the only Reporters string is the TRUST_METRICS label \'Reporters\', rendered as bsp-trust-card-label in the Reputation grid — not the prominent counter, and not the text "Verified Reporters".)');
+});
+
+// AC1 (PoV) — value sourced from the PoV-resolved trustScores, NOT a separate fetch.
+test('T2: the new counter sources its value from trustScores.verifiedReporterCount (PoV-resolved) (AC1)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/trustScores\s*\??\.\s*verifiedReporterCount/.test(src),
+    'the counter must read `verifiedReporterCount` directly off the PoV-resolved `trustScores` object (e.g. `trustScores?.verifiedReporterCount`). Pre-implementation verifiedReporterCount only appears as a TRUST_METRICS tag string and is read as `trustScores[metric.tag]` in the Reputation grid. Reading trustScores ties the count to the existing ?pov= / House-default resolution (AC1), and NOT to the owner-POV useUserCounts.');
+});
+
+// AC2 — when >0 the counter links to the reporters list.
+test('T3: the counter links to /user/${pubkey}/reporters (AC2)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/\/user\/\$\{pubkey\}\/reporters/.test(src),
+    'the >0 state must link to `/user/${pubkey}/reporters` (the reporters list, built in story #3). Pre-implementation this path does not exist in the file.');
+  assert(countOf(src, /bsp-count-link/g) >= 3,
+    'the >0 state must render as a `bsp-count-link` (expected >=3 `bsp-count-link` occurrences in source: Following → /follows, Verified Followers → /followers, Verified Reporters → /reporters).');
+});
+
+// AC2 — the >0 value is a NEGATIVE signal (the --red token via a modifier class).
+test('T4: the >0 value uses a negative-signal modifier backed by the --red token (AC2)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  const css = safeRead(STYLES);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(css.length > 0, 'ui/src/styles.css missing — unexpected.');
+  assert(/bsp-count-value-negative/.test(src),
+    'the >0 value span must carry the `bsp-count-value-negative` modifier class (ADR 0001) so the count reads as a negative signal, distinct from the neutral/positive counts.');
+  const rule = css.match(/\.bsp-count-value-negative\s*\{[^}]*\}/);
+  assert(rule, 'styles.css must define a `.bsp-count-value-negative` rule (ADR 0001).');
+  assert(/var\(\s*--red\s*\)/.test(rule[0]),
+    'the `.bsp-count-value-negative` color must come from the `--red` design token (no hard-coded hex) — the app already encodes "report" as red.');
+});
+
+// AC3 — 0 is neutral and NOT a link: the counter branches on the count value.
+test('T5: the counter branches on the count so 0 is rendered neutrally, not as a link (AC3)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/verifiedReporterCount[^\n]{0,24}?(>\s*0|===?\s*0)/.test(src),
+    'the counter must conditionally render on the reporter count (e.g. `verifiedReporterCount > 0` or `verifiedReporterCount === 0`): only >0 is a link; a genuine 0 is shown neutrally and is NOT a link (AC3). The comparison must be anchored to the count itself — pre-implementation `verifiedReporterCount` is never compared to 0 (the existing `=== 0` checks are on `Object.keys(scores).length`, not the count). (Browser-level "0 is not a link" is asserted in the Playwright spec.)');
+});
+
+// AC4 + AC6 — the value is formatted via the existing fmtCount helper (null -> "—", number -> localized).
+test('T6: the new counter formats its value via the existing fmtCount helper (AC4 placeholder, AC6 number)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(countOf(src, /fmtCount\s*\(/g) >= 3,
+    'the new counter must format its value through the existing `fmtCount` helper (a 3rd `fmtCount(...)` call beside Following and Verified Followers). fmtCount returns "—" for null/undefined (AC4 unavailable) and a localized number otherwise (AC6).');
+});
+
+// AC5 — loading shows a dimmed placeholder via a per-count loading modifier (NOT a bare spinner).
+test('T7: a per-count loading dim exists for the reporters counter (AC5)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  const css = safeRead(STYLES);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(css.length > 0, 'ui/src/styles.css missing — unexpected.');
+  assert(/bsp-count-loading\b/.test(src),
+    'the loading state must apply the `bsp-count-loading` modifier on the reporters counter (ADR 0001) — gated on `trustLoading`, since the value rides trustScores, not userCounts.');
+  const rule = css.match(/\.bsp-count-loading\b[^{]*\{[^}]*\}/);
+  assert(rule, 'styles.css must define a `.bsp-count-loading` rule (distinct from the existing `.bsp-counts-loading`).');
+  assert(/opacity\s*:/.test(rule[0]),
+    'the `.bsp-count-loading` rule must dim the value (an `opacity:` — a dimmed placeholder, never a bare spinner, per AC5).');
+});
+
+// AC6 — the >0 link's accessible name states the number and that it opens the list.
+test('T8: the >0 link carries the canonical accessible name "{n} verified reporters. View list." (AC6)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/aria-label/.test(src),
+    'the >0 reporters link must set an aria-label (the value + label alone do not state the destination).');
+  assert(/verified reporters\. View list\./.test(src),
+    'the accessible name must be the style-guide canonical "{n} verified reporters. View list." (verbatim). Pre-implementation this string is absent.');
+});
+
+// ===========================================================================
+// REGRESSION SENTINELS (must PASS before AND after implementation)
+// ===========================================================================
+
+test('R1: the existing "Following" count is unchanged — useUserCounts + <Link> to /follows (regression)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/useUserCounts/.test(src),
+    'BrainstormProfile.jsx must keep using useUserCounts for the Following count.');
+  assert(/\/user\/\$\{pubkey\}\/follows/.test(src),
+    'the Following count must remain a <Link> to `/user/${pubkey}/follows`.');
+  assert(/bsp-count-label[^>]*>\s*Following/.test(src),
+    'the "Following" label must remain (the new counter is added beside it, not in place of it).');
+});
+
+test('R2: the existing "Verified Followers" count is unchanged — <Link> to /followers (regression)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/\/user\/\$\{pubkey\}\/followers/.test(src),
+    'the Verified Followers count must remain a <Link> to `/user/${pubkey}/followers` (the new counter is added beside it).');
+  assert(/bsp-count-label[^>]*>\s*Verified Followers/.test(src),
+    'the "Verified Followers" label must remain.');
+});
+
+test('R3: the existing Reporters trust card is retained in TRUST_METRICS (ADR 0001 deliberate non-change)', () => {
+  const src = safeRead(PROFILE_PAGE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/tag:\s*'verifiedReporterCount'/.test(src),
+    'the TRUST_METRICS `verifiedReporterCount` entry (the 🚩 "Reporters" trust card) must remain — ADR 0001 leaves it in place, consistent with how Verified Followers appears in both the count row and a trust card. Removing trust cards is out of scope for this story.');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -51,6 +51,7 @@ const profileFollowsList = require('./profile-follows-list.test.js');
 const profileWebsiteLink = require('./profile-website-link.test.js');
 const profileVerifiedFollowersCount = require('./profile-verified-followers-count.test.js');
 const profileFollowersList = require('./profile-followers-list.test.js');
+const profileVerifiedReportersCount = require('./profile-verified-reporters-count.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -142,6 +143,9 @@ async function main() {
   console.log('\nprofile-followers-list suite:');
   const profileFollowersListResult = await profileFollowersList.run();
 
+  console.log('\nprofile-verified-reporters-count suite:');
+  const profileVerifiedReportersCountResult = await profileVerifiedReportersCount.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -229,6 +233,9 @@ async function main() {
   console.log(
     `profile-followers-list suite:                    ${profileFollowersListResult.fail === 0 ? 'PASS' : 'FAIL'} (${profileFollowersListResult.pass} passed, ${profileFollowersListResult.fail} failed)`
   );
+  console.log(
+    `profile-verified-reporters-count suite:          ${profileVerifiedReportersCountResult.fail === 0 ? 'PASS' : 'FAIL'} (${profileVerifiedReportersCountResult.pass} passed, ${profileVerifiedReportersCountResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -259,7 +266,8 @@ async function main() {
     profileFollowsListResult.fail === 0 &&
     profileWebsiteLinkResult.fail === 0 &&
     profileVerifiedFollowersCountResult.fail === 0 &&
-    profileFollowersListResult.fail === 0;
+    profileFollowersListResult.fail === 0 &&
+    profileVerifiedReportersCountResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,7 @@ const profileWebsiteLink = require('./profile-website-link.test.js');
 const profileVerifiedFollowersCount = require('./profile-verified-followers-count.test.js');
 const profileFollowersList = require('./profile-followers-list.test.js');
 const profileVerifiedReportersCount = require('./profile-verified-reporters-count.test.js');
+const verifiedReportersMembershipData = require('./verified-reporters-membership-data.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -146,6 +147,9 @@ async function main() {
   console.log('\nprofile-verified-reporters-count suite:');
   const profileVerifiedReportersCountResult = await profileVerifiedReportersCount.run();
 
+  console.log('\nverified-reporters-membership-data suite:');
+  const verifiedReportersMembershipDataResult = await verifiedReportersMembershipData.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -236,6 +240,9 @@ async function main() {
   console.log(
     `profile-verified-reporters-count suite:          ${profileVerifiedReportersCountResult.fail === 0 ? 'PASS' : 'FAIL'} (${profileVerifiedReportersCountResult.pass} passed, ${profileVerifiedReportersCountResult.fail} failed)`
   );
+  console.log(
+    `verified-reporters-membership-data suite:        ${verifiedReportersMembershipDataResult.fail === 0 ? 'PASS' : 'FAIL'} (${verifiedReportersMembershipDataResult.pass} passed, ${verifiedReportersMembershipDataResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -267,7 +274,8 @@ async function main() {
     profileWebsiteLinkResult.fail === 0 &&
     profileVerifiedFollowersCountResult.fail === 0 &&
     profileFollowersListResult.fail === 0 &&
-    profileVerifiedReportersCountResult.fail === 0;
+    profileVerifiedReportersCountResult.fail === 0 &&
+    verifiedReportersMembershipDataResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -53,6 +53,7 @@ const profileVerifiedFollowersCount = require('./profile-verified-followers-coun
 const profileFollowersList = require('./profile-followers-list.test.js');
 const profileVerifiedReportersCount = require('./profile-verified-reporters-count.test.js');
 const verifiedReportersMembershipData = require('./verified-reporters-membership-data.test.js');
+const verifiedReportersListPage = require('./verified-reporters-list-page.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -150,6 +151,9 @@ async function main() {
   console.log('\nverified-reporters-membership-data suite:');
   const verifiedReportersMembershipDataResult = await verifiedReportersMembershipData.run();
 
+  console.log('\nverified-reporters-list-page suite:');
+  const verifiedReportersListPageResult = await verifiedReportersListPage.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -243,6 +247,9 @@ async function main() {
   console.log(
     `verified-reporters-membership-data suite:        ${verifiedReportersMembershipDataResult.fail === 0 ? 'PASS' : 'FAIL'} (${verifiedReportersMembershipDataResult.pass} passed, ${verifiedReportersMembershipDataResult.fail} failed)`
   );
+  console.log(
+    `verified-reporters-list-page suite:              ${verifiedReportersListPageResult.fail === 0 ? 'PASS' : 'FAIL'} (${verifiedReportersListPageResult.pass} passed, ${verifiedReportersListPageResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -275,7 +282,8 @@ async function main() {
     profileVerifiedFollowersCountResult.fail === 0 &&
     profileFollowersListResult.fail === 0 &&
     profileVerifiedReportersCountResult.fail === 0 &&
-    verifiedReportersMembershipDataResult.fail === 0;
+    verifiedReportersMembershipDataResult.fail === 0 &&
+    verifiedReportersListPageResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/test/verified-reporters-list-page.test.js
+++ b/test/verified-reporters-list-page.test.js
@@ -1,0 +1,224 @@
+/**
+ * Story verified-reporters #3: Verified Reporters list page.
+ * ADR 0003 (verified-reporters). See
+ * engineering-team/stories/verified-reporters/3-verified-reporters-list-page.test-plan.md
+ *
+ * ADR 0003 chose Option A: a new ui/src/pages/BrainstormReporters.jsx mirroring
+ * BrainstormFollowers.jsx, at route /user/:pubkey/reporters (App.jsx), consuming the
+ * existing useGrapevineReporters hook (Story 2). Deltas the page must carry: the
+ * reporters hook, STORAGE_KEY 'bsp-reporters-columns', the style-guide copy (title,
+ * description, House PoV line, empty state, error+retry), the extended About-this-data
+ * popover, default sort by RANK descending (not verifiedFollowerCount), a skeleton
+ * loader (not a text loader), and a backward-compatible `refetch` added to the hook.
+ *
+ * Tests are source-regex sentinels — the profile-follows-list / profile-followers-list
+ * precedent. The page + route do not exist pre-implementation, so T1–T14 FAIL now and
+ * PASS once built. R1–R3 are regression sentinels — PASS before AND after (the existing
+ * follows/followers routes and the untouched BrainstormFollowers page).
+ *
+ * FALSE-POSITIVE AVOIDANCE: ui/src/App.jsx and BrainstormFollowers.jsx already contain
+ * "reporters"/"Verified Reporters"/"verifiedReporterCount" (the followers page has a
+ * "Verified Reporters" COLUMN). Each sentinel targets the NEW reporters page/route
+ * specifically — BrainstormReporters, /user/:pubkey/reporters, the reporters hook,
+ * 'bsp-reporters-columns', and the reporters-specific copy — none of which exist now.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PAGE    = path.resolve(__dirname, '../ui/src/pages/BrainstormReporters.jsx');
+const APP     = path.resolve(__dirname, '../ui/src/App.jsx');
+const STYLES  = path.resolve(__dirname, '../ui/src/styles.css');
+const HOOK    = path.resolve(__dirname, '../ui/src/hooks/useGrapevineReporters.js');
+const FOLLOWERS_PAGE = path.resolve(__dirname, '../ui/src/pages/BrainstormFollowers.jsx');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+
+// AC1 — route registration
+test('T1: ui/src/App.jsx registers /user/:pubkey/reporters → BrainstormReporters (AC1)', () => {
+  const src = safeRead(APP);
+  assert(src.length > 0, 'ui/src/App.jsx missing — unexpected.');
+  assert(/\/user\/:pubkey\/reporters/.test(src),
+    "App.jsx must declare a route with path '/user/:pubkey/reporters' (the link target Story 1's count points at).");
+  assert(/BrainstormReporters/.test(src),
+    'App.jsx must import and map the reporters route to the BrainstormReporters page component.');
+});
+
+// AC1 — page exists, reads :pubkey, title + back link + description
+test('T2: BrainstormReporters.jsx exists, reads :pubkey, shows the title, back link, and description (AC1)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'ui/src/pages/BrainstormReporters.jsx does not exist yet — the Implementer must create the reporters page.');
+  assert(/useParams/.test(src), 'BrainstormReporters.jsx must read the :pubkey route param via useParams.');
+  assert(/Verified Reporters/.test(src), 'the page title must be "Verified Reporters".');
+  assert(/Back to profile/i.test(src) && /\/user\/\$\{pubkey\}(?!\/)/.test(src),
+    'the page must have a "Back to profile" link to `/user/${pubkey}` (the profile).');
+  assert(/Verified users who have reported this account\./.test(src),
+    'the page must show the description "Verified users who have reported this account." (style guide, verbatim).');
+});
+
+// AC1/AC4 — sources rows from the Story-2 hook
+test('T3: the page sources its rows from the useGrapevineReporters hook (AC1/AC4)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx does not exist yet.');
+  assert(/useGrapevineReporters/.test(src),
+    'BrainstormReporters.jsx must consume the useGrapevineReporters hook (Story 2 data; House PoV). Its row count is the live count — never the Meili profile badge.');
+});
+
+// AC2 — columns + Rank rendered + DataTable reuse
+test('T4: columns include Rank (round(influence*100)) and the page reuses DataTable (AC2)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx does not exist yet.');
+  assert(/DataTable/.test(src), 'BrainstormReporters.jsx must reuse the DataTable component (mirror of BrainstormFollowers).');
+  assert(/\brank\b/.test(src), 'the page must define a `rank` column (default-visible: picture/name/rank).');
+  assert(/Math\.round\(\s*[\w.?]+\s*\*\s*100\s*\)/.test(src),
+    'rank must be computed as Math.round(influence * 100) — an integer 0–100 (cf. BrainstormFollowers.jsx:127).');
+});
+
+// AC2 — DEFAULT SORT is rank descending, NOT verifiedFollowerCount (copy-paste guard)
+test('T5: default sort is by RANK descending, not by verifiedFollowerCount (AC2)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx does not exist yet.');
+  assert(/\.sort\s*\(/.test(src), 'the page must pre-sort the whole set before render (like BrainstormFollowers).');
+  assert(/b\.rank[\s\S]{0,18}a\.rank/.test(src),
+    'the default sort must be by RANK descending — a comparator like `(b.rank ?? -1) - (a.rank ?? -1)` (most credible reporters first; ADR 0003).');
+  assert(!/b\.verifiedFollowerCount[\s\S]{0,30}a\.verifiedFollowerCount/.test(src),
+    'copy-paste guard: the default sort must NOT remain verifiedFollowerCount desc (that is the FOLLOWERS page default). Reporters sort by rank.');
+});
+
+// AC3 — row click navigates to the reporter's profile
+test('T6: selecting a reporter row navigates to that reporter\'s /user/<pubkey> profile (AC3)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx does not exist yet.');
+  assert(/onRowClick/.test(src) && /navigate\(\s*`\/user\/\$\{[^}]*pubkey\}`/.test(src),
+    'rows must navigate to /user/<that-pubkey> (e.g. onRowClick={row => navigate(`/user/${row.pubkey}`)}).');
+});
+
+// AC5 — House PoV line, verbatim
+test('T7: the page shows the House point-of-view line (AC5)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx does not exist yet.');
+  assert(/Relative to the House \(default\) web of trust\./.test(src),
+    'the page must show the House PoV line "Relative to the House (default) web of trust. Sign in and build your network to see your own view." (style guide; v1 membership is House-only, so the House line is the honest attribution).');
+});
+
+// AC5 — extended About-this-data popover (local + no-global-view)
+test('T8: the "About this data" popover states local computation AND the no-global-view sentence (AC5)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx does not exist yet.');
+  assert(/About this data/.test(src), 'the page must keep the "About this data" disclosure.');
+  assert(/comput(e|ed)\s+locally|locally by this|this Tapestry instance/i.test(src) && /NIP-?85/i.test(src),
+    'the popover must keep the local/NIP-85 sentence.');
+  assert(/There is no single global number/.test(src),
+    'the popover must be EXTENDED with the no-global-view sentence "There is no single global number" (style guide / PRD §11).');
+});
+
+// AC6 — empty state, verbatim
+test('T9: the empty state uses the style-guide copy (AC6)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx does not exist yet.');
+  assert(/No verified reporters\. No one in this web of trust has reported this account\./.test(src),
+    'the empty state must read "No verified reporters. No one in this web of trust has reported this account." (style guide, verbatim) — not the followers copy, not a blank, not an error.');
+});
+
+// AC7 — skeleton loader (page element + CSS), not a bare text loader
+test('T10: loading shows a skeleton placeholder (a .bsp-skeleton-row + shimmer keyframes), not a bare spinner (AC7)', () => {
+  const src = safeRead(PAGE);
+  const css = safeRead(STYLES);
+  assert(src.length > 0, 'BrainstormReporters.jsx does not exist yet.');
+  assert(css.length > 0, 'ui/src/styles.css missing — unexpected.');
+  assert(/bsp-skeleton-row/.test(src),
+    'the loading state must render skeleton placeholder rows (a `bsp-skeleton-row` element) — ADR 0003 / AC7, improving on the followers text loader.');
+  const rule = css.match(/\.bsp-skeleton-row\s*\{[^}]*\}/);
+  assert(rule, 'styles.css must define a `.bsp-skeleton-row` rule.');
+  assert(/@keyframes\s+bsp-shimmer/.test(css),
+    'styles.css must define the `@keyframes bsp-shimmer` animation the skeleton uses.');
+});
+
+// AC7 — error message (verbatim) + retry control
+test('T11: the error state shows the style-guide copy and a "Try again" retry control (AC7)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx does not exist yet.');
+  assert(/Couldn't load reporters\. Trust scores may still be computing for this view\./.test(src),
+    'the error must show "Couldn\'t load reporters. Trust scores may still be computing for this view. Try again in a moment." (style guide) — never a raw error or "Something went wrong".');
+  assert(/Try again/.test(src),
+    'the error state must offer a "Try again" retry control (AC7).');
+});
+
+// AC7 — the hook gains a backward-compatible refetch the retry calls
+test('T12: useGrapevineReporters exposes a refetch/reload, and the page wires the retry to it (AC7)', () => {
+  const hook = safeRead(HOOK);
+  const page = safeRead(PAGE);
+  assert(hook.length > 0, 'useGrapevineReporters.js missing — unexpected (Story 2 created it).');
+  assert(/refetch|reload/.test(hook),
+    'useGrapevineReporters.js must expose a `refetch` (or `reload`) so the page can retry on error — a backward-compatible addition to the returned object.');
+  assert(page.length > 0, 'BrainstormReporters.jsx does not exist yet.');
+  assert(/refetch|reload/.test(page),
+    'the page must call the hook\'s refetch/reload from the "Try again" button.');
+});
+
+// Delta — distinct localStorage key
+test('T13: the page uses a distinct localStorage key bsp-reporters-columns (delta)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx does not exist yet.');
+  assert(/bsp-reporters-columns/.test(src),
+    "the page must use STORAGE_KEY 'bsp-reporters-columns' (distinct from follows/followers so column prefs don't clobber each other).");
+});
+
+// Regression guard carried into the new page — /api/profiles batch cap (the #29/#34 staging bug)
+test('T14: the page batches /api/profiles at PROFILE_CHUNK ≤ 50 (regression guard inherited)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx does not exist yet.');
+  const m = src.match(/PROFILE_CHUNK\s*=\s*(\d+)/);
+  assert(m, 'BrainstormReporters.jsx must define PROFILE_CHUNK (the /api/profiles batch size).');
+  const chunk = parseInt(m[1], 10);
+  assert(chunk >= 1 && chunk <= 50,
+    `PROFILE_CHUNK=${chunk} must be 1..50 — /api/profiles 400s for >50 pubkeys (fetchProfiles.js:148; the staging Name-column bug).`);
+});
+
+// ===========================================================================
+// REGRESSION SENTINELS (must PASS before AND after implementation)
+// ===========================================================================
+
+test('R1: App.jsx still registers the follows and followers routes (regression)', () => {
+  const src = safeRead(APP);
+  assert(src.length > 0, 'ui/src/App.jsx missing — unexpected.');
+  assert(/\/user\/:pubkey\/follows/.test(src) && /\/user\/:pubkey\/followers/.test(src),
+    'the existing /user/:pubkey/follows and /user/:pubkey/followers routes must remain (the reporters route is added beside them).');
+});
+
+test('R2: BrainstormFollowers.jsx is untouched — still uses useGrapevineFollowers + its own storage key (regression)', () => {
+  const src = safeRead(FOLLOWERS_PAGE);
+  assert(src.length > 0, 'BrainstormFollowers.jsx missing — unexpected.');
+  assert(/useGrapevineFollowers/.test(src),
+    'BrainstormFollowers.jsx must still use the followers hook (ADR 0003 adds a NEW page; it must not edit the followers page).');
+  assert(/bsp-followers-columns/.test(src),
+    "BrainstormFollowers.jsx must keep its own STORAGE_KEY 'bsp-followers-columns'.");
+});
+
+test('R3: BrainstormFollowers default sort remains verifiedFollowerCount desc (the reporters page must not have changed it)', () => {
+  const src = safeRead(FOLLOWERS_PAGE);
+  assert(src.length > 0, 'BrainstormFollowers.jsx missing — unexpected.');
+  assert(/verifiedFollowerCount/.test(src) && /\.sort\s*\(/.test(src),
+    'BrainstormFollowers.jsx must keep its verifiedFollowerCount default sort (guard against editing the wrong file).');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/verified-reporters-membership-data.test.js
+++ b/test/verified-reporters-membership-data.test.js
@@ -1,0 +1,199 @@
+/**
+ * Story verified-reporters #2: Verified reporters membership data.
+ * ADR 0002 (verified-reporters). See
+ * engineering-team/stories/verified-reporters/2-verified-reporters-membership-data.test-plan.md
+ *
+ * ADR 0002 chose Option A: a new isolated endpoint
+ *   GET /api/get-grapevine-reporters?observee=<pk>
+ * backed by a new src/api/grapevineInteractions/queries/reportersWithMetrics.js
+ * (handleGetGrapevineReporters), registered in src/api/index.js, consumed by a new
+ * ui/src/hooks/useGrapevineReporters.js. It is the LITERAL INVERSE of the verified-
+ * reporter count query (src/algos/follows-mutes-reports/calculateVerifiedReporterCounts.sh):
+ *   MATCH (observee:NostrUser {pubkey:$observee})<-[:REPORTS]-(reporter:NostrUser)
+ *   WHERE reporter.influence > $cutoff   // $cutoff = VERIFIED_REPORTERS_INFLUENCE_CUTOFF
+ * returning reporter {pubkey, influence, hops, verified*Count}. Same edge + same
+ * cutoff as the count algo ⇒ count = list length at House PoV; the response's own
+ * `count` is `data.length`. House/owner PoV only for v1 (personalized PoV deferred,
+ * mirroring follows ADR 0026 / followers ADR 0030).
+ *
+ * Tests are source-regex sentinels — the test/profile-follows-list.test.js precedent
+ * (a new endpoint pinned at source without prescribing the exact wiring). The handler,
+ * route, and hook do not exist pre-implementation, so T1–T10 FAIL now and PASS once
+ * built. R1–R2 are regression sentinels — they PASS before AND after (they guard the
+ * untouched follows endpoint + route).
+ *
+ * FALSE-POSITIVE AVOIDANCE: src/api/index.js + followsWithMetrics.js already contain
+ * the strings "REPORTS"/"verifiedReporterCount" (the follows RETURN surfaces the
+ * reporter COUNT per row). Each sentinel below targets the NEW reporters handler/route/
+ * hook specifically — `handleGetGrapevineReporters`, `/api/get-grapevine-reporters`,
+ * the `[:REPORTS]` edge + `VERIFIED_REPORTERS_INFLUENCE_CUTOFF` filter in the new file —
+ * none of which exist pre-implementation.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const HANDLER   = path.resolve(__dirname, '../src/api/grapevineInteractions/queries/reportersWithMetrics.js');
+const API_INDEX = path.resolve(__dirname, '../src/api/index.js');
+const HOOK      = path.resolve(__dirname, '../ui/src/hooks/useGrapevineReporters.js');
+const FOLLOWS_HANDLER = path.resolve(__dirname, '../src/api/grapevineInteractions/queries/followsWithMetrics.js');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+
+// ===========================================================================
+// BACKEND — new endpoint GET /api/get-grapevine-reporters (owner/House POV)
+// ===========================================================================
+
+test('T1: reportersWithMetrics.js exists and exports handleGetGrapevineReporters (ADR 0002 §Impl)', () => {
+  const src = safeRead(HANDLER);
+  assert(src.length > 0,
+    'src/api/grapevineInteractions/queries/reportersWithMetrics.js does not exist yet — the Implementer must create the new endpoint handler (ADR 0002 Option A: a new endpoint).');
+  assert(/handleGetGrapevineReporters/.test(src),
+    'reportersWithMetrics.js must define handleGetGrapevineReporters.');
+  assert(/module\.exports\s*=\s*\{[\s\S]*handleGetGrapevineReporters/.test(src),
+    'reportersWithMetrics.js must export handleGetGrapevineReporters so src/api/index.js can register it.');
+});
+
+test('T2: handler requires + 64-hex-validates `observee`, returning 400 otherwise (AC6)', () => {
+  const src = safeRead(HANDLER);
+  assert(src.length > 0, 'reportersWithMetrics.js does not exist yet.');
+  assert(/req\.query\.observee/.test(src),
+    'handler must read the `observee` query param (req.query.observee).');
+  assert(/\.status\(\s*400\s*\)/.test(src),
+    'handler must return HTTP 400 for a missing/invalid observee (AC6: a bad account id is rejected, not a crash or silent empty success).');
+  assert(/[0-9a-f]\{64\}|isValidHexPubkey|npubEncode/i.test(src),
+    'handler must validate the pubkey shape (64-hex, e.g. /^[0-9a-f]{64}$/i, isValidHexPubkey, or a nip19.npubEncode round-trip — cf. followsWithMetrics.js:36-60).');
+});
+
+test('T3: handler Cypher traverses the inbound :REPORTS edge with a verified-influence filter (AC1)', () => {
+  const src = safeRead(HANDLER);
+  assert(src.length > 0, 'reportersWithMetrics.js does not exist yet.');
+  assert(/\[\s*:REPORTS\s*\]/.test(src),
+    'handler Cypher must traverse the :REPORTS edge between the reported account and its reporters (e.g. (observee)<-[:REPORTS]-(reporter:NostrUser)). This is the same edge the count algo uses (calculateVerifiedReporterCounts.sh).');
+  assert(/influence\s*>/.test(src),
+    'handler must filter reporters by influence above the verified cutoff (e.g. `reporter.influence > $cutoff`) — only VERIFIED reporters are returned (AC1; unverified/sybil reporters excluded).');
+});
+
+test('T4: the verified filter uses VERIFIED_REPORTERS_INFLUENCE_CUTOFF (not the followers cutoff) and the response count is data.length (AC3)', () => {
+  const src = safeRead(HANDLER);
+  assert(src.length > 0, 'reportersWithMetrics.js does not exist yet.');
+  assert(/VERIFIED_REPORTERS_INFLUENCE_CUTOFF/.test(src),
+    'the verified cutoff MUST be VERIFIED_REPORTERS_INFLUENCE_CUTOFF — the SAME config var the count algo (calculateVerifiedReporterCounts.sh) uses. This is what makes count = list length hold (AC3).');
+  assert(!/VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF/.test(src),
+    'copy-paste guard: do NOT use VERIFIED_FOLLOWERS_INFLUENCE_CUTOFF here (it would silently break count = list length). Use the reporters cutoff.');
+  assert(/getConfigFromFile/.test(src),
+    'the cutoff must be read via getConfigFromFile (cf. followsWithMetrics.js:19,64,76).');
+  assert(/count\s*:\s*data\.length/.test(src),
+    'the response `count` must be `data.length` so count === list length within the capability (AC3).');
+});
+
+test('T5: success rows carry identity + credibility metric per reporter (AC2)', () => {
+  const src = safeRead(HANDLER);
+  assert(src.length > 0, 'reportersWithMetrics.js does not exist yet.');
+  for (const field of ['pubkey', 'influence', 'hops', 'verifiedFollowerCount', 'verifiedMuterCount', 'verifiedReporterCount']) {
+    assert(new RegExp('\\b' + field + '\\b').test(src),
+      `each returned reporter must surface \`${field}\` (AC2: an identifier + the Rank/credibility metric; the full column set mirrors followers for Story 3 parity).`);
+  }
+});
+
+test('T6: a non-owner `observer` is rejected with 400 — owner/House POV only in v1 (AC1/AC4; personalized POV deferred)', () => {
+  const src = safeRead(HANDLER);
+  assert(src.length > 0, 'reportersWithMetrics.js does not exist yet.');
+  assert(/observer/.test(src),
+    'handler must look at the `observer` param to reject non-owner values in v1.');
+  assert(/\.status\(\s*400\s*\)[\s\S]{0,260}(customer|owner[\s-]?only|not\s*(yet\s*)?support)/i.test(src) ||
+         /(customer|owner[\s-]?only|not\s*(yet\s*)?support)[\s\S]{0,260}\.status\(\s*400\s*\)/i.test(src),
+    'a non-owner `observer` must return 400 stating customer/personalized observers are not yet supported (v1 is owner/House POV only — ADR 0002, mirrors ADR 0026/0030). AC4 (House fallback) is the v1 default path.');
+});
+
+test('T7: success response shape is {success, observer:\'owner\', observee, count, data} (AC3/AC5)', () => {
+  const src = safeRead(HANDLER);
+  assert(src.length > 0, 'reportersWithMetrics.js does not exist yet.');
+  for (const key of ['success', 'observer', 'observee', 'count', 'data']) {
+    assert(new RegExp('\\b' + key + '\\b').test(src),
+      `the success response must include \`${key}\` (ADR 0002: { success:true, observer:'owner', observee, count, data:[…] }).`);
+  }
+  assert(/observer\s*:\s*['"]owner['"]/.test(src),
+    "the response must report observer:'owner' (v1 House/owner POV).");
+  // AC5: an empty result is a normal success — `data` is built by mapping records, so
+  // zero verified reporters yields data:[] / count:0 with a 200, not an error path.
+  assert(/result\.records/.test(src) && /\.map\s*\(/.test(src),
+    'data must be built from result.records via .map (so a zero-reporter account yields data:[] count:0 as a normal 200 success — AC5 — not an error).');
+});
+
+test('T8: handler enforces the Neo4j deadline (NEO4J_QUERY_TIMEOUT_MS) with a 504 {success:false} branch (ADR §Impl, mirrors follows)', () => {
+  const src = safeRead(HANDLER);
+  assert(src.length > 0, 'reportersWithMetrics.js does not exist yet.');
+  assert(/NEO4J_QUERY_TIMEOUT_MS/.test(src),
+    'handler must read NEO4J_QUERY_TIMEOUT_MS (same deadline pattern as followsWithMetrics.js:76).');
+  assert(/timeout\s*:/.test(src),
+    'handler must pass a driver-layer { timeout: ... } to session.run so a runaway query fails fast (followsWithMetrics.js:96).');
+  const win = src.match(/\.status\(\s*504\s*\)\s*\.json\(\s*\{[\s\S]{0,400}?\}/);
+  assert(win, 'handler must return HTTP 504 with a JSON object body on query timeout (no `.status(504).json({...})` found).');
+  assert(/success\s*:\s*false/.test(win[0]),
+    'the 504 JSON body must include `success: false` (followsWithMetrics.js:123-126).');
+});
+
+test('T9: GET /api/get-grapevine-reporters is registered in src/api/index.js → handleGetGrapevineReporters (AC: endpoint reachable)', () => {
+  const src = safeRead(API_INDEX);
+  assert(src.length > 0, 'src/api/index.js missing — unexpected.');
+  assert(/['"]\/api\/get-grapevine-reporters['"]/.test(src),
+    "src/api/index.js must register the route '/api/get-grapevine-reporters' (alongside the follows/followers routes).");
+  assert(/handleGetGrapevineReporters/.test(src),
+    'src/api/index.js must wire the route to handleGetGrapevineReporters (import + app.get).');
+});
+
+// ===========================================================================
+// FRONTEND — the data hook (the page that consumes it is Story 3, not here)
+// ===========================================================================
+
+test('T10: ui/src/hooks/useGrapevineReporters.js fetches /api/get-grapevine-reporters (ADR §Impl)', () => {
+  const src = safeRead(HOOK);
+  assert(src.length > 0,
+    'useGrapevineReporters.js does not exist yet — the Implementer must create the data hook (mirror useGrapevineFollows.js).');
+  assert(/get-grapevine-reporters/.test(src),
+    'useGrapevineReporters.js must call the /api/get-grapevine-reporters endpoint.');
+  assert(/fetch\s*\(/.test(src),
+    'useGrapevineReporters.js must use fetch (matching the useGrapevineFollows.js convention).');
+});
+
+// ===========================================================================
+// REGRESSION SENTINELS (must PASS before AND after implementation)
+// ===========================================================================
+
+test('R1: the follows endpoint is untouched — followsWithMetrics.js still exports handleGetGrapevineFollows over the :FOLLOWS edge (regression)', () => {
+  const src = safeRead(FOLLOWS_HANDLER);
+  assert(src.length > 0, 'followsWithMetrics.js missing — unexpected.');
+  assert(/handleGetGrapevineFollows/.test(src),
+    'followsWithMetrics.js must still export handleGetGrapevineFollows (ADR 0002 adds a NEW endpoint; it must not edit the follows handler).');
+  assert(/:FOLLOWS\s*\]\s*->/.test(src),
+    'the follows handler must still traverse (observee)-[:FOLLOWS]->(f) — unchanged.');
+});
+
+test('R2: the existing /api/get-grapevine-follows route remains registered (regression)', () => {
+  const src = safeRead(API_INDEX);
+  assert(src.length > 0, 'src/api/index.js missing — unexpected.');
+  assert(/['"]\/api\/get-grapevine-follows['"]/.test(src),
+    'the existing /api/get-grapevine-follows registration must remain (the live Follows feature depends on it).');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/tests/brainstorm/profile-verified-reporters-count.spec.js
+++ b/tests/brainstorm/profile-verified-reporters-count.spec.js
@@ -1,0 +1,71 @@
+/**
+ * Playwright behavioral check for story verified-reporters #1 / ADR 0001: the
+ * profile page shows a "Verified Reporters" count beside "Following" and "Verified
+ * Followers", as a state-dependent counter (link only when > 0).
+ * See engineering-team/stories/verified-reporters/1-verified-reporters-count.test-plan.md
+ *
+ * SUPPLEMENTARY + LIVE-DATA DEPENDENT (mirrors the profile-verified-followers-count
+ * spec). The deterministic coverage is the node suite
+ * test/profile-verified-reporters-count.test.js (no stack dependency). This spec
+ * additionally verifies the browser-rendered result and the not-an-anchor behavior
+ * that source-regex can only approximate.
+ *
+ * Preconditions / fragility:
+ *   - A reachable Brainstorm instance (BRAINSTORM_BASE_URL or http://localhost:7778)
+ *     with the change BUILT into the UI (`npm run build` in ui/) AND House-PoV WoT
+ *     scores loaded into Meilisearch (the count comes from
+ *     wot_verifiedReporterCount_<houseSuffix>).
+ *   - Relies on LIVE DATA. The account below (Jack Dorsey) is a well-indexed account
+ *     expected to have trust scores loaded and — being broadly trusted — ZERO
+ *     verified reporters under the House PoV, which exercises the "0 → not a link"
+ *     state. If scores aren't loaded the counter shows "—" (also not a link).
+ *
+ * Not run pre-implementation (current code has no such counter); exercised at the
+ * staging smoke after the feature deploys.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = process.env.BRAINSTORM_BASE_URL || 'http://localhost:7778';
+// Jack Dorsey — a well-indexed account: trust scores loaded, and (broadly trusted)
+// expected to have 0 verified reporters under the House PoV.
+const ZERO_PUBKEY = '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2';
+
+test.describe('Story verified-reporters #1 — Verified Reporters count on the profile', () => {
+  test('a "Verified Reporters" count is shown beside "Following" and "Verified Followers"', async ({ page }) => {
+    await page.goto(`${BASE_URL}/user/${ZERO_PUBKEY}`);
+
+    await expect(page.getByText('Following', { exact: true })).toBeVisible();
+    await expect(page.getByText('Verified Followers', { exact: true })).toBeVisible();
+    await expect(page.getByText('Verified Reporters', { exact: true })).toBeVisible();
+  });
+
+  test('with 0 verified reporters the counter is NOT a link; the sibling counts remain links', async ({ page }) => {
+    await page.goto(`${BASE_URL}/user/${ZERO_PUBKEY}`);
+
+    // AC3: a genuine 0 (or unavailable "—") renders the Verified Reporters counter
+    // as plain text, not a <Link> — there is nothing to inspect.
+    await expect(page.getByText('Verified Reporters', { exact: true })).toBeVisible();
+    expect(
+      await page.getByRole('link', { name: /verified reporters/i }).count(),
+      'with 0 verified reporters the counter must be plain text, not a <Link> (the link appears only when count > 0).'
+    ).toBe(0);
+
+    // Regression: the sibling counts are still same-tab links.
+    await expect(page.getByRole('link', { name: /^Following/i })).toHaveAttribute('href', new RegExp(`/user/${ZERO_PUBKEY}/follows$`));
+    await expect(page.getByRole('link', { name: /verified followers/i })).toHaveAttribute('href', new RegExp(`/user/${ZERO_PUBKEY}/followers$`));
+  });
+
+  // MANUAL / FIXTURE-DEPENDENT (left as a documented check, like the PoV check below):
+  // The > 0 state — link to /user/:pubkey/reporters, the --red negative value, and the
+  // aria-label "{n} verified reporters. View list." — needs a fixture account that has
+  // verified reporters under the active PoV at smoke time. To verify:
+  //   1. Pick a pubkey with >0 verified reporters under the House PoV (or pin one via ?pov=).
+  //   2. Confirm the "Verified Reporters" count is a same-tab link whose href matches
+  //      /\/user\/[0-9a-f]{64}\/reporters$/ and is NOT target=_blank.
+  //   3. Confirm its accessible name matches /\d+ verified reporters\. view list\./i.
+  //   4. Confirm the value renders in the --red negative color.
+  //
+  // PoV (AC1) is exercisable by appending ?pov=<8hex> (e.g. ?pov=a1420e44) and confirming
+  // the count reflects that PoV when its scores are indexed, falling back to House otherwise.
+});

--- a/tests/brainstorm/profile-verified-reporters-list.spec.js
+++ b/tests/brainstorm/profile-verified-reporters-list.spec.js
@@ -1,0 +1,64 @@
+/**
+ * Playwright behavioral check for story verified-reporters #3 / ADR 0003: the
+ * /user/:pubkey/reporters page lists an account's verified reporters.
+ * See engineering-team/stories/verified-reporters/3-verified-reporters-list-page.test-plan.md
+ *
+ * SUPPLEMENTARY + LIVE-DATA DEPENDENT (mirrors profile-followers-list.spec.js). The
+ * deterministic coverage is the node suite test/verified-reporters-list-page.test.js
+ * (no stack dependency). This spec verifies the browser-rendered page shell and the
+ * empty state that source-regex can only approximate.
+ *
+ * Preconditions / fragility:
+ *   - A reachable Brainstorm instance (BRAINSTORM_BASE_URL or http://localhost:7778)
+ *     with the change BUILT into the UI (`npm run build` in ui/) AND the verified-
+ *     reporter membership endpoint live (GET /api/get-grapevine-reporters) with House
+ *     WoT scores + [:REPORTS] edges loaded.
+ *   - Relies on LIVE DATA. Most accounts have ZERO verified reporters (being reported
+ *     by trusted users is rare), so the account below exercises the EMPTY state.
+ *
+ * Not run pre-implementation (the page/route do not exist yet); exercised at the
+ * staging smoke after the feature deploys.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = process.env.BRAINSTORM_BASE_URL || 'http://localhost:7778';
+// A well-indexed, broadly-trusted account: scores loaded, expected 0 verified reporters.
+const ZERO_PUBKEY = '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2';
+
+const reportersUrl = (pk) => `${BASE_URL}/user/${pk}/reporters`;
+
+test.describe('Story verified-reporters #3 — verified reporters list page', () => {
+  test('the page shows the title, a back link to the profile, and the description', async ({ page }) => {
+    await page.goto(reportersUrl(ZERO_PUBKEY));
+
+    await expect(page.getByRole('heading', { name: /verified reporters/i })).toBeVisible();
+    await expect(page.getByText('Verified users who have reported this account.', { exact: true })).toBeVisible();
+
+    const back = page.getByRole('link', { name: /back to profile/i });
+    await expect(back).toBeVisible();
+    await expect(back).toHaveAttribute('href', new RegExp(`/user/${ZERO_PUBKEY}$`));
+  });
+
+  test('an account with no verified reporters shows the designed empty state (not blank, not an error)', async ({ page }) => {
+    await page.goto(reportersUrl(ZERO_PUBKEY));
+    await expect(
+      page.getByText('No verified reporters. No one in this web of trust has reported this account.', { exact: true })
+    ).toBeVisible();
+  });
+
+  test('the point-of-view attribution line is present', async ({ page }) => {
+    await page.goto(reportersUrl(ZERO_PUBKEY));
+    // v1 membership is House-only, so the House PoV line is the honest attribution.
+    await expect(page.getByText(/Relative to the House \(default\) web of trust\./)).toBeVisible();
+  });
+
+  // MANUAL / FIXTURE-DEPENDENT (documented, like the followers spec's mega-account note):
+  // The populated path — rows sorted by Rank desc, a row click navigating to the
+  // reporter's /user/<pubkey> profile, and row count == the profile's Verified Reporters
+  // count — needs an account that actually has verified reporters under the House PoV at
+  // smoke time. To verify: open a known-reported account's /reporters page, confirm the
+  // rows are Rank-descending, click a row → lands on that reporter's profile, and the row
+  // count matches the profile badge (allowing for Meili-vs-Neo4j refresh skew, per ADR 0002).
+  // Entry point: from the profile, the "Verified Reporters" count (Story 1) links here when > 0.
+});

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -67,6 +67,7 @@ import BrainstormSearch from './pages/BrainstormSearch';
 import BrainstormProfile from './pages/BrainstormProfile';
 import BrainstormFollows from './pages/BrainstormFollows';
 import BrainstormFollowers from './pages/BrainstormFollowers';
+import BrainstormReporters from './pages/BrainstormReporters';
 import BrainstormSettings from './pages/BrainstormSettings';
 import BrainstormPersonalization from './pages/BrainstormPersonalization';
 import BrainstormHowSearchWorks from './pages/BrainstormHowSearchWorks';
@@ -89,6 +90,10 @@ const router = createBrowserRouter([
   {
     path: '/user/:pubkey/followers',
     element: <BrainstormFollowers />,
+  },
+  {
+    path: '/user/:pubkey/reporters',
+    element: <BrainstormReporters />,
   },
   {
     path: '/settings',

--- a/ui/src/hooks/useGrapevineReporters.js
+++ b/ui/src/hooks/useGrapevineReporters.js
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook: fetch the VERIFIED users who NIP-56-reported <observee>, with owner/House-POV
+ * GrapeRank metrics, from `/api/get-grapevine-reporters`. Returns { data, loading, error }.
+ *
+ * v1 is owner/House POV only (ADR 0002), so `observer` is not sent — the endpoint
+ * defaults to the instance owner. Mirrors useGrapevineFollows.js.
+ */
+export default function useGrapevineReporters(observee) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!observee) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    fetch(`/api/get-grapevine-reporters?observee=${observee}`, { signal: controller.signal })
+      .then(r => r.json())
+      .then(json => {
+        if (json?.success && Array.isArray(json.data)) {
+          setData(json.data);
+        } else {
+          setData(null);
+          setError(json?.message || json?.error || 'No data');
+        }
+      })
+      .catch(err => {
+        if (err.name === 'AbortError') return;
+        setError(err.message || 'Fetch failed');
+        setData(null);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [observee]);
+
+  return { data, loading, error };
+}

--- a/ui/src/hooks/useGrapevineReporters.js
+++ b/ui/src/hooks/useGrapevineReporters.js
@@ -11,6 +11,7 @@ export default function useGrapevineReporters(observee) {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [reloadNonce, setReloadNonce] = useState(0);
 
   useEffect(() => {
     if (!observee) {
@@ -44,7 +45,11 @@ export default function useGrapevineReporters(observee) {
       });
 
     return () => controller.abort();
-  }, [observee]);
+  }, [observee, reloadNonce]);
 
-  return { data, loading, error };
+  // Backward-compatible retry (story #3): bump the nonce to re-run the fetch
+  // (wired to the list page's "Try again" control on error).
+  const refetch = () => setReloadNonce(n => n + 1);
+
+  return { data, loading, error, refetch };
 }

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -95,6 +95,9 @@ export default function BrainstormProfile() {
   const nip05Verified = useNip05Verification(pubkey, profile?.nip05);
   const followingCount = userCounts?.followingCount ?? null;
   const fmtCount = (n) => (n == null ? '—' : new Intl.NumberFormat().format(n));
+  // Verified Reporters count rides the PoV-resolved trustScores (same source as
+  // Verified Followers). `?? null` distinguishes a genuine 0 from "not loaded".
+  const verifiedReporterCount = trustScores?.verifiedReporterCount ?? null;
 
   const npub = useMemo(() => {
     try { return nip19.npubEncode(pubkey); } catch { return null; }
@@ -233,7 +236,7 @@ export default function BrainstormProfile() {
               </div>
             </div>
 
-            {/* Following + Verified Followers counts */}
+            {/* Following + Verified Followers + Verified Reporters counts */}
             <div className={`bsp-counts ${userCountsLoading ? 'bsp-counts-loading' : ''}`}>
               <Link to={`/user/${pubkey}/follows`} className="bsp-count bsp-count-link">
                 <span className="bsp-count-value">{fmtCount(followingCount)}</span>
@@ -245,6 +248,25 @@ export default function BrainstormProfile() {
                 <span className="bsp-count-value">{fmtCount(trustScores?.verifiedFollowerCount ?? trustScores?.followers)}</span>
                 <span className="bsp-count-label">Verified Followers</span>
               </Link>
+              {/* Verified Reporters → reporters list (verified-reporters epic, ADR 0001). A
+                  negative signal: only a <Link> when >0; a genuine 0 is neutral and not a
+                  link; "—" when unavailable; dimmed "—" while the PoV scores load. The list
+                  page (/user/:pubkey/reporters) ships in story #3. */}
+              {verifiedReporterCount > 0 ? (
+                <Link
+                  to={`/user/${pubkey}/reporters`}
+                  className="bsp-count bsp-count-link"
+                  aria-label={`${verifiedReporterCount} verified reporters. View list.`}
+                >
+                  <span className="bsp-count-value bsp-count-value-negative">{fmtCount(verifiedReporterCount)}</span>
+                  <span className="bsp-count-label">Verified Reporters</span>
+                </Link>
+              ) : (
+                <span className={`bsp-count${trustLoading ? ' bsp-count-loading' : ''}`}>
+                  <span className="bsp-count-value">{fmtCount(verifiedReporterCount)}</span>
+                  <span className="bsp-count-label">Verified Reporters</span>
+                </span>
+              )}
             </div>
 
             {/* Action buttons */}

--- a/ui/src/pages/BrainstormReporters.jsx
+++ b/ui/src/pages/BrainstormReporters.jsx
@@ -1,0 +1,252 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { nip19 } from 'nostr-tools';
+import { useAuth } from '../context/AuthContext';
+import BrainstormUserMenu from '../components/BrainstormUserMenu';
+import DataTable from '../components/DataTable';
+import useGrapevineReporters from '../hooks/useGrapevineReporters';
+
+/* ── Helpers ──────────────────────────────────────────── */
+
+function safeNpub(pubkey) {
+  try { return nip19.npubEncode(pubkey); } catch { return pubkey; }
+}
+function shortNpub(npub) {
+  if (!npub) return '—';
+  return npub.length > 20 ? `${npub.slice(0, 12)}…${npub.slice(-6)}` : npub;
+}
+
+const PAGE_SIZE = 50;
+// Reporters-specific localStorage key — distinct from the follows/followers page keys so
+// the pages do not clobber each other's column-visibility prefs.
+const STORAGE_KEY = 'bsp-reporters-columns';
+
+// Column definitions + default visibility (pic/name/rank shown; the rest hidden).
+const ALL_COLUMNS = [
+  { key: 'picture', label: '', sortable: false, render: (_v, row) => (
+    row.picture
+      ? <img src={row.picture} alt="" className="bsp-follows-avatar" onError={e => { e.target.style.display = 'none'; }} />
+      : <div className="bsp-follows-avatar bsp-follows-avatar-ph">{(row.name || '?')[0].toUpperCase()}</div>
+  ) },
+  { key: 'name', label: 'Name', render: v => v || '—' },
+  { key: 'rank', label: 'Rank', render: v => (v == null ? '—' : v) },
+  { key: 'npub', label: 'npub', render: v => <code className="bsp-follows-npub">{shortNpub(v)}</code> },
+  { key: 'hops', label: 'Hops', render: v => (v == null ? '—' : v) },
+  { key: 'verifiedFollowerCount', label: 'Verified Followers', render: v => (v == null ? '—' : v) },
+  { key: 'verifiedMuterCount', label: 'Verified Muters', render: v => (v == null ? '—' : v) },
+  { key: 'verifiedReporterCount', label: 'Verified Reporters', render: v => (v == null ? '—' : v) },
+];
+const DEFAULT_VISIBLE = {
+  picture: true, name: true, rank: true,
+  npub: false, hops: false,
+  verifiedFollowerCount: false, verifiedMuterCount: false, verifiedReporterCount: false,
+};
+
+function loadVisible() {
+  try {
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    if (saved && typeof saved === 'object') return { ...DEFAULT_VISIBLE, ...saved };
+  } catch { /* ignore */ }
+  return { ...DEFAULT_VISIBLE };
+}
+
+// /api/profiles caps at 50 pubkeys per request (src/api/profiles/fetchProfiles.js:148),
+// so profile lookups are batched at PROFILE_CHUNK and merged chunk-by-chunk as they arrive.
+const PROFILE_CHUNK = 50;
+
+/* ── Local-data disclosure popover (tap to open; mobile-friendly) ── */
+
+function InfoPopover({ open, onClose }) {
+  if (!open) return null;
+  return (
+    <div className="bsp-confirm-overlay" onClick={onClose}>
+      <div className="bsp-confirm-box bsp-follows-info" onClick={e => e.stopPropagation()}>
+        <h3 className="bsp-confirm-title">About this data</h3>
+        <p className="bsp-confirm-message">
+          All data on this page is computed locally by this Tapestry instance and is not imported via NIP-85.
+        </p>
+        <p className="bsp-confirm-message">
+          Counts are personal to each viewer's web of trust. There is no single global number. When you have no calculated web of trust, the House (default) view is shown.
+        </p>
+        <div className="bsp-confirm-buttons">
+          <button className="bsp-confirm-ok" onClick={onClose}>Got it</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Main component ──────────────────────────────────── */
+
+export default function BrainstormReporters() {
+  const { pubkey } = useParams();
+  const navigate = useNavigate();
+  const { user, login, logout } = useAuth();
+
+  const { data: reporters, loading, error, refetch } = useGrapevineReporters(pubkey);
+
+  const [profiles, setProfiles] = useState({});
+  const [search, setSearch] = useState('');
+  const [visible, setVisible] = useState(loadVisible);
+  const [showCols, setShowCols] = useState(false);
+  const [showInfo, setShowInfo] = useState(false);
+
+  // Persist column show/hide choices across reloads/sessions.
+  useEffect(() => {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(visible)); } catch { /* ignore */ }
+  }, [visible]);
+
+  // Batch-load names/pics for the reporter pubkeys. /api/profiles caps at 50 pubkeys/request,
+  // so chunk at PROFILE_CHUNK and merge each chunk as it returns.
+  useEffect(() => {
+    if (!reporters || reporters.length === 0) { setProfiles({}); return; }
+    let cancelled = false;
+    setProfiles({});
+    const pubkeys = reporters.map(f => f.pubkey);
+    (async () => {
+      for (let i = 0; i < pubkeys.length && !cancelled; i += PROFILE_CHUNK) {
+        const batch = pubkeys.slice(i, i + PROFILE_CHUNK);
+        try {
+          const r = await fetch(`/api/profiles?pubkeys=${batch.join(',')}`);
+          const j = await r.json();
+          if (!cancelled && j?.profiles) setProfiles(prev => ({ ...prev, ...j.profiles }));
+        } catch { /* tolerate partial profile failures */ }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [reporters]);
+
+  // Build rows: merge metrics + profile, derive rank/name/npub.
+  const rows = useMemo(() => {
+    const list = (reporters || []).map(f => {
+      const p = profiles[f.pubkey] || {};
+      const npub = safeNpub(f.pubkey);
+      return {
+        pubkey: f.pubkey,
+        picture: p.picture || null,
+        name: p.display_name || p.name || shortNpub(npub),
+        npub,
+        rank: f.influence == null ? null : Math.round(f.influence * 100),
+        hops: f.hops,
+        verifiedFollowerCount: f.verifiedFollowerCount,
+        verifiedMuterCount: f.verifiedMuterCount,
+        verifiedReporterCount: f.verifiedReporterCount,
+      };
+    });
+    // Default sort: Rank (credibility), descending — most credible reporters first.
+    list.sort((a, b) => (b.rank ?? -1) - (a.rank ?? -1));
+    return list;
+  }, [reporters, profiles]);
+
+  // Page-level search — matches name / npub / pubkey even when those columns are hidden.
+  const searched = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter(r =>
+      (r.name && r.name.toLowerCase().includes(q)) ||
+      (r.npub && r.npub.toLowerCase().includes(q)) ||
+      r.pubkey.toLowerCase().includes(q)
+    );
+  }, [rows, search]);
+
+  const columns = useMemo(() => ALL_COLUMNS.filter(c => visible[c.key]), [visible]);
+
+  return (
+    <div className="bsp-page">
+      {/* Top bar */}
+      <div className="bsp-top-bar">
+        <a href="/" className="bsp-logo">
+          <img src="/brainstorm.svg" alt="" className="bsp-logo-img" />
+        </a>
+        <div className="bsp-auth">
+          <BrainstormUserMenu user={user} login={login} logout={logout} />
+        </div>
+      </div>
+
+      <div className="bsp-content">
+        {/* Header + back link */}
+        <div className="bsp-follows-header">
+          <Link to={`/user/${pubkey}`} className="bsp-back-link">← Back to profile</Link>
+          <h1 className="bsp-follows-title">Verified Reporters</h1>
+          <button
+            type="button"
+            className="bsp-info-btn"
+            aria-label="About this data"
+            title="About this data"
+            onClick={() => setShowInfo(true)}
+          >ⓘ</button>
+        </div>
+        <p className="bsp-follows-subtitle">Verified users who have reported this account.</p>
+        {/* v1 membership is House-only, so the House point of view is the honest attribution. */}
+        <p className="bsp-follows-pov">Relative to the House (default) web of trust. Sign in and build your network to see your own view.</p>
+
+        {/* Controls: search + columns toggle */}
+        <div className="bsp-follows-controls">
+          <input
+            type="search"
+            className="bsp-follows-search"
+            placeholder="Search by name or npub…"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+          <div className="bsp-follows-colmenu">
+            <button type="button" className="bsp-follows-colbtn" onClick={() => setShowCols(s => !s)}>
+              Columns ▾
+            </button>
+            {showCols && (
+              <div className="bsp-follows-colpanel" onMouseLeave={() => setShowCols(false)}>
+                {ALL_COLUMNS.map(c => (
+                  <label key={c.key} className="bsp-follows-colopt">
+                    <input
+                      type="checkbox"
+                      checked={!!visible[c.key]}
+                      onChange={() => setVisible(v => ({ ...v, [c.key]: !v[c.key] }))}
+                    />
+                    {c.label || 'Picture'}
+                  </label>
+                ))}
+                <button
+                  type="button"
+                  className="bsp-follows-colreset"
+                  onClick={() => setVisible({ ...DEFAULT_VISIBLE })}
+                >Reset to defaults</button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Body */}
+        {loading && (
+          <div className="bsp-reporters-skeleton" aria-label="Loading reporters">
+            <div className="bsp-skeleton-row" />
+            <div className="bsp-skeleton-row" />
+            <div className="bsp-skeleton-row" />
+            <div className="bsp-skeleton-row" />
+          </div>
+        )}
+        {error && !loading && (
+          <div className="bsp-trust-unavailable">
+            <span className="bsp-trust-icon">🔒</span>
+            <span>Couldn't load reporters. Trust scores may still be computing for this view. Try again in a moment.</span>
+            <button type="button" className="bsp-follows-colbtn" onClick={refetch}>Try again</button>
+          </div>
+        )}
+        {!loading && !error && rows.length === 0 && (
+          <div className="bsp-empty">No verified reporters. No one in this web of trust has reported this account.</div>
+        )}
+        {!loading && !error && rows.length > 0 && (
+          <DataTable
+            columns={columns}
+            data={searched}
+            pageSize={PAGE_SIZE}
+            showFilter={false}
+            onRowClick={row => navigate(`/user/${row.pubkey}`)}
+            emptyMessage="No matching accounts."
+          />
+        )}
+      </div>
+
+      <InfoPopover open={showInfo} onClose={() => setShowInfo(false)} />
+    </div>
+  );
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -4169,6 +4169,9 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
 .bsp-back-link { font-size: 0.85rem; opacity: 0.75; text-decoration: none; }
 .bsp-back-link:hover { opacity: 1; text-decoration: underline; }
 .bsp-follows-title { margin: 0; font-size: 1.4rem; }
+/* Reporters list: description + point-of-view attribution lines (verified-reporters #3). */
+.bsp-follows-subtitle { margin: 0.35rem 0 0; font-size: 0.9rem; opacity: 0.7; }
+.bsp-follows-pov { margin: 0.4rem 0 0; font-size: 0.82rem; opacity: 0.6; }
 .bsp-info-btn {
   margin-left: auto;
   border: 1px solid rgba(127, 127, 127, 0.4);
@@ -4247,6 +4250,20 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
 }
 .bsp-follows-npub { font-size: 0.8rem; opacity: 0.85; }
 .bsp-empty { padding: 2rem; text-align: center; opacity: 0.7; }
+/* Skeleton loader for list pages (verified-reporters #3 / ADR 0003) — a designed
+   placeholder, never a bare spinner. */
+.bsp-skeleton-row {
+  height: 2.25rem;
+  border-radius: 6px;
+  background: linear-gradient(90deg, rgba(255,255,255,.04), rgba(255,255,255,.09), rgba(255,255,255,.04));
+  background-size: 200% 100%;
+  animation: bsp-shimmer 1.2s infinite;
+  margin-bottom: 0.5rem;
+}
+@keyframes bsp-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
 
 .table-pagination {
   display: flex;

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3405,6 +3405,15 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
 .bsp-counts-loading .bsp-count-value {
   opacity: 0.4;
 }
+/* Verified Reporters: negative signal (the app encodes "report" as red). */
+.bsp-count-value-negative {
+  color: var(--red);
+}
+/* Per-count loading dim — the reporters count rides trustScores (trustLoading),
+   not the row-level userCounts loading, so it dims on its own. */
+.bsp-count-loading .bsp-count-value {
+  opacity: 0.4;
+}
 
 /* Sections */
 .bsp-section {


### PR DESCRIPTION
## Summary

Adds the **Verified Reporters** signal to the profile, parallel to Following / Verified Followers: a point-of-view-filtered count of the *verified* users (inside the viewer's web of trust) who have NIP-56-reported the account, linking to a list of exactly who they are. The credible negative trust signal — manufactured pile-ons from unverified accounts stay invisible. Built through the full product → engineering flow (discovery → PRD → 3 stories, each ADR + failing tests + impl + review PASS); book closed with audit + PRD addendum.

v1 is **House/owner PoV only** for the list membership (per-viewer membership deferred, mirroring the follows/followers precedent); the count is per-PoV via the existing Meili field.

## Changes

- **Profile count** — `ui/src/pages/BrainstormProfile.jsx`: a third counter in the `.bsp-counts` row; negative-signal `<Link>` to `/user/:pubkey/reporters` when >0, neutral `0`, `—` unavailable, dimmed loading. Value from the already-PoV-resolved `trustScores.verifiedReporterCount`.
- **Membership API** — new `src/api/grapevineInteractions/queries/reportersWithMetrics.js` (`GET /api/get-grapevine-reporters`), registered in `src/api/index.js`. Inverse of the verified-reporter count query (`(observee)<-[:REPORTS]-(reporter) WHERE reporter.influence > VERIFIED_REPORTERS_INFLUENCE_CUTOFF`); `count === data.length`.
- **List page** — new `ui/src/pages/BrainstormReporters.jsx` + route in `ui/src/App.jsx` + hook `ui/src/hooks/useGrapevineReporters.js`; mirrors the Followers list (DataTable, sort/search/columns, "About this data" popover), sorted by Rank desc, House-PoV attribution line, skeleton loader, error retry.
- **Styles** — `ui/src/styles.css`: negative-count, per-count loading dim, skeleton shimmer, list subtitle/PoV lines.
- **Tests** — `test/profile-verified-reporters-count.test.js`, `test/verified-reporters-membership-data.test.js`, `test/verified-reporters-list-page.test.js` (wired into `test/test.js`); supplementary Playwright specs under `tests/brainstorm/`.
- **Docs** — `product-team/` (discovery→PRD→stories-queue) and `engineering-team/` (stories, ADRs 0001–0003, reviews, book audit + PRD addendum).

## Test plan

- [x] `npm test` green locally (Overall PASS; reporters suites 11/12/17).
- [x] `npm run build` in `ui/` compiles.
- [ ] After merge: deploy-staging.yml runs.
- [ ] Smoke test on staging.brainstorm.world.
- [ ] Tier 3: `GET /api/get-grapevine-reporters?observee=<pk>` returns `{success, observer:'owner', observee, count, data}` with `count === data.length`.
- [ ] Tier 4: a profile shows the "Verified Reporters" count; `/user/:pubkey/reporters` renders (page shell + empty state on a 0-reporter account).
- [ ] Tier 5: Following / Verified Followers counts + their list pages still work.

> Staging only — do NOT promote to main yet (staging holds other unrelated features not ready for prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)