### PR TITLE
docs(CLAUDE.md): proactively pick Product vs Engineering lane at session start

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,16 @@ The seven phases — **Discovery → User Modeling → Scope → Domain Modeling
 
 Most people who use the product flow will never type a slash command. **Natural language is the default way in; slash commands are shortcuts for people who already know the flow.** Claude reads what the user says, infers which phase they mean, confirms it in plain language, and proceeds. The non-technical user never needs to know slash commands exist.
 
+### At session start — pick the lane proactively
+
+Before picking up work, **evaluate on your own which flow fits** — the **Product Team** (figuring out *what* to build) or the **Engineering Team** (figuring out *how* to build it) — and either enter that flow or ask the one-question clarifier (see "When in doubt" below). Don't wait to be told which team to use, and don't let a concrete-*sounding* request default you into Engineering:
+
+- **New or underspecified feature area** (the requirements aren't yet settled) → lean **Product Team**. A request that names a concrete feature ("add an X count," "build a Y page") still belongs in Discovery when the product questions underneath it — point of view, fallbacks, who it's for, what's in/out of scope — aren't yet answered. That is exactly what Product Team Mode is for.
+- **Defined story, clear *how*, or a bug / refactor / doc change** → **Engineering Team** (`/plan-feature` …), or the Protocol-Spec docs-mode flow for BIBLE/ADR work.
+- **Genuinely on the fence** → ask one question rather than defaulting into build mode.
+
+The failure mode this guards against: defaulting into Engineering because a request *sounds* well-specified, and thereby skipping the Discovery → User Modeling → Scope → Domain → Design → PRD work that actually surfaces the requirements.
+
 ### Register — who am I talking to?
 
 - **User spoke naturally** (no slash command) → treat them as non-technical. Enter the phase with the **plain-language entry message** from that phase's workflow file (its `## Natural language` section). Do **not** say "I'm acting as the UX Researcher. Phase 2: User Modeling" — role labels and phase numbers are internal machinery. Say what you're about to do in plain words, then ask "Ready?" before starting. Never use jargon like "persona," "acceptance criteria," or "entity" with this user — translate their words into structure silently.


### PR DESCRIPTION
## Summary

Promotes a working preference to a **team-wide rule** (requested by Vinney + Avi): at the start of a session, evaluate on your own whether the **Product Team** or **Engineering Team** flow fits, and either enter it or ask the one-question clarifier — rather than letting a concrete-*sounding* request default into Engineering and skip Discovery. Adds an "At session start — pick the lane proactively" subsection to CLAUDE.md's Intent Detection section. CLAUDE.md only.

## Changes

- **`CLAUDE.md`** §"Intent Detection" — new subsection "At session start — pick the lane proactively": lean Product Team for new/underspecified feature areas; Engineering for defined story / clear how / bug / refactor / docs; ask one question when on the fence. Names the failure mode (defaulting into Engineering because a request sounds well-specified).

## Test plan

- [ ] After merge: deploy-staging.yml runs; app stays healthy (docs-only).
- [ ] CLAUDE.md change present on the merged staging tree.
- [ ] `npm test` Overall PASS (docs-only; no tests touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)