### PR TITLE
Promote staging → main: protocols/ directory scaffold (story 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Before starting work, read all four:
 
 - [`docs/*HANDOFF*.md`](./docs/) — session continuity notes. Each handoff doc starts with a `**Status:**` line: `🔴 OPEN` = work hasn't been picked up; `✅ ADDRESSED / SUPERSEDED` = the follow-on work has shipped (the body is preserved for historical context, no action needed). Always scan for `OPEN` handoffs before starting fresh work — a previous session may have left specific instructions for the new one.
 - [`engineering-team/stories/_intake.md`](./engineering-team/stories/_intake.md) — queued-but-unplanned work catalog. See [engineering-team/README.md](./engineering-team/README.md) for the format. Scan before opening a fresh feature request — there's often a relevant entry already triaged.
+- [`protocols/README.md`](./protocols/README.md) — index of every protocol spec we author (published Custom NIPs, local pre-NIPs) with per-spec status, plus [`protocols/worksheet.md`](./protocols/worksheet.md) for open protocol problems. Check before any protocol/NIP/wire-format work — the spec's status and current source of truth are recorded there.
 
 ## Product Team Mode (upstream — optional)
 

--- a/docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md
+++ b/docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md
@@ -1,0 +1,142 @@
+# Protocols Directory — Design Handoff
+
+**Status:** 🔴 OPEN
+**Date:** 2026-06-09
+**Origin:** Planning session with the project owner (author of the Decentralized Lists Custom NIP). Scoped via `/discuss`-style conversation; execution is Protocol-Spec docs-mode work (see `engineering-team/workflows/protocol-spec-workflow.md`).
+**Owner sign-offs so far:** repo-root location ✅ · directory structure ✅ · the migration map below reviewed in conversation ✅ (final ratification happens per-story).
+
+---
+
+## 1. Why this exists
+
+Protocol-level material — wire formats that an independent, non-Tapestry implementation would need in order to interoperate — is currently scattered:
+
+- **BIBLE.md** carries most of it, interleaved with Tapestry implementation detail (§5 The Tapestry Protocol, §8 Word-Wrapper JSON, §22 Community-Reference Model, §23 `n`/`s` tags, §25 `b` tag, §26 Resolved Definition).
+- The **Decentralized Lists** Custom NIP is published on NostrHub, but a *newer* draft sits at the root of the unmerged `feat/communities` branch, alongside a complete-but-unpublished companion NIP and two community DList specs.
+- The **Tags** feature's wire formats exist only as ADRs and firmware concepts on the unmerged `feat/pubkey-tagging-target` branch.
+
+The confirmed diagnosis: the BIBLE is doing double duty as both *protocol spec* and *implementation bible*, and the NIP-shaped artifacts have no home, no status tracking, and no reconciliation against their published versions. This handoff defines a dedicated `protocols/` directory and the migration plan.
+
+## 2. The boundary rule (BIBLE vs. protocols/)
+
+> **Does it leave the machine as signed nostr events that an independent implementation would need to parse or produce to interoperate?**
+> Wire format (kinds, tag names/values, event shapes, resolution algorithms) → `protocols/`.
+> How *our* stack stores, computes, ranks, or displays it (Neo4j edges, Meili fields, GrapeRank pipelines, UI, emission sites, trust gates, deployment history) → **BIBLE**.
+
+Notes on the grey zone:
+
+- **"Is it a feature?" is not the test.** Pinning is a Tapestry feature, but a pin is a published, signed, third-party-readable event — its *event format* is protocol; the pinned-tab UI and Trusted-List pipeline are BIBLE.
+- The `drafts/` tier exists precisely for wire formats whose only consumer today is us. A pre-NIP may stay internal forever and never graduate to publication; that's fine.
+- **Deployment history stays out of NIPs.** Example: the legacy z-tag pubkey exception (`LEGACY_Z_TAG_PUBKEY = 82b75e47…`, ADR 0015 on the tags branch) is wire-binding for *our* deployments but must not be hardcoded into a universal spec. The spec says "the deployment's `tag` concept header"; the literal lives in the ADR/BIBLE. The general question it raises goes on the worksheet (entry W1).
+- After migration, the BIBLE keeps each affected section but rewritten as: a short normative pointer to the `protocols/` doc + the Tapestry-specific implementation detail that was always its real job. **Each wire format is normative in exactly one place.**
+
+## 3. Directory layout & status ladder
+
+```
+protocols/                      # repo root (decided)
+  README.md                     # index of all specs + status, the boundary rule, the ladder
+  worksheet.md                  # cross-cutting protocol problems & ideas not yet owned by one spec
+  nips/                         # published (NostrHub Custom NIPs or github NIPs) — the public face
+    decentralized-lists.md
+  drafts/                       # pre-NIPs: local drafts; may publish later, may stay internal
+    decentralized-lists-compat.md
+    tapestry-concepts.md
+    class-thread-tags.md
+    inherit-from.md
+    communities.md
+    tags.md
+```
+
+**Status ladder** (every spec's header carries one):
+
+| Status | Meaning |
+|---|---|
+| 💭 idea | worksheet-grade; not yet a coherent doc |
+| 📝 pre-NIP | local draft in `drafts/`; not published; may stay internal by design |
+| 🧪 pre-NIP (publish-ready) | content complete; awaiting decision/act of publication |
+| 🚀 published | live on NostrHub (or github NIPs); file in `nips/` is the working copy |
+| 🚀 published (update pending) | local working copy has diverged ahead of the published version; republish needed |
+
+Each spec header also records: **canonical external URL** (naddr for NostrHub), **last-published date**, and **sources** (ADRs/BIBLE sections it was distilled from).
+
+## 4. Migration map
+
+| # | Spec | Target file | Status at creation | Sources |
+|---|---|---|---|---|
+| 1 | **Decentralized Lists** (base NIP) | `nips/decentralized-lists.md` | 🚀 published (update pending) | `feat/communities:DECENTRALIZED_LISTS.md` (newer than published — see §5); published naddr `…decentralized-lists` (kind 30817, author npub1u5njm…, published 2026-02-26, relay `wss://david.nostr1.com`) |
+| 2 | **DList Cross-NIP Compatibility** (companion) | `drafts/decentralized-lists-compat.md` | 🧪 pre-NIP (publish-ready) | `feat/communities:DECENTRALIZED_LISTS_COMPAT.md` — complete: `item-kind` tag, Methods 1/2/3, authorial voice (curator vs. creator), replaceability semantics |
+| 3 | **Tapestry Concepts** (DList extensions) | `drafts/tapestry-concepts.md` | 📝 pre-NIP | BIBLE §5 (kind unification, a-tag addressing, `z` semantics as we extend them, `concept-graph` header tag, JSON storage) + §8 (word-wrapper JSON format) + §9 core-nodes wire shapes |
+| 4 | **Class-Thread Membership Tags** (`n`, `s`) | `drafts/class-thread-tags.md` | 📝 pre-NIP | BIBLE §23 + ADR 0011 (community-reference line). Includes the lowercase/uppercase direction principle and the single-char namespace discipline |
+| 5 | **Inherit-From & Resolved Definition** (`b`) | `drafts/inherit-from.md` | 📝 pre-NIP | BIBLE §25 + §26, ADRs 0027/0028. Wire format, `INHERITS_FROM` direction (no flip), live read-time resolution algorithm, first-listed-wins multi-parent rule |
+| 6 | **Communities** | `drafts/communities.md` | 📝 pre-NIP | BIBLE §22 (community-reference model, export, grapevine resolution) + `feat/communities:COMMUNITY_RECORDS_DLIST.md` + `feat/communities:COMMUNITY_ENDORSEMENTS_DLIST.md` + the communities ADR line (0034, 0040, …) |
+| 7 | **Tags & Taggings** | `drafts/tags.md` | 📝 pre-NIP | `feat/pubkey-tagging-target`: ADR 0001 (profile-tag architecture), ADR 0009 (pin-a-tag), firmware concepts `tag` / `nostr-user-tag` / `tag-pinning` — see §6 below |
+
+BIBLE §27 (PoV Resolution) was evaluated and **stays in the BIBLE**: PoV selection/fallback is how our deployment computes and presents trust metrics, not a wire format. (Kind-30382 Trusted Assertions are someone else's NIP — NIP-85-adjacent — which we consume, not author.)
+
+## 5. Decentralized Lists reconciliation (investigated 2026-06-09)
+
+**Finding: the local draft is strictly newer than the published version.**
+
+- **Published** (NostrHub kind 30817, `d=decentralized-lists`, 2026-02-26): base spec only — header/item declarations, `names`/`required`/`allowed`, the `z` pointer, NIP-25 reactions, 7 examples, nonstandard declaration, retrieval filters. Ends at "List curation and spam prevention." No `item-kind`, no NIP-72 material, no three-element descriptions, no companion reference.
+- **Local** (`feat/communities` root, last edited 2026-05-10): everything published **plus** (a) the three-element human-readable-description convention on `required`/`allowed`/`recommended`/`disallowed`; (b) a cross-reference to the companion compat NIP; (c) an **unfinished** "Backwards Compatibility with Preexisting NIPs" section (NIP-72 / kind 34550) containing two "to be completed" placeholders.
+- The owner's recollection ("we were adding features later spun off into an auxiliary NIP, never got around to it") is confirmed — except the spin-off *did* happen: `DECENTRALIZED_LISTS_COMPAT.md` is that auxiliary NIP, and it is complete. What never happened was the cleanup of the base draft.
+
+**Reconciliation plan (Story 2 below):** take the local draft as the new working copy; **delete** the embedded Backwards-Compat section (superseded by the companion); **keep** the three-element convention and the companion cross-ref; land as `nips/decentralized-lists.md` with status 🚀 published (update pending). Republishing to NostrHub is the **owner's act** (author keys; the relay `david.nostr1.com` requires AUTH) — the repo work ends at "ready to republish."
+
+## 6. Tags & Taggings wire formats (surveyed from `feat/pubkey-tagging-target`)
+
+Three event shapes, all kind-39999 DList items distinguished by the concept their `z` tag points at:
+
+| Event | Key tags | Statement |
+|---|---|---|
+| **Tag definition** (`z`→`tag` concept) | `d`=slug; content `{tag:{slug,name,description}}` | "Podcaster is a tag" |
+| **Tagging** (`z`→`nostr-user-tag`) | `p`=target pubkey, `e`=tag event id, `polarity` (`"1"` apply / `"-1"` dispute; absent ⇒ apply) | "Avi is a Podcaster" |
+| **Pin** (`z`→`tag-pinning`) | `e`+`a`→the tag (id pins a version; `a` survives edits), `curation-method` JSON (`observer`, `method` e.g. `nip85:rank`, `cutoff`, `includeScoreInTL`) | "I pin Podcaster into my curated set" |
+
+Plus NIP-09 kind-5 deletion for unpinning. Two new non-indexed tag names enter the namespace: `polarity`, `curation-method`. Polarity semantics v1: `>= 0.5` applied, `<= -0.5` disputed, the open interval reserved for a future graded-valence arc.
+
+In-spec vs. out-of-spec for `drafts/tags.md`:
+
+- **In:** all three wire formats, polarity semantics, the pin event format, kind-5 unpinning, and a *planned* section on tagging events (targets of kinds 39998/39999 are next, per the owner).
+- **Out (BIBLE/ADR):** the legacy z-tag pubkey exception (ADR 0015), pinned-tab UI, Trusted-List (kind 30392) publication pipeline, "most pinned" aggregation, PoV-aware read filtering.
+
+Naming note for the spec author: `nostr-user-tag` is pubkey-specific, but event-tagging is imminent — the draft should either define a target-typed family or name the planned generalization explicitly, so the concept handle question doesn't bind the spec to pubkeys.
+
+## 7. Worksheet seed entries
+
+`protocols/worksheet.md` opens with:
+
+- **W1 — Cross-deployment concept identity.** A spec can't say "z-tag points to `39998:<dev-literal>:tag`". How do independent deployments agree on which concept header is canonical? Related: BIBLE §22's accepted Flaw A (firmware-blessed pointer) and its registry-as-DList exit; the `b`-edge grapevine aggregation as candidate mechanism (ADR 0027).
+- **W2 — Single-char tag namespace registry.** `z`, `n`, `s`, `b` assigned; uppercase forms reserved for parent-claims-child inverses (`B` explicitly reserved); candidate letters for `IS_A_PROPERTY_OF` / `REFERENCES` TBD (BIBLE §23). One table to prevent collisions across all our specs.
+- **W3 — Polarity valence arc.** The reserved `(-0.5, 0.5)` interval and a future graded `[-1, +1]` weighting (tags branch follow-ups).
+- **W4 — `e` vs. `a` for parent-tag references.** Flagged in the tags branch's own follow-ups; interacts with replaceability semantics.
+- **W5 — `REFERENCES` publishing semantics.** Consumer-owned tag on the consumer's Header vs. a separate reference-manifest event (BIBLE §23 open question).
+- **W6 — Set-valued override algebra** for Resolved Definition (deferred by ADRs 0027/0028 to the first consumer that needs it).
+- **W7 — `item-kind` interplay with concept headers.** The compat companion's `item-kind` mechanism vs. Tapestry's concept-header conventions — do they compose or compete?
+
+## 8. Execution plan (per-story, docs-mode)
+
+Run each as a Protocol-Spec docs-mode story (Test Design skipped; Implementer authors prose; Reviewer audits accuracy against sources). Order respects dependencies:
+
+1. **Scaffold** — create `protocols/` with `README.md` (boundary rule, ladder, index) and `worksheet.md` (W1–W7).
+2. **DLists reconciliation** — base NIP per §5 plan + compat companion moved in. Ends "ready to republish"; owner republishes to NostrHub out-of-band, then status flips to 🚀 published and the naddr/last-published header updates.
+3. **Tapestry Concepts** — extract from BIBLE §5/§8/§9; rewrite those BIBLE sections as pointer + implementation detail.
+4. **Class-thread tags** — extract from BIBLE §23; same BIBLE rewrite pattern.
+5. **Inherit-From & Resolved Definition** — extract from BIBLE §25/§26; same pattern.
+6. **Communities** — distill §22 + the two `feat/communities` DList specs.
+7. **Tags & Taggings** — distill from tags-branch ADRs + firmware per §6.
+
+Stories 3–5 are pure extractions (low risk, mechanical + editorial). Stories 6–7 are syntheses (more Reviewer attention). 2 unblocks the owner's publishing intent and should go early.
+
+### Logistics
+
+- **Branch copying, not merging.** Sources for stories 2, 6, 7 live on unmerged branches (`feat/communities`, `feat/pubkey-tagging-target`). The work *copies content* from those branches into `staging` (`git show <branch>:<file>`); no code merge is implied or required. The branch-root `DECENTRALIZED_LISTS*.md` / `COMMUNITY_*_DLIST.md` files should be deleted from `feat/communities` when that branch is next touched (note left here; not this work's job).
+- **Specs describing unmerged features** (tags, communities) carry an explicit header note: "describes a feature in flight on branch X; not yet on main."
+- **No firmware or code changes** anywhere in this plan. CLAUDE.md "Also check at session start" list gains a pointer to `protocols/README.md` once the scaffold lands (story 1).
+
+## 9. Open questions for ratification
+
+1. Exact spec filenames/slugs above are proposals — confirm at each story's gate.
+2. Should `nips/` mirror the *published* text verbatim with deltas tracked separately, or be the working copy (current plan: working copy + status ladder marks divergence)?
+3. Does the Tags spec (story 7) wait for the tags branch to merge, or proceed now with the in-flight header note (current plan: proceed now)?
+4. Naming for the generalized tagging concept (see §6 naming note) — needs the owner's call during story 7.

--- a/engineering-team/reviews/protocols-directory/1-scaffold-protocols-directory.md
+++ b/engineering-team/reviews/protocols-directory/1-scaffold-protocols-directory.md
@@ -57,4 +57,10 @@ Audit produced 8 raw findings; adversarial verification confirmed 5, refuted 2, 
 
 ## Verdict
 
-**CHANGES_REQUESTED** — solely for Blocking #1, a one-phrase citation fix in `protocols/worksheet.md` (W5: §22 → §23). Everything else passes: all seven acceptance criteria met, quality gates green, BIBLE untouched, factual claims verified at source. On the fix landing, this review converts to PASS without re-running the full audit (the fix is itself the audited correction).
+~~**CHANGES_REQUESTED**~~ → **PASS** (see re-review below)
+
+Initial verdict CHANGES_REQUESTED — solely for Blocking #1, a one-phrase citation fix in `protocols/worksheet.md` (W5: §22 → §23). Everything else passed: all seven acceptance criteria met, quality gates green, BIBLE untouched, factual claims verified at source.
+
+## Re-review (2026-06-10, commit `764c5a90`)
+
+Blocking #1 fixed as asked: W5 now cites §23 (BIBLE.md:1631) for the flaw-A-exit linkage, with §22's deferred list correctly characterized as carrying REFERENCES only as a reserved-future candidate. Non-blocking #1 folded in: W4 now scopes the `a`-tag mandate to Method 2 and notes Method 3's `z`-tag form. Diff verified to touch only the two phrases asked; `npm test` re-run green. Per the initial verdict's terms, the review converts to **PASS**.

--- a/engineering-team/reviews/protocols-directory/1-scaffold-protocols-directory.md
+++ b/engineering-team/reviews/protocols-directory/1-scaffold-protocols-directory.md
@@ -1,0 +1,60 @@
+# Review: Story 1 — Scaffold the protocols/ directory
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-10
+**Diff:** commit `b29df49d` (3 files, +134/-0: `protocols/README.md`, `protocols/worksheet.md`, `CLAUDE.md`)
+**Mode:** docs-mode (Protocol-Spec workflow). Architecture skipped per approved story — design record is `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md`. Test Design skipped.
+**Method note:** the implementation was authored in this same session, so the accuracy audit was fanned out to 12 independent agents across five dimensions (acceptance criteria, README facts, worksheet facts, link/anchor integrity, handoff consistency), with every non-note finding adversarially verified. Quality gates were run directly by the Reviewer.
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **PASS** (full suite, `Overall: PASS`)
+- [x] `npm run test:playwright` — skipped: docs-only change, no UI surface touched
+- [x] _Lint not configured — skipped._
+- [x] _Typecheck not configured — skipped._
+- [x] _Build not configured — skipped._
+- [x] `BIBLE.md` byte-identical — `git diff b29df49d~1 b29df49d -- BIBLE.md` is empty (hard story criterion)
+- [x] Diff scope — exactly the three intended files; no code, firmware, or tooling
+
+## Spec adherence (acceptance criteria, audited independently)
+
+- [x] AC1 — README states boundary rule + grey-zone notes + five-step ladder (handoff §2–§3).
+- [x] AC2 — all seven specs from handoff §4 indexed with planned file, status, today's source.
+- [x] AC3 — no dead links; planned files are plain text; all seven BIBLE anchors verified against GitHub slugification; branch refs are `git show`-able code text.
+- [x] AC4 — worksheet W1–W7 present, self-contained, with refs. **One mis-citation found — see Blocking #1.**
+- [x] AC5 — CLAUDE.md session-start list gains the `protocols/README.md` bullet.
+- [x] AC6 — `npm test` green.
+- [x] AC7 — BIBLE.md byte-identical.
+- [x] No criterion silently dropped; no behavior beyond the story (two pre-disclosed authorial choices — worksheet status convention, `branch:path` notation — accepted as within the "pick up cold" criterion).
+
+## Design-record adherence (handoff in lieu of ADR)
+
+- [x] Layout, ladder, boundary rule, index statuses match handoff §2–§4; W1–W7 match §7 in substance.
+- [x] Factual claims verified at source: BIBLE §5/§8/§9/§22/§23/§25/§26 titles and content; ADRs 0011/0027/0028 on staging; ADRs 0001/0009/0015 and firmware concepts `tag`/`nostr-user-tag`/`tag-pinning` on `feat/pubkey-tagging-target`; all four spec files on `feat/communities`; NostrHub naddr reachable.
+- [x] No new dependencies.
+
+## Concept-graph integrity
+
+- [x] N/A — docs-only; no concepts defined or modified, no firmware reinstall needed. Handles appearing in prose are illustrative, correctly in `kind:pubkey:slug` form.
+
+## Things tests can't catch
+
+- [x] No secrets committed (the one pubkey literal discussed is already public wire data).
+- [x] No debug artifacts / commented-out content.
+
+## Findings
+
+Audit produced 8 raw findings; adversarial verification confirmed 5, refuted 2, and 1 was a note.
+
+### Blocking
+
+1. **protocols/worksheet.md:51 (W5)** — says BIBLE **§22** "lists it on the flaw-A exit path." Wrong section: §22's Deferred list names REFERENCES only as a reserved-future candidate; it is **§23** (BIBLE.md:1631, future-candidate tags) that ties REFERENCES to the flaw-A exit (`REFERENCES (Story #8 community-reference; flaw-A exit)`). Substance correct, citation wrong. Asked change: cite §23 for the flaw-A-exit linkage (one-phrase edit).
+
+### Non-blocking
+
+1. **protocols/worksheet.md:45 (W4)** — "the compat companion mandates `a`-tags for kind-34550 items because they're replaceable" is true of **Method 2** specifically (Method 3 uses `z` tags on the 34550 event itself). Optional: add "(Method 2)".
+2. **protocols/README.md:50–56 (index, "Content lives today" column)** — four rows (specs #2, #3, #4, #6) drop the handoff §4 scope parentheticals (e.g. what the compat companion's "complete" covers; §5's "kind unification, a-tag addressing…"). Two sibling findings of the same flavor were refuted on the grounds that an index points rather than describes, and the handoff is one link away — I concur, and judge all six the same way: acceptable index design, not information loss. Optional improvement only: restore the short scope notes if the index is meant to stand alone after the handoff is eventually marked SUPERSEDED. Worth revisiting when the epic closes.
+
+## Verdict
+
+**CHANGES_REQUESTED** — solely for Blocking #1, a one-phrase citation fix in `protocols/worksheet.md` (W5: §22 → §23). Everything else passes: all seven acceptance criteria met, quality gates green, BIBLE untouched, factual claims verified at source. On the fix landing, this review converts to PASS without re-running the full audit (the fix is itself the audited correction).

--- a/engineering-team/reviews/protocols-directory/1-scaffold-protocols-directory.md
+++ b/engineering-team/reviews/protocols-directory/1-scaffold-protocols-directory.md
@@ -2,7 +2,7 @@
 
 **Reviewer:** Claude (acting as Reviewer)
 **Date:** 2026-06-10
-**Diff:** commit `b29df49d` (3 files, +134/-0: `protocols/README.md`, `protocols/worksheet.md`, `CLAUDE.md`)
+**Diff:** commit `8640ca8c` (3 files, +134/-0: `protocols/README.md`, `protocols/worksheet.md`, `CLAUDE.md`)
 **Mode:** docs-mode (Protocol-Spec workflow). Architecture skipped per approved story — design record is `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md`. Test Design skipped.
 **Method note:** the implementation was authored in this same session, so the accuracy audit was fanned out to 12 independent agents across five dimensions (acceptance criteria, README facts, worksheet facts, link/anchor integrity, handoff consistency), with every non-note finding adversarially verified. Quality gates were run directly by the Reviewer.
 
@@ -13,7 +13,7 @@
 - [x] _Lint not configured — skipped._
 - [x] _Typecheck not configured — skipped._
 - [x] _Build not configured — skipped._
-- [x] `BIBLE.md` byte-identical — `git diff b29df49d~1 b29df49d -- BIBLE.md` is empty (hard story criterion)
+- [x] `BIBLE.md` byte-identical — `git diff 8640ca8c~1 8640ca8c -- BIBLE.md` is empty (hard story criterion)
 - [x] Diff scope — exactly the three intended files; no code, firmware, or tooling
 
 ## Spec adherence (acceptance criteria, audited independently)
@@ -61,6 +61,6 @@ Audit produced 8 raw findings; adversarial verification confirmed 5, refuted 2, 
 
 Initial verdict CHANGES_REQUESTED — solely for Blocking #1, a one-phrase citation fix in `protocols/worksheet.md` (W5: §22 → §23). Everything else passed: all seven acceptance criteria met, quality gates green, BIBLE untouched, factual claims verified at source.
 
-## Re-review (2026-06-10, commit `764c5a90`)
+## Re-review (2026-06-10, commit `08c4570a`)
 
 Blocking #1 fixed as asked: W5 now cites §23 (BIBLE.md:1631) for the flaw-A-exit linkage, with §22's deferred list correctly characterized as carrying REFERENCES only as a reserved-future candidate. Non-blocking #1 folded in: W4 now scopes the `a`-tag mandate to Method 2 and notes Method 3's `z`-tag form. Diff verified to touch only the two phrases asked; `npm test` re-run green. Per the initial verdict's terms, the review converts to **PASS**.

--- a/engineering-team/stories/protocols-directory/1-scaffold-protocols-directory.md
+++ b/engineering-team/stories/protocols-directory/1-scaffold-protocols-directory.md
@@ -1,6 +1,6 @@
 # Story 1: Scaffold the protocols/ directory
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-09
 **Type:** Doc
 **Epic:** protocols-directory — realizes `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md`
@@ -47,4 +47,4 @@ None. Docs-only scaffold; no events, kinds, or concept handles are defined or mo
 - Design record: `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` (this epic's capture doc)
 - ADR: (recommended skipped — see open questions)
 - Test plan: skipped (docs-mode)
-- Review: `engineering-team/reviews/protocols-directory/1-scaffold-protocols-directory.md` — CHANGES_REQUESTED (one citation fix), converts to PASS on fix
+- Review: `engineering-team/reviews/protocols-directory/1-scaffold-protocols-directory.md` — PASS (after one-citation kickback, fixed in `764c5a90`)

--- a/engineering-team/stories/protocols-directory/1-scaffold-protocols-directory.md
+++ b/engineering-team/stories/protocols-directory/1-scaffold-protocols-directory.md
@@ -1,0 +1,50 @@
+# Story 1: Scaffold the protocols/ directory
+
+**Status:** Approved
+**Created:** 2026-06-09
+**Type:** Doc
+**Epic:** protocols-directory — realizes `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md`
+
+## Background
+
+Protocol-level material — wire formats an independent implementation would need to interoperate — is scattered across BIBLE.md sections, two unmerged branches, and a published NostrHub Custom NIP whose local draft has silently diverged ahead of it. There is no single place to see what protocol specs exist, what state each is in, or where the open protocol problems live. The design handoff (`docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md`, 🔴 OPEN) settled the remedy: a dedicated `protocols/` directory at the repo root with a boundary rule, a status ladder, and a per-spec migration plan.
+
+This story creates the **container only** — the directory, its index, and the worksheet — so that the six migration stories that follow each have a defined place to land. No spec content moves yet.
+
+## User-facing description
+
+As a protocol author (or a contributor orienting on the project), I want a single directory that indexes every protocol spec we author — published, draft, or planned — with its current status and the location of its content today, so that I can tell at a glance what exists, what's diverged, and what's unsolved, without spelunking through the BIBLE, old branches, and NostrHub.
+
+## Acceptance criteria
+
+- [ ] Given a fresh clone of `staging`, when a reader opens `protocols/README.md`, then it states the BIBLE-vs-protocols boundary rule (the "signed events on the wire" test, including the grey-zone notes from handoff §2) and the five-step status ladder from handoff §3.
+- [ ] Given `protocols/README.md`, when a reader consults its spec index, then all seven specs from the handoff's migration map (§4) appear, each with: proposed target file, current status, and a pointer to where the content lives **today** (BIBLE section, branch path, or NostrHub naddr).
+- [ ] Given that stories 2–7 have not yet run, when a reader follows the index, then no entry presents a dead link — not-yet-migrated specs are explicitly marked planned, and the BIBLE/branches remain identified as the current source of truth.
+- [ ] Given `protocols/worksheet.md`, when a reader opens it, then entries W1–W7 from handoff §7 are present, each self-contained enough to pick up cold (problem statement plus the ADR/BIBLE references it relates to).
+- [ ] Given `CLAUDE.md`, when a new session starts and follows the "Also check at session start" list, then it is directed to `protocols/README.md` alongside the existing handoff/intake pointers.
+- [ ] Given the full change, when `npm test` runs, then it passes unchanged (docs-mode quality gate: no code, no tooling, no firmware).
+- [ ] Given BIBLE.md, when this story is complete, then it is byte-identical to before — no wire-format content moves in this story, and nothing is normative in two places.
+
+## Concepts touched
+
+None. Docs-only scaffold; no events, kinds, or concept handles are defined or modified. (Concept Graph API was unreachable during planning; irrelevant here.)
+
+## Out of scope
+
+- Migrating or reconciling any spec content (stories 2–7 of the handoff's §8 plan).
+- Any edit to BIBLE.md.
+- Republishing anything to NostrHub (owner's act, story 2's tail).
+- Deleting the stray spec files from `feat/communities` (noted in handoff §8 logistics; belongs to that branch's next touch).
+- Any code, firmware, or tooling change.
+
+## Open questions
+
+- **Does this story take the Architecture phase?** Recommendation: no — per the project type table, Doc changes run Implementer + Reviewer only, and the design (layout, ladder, boundary rule) is already recorded in the handoff doc, which serves as this epic's design record. An ADR here would duplicate it. Confirm at the gate.
+- Handoff §9 Q1–Q2 (final spec filenames; `nips/` as working copy vs. verbatim mirror) are settled *provisionally* per the handoff for the purposes of the index; each migration story's gate may still revise its own entry.
+
+## Linked artifacts
+
+- Design record: `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` (this epic's capture doc)
+- ADR: (recommended skipped — see open questions)
+- Test plan: skipped (docs-mode)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/protocols-directory/1-scaffold-protocols-directory.md
+++ b/engineering-team/stories/protocols-directory/1-scaffold-protocols-directory.md
@@ -47,4 +47,4 @@ None. Docs-only scaffold; no events, kinds, or concept handles are defined or mo
 - Design record: `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` (this epic's capture doc)
 - ADR: (recommended skipped — see open questions)
 - Test plan: skipped (docs-mode)
-- Review: `engineering-team/reviews/protocols-directory/1-scaffold-protocols-directory.md` — PASS (after one-citation kickback, fixed in `764c5a90`)
+- Review: `engineering-team/reviews/protocols-directory/1-scaffold-protocols-directory.md` — PASS (after one-citation kickback, fixed in `08c4570a`)

--- a/engineering-team/stories/protocols-directory/1-scaffold-protocols-directory.md
+++ b/engineering-team/stories/protocols-directory/1-scaffold-protocols-directory.md
@@ -47,4 +47,4 @@ None. Docs-only scaffold; no events, kinds, or concept handles are defined or mo
 - Design record: `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` (this epic's capture doc)
 - ADR: (recommended skipped — see open questions)
 - Test plan: skipped (docs-mode)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/protocols-directory/1-scaffold-protocols-directory.md` — CHANGES_REQUESTED (one citation fix), converts to PASS on fix

--- a/protocols/README.md
+++ b/protocols/README.md
@@ -1,0 +1,64 @@
+# Protocols
+
+The home for every protocol specification this project authors — published Custom NIPs, local pre-NIPs, and the worksheet of unsolved protocol problems. Created by the protocols-directory epic; design record: [docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md](../docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md). Process: specs are ratified through the [Protocol-Spec workflow](../engineering-team/workflows/protocol-spec-workflow.md) (docs-mode).
+
+## The boundary rule (what belongs here vs. the BIBLE)
+
+> **Does it leave the machine as signed nostr events that an independent implementation would need to parse or produce to interoperate?**
+> Wire format (kinds, tag names/values, event shapes, resolution algorithms) → **here**.
+> How *our* stack stores, computes, ranks, or displays it (Neo4j edges, Meili fields, GrapeRank pipelines, UI, emission sites, trust gates, deployment history) → **[BIBLE.md](../BIBLE.md)**.
+
+Grey-zone guidance:
+
+- **"Is it a feature?" is not the test.** Pinning is a Tapestry feature, but a pin is a published, signed, third-party-readable event — its *event format* is protocol; the pinned-tab UI and Trusted-List pipeline are BIBLE.
+- **`drafts/` exists for internal wire formats.** A pre-NIP may document a format whose only consumer today is us, and may stay internal forever without ever publishing. That's a valid end state, not a failure.
+- **Deployment history stays out of specs.** Example: the legacy z-tag pubkey exception (`LEGACY_Z_TAG_PUBKEY`, tags-branch ADR 0015) is wire-binding for our deployments but must not be hardcoded into a universal spec. Specs say "the deployment's `tag` concept header"; the literal lives in the ADR/BIBLE. The general question it raises is [worksheet](./worksheet.md) entry W1.
+- **Each wire format is normative in exactly one place.** When a spec migrates here, the corresponding BIBLE section is rewritten as a short pointer to it plus the Tapestry-specific implementation detail that was always its real job.
+
+## Layout
+
+```
+protocols/
+  README.md       # this file — index, boundary rule, status ladder
+  worksheet.md    # cross-cutting protocol problems & ideas not yet owned by one spec
+  nips/           # published specs (NostrHub Custom NIPs / github NIPs) — working copies
+  drafts/         # pre-NIPs: local drafts; may publish later, may stay internal
+```
+
+## Status ladder
+
+Every spec's header carries one of:
+
+| Status | Meaning |
+|---|---|
+| 💭 idea | worksheet-grade; not yet a coherent doc |
+| 📝 pre-NIP | local draft in `drafts/`; not published; may stay internal by design |
+| 🧪 pre-NIP (publish-ready) | content complete; awaiting the decision/act of publication |
+| 🚀 published | live on NostrHub (or github NIPs); the file in `nips/` is the working copy |
+| 🚀 published (update pending) | the local working copy has diverged ahead of the published version; republish needed |
+
+Spec headers also record: **canonical external URL** (naddr for NostrHub Custom NIPs), **last-published date**, and **sources** (the ADRs / BIBLE sections the spec was distilled from).
+
+**Publishing is the author's act.** Republishing to NostrHub requires the author's keys (and the hosting relay may require AUTH). Repo work ends at "publish-ready"; after the author publishes, the spec's status and last-published header are updated here.
+
+## Spec index
+
+Migration is in progress — specs land here story by story (see the [design handoff](../docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md) §8 for the plan). Until a spec's migration story has run, **its listed source location remains the source of truth** and the planned file does not exist yet.
+
+| Spec | Planned file | Status | Content lives today | Migration |
+|---|---|---|---|---|
+| Decentralized Lists (base NIP) | `nips/decentralized-lists.md` | 🚀 published (update pending) | Published: [NostrHub](https://nostrhub.io/naddr1qvzqqqrcvypzpef89h53f0fsza2ugwdc3e54nfpun5nxfqclpy79r6w8nxsk5yp0qythwumn8ghj7erpwe5kgtnwdaehgu339e3k7mf0qqfkgetrv4h8gunpd35h5ety94kxjum5wv4px7v6) (kind 30817, 2026-02-26). Newer local draft: `feat/communities:DECENTRALIZED_LISTS.md` | story 2 — pending |
+| DList Cross-NIP Compatibility (companion) | `drafts/decentralized-lists-compat.md` | 🧪 pre-NIP (publish-ready) | `feat/communities:DECENTRALIZED_LISTS_COMPAT.md` | story 2 — pending |
+| Tapestry Concepts (DList extensions) | `drafts/tapestry-concepts.md` | 📝 pre-NIP | [BIBLE §5](../BIBLE.md#5-the-tapestry-protocol) (kinds, addressing, `z`, `concept-graph` tag), [§8](../BIBLE.md#8-word-wrapper-json-format) (word-wrapper JSON), [§9](../BIBLE.md#9-core-nodes-of-a-concept) (core nodes) | story 3 — pending |
+| Class-Thread Membership Tags (`n`, `s`) | `drafts/class-thread-tags.md` | 📝 pre-NIP | [BIBLE §23](../BIBLE.md#23-class-thread-membership-tags-n-s) + ADR 0011 (community-reference line) | story 4 — pending |
+| Inherit-From & Resolved Definition (`b`) | `drafts/inherit-from.md` | 📝 pre-NIP | [BIBLE §25](../BIBLE.md#25-the-inherit-from-tag-b) + [§26](../BIBLE.md#26-resolved-definition), ADRs 0027/0028 | story 5 — pending |
+| Communities | `drafts/communities.md` | 📝 pre-NIP | [BIBLE §22](../BIBLE.md#22-community-reference-model), `feat/communities:COMMUNITY_RECORDS_DLIST.md`, `feat/communities:COMMUNITY_ENDORSEMENTS_DLIST.md`, communities ADR line | story 6 — pending |
+| Tags & Taggings | `drafts/tags.md` | 📝 pre-NIP | `feat/pubkey-tagging-target` branch: ADRs 0001 (profile-tag architecture), 0009 (pin-a-tag); firmware concepts `tag` / `nostr-user-tag` / `tag-pinning` | story 7 — pending |
+
+Branch-path notation: `branch:path` means the file exists at that path on the named (unmerged) branch — read it with `git show <branch>:<path>`. Migration **copies** content from those branches; it never implies merging them.
+
+Specs describing features still in flight on a branch (Tags, Communities) carry an explicit header note saying so.
+
+## Worksheet
+
+[worksheet.md](./worksheet.md) holds protocol problems and ideas that are unsolved, cross-cutting, or not yet owned by a single spec. Anything 💭 idea-grade starts there; when an entry matures into a coherent design, it graduates to a `drafts/` pre-NIP and the worksheet entry records the handoff.

--- a/protocols/worksheet.md
+++ b/protocols/worksheet.md
@@ -1,0 +1,69 @@
+# Protocol Worksheet
+
+Problems and ideas that are unsolved, cross-cutting, or not yet owned by a single spec. Each entry is self-contained: the problem, why it matters, and where the related thinking lives. When an entry matures into a coherent design, it graduates to a `drafts/` pre-NIP and the entry here records the handoff instead of being deleted.
+
+Entry format: `W<n>` id, status (**Open** / **Graduated → <spec>** / **Closed**), date raised, problem statement, related references.
+
+---
+
+## W1 — Cross-deployment concept identity
+
+**Status:** Open · raised 2026-06-09
+
+Concept handles embed their publisher's pubkey (`39998:<pubkey>:<slug>`), so every event that joins a concept via `z` tag bakes that pubkey into signed history. Today the Tags concepts (`tag`, `nostr-user-tag`, `tag-pinning`) are addressed under a dev-machine literal that became wire-binding by accident (tags-branch ADR 0015's `LEGACY_Z_TAG_PUBKEY` exception). A universal spec cannot hardcode one deployment's key — so: **how do independent deployments and implementations agree on which concept header is canonical for a given concept?**
+
+Known candidate directions, none ratified:
+
+- **Firmware-blessed pointer** — the current cold-start compromise (BIBLE §22, "Flaw A"): centralized editorial choice, accepted temporarily.
+- **Registry-as-DList** — the per-concept pointer becomes a community-curated, Grapevine-ranked DList (BIBLE §22's named exit from Flaw A).
+- **`b`-edge aggregation** — a concept's incoming `INHERITS_FROM` edges, weighted by each child author's GrapeRank influence from the observer's PoV, yield "which definition my web of trust agrees on" (ADR 0027; BIBLE §25). Candidate mechanism for the registry exit.
+
+**Refs:** BIBLE §22 (community-reference model, Flaw A + exit), §25 (`b` tag); ADRs 0027/0028; tags-branch ADR 0015 (the legacy-literal incident that exposed the problem); handoff doc §2.
+
+## W2 — Single-char tag namespace registry
+
+**Status:** Open · raised 2026-06-09
+
+Our specs are steadily claiming single-char (NIP-01 relay-indexed) tag letters: `z` (parent pointer), `n` (HAS_ELEMENT-inverse), `s` (IS_A_SUPERSET_OF-inverse), `b` (inherit-from). The direction principle (BIBLE §23): lowercase = child-claims-parent; uppercase forms are reserved for parent-claims-child inverses (`B` explicitly reserved, unassigned) and must not be assigned speculatively. Candidate letters for `IS_A_PROPERTY_OF` and `REFERENCES` are TBD. **One registry table is needed across all our specs so future ADRs don't collide letters** — and to decide how it composes with letters other NIPs already use.
+
+**Refs:** BIBLE §23 (direction principle, future-candidate tags), §25 (`b`/`B`); ADRs 0011, 0027.
+
+## W3 — Polarity valence arc
+
+**Status:** Open · raised 2026-06-09
+
+Tagging events carry `polarity` `"1"` (apply) or `"-1"` (dispute); v1 semantics bucket `>= 0.5` as applied and `<= -0.5` as disputed, deliberately reserving the open interval `(-0.5, 0.5)` for a future graded-valence arc (GrapeRank-style weights in `[-1, +1]`). **The graded semantics are undesigned**: what does a 0.3 mean, who interprets it, and does the bucketing rule belong in the Tags spec or in trust-metric-interpreter territory?
+
+**Refs:** tags-branch ADR 0001 (polarity wire format + v1 buckets); tags-branch follow-ups (valence arc deferred); handoff doc §6.
+
+## W4 — `e` vs. `a` for parent-tag references
+
+**Status:** Open · raised 2026-06-09
+
+Tagging and pin events reference the tag they apply/pin by `e` (event id — pins a specific version) and/or `a` (address — survives the author's edits). The tags branch flagged this choice for re-evaluation in its own follow-ups: replaceable events make `e`-references go stale, while `a`-references change meaning under the author's later edits. **Which reference (or which combination, with what precedence) should the spec mandate, and does the answer differ for taggings vs. pins?**
+
+**Refs:** tags-branch ADRs 0001/0009 + follow-ups; the same question shape appears in the DList compat companion (`a` mandated for kind-34550 items because they're replaceable).
+
+## W5 — `REFERENCES` publishing semantics
+
+**Status:** Open · raised 2026-06-09
+
+The concept-level `REFERENCES` relationship (a non-committal "may pull later" bookmark between concepts) has no settled wire form. BIBLE §23 records the open question: **is it a consumer-owned tag on the consumer's own concept Header, or a separate "reference manifest" kind-39999 event?** Interacts with W2 (it's a candidate for a single-char letter) and with the registry exit in W1 (BIBLE §22 lists it on the flaw-A exit path).
+
+**Refs:** BIBLE §22 (deferred list), §23 (future-candidate relationship tags); ADR 0006 line.
+
+## W6 — Set-valued override algebra for Resolved Definition
+
+**Status:** Open · raised 2026-06-09
+
+Resolved Definition (BIBLE §26) is field-level in v1: a child's stated field replaces the inherited one wholesale. **How a child adds/removes/replaces individual *elements* of an inherited set** (e.g. "Alice's `dogs` minus Fido plus Rex") is explicitly deferred — by ADRs 0027 and 0028 — to the first consumer that needs it. When that consumer appears, the algebra belongs in the inherit-from spec.
+
+**Refs:** BIBLE §25 (scope note), §26 (Scope v1); ADRs 0027/0028.
+
+## W7 — `item-kind` interplay with concept headers
+
+**Status:** Open · raised 2026-06-09
+
+The DList compat companion introduces `item-kind` on list headers to declare which foreign event kinds a list accepts (e.g. kind 34550 NIP-72 communities as list items). Tapestry's concept headers carry their own conventions (`concept-graph` pointer, firmware schemas, `required`/`allowed` declarations). **Do these compose or compete?** E.g.: should Tapestry concept headers declare `item-kind`? Does a foreign-kind item participate in class threads (`n`/`s`) and inheritance (`b`)? Does the firmware JSON-schema mechanism subsume the header's schema-declaration tags or duplicate them?
+
+**Refs:** `feat/communities:DECENTRALIZED_LISTS_COMPAT.md` (`item-kind`, Methods 2/3); BIBLE §5 (concept-graph tag), §7 (firmware schemas), §23 (`n`/`s` trust constraints).

--- a/protocols/worksheet.md
+++ b/protocols/worksheet.md
@@ -42,13 +42,13 @@ Tagging events carry `polarity` `"1"` (apply) or `"-1"` (dispute); v1 semantics 
 
 Tagging and pin events reference the tag they apply/pin by `e` (event id — pins a specific version) and/or `a` (address — survives the author's edits). The tags branch flagged this choice for re-evaluation in its own follow-ups: replaceable events make `e`-references go stale, while `a`-references change meaning under the author's later edits. **Which reference (or which combination, with what precedence) should the spec mandate, and does the answer differ for taggings vs. pins?**
 
-**Refs:** tags-branch ADRs 0001/0009 + follow-ups; the same question shape appears in the DList compat companion (`a` mandated for kind-34550 items because they're replaceable).
+**Refs:** tags-branch ADRs 0001/0009 + follow-ups; the same question shape appears in the DList compat companion (Method 2 mandates `a` for items pointing at kind-34550 events because they're replaceable; Method 3 rides on `z` tags instead).
 
 ## W5 — `REFERENCES` publishing semantics
 
 **Status:** Open · raised 2026-06-09
 
-The concept-level `REFERENCES` relationship (a non-committal "may pull later" bookmark between concepts) has no settled wire form. BIBLE §23 records the open question: **is it a consumer-owned tag on the consumer's own concept Header, or a separate "reference manifest" kind-39999 event?** Interacts with W2 (it's a candidate for a single-char letter) and with the registry exit in W1 (BIBLE §22 lists it on the flaw-A exit path).
+The concept-level `REFERENCES` relationship (a non-committal "may pull later" bookmark between concepts) has no settled wire form. BIBLE §23 records the open question: **is it a consumer-owned tag on the consumer's own concept Header, or a separate "reference manifest" kind-39999 event?** Interacts with W2 (it's a candidate for a single-char letter) and with the registry exit in W1 (BIBLE §23 ties it to the flaw-A exit; §22's deferred list carries it only as a reserved-future candidate).
 
 **Refs:** BIBLE §22 (deferred list), §23 (future-candidate relationship tags); ADR 0006 line.
 


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`.

## Bundled

- **#259** — protocols/ directory scaffold + design handoff (protocols-directory epic, story 1). Docs-only: `protocols/README.md` (boundary rule, status ladder, 7-spec index), `protocols/worksheet.md` (W1–W7), `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md`, CLAUDE.md session-start pointer, story + review records.

## Net production impact

None at runtime — no code, firmware, or UI changes; BIBLE.md byte-identical. The change adds repo documentation only. No user-visible difference on brainstorm.world.

## Verification trail

- #259 staging deploy: run 27240066296, 1m25s, green.
- Staging smoke: Tier 1 stable in minimum 3 polls; Tier 2 all pages/APIs 200, search 200 with hits, get-user-data 504-JSON per known gotcha (expected); Tiers 3/4 N/A (docs-only); Tier 5 clean.
- `npm test` green at every phase commit; 12-agent independent docs audit PASS.

## Test plan

- [ ] After merge: deploy-brainstorm.yml runs to completion.
- [ ] Smoke test on brainstorm.world (Tiers 1/2/5; 3/4 N/A for docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)