### PR TITLE
Ratify three-PoV resolution standard into BIBLE §27 (+ retire design doc)

### DIFF
--- a/BIBLE.md
+++ b/BIBLE.md
@@ -37,6 +37,7 @@
 24. [Task Queue (BullMQ behind /api/run-task)](#24-task-queue-bullmq-behind-apirun-task)
 25. [The Inherit-From Tag (`b`)](#25-the-inherit-from-tag-b)
 26. [Resolved Definition](#26-resolved-definition)
+27. [Point of View (PoV) Resolution](#27-point-of-view-pov-resolution)
 
 ---
 
@@ -1740,6 +1741,61 @@ merge_walk(node, visited):
 **Scope (v1).** Field-level override only — a stated field replaces the inherited one wholesale. The **set-valued override algebra** (how a child adds/removes/replaces individual elements of an inherited *set*) **remains deferred** (ADR 0027), to the first consumer that needs it.
 
 See ADR 0028 for the rationale and the rejected alternative (WoT-weighted field resolution, which would make a node's own definition vary by observer).
+
+---
+
+## 27. Point of View (PoV) Resolution
+
+**Every trust metric in Tapestry is computed relative to a Point of View — and there are exactly three of them.** A "trust metric" is any count, score, or list derived from the web of trust (verified-follower counts, GrapeRank influence/rank, verified-reporter lists, search ranking). The same metric reads differently depending on *whose* web of trust answers it, so a surface that mixes sources can show the *same* number three different ways. This section is the canonical definition of the three PoVs, which source is authoritative for each, and the (target) model for selecting between them. Established by ADR 0033, ratifying the design captured in `docs/POV_RESOLUTION_DESIGN_HANDOFF.md`.
+
+The section is split deliberately: **The standard** is normative and true today; **Status today** is what's actually wired; **Target direction** is direction, not yet built; **Open questions** are undecided. Do not read a target as a present-tense guarantee.
+
+### The standard (ratified)
+
+Every trust metric is computed relative to exactly one of three Points of View:
+
+| PoV | Whose web of trust | Source of truth | Availability |
+|---|---|---|---|
+| **Owner** | the local Brainstorm instance's owner | **Neo4j** — `NostrUser` node properties (`influence`, `verified*Count`, `hops`) + live traversals | always locally available (the instance computes it) |
+| **House** | the deployment's "house" web of trust | **kind 30382 Trusted Assertions** → Meili `wot_*_<houseSuffix>` | only if House assertions are published/imported |
+| **Personalized** | the end-user's own web of trust | **kind 30382** per-user → Meili `wot_*_<userSuffix>` | only if that user's assertions exist |
+
+Two normative rules accompany the table:
+
+- **Following stays on strfry, non-PoV.** The Following count is read from strfry (kind-3 `p`-tags). It is **not** a trust metric and has **no** PoV — it is the freshest, cheapest count and is immune to the GrapeRank batch. (When the Owner scoring batch died mid-run on 2026-06-07, Following stayed correct while the PoV-derived counts went stale — evidence it must never be folded into the PoV machinery.)
+- **Neo4j-sourced grapevine data is the Owner PoV — not "House."** Earlier copy and docs labeled Neo4j-sourced counts/lists "House (default)"; that was a **mislabel**. Anything read from Neo4j node properties or live traversals is the **Owner** PoV. "House" is specifically the kind-30382 → Meili `wot_*_<houseSuffix>` read.
+
+### Status today
+
+What each surface actually uses right now:
+
+| Surface | Datum | Source today |
+|---|---|---|
+| Profile | Following count | strfry (`get-user-counts`) — non-PoV |
+| Profile | Verified Followers / Verified Reporters counts | **Owner (Neo4j)** — shipped in profile #35/#36 (ADR 0031/0032); badge value agrees with the list table |
+| `/follows`, `/followers`, `/reporters` tables | rows + count | **Owner** (live Neo4j) |
+| Search page | ranking / scores | Meili, with a 2-way **House ↔ Personalized** toggle |
+
+### Target direction (not yet built)
+
+The following is the intended direction. **None of it is implemented yet** — it is recorded here so future work builds toward one model, not so surfaces can claim the behavior today.
+
+- **Selection + persistence.** One **selected PoV** per end-user at a time (Owner / House / Personalized), **stored** (session and/or backend) and **sticky across pages** — change it on one page and it applies everywhere. A **3-way selector** UI: the search page's current 2-way House↔Personalized toggle gains **Owner**, and the same selector eventually appears on the profile, with the choice remembered when navigating back to search.
+- **Fallback.** A surface always **attempts the selected PoV**; if the datum for that PoV is **unavailable**, it falls back along a **feature-specific chain** — the right fallback differs for the search bar vs a profile badge vs a list table vs future surfaces, so the chain is defined per feature, not globally.
+- **Freshness is part of availability.** A PoV's data can be present-but-stale or mid-recompute (e.g. the interrupted Owner batch). "Available" is not just present/absent — stale/partial is a **state**, to be surfaced ("computing… / as of \<time\>") rather than silently shown as degraded numbers. A naïve "absent → fall back" rule is insufficient.
+
+### Open questions
+
+Undecided; each is a candidate for a future `pov-resolution` story (carried from the design handoff):
+
+1. **Default selected PoV** for a new/anonymous user — Owner (always available) or House (richer, if present)?
+2. **Resolver shape** — one unified PoV-aware endpoint vs a shared server module each endpoint calls (determines how many new endpoints exist).
+3. **Freshness signaling** — how is "stale/partial" detected (batch run-state, timestamps on node props, a computed-at field), and do surfaces show a health indicator?
+4. **Per-feature fallback chains** — enumerate them (search bar, profile badges, tables, future) across the three PoVs plus the raw/strfry primitives.
+5. **Personalized source** — kind-30382-only, or also a local per-customer calculation?
+6. **count = list-length guarantee** per PoV — exact (single live source) vs steady-state (precomputed badge + live table).
+
+See ADR 0033 for the ratification decision (the normative/aspirational split) and the open questions it deliberately left undecided.
 
 ---
 

--- a/docs/POV_RESOLUTION_DESIGN_HANDOFF.md
+++ b/docs/POV_RESOLUTION_DESIGN_HANDOFF.md
@@ -1,0 +1,90 @@
+# Point of View (PoV) Resolution — Design Handoff
+
+**Status:** 🔴 OPEN
+**Created:** 2026-06-07
+**Provenance:** Scoped via `/discuss` (Product Expert lens) during the verified-reporters book close, after a staging smoke found the *same* trust metric showing three different values across sources. This is the **Capture** step of the Protocol-Spec Workflow (`engineering-team/workflows/protocol-spec-workflow.md`): settled decisions + open questions, captured so nothing lives only in the transcript. Ratify settled pieces into `BIBLE.md` + ADRs in docs-mode; flip this to ✅ SUPERSEDED once they land.
+
+---
+
+## 1. Why this exists — the problem
+
+Tapestry surfaces trust metrics (counts, scores, lists) from several uncoordinated sources, so the *same* metric can read differently depending on which source — and which PoV "suffix" — a given surface happens to hit.
+
+**Concrete failure (staging, 2026-06-07):** Jack's profile badge showed **"26,711 Verified Followers"** while his `/followers` page showed **568**. Diagnosis:
+- The badge reads Meili under `?pov=a1420e44`, where `wot_verifiedFollowerCount_a1420e44` is **absent**, so the shipped code `verifiedFollowerCount ?? followers` **silently fell back to raw total followers (26,711) and labeled it "Verified Followers."**
+- The page reads **live Neo4j (Owner PoV)**: `follower.influence > 0.05` → 568.
+- Compounding it: the Owner scoring batch (`updateAllScoresForOwner` → `processOwnerFollowsMutesReports`) had **failed mid-run** (interrupted by a redeploy), so even the live Owner `influence` data was partial — 568 is itself not trustworthy right now.
+
+Fixing one instance doesn't generalize. We need a standard for *which* source answers *which* question, for *whom*, and what happens when the preferred answer isn't available (or isn't fresh).
+
+## 2. The standard — three Points of View
+
+Every trust metric is computed relative to a Point of View. There are exactly **three**:
+
+| PoV | Whose web of trust | Source of truth | Availability |
+|---|---|---|---|
+| **Owner** | the local Brainstorm instance's owner | **Neo4j** — `NostrUser` node properties (`influence`, `verified*Count`, `hops`) + live traversals | Always locally available (the instance computes it). |
+| **House** | the deployment's "house" WoT | **kind 30382 Trusted Assertions** → Meili `wot_*_<houseSuffix>` | Only if House assertions are published/imported. |
+| **Personalized** | the end-user's own WoT | **kind 30382** per-user → Meili `wot_*_<userSuffix>` (eventually, possibly a local per-customer calc) | Only if that user's assertions exist. |
+
+**Naming correction this forces:** what the grapevine tables and the verified-reporters v1 actually use is the **Owner** PoV (Neo4j), *not* "House." Earlier docs/copy that said "House (default)" for Neo4j-sourced data are mislabeled and should say **Owner**.
+
+## 3. Selection + persistence model (target)
+
+- One **selected PoV** per end-user at a time (Owner / House / Personalized).
+- **Stored** in session and/or backend, **sticky across pages** — change it on one page, it applies everywhere.
+- A **3-way PoV selector** UI. Today the search page has a 2-way House↔Personalized toggle → add Owner. Eventually put the same selector on the profile page; a change there is remembered when navigating back to search.
+
+## 4. Fallback model (target)
+
+- A surface always **attempts the selected PoV**.
+- If the datum for that PoV is **unavailable**, fall back along a **feature-specific chain** (the right fallback differs for the search bar vs a profile badge vs a table vs future surfaces).
+- **Data health / freshness is part of "availability"** (new dimension, surfaced 2026-06-07): a PoV's data can be present-but-stale or mid-recompute (e.g., the interrupted Owner batch). The model must treat stale/partial as a *state* — ideally surfaced ("computing… / as of <time>") rather than silently showing degraded numbers. Naïve "absent → fall back" is insufficient.
+
+## 5. Source / endpoint inventory (first-pass — NOT final)
+
+- **Keep as-is:** `/api/get-user-counts` — Following from strfry (kind-3 `p`-tags). Non-PoV, freshest, cheap; never moves.
+- **Keep, later parameterize by PoV:** the grapevine table endpoints (`get-grapevine-follows` / `…-followers` / `…-reporters`) — Owner/live today.
+- **Keep as the House/Personalized read:** `/api/search/profiles/meili/document/:pubkey` — the kind-30382 store; the resolver reads it for House/Personalized.
+- **Likely new:** a **PoV-resolver** seam — a shared server module and/or a unified endpoint taking `(pubkey, datum, selectedPoV)` → applies source + fallback chain; plus a small **preference** store/endpoint for the sticky selection.
+- The "how many new endpoints" question turns on resolver shape (endpoint vs module) — open below.
+
+## 6. Per-feature application (current → target)
+
+| Surface | Datum | Source today | Target |
+|---|---|---|---|
+| Profile | Following count | strfry (`get-user-counts`) | unchanged (non-PoV) |
+| Profile | Verified Followers / Reporters counts | Meili `wot_*` (broken) | **Owner (Neo4j) now**; PoV-selectable later |
+| `/follows`, `/followers`, `/reporters` tables | rows + count | Neo4j Owner (live) | Owner now; PoV-selectable later |
+| Search page | ranking / scores | Meili (House↔Personalized toggle) | add **Owner** to the toggle; use the shared selection |
+
+## 7. Settled decisions (so far)
+
+1. **Three PoVs:** Owner / House / Personalized, with the §2 source map.
+2. **Owner = Neo4j** (node props + live); **House / Personalized = kind 30382 → Meili**.
+3. **Following stays on strfry** (non-PoV, freshest, immune to the GrapeRank batch — it stayed correct while Owner scoring died).
+4. **Near-term (verified-reporters follow-on, becomes its own story):** the profile **Verified Followers + Verified Reporters badges → Owner PoV** = `NostrUser.verified{Follower,Reporter}Count ?? live count-only cypher`, same `VERIFIED_*_INFLUENCE_CUTOFF` (0.05) as the tables; **drop the broken `?? followers` raw fallback**; **relabel the `/reporters` PoV line "House" → "Owner";** badges and tables **share the source**.
+5. **Data health / freshness** is a first-class dimension of availability — not just present/absent.
+
+## 8. Open questions
+
+1. **Default selected PoV** for a new/anonymous user — Owner (always available) or House (richer, if present)?
+2. **Resolver shape:** one unified PoV-aware endpoint vs a shared server module each endpoint calls. (Determines the new-endpoint count.)
+3. **Freshness signaling:** do surfaces show a freshness/health indicator, and how is "stale/partial" detected — batch run-state, timestamps on node props, a computed-at field?
+4. **Per-feature fallback chains:** enumerate them (search bar, profile badges, tables, future). What does each fall back to, in what order across the three PoVs + the raw/strfry primitives?
+5. **Personalized source:** kind-30382-only, or also a local per-customer calc (the `NostrUserWotMetricsCard` machinery)?
+6. **count = list-length guarantee** per PoV: exact (single live source) vs steady-state (precomputed badge + live table). Ties to ADR 0002 / 0003.
+
+## 9. Related findings (ops / data)
+
+- **Deploy interrupts scoring batch (ops bug):** `updateAllScoresForOwner` failed mid-`processOwnerFollowsMutesReports` (~2026-06-07), apparently interrupted by a PR-merge/redeploy, leaving Owner `influence` partial. Scoring jobs should be **resumable or drained on deploy** (task-queue-scheduler territory). → worth a standalone intake item. Until re-run, staging Owner numbers are unreliable; **a full Owner recompute is hours-long at staging's prod scale (~32M FOLLOWS).**
+- **Cutoff / "verified == raw followers" anomaly:** `VERIFIED_{FOLLOWERS,MUTERS,REPORTERS}_INFLUENCE_CUTOFF` all default `0.05` in `config/graperank.conf.template`, yet some Meili `wot_verifiedFollowerCount_<suffix>` values exactly equal `wot_followers_<suffix>` (e.g. 34376, 23024) — suggesting some path computed "verified" without an influence filter. Confirm against a healthy computation; relates to the existing cutoff-inconsistency intake item.
+
+## 10. Ratification path
+
+Per the Protocol-Spec Workflow, ratify settled pieces into the spec via the eng-team flow in **docs-mode**: `/plan-feature` (thin story) → `/design-architecture` (ADR) → *skip Test Design* → `/implement-feature` (write the BIBLE section) → `/review-changes` (accuracy audit) → `cycle-staging`.
+
+- **Spec piece to ratify first:** the three-PoV definitions + source map + selection/fallback model (a new BIBLE section + an ADR like *"PoV resolution standard"*).
+- **Code piece (separate, normal eng-team flow):** the near-term §7.4 Owner-badge change — that's code, not spec, so it goes through `/plan-feature` → ADR → tests → impl → review as its own story.
+
+Flip this doc to ✅ SUPERSEDED once the standard lands in `BIBLE.md`.

--- a/docs/POV_RESOLUTION_DESIGN_HANDOFF.md
+++ b/docs/POV_RESOLUTION_DESIGN_HANDOFF.md
@@ -1,6 +1,7 @@
 # Point of View (PoV) Resolution — Design Handoff
 
-**Status:** 🔴 OPEN
+**Status:** ✅ SUPERSEDED
+**Superseded by:** **`BIBLE.md` §27 (Point of View (PoV) Resolution)** — the canonical home for this standard (ratified via ADR 0033, pov-resolution story #1). Body preserved below for history.
 **Created:** 2026-06-07
 **Provenance:** Scoped via `/discuss` (Product Expert lens) during the verified-reporters book close, after a staging smoke found the *same* trust metric showing three different values across sources. This is the **Capture** step of the Protocol-Spec Workflow (`engineering-team/workflows/protocol-spec-workflow.md`): settled decisions + open questions, captured so nothing lives only in the transcript. Ratify settled pieces into `BIBLE.md` + ADRs in docs-mode; flip this to ✅ SUPERSEDED once they land.
 

--- a/engineering-team/decisions/pov-resolution/0033-three-pov-resolution-standard.md
+++ b/engineering-team/decisions/pov-resolution/0033-three-pov-resolution-standard.md
@@ -1,0 +1,119 @@
+# ADR 0033: Three-PoV Resolution Standard (spec ratification)
+
+**Status:** Accepted
+**Date:** 2026-06-08
+**Story:** `engineering-team/stories/pov-resolution/1-ratify-three-pov-standard.md`
+**Mode:** Docs-mode (Protocol-Spec Workflow phase 3 — Test Design skipped)
+
+## Context
+Tapestry computes trust metrics from several uncoordinated sources (Neo4j node props, Neo4j
+live traversals, Meili `wot_*_<suffix>` documents, strfry kind-3). The same metric can read
+differently per source/suffix. The staging failure (2026-06-07) — Jack's badge "26,711
+Verified Followers" vs his /followers page "568" — was one instance; the fix already shipped
+(profile #35/#36, ADR 0031/0032: Owner-PoV counts, badge==table, merged via PR #254). The
+*standard* that prevents the whole class was settled in `docs/POV_RESOLUTION_DESIGN_HANDOFF.md`
+(Status OPEN) and now needs to live in the canonical spec.
+
+This ADR decides **how** to ratify that standard into `BIBLE.md` — not new behavior. The
+deliverable is a new BIBLE section + the handoff-doc flip. No code, no concept/schema change.
+
+Concept Graph API (localhost:8877) was unreachable (local stack down); this is pure spec, so
+no handle resolution is required — but the new section's concept references (graperank,
+nostr-user, web-of-trust) should be confirmed against `/api/concept-graph/summaries` when the
+stack is up.
+
+The hard constraint: **the section must not present unbuilt behavior as present.** The three
+PoVs + source map + Following-on-strfry + the Owner naming correction are true today; the
+sticky 3-way selector, the per-feature fallback chains, and freshness-as-availability are
+*direction*, not fact.
+
+## Options considered
+
+### Option A — Inline per-subsection "Status:" tags
+Write §27 as one flowing section; each subsection gets a `**Status: ratified**` or
+`**Status: target**` tag inline.
+- **Pros:** compact; status sits next to the claim.
+- **Cons:** easy for a reader to skim past a tag and read a target as fact; the normative/
+  aspirational boundary is diffuse; harder to audit "did we overclaim anywhere."
+
+### Option B — Structural split: "The standard (ratified)" vs "Target direction (not yet built)"
+§27 is divided into clearly-labeled blocks: (1) **The standard** — the normative core (three
+PoVs, source map, Following-on-strfry, naming correction) stated as spec fact; (2) **Status
+today** — what's actually wired (Owner badges shipped; search 2-way toggle; tables Owner-live);
+(3) **Target direction** — the selection/persistence + fallback models + freshness, explicitly
+flagged as not-yet-built; (4) **Open questions** — the §8 list, inline. Physical separation
+*is* the normative/aspirational boundary.
+- **Pros:** impossible to mistake target for fact — they're in different blocks under different
+  headings; trivially auditable; matches how §25/§26 separate "what's defined" from "scope/
+  deferred"; the spec stays self-contained (open questions inline) so the handoff doc can retire.
+- **Cons:** slightly longer; one fact (e.g. the source map) is referenced from two blocks
+  (standard + status) — mitigated by stating it once in "the standard" and having "status"
+  point to it.
+
+### Option C — BIBLE carries only the normative core; everything target/open stays in the handoff doc
+Ratify just the three PoVs + source map into BIBLE; leave selection/fallback/open-questions in
+the (kept-OPEN) handoff doc.
+- **Pros:** smallest BIBLE change; cleanest normative core.
+- **Cons:** the handoff doc can't retire (violates the workflow's "flip to SUPERSEDED once it
+  lands"); the spec isn't self-contained — a reader must chase a `docs/` file for the direction;
+  splits one topic across two homes. Rejected.
+
+## Decision
+**Option B.** A structurally-split §27 with four blocks — **The standard (ratified)**,
+**Status today**, **Target direction (not yet built)**, **Open questions** — places the
+normative/aspirational boundary in the document structure itself, makes overclaiming
+auditable, keeps the spec self-contained, and lets the handoff doc retire (flip to SUPERSEDED).
+
+## Consequences
+- **Enables:** one canonical authority for PoV; future PoV stories (resolver, selector) cite
+  §27; the handoff doc retires cleanly.
+- **Constrains:** future PoV changes must update §27 (the cost of a single source of truth).
+- **Follow-ups (deferred, tracked in the epic):** the §8 open questions become future
+  pov-resolution stories; this ADR settles none of them.
+- **Firmware reinstall required?** No — pure spec, no concept definitions changed.
+
+## Implementation notes
+Concrete, for the Implementer (docs-mode — BIBLE prose + the flip, nothing else):
+
+- **File: `BIBLE.md`** — insert a new `## 27. Point of View (PoV) Resolution` **after §26
+  (Resolved Definition, ends ~line 1743) and before the closing footer line**
+  (`*This document is maintained…*`). Mirror §22/§25/§26 style: bold thesis lead, tables,
+  normative language, ADR cross-ref at the end (`See ADR 0033…`). Four blocks:
+  1. **The standard (ratified).** Lead sentence: every trust metric is computed relative to
+     exactly one of three PoVs. The three-PoV table — columns **PoV | Whose web of trust |
+     Source of truth | Availability** — with the rows from handoff §2 (Owner→Neo4j node props
+     `influence`/`verified*Count`/`hops` + live traversals, always locally available;
+     House→kind 30382 Trusted Assertions → Meili `wot_*_<houseSuffix>`, only if published/
+     imported; Personalized→kind 30382 per-user → Meili `wot_*_<userSuffix>`, only if that
+     user's assertions exist). Then two normative statements: **Following stays on strfry**
+     (kind-3 p-tags), non-PoV, freshest, immune to the GrapeRank batch; and the **naming
+     correction** — Neo4j-sourced grapevine data is **Owner**, not "House"; prior
+     "House (default)" labels for Neo4j data were mislabeled.
+  2. **Status today.** A per-surface **current state** table (Surface | Datum | Source today):
+     profile Following → strfry; profile Verified Followers/Reporters → **Owner (Neo4j),
+     shipped profile #35/#36 (ADR 0031/0032), badge==table**; /follows·/followers·/reporters
+     tables → Owner live; search page → Meili, 2-way House↔Personalized toggle.
+  3. **Target direction (not yet built).** Explicitly flagged. The selection/persistence model
+     (one selected PoV per user, sticky across pages, a 3-way selector); the fallback model
+     (attempt selected PoV → feature-specific fallback chain on unavailability); **freshness as
+     part of availability** (stale/partial is a state, ideally surfaced, not silently degraded).
+     Optionally a "target" column or a small current→target table folding in block 2.
+  4. **Open questions.** Inline list from handoff §8: default PoV for anonymous users; resolver
+     shape (endpoint vs shared module); freshness signaling mechanism; exact per-feature
+     fallback chains; Personalized source; count=list-length guarantee per PoV.
+- **File: `BIBLE.md` TOC** (~line 39) — add `27. [Point of View (PoV) Resolution](#27-point-of-view-pov-resolution)`.
+  Verify the GitHub anchor resolves: "Point of View (PoV) Resolution" → `#27-point-of-view-pov-resolution`
+  (lowercase, parens dropped, spaces→hyphens).
+- **File: `docs/POV_RESOLUTION_DESIGN_HANDOFF.md`** — flip the `**Status:**` line to
+  **✅ SUPERSEDED**, add a one-line pointer at top to `BIBLE.md §27`. **Keep the body** for
+  history (per CLAUDE.md's HANDOFF convention: SUPERSEDED preserves the body). Do not trim.
+- **Optional (nice-to-have, keep the change focused — skip if it widens the diff):** light
+  one-line cross-refs to §27 from §11 (API Reference, `get-user-counts`) and §14
+  (Configuration, `VERIFIED_*_INFLUENCE_CUTOFF`). Not required by any AC.
+
+## Out of scope
+- **All code** — no resolver, endpoint, selector UI, or preference store (future epic stories).
+- **Deciding any §8 open question** — they are documented as open, not resolved.
+- **Test Design** — skipped (docs-mode; no executable behavior). The only gates are `npm test`
+  staying green and the Reviewer's accuracy/consistency audit.
+- Changing cutoff values; report-type breakdown; pile-on discounting.

--- a/engineering-team/epics/pov-resolution.md
+++ b/engineering-team/epics/pov-resolution.md
@@ -1,0 +1,24 @@
+# Epic: PoV Resolution
+
+**Status:** Active
+**Provenance:** `docs/POV_RESOLUTION_DESIGN_HANDOFF.md` (Protocol-Spec Workflow — Scope+Capture done)
+
+## What this is
+The cross-cutting standard for *which source answers which trust question, for whom, and
+what happens when the preferred answer isn't available*. Every trust metric in Tapestry is
+computed relative to one of exactly three Points of View — Owner / House / Personalized.
+This epic ratifies that standard into the canonical spec and (later) builds the resolver +
+3-way selector that makes PoV selectable and sticky.
+
+## Stories
+`stories/pov-resolution/`:
+1. **ratify-three-pov-standard** — docs-mode: settled three-PoV definitions + source map +
+   selection/fallback *model* → new BIBLE section + ADR 0033. *(this story)*
+
+## ADRs
+`decisions/pov-resolution/` — 0033 (this story).
+
+## Deferred (open questions — design-doc §8, future stories)
+Default PoV for anonymous users; resolver shape (endpoint vs shared module); freshness
+signaling mechanism; exact per-feature fallback chains; Personalized source; the
+count=list-length guarantee per PoV; the 3-way selector UI + sticky-preference store.

--- a/engineering-team/reviews/pov-resolution/1-ratify-three-pov-standard.md
+++ b/engineering-team/reviews/pov-resolution/1-ratify-three-pov-standard.md
@@ -1,0 +1,54 @@
+# Review: Story pov-resolution #1 — Ratify the three-PoV resolution standard
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-08
+**Mode:** Docs-mode (Protocol-Spec Workflow phase 3 — accuracy/consistency audit, not coverage)
+**Diff:** `git diff origin/staging...HEAD` — commits `4a147dc3` (impl: BIBLE §27 + handoff flip), `dad45164` (ADR 0033), `28f983c0` (story + epic)
+**Story:** `engineering-team/stories/pov-resolution/1-ratify-three-pov-standard.md`
+**ADR:** `engineering-team/decisions/pov-resolution/0033-three-pov-resolution-standard.md`
+**Test plan:** N/A — Test Design skipped (docs-mode; no executable behavior)
+
+## Quality gates (run by reviewer, not trusted)
+- [x] `npm test` — **Overall PASS, no FAIL suites.** Docs-only change touched no tests. (This branch was cut from `staging` before profile #35/#36 merged, so its suite counts predate those stories' #36 updates — expected, not a regression.)
+- [x] Diff scope — **spec/docs only**: `BIBLE.md`, `docs/POV_RESOLUTION_DESIGN_HANDOFF.md`, `engineering-team/**`. No source, concept, schema, or firmware files touched.
+- [x] _Lint/typecheck not configured — skipped._
+
+## Accuracy audit (are the §27 claims true?)
+Cross-checked every factual claim against the source of truth (`docs/POV_RESOLUTION_DESIGN_HANDOFF.md`) and the shipped reality.
+
+- [x] **Three PoVs + source map** (BIBLE.md:1757–1761) reproduce handoff §2 exactly: Owner → Neo4j node props (`influence`/`verified*Count`/`hops`) + live traversals, always available; House → kind 30382 → Meili `wot_*_<houseSuffix>`, only if published/imported; Personalized → kind 30382 per-user → Meili `wot_*_<userSuffix>`, only if that user's assertions exist.
+- [x] **Following stays on strfry / non-PoV** (BIBLE.md:1765) — matches handoff §7.3; the batch-immunity rationale is accurate.
+- [x] **Owner-not-House naming correction** (BIBLE.md:1766) — matches handoff §2; correctly scopes "House" to the kind-30382 → Meili read.
+- [x] **"Status today" matches reality** (BIBLE.md:1772–1777). Verified profile Verified Followers/Reporters = Owner (Neo4j), shipped profile #35/#36 — ADR `0031`/`0032`, `VerificationInfo.jsx`, `reportersWithMetrics.js` all confirmed present on `origin/staging` (PR #254). Badge==table independently confirmed at PR #254 smoke (Jack VR badge 6 == `get-grapevine-reporters` count 6). Grapevine tables = Owner live; search = Meili 2-way House↔Personalized — both accurate.
+- [x] **Target-direction block is unambiguously not-built** (BIBLE.md:1779–1785): "The following is the intended direction. **None of it is implemented yet**." No selector/fallback/freshness claim reads as present-tense. This is ADR 0033's core constraint (Option B) — satisfied.
+- [x] **Open questions (6) listed as open** (BIBLE.md:1791–1796), one-to-one with handoff §8 (default PoV, resolver shape, freshness signaling, per-feature fallback chains, Personalized source, count=list-length). None silently decided. The handoff §2 "possibly a local per-customer calc" nuance is preserved as open-question #5.
+
+## Consistency / cross-reference audit
+- [x] TOC entry (BIBLE.md:40) text matches the heading (BIBLE.md:1747).
+- [x] GitHub anchor `#27-point-of-view-pov-resolution` resolves to the heading (verified by slug computation: lowercase, parens dropped, spaces→hyphens → exact match).
+- [x] `See ADR 0033` cross-ref present (BIBLE.md:1798).
+- [x] §27 sits **after §26** (line 1711) and **before** the maintainer footer (line 1802). Internal ordering intact.
+- [x] Handoff doc flipped to **✅ SUPERSEDED** with a `**Superseded by:** BIBLE.md §27` pointer naming the section correctly; **body preserved** (full §1–§10 retained for history, per the CLAUDE.md SUPERSEDED convention).
+- [x] Story Deviations + Linked artifacts updated; ADR linked.
+
+## ADR conformance
+- [x] **Option B (four-block structural split)** used verbatim: *The standard (ratified)* / *Status today* / *Target direction (not yet built)* / *Open questions* (BIBLE.md:1753, 1768, 1779, 1787).
+- [x] Optional §11/§14 cross-refs **correctly skipped** — ADR 0033 marked them optional "to keep the diff focused"; omission is conformant, not a defect.
+- [x] No code/concept/schema/firmware change; **no firmware reinstall** (pure spec, per ADR Consequences).
+
+## Things tests can't catch
+- [x] Prose does not overclaim: built vs target vs open are physically separated; a reader cannot mistake the selector/fallback for shipped behavior.
+- [x] No stale "House (default)" labels reintroduced in the new section.
+- [x] The handoff doc's open questions survive the retirement (mirrored into §27 + the epic's Deferred list) — no thinking lost.
+
+## Findings
+
+### Blocking
+None.
+
+### Non-blocking
+1. **The "ADR 0031/0032 / profile #35/#36" reference in §27 resolves on the merge target, not on this branch in isolation.** Those ADR files live on `origin/staging` (PR #254), and this docs branch was cut before they merged. Once this PR merges into `staging` (which carries them), the reference resolves in the combined tree. The claim is factually accurate today; only the in-repo file does not exist on this isolated branch. No action needed.
+2. **Branch is 13 commits behind `origin/staging`.** The 13 are profile code + artifacts (disjoint file set from this docs change), so the merge is expected to be clean — but the PR may report `BEHIND`. Handle in the `cycle-staging` step (rebase if flagged); not a review concern.
+
+## Verdict
+**PASS** — all 10 story ACs met, ADR 0033 conformant (Option B structural split, optional cross-refs legitimately skipped), every §27 factual claim verified against the design handoff and the shipped PR #254 reality, the target/open material clearly non-normative, cross-references and the anchor resolve, the handoff doc retired with body preserved, and the gate is green (`npm test` Overall PASS; docs-only, no test touched). Only two minor, no-action non-blocking notes.

--- a/engineering-team/stories/pov-resolution/1-ratify-three-pov-standard.md
+++ b/engineering-team/stories/pov-resolution/1-ratify-three-pov-standard.md
@@ -1,0 +1,81 @@
+# Story 1: Ratify the three-PoV resolution standard into the spec
+
+**Status:** Approved
+**Created:** 2026-06-08
+**Type:** Doc
+**Epic:** `pov-resolution`
+**Mode:** Docs-mode (Protocol-Spec Workflow phase 3 — Test Design skipped)
+
+## Background
+Tapestry surfaces trust metrics (counts, scores, lists) from several uncoordinated sources,
+so the *same* metric can read differently depending on which source — and which PoV
+"suffix" — a surface hits. The concrete failure (staging, 2026-06-07): Jack's profile badge
+showed "26,711 Verified Followers" while his /followers page showed 568 — a Meili-suffix miss
+silently falling back to raw followers, compounded by a half-finished Owner scoring batch.
+
+The fix for that one badge already shipped (profile #35/#36, ADR 0031/0032 — Owner-PoV counts,
+badge==table). But fixing instances doesn't generalize. The design work in
+`docs/POV_RESOLUTION_DESIGN_HANDOFF.md` (Status OPEN) settled the *standard*; this story
+ratifies the settled pieces into the canonical spec (BIBLE) so future surfaces have one
+authority to build against, instead of the standard living only in a handoff doc.
+
+This is a **docs-mode** change: the deliverable is BIBLE prose + an ADR, not code.
+
+## User-facing description
+As a Tapestry contributor (or fork operator) reading the spec, I want a single canonical
+definition of the three Points of View, which source is authoritative for each, and how
+selection/fallback is meant to work — so I build new trust surfaces against one standard
+rather than rediscovering it per-feature.
+
+## Acceptance criteria
+Testable from the outside (doc-level inspection).
+
+- [ ] BIBLE gains a new top-level section "Point of View (PoV) Resolution" defining exactly
+      **three** PoVs — Owner, House, Personalized — each with its authoritative source
+      (Owner→Neo4j node props + live traversals; House→kind 30382 → Meili `wot_*_<houseSuffix>`;
+      Personalized→kind 30382 per-user → Meili `wot_*_<userSuffix>`) and its availability condition.
+- [ ] The section states that the **Following count stays on strfry** (kind-3 p-tags) and is
+      **non-PoV** (freshest, immune to the GrapeRank batch).
+- [ ] The section carries the **naming correction**: Neo4j-sourced grapevine data is the
+      **Owner** PoV, not "House"; prior "House (default)" labels for Neo4j data were mislabeled.
+- [ ] The section describes the **selection/persistence model** and the **fallback model** as
+      *target* direction (clearly marked target/aspirational, not present-tense fact), including
+      that data **health/freshness** is part of "availability" (stale/partial is a state, not absence).
+- [ ] The section includes a **per-feature current→target** view for the profile counts, the
+      grapevine tables, and the search page; and notes the profile Verified Followers/Reporters
+      badges **already** use Owner PoV (shipped: profile #35/#36).
+- [ ] The section explicitly lists the **open questions** (design-doc §8) as *open / not yet
+      decided* — default PoV for anonymous users, resolver shape, freshness signaling, exact
+      per-feature fallback chains, Personalized source, count=list-length guarantee.
+- [ ] The Table of Contents links to the new section and the anchor resolves.
+- [ ] `docs/POV_RESOLUTION_DESIGN_HANDOFF.md` is flipped to **✅ SUPERSEDED** with a pointer to
+      the BIBLE section (its open questions preserved as the epic's deferred work).
+- [ ] An ADR (0033) records the ratification decision and what was deliberately left open.
+- [ ] `npm test` stays green (no regression from the docs change).
+
+## Concepts touched
+(Concept Graph API was unreachable at planning — Architect to confirm handles via
+`/api/concept-graph/summaries`.)
+- `…:graperank` — the rank/influence + the verified cutoffs the PoVs are computed from.
+- `…:nostr-user` — carries the Owner-PoV node properties (influence, verified*Count, hops).
+- `…:web-of-trust` — the per-PoV web of trust each metric is relative to.
+
+## Out of scope
+- **Any code.** No resolver, no endpoint, no selector UI, no preference store — spec only.
+- **Deciding the open questions** — they are *documented as open*, not resolved here.
+- **Re-litigating the shipped Owner-PoV badge change** (profile #35/#36) — only *documented*.
+- Changing cutoff values; report-type breakdown; pile-on discounting.
+
+## Open questions
+- **Test Design is skipped** (docs-mode — no executable behavior). The only gate is
+  `npm test` staying green + the Reviewer's accuracy/consistency audit.
+- Section number/placement (likely §27, after §26 Resolved Definition) and exact anchor text
+  are the Architect's call (ADR 0033).
+- Which sub-pieces are **normative** ("MUST/standard") vs **aspirational** ("target") — the
+  Architect draws that line in ADR 0033.
+
+## Linked artifacts
+- Design handoff: `docs/POV_RESOLUTION_DESIGN_HANDOFF.md` (to be flipped to SUPERSEDED)
+- ADR: (filled in after Architecture phase — 0033)
+- Test plan: N/A (docs-mode — Test Design skipped)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/pov-resolution/1-ratify-three-pov-standard.md
+++ b/engineering-team/stories/pov-resolution/1-ratify-three-pov-standard.md
@@ -1,6 +1,6 @@
 # Story 1: Ratify the three-PoV resolution standard into the spec
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-08
 **Type:** Doc
 **Epic:** `pov-resolution`
@@ -87,4 +87,4 @@ Testable from the outside (doc-level inspection).
 - Design handoff: `docs/POV_RESOLUTION_DESIGN_HANDOFF.md` (flipped to ✅ SUPERSEDED → BIBLE §27)
 - ADR: `engineering-team/decisions/pov-resolution/0033-three-pov-resolution-standard.md` (Accepted)
 - Test plan: N/A (docs-mode — Test Design skipped)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/pov-resolution/1-ratify-three-pov-standard.md` — **PASS** (2026-06-08)

--- a/engineering-team/stories/pov-resolution/1-ratify-three-pov-standard.md
+++ b/engineering-team/stories/pov-resolution/1-ratify-three-pov-standard.md
@@ -74,8 +74,17 @@ Testable from the outside (doc-level inspection).
 - Which sub-pieces are **normative** ("MUST/standard") vs **aspirational** ("target") — the
   Architect draws that line in ADR 0033.
 
+## Deviations
+- None. Implemented exactly per ADR 0033 (Option B structural split): BIBLE §27 with four
+  blocks (The standard / Status today / Target direction / Open questions) + TOC entry; the
+  handoff doc flipped to ✅ SUPERSEDED with a BIBLE §27 pointer, body preserved.
+- Optional §11/§14 cross-refs were **skipped** (ADR marked them optional; kept the diff focused).
+- `npm test` Overall PASS, no suite regressed (docs-only change; no tests touched). Note: this
+  branch was cut from `staging` before profile #35/#36 merged, so its suite counts predate
+  those stories' #36 updates — irrelevant to this docs change.
+
 ## Linked artifacts
-- Design handoff: `docs/POV_RESOLUTION_DESIGN_HANDOFF.md` (to be flipped to SUPERSEDED)
+- Design handoff: `docs/POV_RESOLUTION_DESIGN_HANDOFF.md` (flipped to ✅ SUPERSEDED → BIBLE §27)
 - ADR: `engineering-team/decisions/pov-resolution/0033-three-pov-resolution-standard.md` (Accepted)
 - Test plan: N/A (docs-mode — Test Design skipped)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/pov-resolution/1-ratify-three-pov-standard.md
+++ b/engineering-team/stories/pov-resolution/1-ratify-three-pov-standard.md
@@ -76,6 +76,6 @@ Testable from the outside (doc-level inspection).
 
 ## Linked artifacts
 - Design handoff: `docs/POV_RESOLUTION_DESIGN_HANDOFF.md` (to be flipped to SUPERSEDED)
-- ADR: (filled in after Architecture phase — 0033)
+- ADR: `engineering-team/decisions/pov-resolution/0033-three-pov-resolution-standard.md` (Accepted)
 - Test plan: N/A (docs-mode — Test Design skipped)
 - Review: (filled in after Review phase)


### PR DESCRIPTION
## Summary

Ratifies the **three-Point-of-View resolution standard** into the canonical spec, via the Protocol-Spec Workflow (docs-mode). Tapestry computes trust metrics from several uncoordinated sources, so the *same* metric can read three different ways (the staging "26,711 vs 568 Verified Followers" bug). The settled standard — every trust metric is relative to one of exactly three PoVs (Owner / House / Personalized), with a defined source map — now lives in `BIBLE.md §27` instead of only in a handoff doc. Docs/spec only — **no source, concept, or firmware changes.**

## Changes

- **`BIBLE.md`** — new **§27 "Point of View (PoV) Resolution"** (+ TOC entry). Four structurally-separated blocks so target is never mistaken for fact: *The standard (ratified)* (three-PoV source map; Following-stays-on-strfry; the Owner-not-"House" naming correction), *Status today* (profile verified counts = Owner/Neo4j per #35/#36; tables = Owner live; search = Meili 2-way toggle), *Target direction (not yet built)* (sticky 3-way selector, feature-specific fallback, freshness-as-availability), *Open questions* (the 6 deferred decisions).
- **`docs/POV_RESOLUTION_DESIGN_HANDOFF.md`** — flipped 🔴 OPEN → **✅ SUPERSEDED** with a pointer to BIBLE §27; body preserved for history.
- **`engineering-team/`** — new `pov-resolution` epic + story #1, ADR 0033, and the PASS review.

## Test plan

- [ ] After merge: deploy-staging.yml runs.
- [ ] Tier 1 stability + Tier 2 sanity stay green (the real risk: docs merged onto the live #35/#36 profile code must not disturb the running app).
- [ ] BIBLE §27 present + handoff doc SUPERSEDED in the merged `staging` tree.
- [ ] Tier 5 regression: profile verified-counts endpoints from #254 still behave (`get-user-counts` → verifiedFollowerCount/verifiedReporterCount; `owner-info` → cutoffs).
- [ ] No Tier 4 (no UI change). `npm test` Overall PASS on the combined tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)