### PR TITLE
docs: Decentralized Lists reconciliation (protocols-directory story 2)

### DIFF
--- a/engineering-team/reviews/protocols-directory/2-decentralized-lists-reconciliation.md
+++ b/engineering-team/reviews/protocols-directory/2-decentralized-lists-reconciliation.md
@@ -1,0 +1,61 @@
+# Review: Story 2 — Decentralized Lists reconciliation
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-10
+**Diff:** commit `1add2878` (3 files, +640/−3: `protocols/nips/decentralized-lists.md`, `protocols/drafts/decentralized-lists-compat.md`, `protocols/README.md`)
+**Mode:** docs-mode (Protocol-Spec workflow). Architecture skipped per approved story — design record is `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` §5. Test Design skipped.
+**Method note:** implementation authored in this same session, so the audit was fanned out to independent agents across four dimensions — content fidelity (machine diff against the `feat/communities` sources), acceptance-criteria conformance, header/index metadata accuracy (incl. `nak` decode of the naddr), and spec semantics after surgery (dangling references, base↔companion citation integrity). Result: **zero confirmed findings**; 13 notes, all confirmations or cosmetics. Quality gates run directly by the Reviewer.
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **PASS** (full suite, `Overall: PASS`)
+- [x] `npm run test:playwright` — skipped: docs-only change, no UI surface
+- [x] _Lint/typecheck/build not configured — skipped._
+- [x] `BIBLE.md` byte-identical — zero-line diff (hard story criterion)
+- [x] Diff scope — exactly the three intended files
+- [x] `feat/communities` untouched — tip still `db7f02bb`; sources read via `git show` only
+
+## Spec adherence (acceptance criteria, audited independently)
+
+- [x] AC1 — base NIP = newer branch draft minus the entire "Backwards Compatibility with Preexisting NIPs" section; truncation boundary exact (last section is "List curation and spam prevention", final paragraph matches source); three-element convention and companion cross-ref retained.
+- [x] AC2 — zero "to be completed" placeholders in either file.
+- [x] AC3 — header block records status 🚀 published (update pending), the canonical naddr (independently decoded: kind 30817, `d=decentralized-lists`, pubkey `e5272de9…`), last-published 2026-02-26, sources, and an accurate divergence statement for the republish act.
+- [x] AC4 — companion is a faithful copy (machine-diff: only the one link retarget) with 🧪 pre-NIP (publish-ready) header.
+- [x] AC5 — all cross-references resolve on disk in both directions; no branch-root paths remain.
+- [x] AC6 — index rows flipped to working-copy-here with live links; branch no longer named as location; published-version-behind signal retained; other five rows untouched.
+- [x] AC7 — `npm test` green; BIBLE byte-identical.
+- [x] AC8 — `feat/communities` unchanged.
+
+## Fidelity-rule adherence
+
+Machine diff of the reconciled base body against the truncated source shows **exactly five changed lines**, matching the Implementer's flagged list; the companion shows exactly one. All six physical edits, verified mechanical and unambiguous:
+
+1. Base: companion link `DECENTRALIZED_LISTS_COMPAT.md` → `../drafts/decentralized-lists-compat.md`
+2. Base line ~43: missing space after `` `["t", "Switzerland"]` ``
+3. Base Example 5: trailing comma before `}` removed (invalid JSON)
+4. Base Example 7: `["names", "dog, "dogs"],` → `["names", "dog", "dogs"],` (malformed quoting)
+5. Base Example 7: missing comma after `["d", "<d_tag_for_Fido>"]`
+6. Companion: base-NIP link → `../nips/decentralized-lists.md`
+
+No semantic rewording anywhere. The **deliberately-unfixed observation** stands as the right call: the "Nonstandard methods" widgets example reuses `"id": "<id_lists>"` where `<id_widgets>` may have been intended — ambiguous, left as authored, **flagged to the author for the republish pass**.
+
+## Spec semantics after surgery
+
+- [x] No dangling references into the removed section; both "see below" references resolve to retained sections.
+- [x] Companion's citations into the base (Example 4, schema-declaration conventions, z-tag a-tag form, kinds) all resolve in the reconciled file.
+- [x] Examples 1–7 present and sequential; retrieval filters consistent with declared kinds; document reads whole as a publishable spec.
+
+## Findings
+
+### Blocking
+
+None.
+
+### Non-blocking
+
+1. **protocols/nips/decentralized-lists.md:6** — the header's divergence statement summarizes the mechanical fixes ("quoting/commas") rather than enumerating all five individually. The fidelity rule's flag-each-edit requirement is satisfied by the Implementer's report and this review (the enumeration above); the header is a summary for the republish act and is accurate. No change asked.
+2. **protocols/nips/decentralized-lists.md:9** — one cosmetic blank line between the metadata separator and the title, beyond the five flagged edits. Standard markdown spacing; accepted.
+
+## Verdict
+
+**PASS** — the working copy is the reconciled, publication-ready text; the delta the author will republish is accurately stated in the file header; fidelity to the author's voice is machine-verified. Ready for the deploy chain, and thereafter for the author's NostrHub republication (out of scope here, per the story).

--- a/engineering-team/stories/protocols-directory/2-decentralized-lists-reconciliation.md
+++ b/engineering-team/stories/protocols-directory/2-decentralized-lists-reconciliation.md
@@ -1,0 +1,52 @@
+# Story 2: Decentralized Lists reconciliation
+
+**Status:** Approved
+**Created:** 2026-06-10
+**Type:** Doc
+**Epic:** protocols-directory — realizes `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` (§5 findings, §8 story 2)
+
+## Background
+
+The Decentralized Lists Custom NIP — authored by the project owner — exists in two diverged copies: the version published on NostrHub (kind 30817, 2026-02-26) and a strictly newer local draft sitting at the root of the unmerged `feat/communities` branch (last edited 2026-05-10). The local draft adds the three-element description convention and a cross-reference to a companion NIP, but also carries an **unfinished** "Backwards Compatibility with Preexisting NIPs" section containing "to be completed" placeholders — material that was since spun off into the companion NIP (`DECENTRALIZED_LISTS_COMPAT.md`, complete on the same branch) and never cleaned out of the base draft.
+
+Today, neither copy is the working copy: the repo's `protocols/` index (story 1) points at the branch as the interim source of truth, and the published version is behind. The owner wants to republish but can't until the reconciliation happens. This story produces the single authoritative working copy of both documents in `protocols/`, leaving the base NIP ready for the owner to republish.
+
+## User-facing description
+
+As the NIP's author, I want one reconciled, publication-ready working copy of the Decentralized Lists base NIP in the repo — with the half-finished compat material removed in favor of the completed companion NIP — so that I can republish to NostrHub with confidence that the text is current, complete, and consistent, and so future edits happen in exactly one place.
+
+## Acceptance criteria
+
+- [ ] Given a fresh clone of `staging`, when a reader opens `protocols/nips/decentralized-lists.md`, then it contains the newer local draft's content (`feat/communities:DECENTRALIZED_LISTS.md`) **minus** the entire "Backwards Compatibility with Preexisting NIPs" section, and **retaining** the three-element description convention and the cross-reference to the companion NIP.
+- [ ] Given the reconciled base NIP, when searched for "to be completed" (or similar placeholder text), then no unfinished placeholders remain anywhere in the document.
+- [ ] Given the base NIP's header block, when a reader consults it, then it records: status 🚀 published (update pending), the canonical NostrHub naddr, last-published date 2026-02-26, sources, and a short statement of exactly how the working copy diverges from the published version (the delta the owner will be republishing).
+- [ ] Given `protocols/drafts/decentralized-lists-compat.md`, when compared with `feat/communities:DECENTRALIZED_LISTS_COMPAT.md`, then the content is faithful to the branch original, with a header block recording status 🧪 pre-NIP (publish-ready) and its sources.
+- [ ] Given either new file, when any internal cross-reference is followed (base ↔ companion, links to other NIPs), then it resolves — no link still points at branch-root paths that don't exist on `staging`.
+- [ ] Given `protocols/README.md`, when a reader consults the spec index, then the two Decentralized Lists rows link to the new in-repo files as the working copies, no longer name the `feat/communities` branch as the current location, and the base NIP's row still signals that the published NostrHub version is behind until the owner republishes.
+- [ ] Given the full change, when `npm test` runs, then it passes unchanged; and `BIBLE.md` is byte-identical to before.
+- [ ] Given the two source files on `feat/communities`, when this story completes, then that branch is untouched (content is copied via `git show`, never merged; branch-side cleanup stays deferred per handoff §8 logistics).
+
+**Fidelity rule for the copy:** mechanical defects in the source (e.g. Example 7's malformed JSON quoting `["names", "dog, "dogs"]`) may be corrected where the intent is unambiguous; every such correction must be individually flagged for the Reviewer. No semantic rewording, restructuring, or "improvement" of the spec's prose — the author's voice is the spec.
+
+## Concepts touched
+
+None in the concept-graph sense (docs-only; no events published, no firmware). The documents *describe* kinds 9998/9999/39998/39999 and the `z`-tag pattern, which BIBLE §5 implements — no implementation text changes here.
+
+## Out of scope
+
+- The actual republication to NostrHub (the owner's act, requiring the author's keys; the relay requires AUTH). The follow-up status flip to 🚀 published + new last-published date is a one-line edit for whichever session follows the republication.
+- Deleting `DECENTRALIZED_LISTS*.md` from the `feat/communities` branch root (deferred to that branch's next touch, per handoff).
+- Any edit to BIBLE.md, the worksheet, or the other five specs in the index.
+- Publishing the companion to NostrHub (separate decision; it stays 🧪 publish-ready).
+
+## Open questions
+
+- **Architecture phase?** Recommendation: skip, as in story 1 — handoff §5 *is* the edit plan; type Doc → Implementer + Reviewer. Confirm at the gate.
+- Whether the companion should keep its original standalone title ("Decentralized Lists: Cross-NIP Compatibility") verbatim — assumed yes (author's voice); flag at review if the Implementer sees a reason otherwise.
+
+## Linked artifacts
+
+- Design record: `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` §5 (reconciliation findings + plan)
+- ADR: (recommended skipped — see open questions)
+- Test plan: skipped (docs-mode)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/protocols-directory/2-decentralized-lists-reconciliation.md
+++ b/engineering-team/stories/protocols-directory/2-decentralized-lists-reconciliation.md
@@ -1,6 +1,6 @@
 # Story 2: Decentralized Lists reconciliation
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-10
 **Type:** Doc
 **Epic:** protocols-directory — realizes `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` (§5 findings, §8 story 2)
@@ -49,4 +49,4 @@ None in the concept-graph sense (docs-only; no events published, no firmware). T
 - Design record: `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` §5 (reconciliation findings + plan)
 - ADR: (recommended skipped — see open questions)
 - Test plan: skipped (docs-mode)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/protocols-directory/2-decentralized-lists-reconciliation.md` — PASS

--- a/protocols/README.md
+++ b/protocols/README.md
@@ -45,10 +45,10 @@ Spec headers also record: **canonical external URL** (naddr for NostrHub Custom 
 
 Migration is in progress — specs land here story by story (see the [design handoff](../docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md) §8 for the plan). Until a spec's migration story has run, **its listed source location remains the source of truth** and the planned file does not exist yet.
 
-| Spec | Planned file | Status | Content lives today | Migration |
+| Spec | File | Status | Content lives today | Migration |
 |---|---|---|---|---|
-| Decentralized Lists (base NIP) | `nips/decentralized-lists.md` | 🚀 published (update pending) | Published: [NostrHub](https://nostrhub.io/naddr1qvzqqqrcvypzpef89h53f0fsza2ugwdc3e54nfpun5nxfqclpy79r6w8nxsk5yp0qythwumn8ghj7erpwe5kgtnwdaehgu339e3k7mf0qqfkgetrv4h8gunpd35h5ety94kxjum5wv4px7v6) (kind 30817, 2026-02-26). Newer local draft: `feat/communities:DECENTRALIZED_LISTS.md` | story 2 — pending |
-| DList Cross-NIP Compatibility (companion) | `drafts/decentralized-lists-compat.md` | 🧪 pre-NIP (publish-ready) | `feat/communities:DECENTRALIZED_LISTS_COMPAT.md` | story 2 — pending |
+| Decentralized Lists (base NIP) | [nips/decentralized-lists.md](./nips/decentralized-lists.md) | 🚀 published (update pending) | **Working copy here.** The [NostrHub](https://nostrhub.io/naddr1qvzqqqrcvypzpef89h53f0fsza2ugwdc3e54nfpun5nxfqclpy79r6w8nxsk5yp0qythwumn8ghj7erpwe5kgtnwdaehgu339e3k7mf0qqfkgetrv4h8gunpd35h5ety94kxjum5wv4px7v6) version (kind 30817, 2026-02-26) is behind until the author republishes | story 2 ✅ |
+| DList Cross-NIP Compatibility (companion) | [drafts/decentralized-lists-compat.md](./drafts/decentralized-lists-compat.md) | 🧪 pre-NIP (publish-ready) | **Working copy here** | story 2 ✅ |
 | Tapestry Concepts (DList extensions) | `drafts/tapestry-concepts.md` | 📝 pre-NIP | [BIBLE §5](../BIBLE.md#5-the-tapestry-protocol) (kinds, addressing, `z`, `concept-graph` tag), [§8](../BIBLE.md#8-word-wrapper-json-format) (word-wrapper JSON), [§9](../BIBLE.md#9-core-nodes-of-a-concept) (core nodes) | story 3 — pending |
 | Class-Thread Membership Tags (`n`, `s`) | `drafts/class-thread-tags.md` | 📝 pre-NIP | [BIBLE §23](../BIBLE.md#23-class-thread-membership-tags-n-s) + ADR 0011 (community-reference line) | story 4 — pending |
 | Inherit-From & Resolved Definition (`b`) | `drafts/inherit-from.md` | 📝 pre-NIP | [BIBLE §25](../BIBLE.md#25-the-inherit-from-tag-b) + [§26](../BIBLE.md#26-resolved-definition), ADRs 0027/0028 | story 5 — pending |

--- a/protocols/drafts/decentralized-lists-compat.md
+++ b/protocols/drafts/decentralized-lists-compat.md
@@ -1,0 +1,224 @@
+> **Repo metadata — not part of the spec text.**
+> **Status:** 🧪 pre-NIP (publish-ready)
+> **Canonical:** not yet published
+> **Sources:** `feat/communities:DECENTRALIZED_LISTS_COMPAT.md`, copied per protocols-directory story 2
+
+---
+
+Decentralized Lists: Cross-NIP Compatibility
+=====
+
+This NIP extends the [Decentralized Lists NIP](../nips/decentralized-lists.md) (the "base NIP") with conventions for incorporating event kinds defined by other NIPs into the Decentralized Lists pattern.
+
+The base NIP defines the pattern — a list header event declares a list, and list item events join that list via a `z` tag pointer back to the header. The base NIP uses kinds `9998`/`39998` for headers and `9999`/`39999` for items. This NIP describes how the same pattern can interoperate with foreign event kinds without modifying their respective NIPs.
+
+NIP-72: Moderated Communities is the worked example below. The conventions generalize to other addressable event kinds.
+
+## Relationship to the base NIP
+
+This NIP is additive. It introduces one new list-header tag (`item-kind`) and codifies one usage pattern (using a foreign-kind event as a list item). It does not change any wire format or behavior defined in the base NIP.
+
+A reader who understands only the base NIP can still parse list events that follow the canonical kinds. Events that participate in the conventions described here either appear as ordinary kind `9999`/`39999` items carrying an `a` tag (Method 2 below) or as foreign-kind events carrying additional `z` tags that base-only readers can ignore (Method 3 below). Both are normal nostr extension patterns.
+
+## The two roles a foreign kind can play
+
+A foreign event kind can play either or both of these roles in a Decentralized List:
+
+- **Foreign kind as list item** — an event of a kind defined by another NIP carries its own native data and additionally functions as a member of a Decentralized List. The most common case, and the focus of this NIP.
+- **Foreign kind as list header** — an event of a kind defined by another NIP serves as the parent that items point at via `z` tag. Useful when the foreign event is naturally the "thing being listed against" (e.g. a community whose members are tracked by independent endorsement events). Briefly noted at the end; full treatment is left for a future addendum.
+
+## Declaring accepted item kinds: the `item-kind` tag
+
+By default, a list header expects items to be kind `9999` or `39999` events. A list header can broaden this by declaring one or more `item-kind` tags, each carrying a single kind number:
+
+```json
+["item-kind", "39999"],
+["item-kind", "34550"]
+```
+
+Multiple `item-kind` tags are listed individually, following the same convention as `required` and `allowed` in the base NIP. A list header that omits `item-kind` is taken to accept only the standard kinds (`9999`/`39999`).
+
+As with the base NIP's schema-declaration tags, an optional third element MAY be included on any `item-kind` tag to provide a brief human-readable description of the kind being accepted. For example: `["item-kind", "34550", "NIP-72 community-definition events"]`. The description is informational only and does not affect validation.
+
+The `item-kind` tag tells consumers which event kinds to query for when retrieving items on a list. Schema declarations on the header (`required`, `allowed`, `recommended`, `disallowed`) apply *additively* over whatever requirements the foreign kind already imposes by its own NIP — they do not override the foreign kind's own spec.
+
+## Authorial voice
+
+A foreign-kind event listed on a Decentralized List can be authored by either:
+
+- a **curator** — someone other than the foreign event's author publishes a separate kind `9999`/`39999` list-item event whose `a` tag points at the foreign event; or
+- the **foreign event's creator** — the foreign event itself carries one or more `z` tags pointing at list headers (or to lists by their human-readable names), making the foreign event simultaneously a valid event of its native kind and a list item on one or more lists.
+
+These two voices make different statements:
+
+- The curator says: *"I include this on my list."*
+- The creator says: *"I claim to be on this list."*
+
+Both forms are valid. Both can coexist for the same foreign event on the same list. This NIP places no preference on one over the other; the choice is up to whoever is making the listing claim. Trust-metric interpreters consuming the list will generally weight curator-authored claims and creator-authored self-claims differently.
+
+## Example: NIP-72 Moderated Communities
+
+NIP-72 defines a kind `34550` community-definition event. Suppose we wish to maintain a list of communities curated by trust-graph methods, drawing on the existing NIP-72 ecosystem rather than starting from scratch. There are three approaches, distinguished primarily by who is authoring the listing claim.
+
+### Method 1: Native, no NIP-72 interop
+
+Standard list-header plus standard list-items, ignoring NIP-72 entirely. Items are kind `39999` events that exist purely as native list constructs and do not reference any kind `34550` event. Use this when the community has no existing NIP-72 representation and cross-compatibility is not a goal.
+
+List header:
+
+```json
+{
+  "kind": 39998,
+  "tags": [
+    ["d", "<d_tag_for_list_of_brainstorm_communities>"],
+    ["names", "Brainstorm Community", "Brainstorm Communities"],
+    ["description", "Communities curated using trust-graph (GrapeRank-style) methods."],
+    ["required", "t"],
+    ["required", "name"]
+  ]
+}
+```
+
+List item:
+
+```json
+{
+  "kind": 39999,
+  "tags": [
+    ["z", "39998:<curator_pubkey>:<d_tag_for_list_of_brainstorm_communities>"],
+    ["d", "<d_tag_for_Bitcoin_Army>"],
+    ["t", "Bitcoin Army"],
+    ["name", "Bitcoin Army"]
+  ]
+}
+```
+
+### Method 2: Curator-authored references to NIP-72 communities
+
+A standard kind `39999` list-item, where the item points by `a` tag at an existing kind `34550` community event. The kind `34550` event itself is unmodified. The list-item event is authored by the curator. **Speaker: "I include this community on my list."**
+
+Use this when:
+
+- You want to include an existing NIP-72 community in a curated list without requiring its creator's cooperation.
+- You want each curator's entries to be independent events authored by them, with provenance preserved.
+
+This is the recommended path for absorbing the existing NIP-72 ecosystem and the natural fit for personal-projection list models where each user maintains their own list.
+
+List header:
+
+```json
+{
+  "kind": 39998,
+  "tags": [
+    ["d", "<d_tag_for_list_of_brainstorm_communities>"],
+    ["names", "Brainstorm Community", "Brainstorm Communities"],
+    ["description", "Communities curated using trust-graph methods. Items are pointers to NIP-72 kind 34550 events."],
+    ["required", "a"],
+    ["item-kind", "39999"]
+  ]
+}
+```
+
+List item (one per (curator, community)):
+
+```json
+{
+  "kind": 39999,
+  "tags": [
+    ["z", "39998:<curator_pubkey>:<d_tag_for_list_of_brainstorm_communities>"],
+    ["a", "34550:<community_creator_pubkey>:<d_tag_of_community>"],
+    ["name", "Bitcoin Army"]
+  ]
+}
+```
+
+The required pointer is `a` (not `e`) because kind `34550` is a replaceable event; the addressable `a` tag is the stable identifier.
+
+### Method 3: Creator-authored self-listing
+
+The kind `34550` community event itself plays the role of list item, by carrying one or more `z` tags pointing at list headers. The community event remains a fully valid NIP-72 event — extra `z` tags are harmless to readers that do not recognize them. The listing claim is authored by the community creator. **Speaker: "I claim to be on this list."**
+
+Use this when:
+
+- The community creator wishes to declare affiliation with one or more curated lists.
+- You want to save an event per listing, accepting that listings only exist while the creator continues to publish them (replaceable-event semantics — see below).
+- You want a single canonical event that NIP-72 clients see as a normal community and list-aware clients additionally see as a list item.
+
+This method has the advantage of being more economical than Method 2 in the sense that there is one less event required for specification of each listing. The primary disadvantage is that it requires the kind `34550` event author's cooperation: an existing NIP-72 community cannot be brought onto a curated list this way without its creator re-publishing. A secondary disadvantage applies if the foreign NIP is already using the `z` tag for some other purpose; this is unusual but should be checked on a per-NIP basis before adopting Method 3 for that kind.
+
+List header (declaring kind `34550` as an accepted item kind alongside `39999`):
+
+```json
+{
+  "kind": 39998,
+  "tags": [
+    ["d", "<d_tag_for_list_of_brainstorm_communities>"],
+    ["names", "Brainstorm Community", "Brainstorm Communities"],
+    ["description", "Communities curated using trust-graph methods. Accepts kind 39999 pointers (Method 2) and kind 34550 self-listings (Method 3)."],
+    ["item-kind", "39999"],
+    ["item-kind", "34550"]
+  ]
+}
+```
+
+The kind `34550` tags required by NIP-72 (`name`, `description`, `p moderator`, `relay`, etc.) are imposed by NIP-72 itself and need not be re-declared on this header. Any `required`/`allowed` declarations on the list header apply additively.
+
+List item (a NIP-72 community event with `z` tags added):
+
+```json
+{
+  "kind": 34550,
+  "tags": [
+    ["d", "<d_tag_of_community>"],
+    ["name", "Bitcoin Army"],
+    ["description", "..."],
+    ["image", "https://..."],
+    ["p", "<moderator_pubkey>", "moderator"],
+    ["relay", "wss://..."],
+    ["z", "brainstorm-community"],
+    ["z", "39998:<curator_X_pubkey>:<X_d_tag>"],
+    ["z", "39998:<curator_Y_pubkey>:<Y_d_tag>"]
+  ]
+}
+```
+
+This example shows three `z` tags on the same event, illustrating that one community can claim membership on multiple lists simultaneously: a generic claim by the human-readable name `"brainstorm-community"`, plus specific affiliations with two curator-maintained lists. Multiple `z` tags follow the same multi-list pattern shown in Example 4 of the base NIP. The creator may use any combination — a single generic claim, one or more specific list affiliations, or a mix — according to which lists they wish to associate with.
+
+## Methods 2 and 3 coexist
+
+Methods 2 and 3 are not in conflict and are not interchangeable encodings of the same statement. They are different speakers (curator vs. creator) making different claims about the same artifact. A given community may appear on the same list by both means simultaneously, and both statements are valid.
+
+A list-aware client looking for items on a list whose header declares both `["item-kind", "39999"]` and `["item-kind", "34550"]` should query both forms and merge:
+
+```json
+{ "kinds": [39999], "#z": ["39998:<list_pubkey>:<list_d_tag>"] }
+```
+```json
+{ "kinds": [34550], "#z": ["39998:<list_pubkey>:<list_d_tag>", "brainstorm-community"] }
+```
+
+De-duplicate on the kind `34550` a-tag where the same community surfaces via both methods. Preserve authorship — the speaker of each entry is part of its meaning, and trust-metric interpreters will generally weight curator-authored claims and creator-authored self-claims differently.
+
+## Replaceability semantics differ across methods
+
+Method 2 entries are independent kind `39999` events authored by curators. Each curator's entry persists or is replaced by that curator on their own schedule.
+
+Method 3 entries live as `z` tags on the creator's replaceable kind `34550` event. When the creator next publishes a new version of their community event, the live `z` tag set is whatever they include in that version. Listings authored by creators can therefore appear or disappear with each republish of the underlying community event; listings authored by curators are independent and accumulate per curator.
+
+This asymmetry is a feature, not a bug — the two methods carry different commitment semantics, and consumers should be aware of which voice each entry comes from.
+
+## Extending to other NIPs
+
+The pattern in this NIP is not specific to NIP-72. Any addressable event kind whose author may wish to participate in community-curated lists, or whose representation may be referenced by curators of such lists, can be incorporated using the same three methods. To extend this NIP to another foreign kind:
+
+1. Determine whether the foreign kind makes sense as a list item, a list header, or both.
+2. For foreign-kind-item lists: declare the foreign kind via `item-kind` on the relevant list header. Decide whether your application supports curator-authored references (Method 2), creator self-listings (Method 3), or both.
+3. Note any conflicts: if the foreign NIP already uses the `z` tag for some other purpose, Method 3 is unsuitable for that kind, and Method 2 should be used exclusively.
+
+No further protocol-level conventions are required. Application-layer conventions (e.g. trust scoring, member-status determination, content visibility) are outside the scope of this NIP.
+
+## A note on referencing foreign events
+
+The natural and recommended pattern for referencing a foreign-kind event from a Decentralized List is via an `a` tag on a canonical kind `39999` list item (Method 2 above), not via `z` tag with the foreign event as parent. Most foreign event kinds — NIP-72 communities included — are not structured as list parents: they define a thing, not a list of items, and have no schema declarations to govern items pointing at them.
+
+The base NIP's a-tag form for `z` tag values (`<kind>:<pubkey>:<d-tag>`) does not formally constrain the kind to `39998`, so a foreign-kind event *could* in principle be z-tagged at by items. In practice this is rare, schema-poor, and almost always better expressed as: (1) a canonical kind `39998` header for the list of interest, with (2) kind `39999` items carrying `a` tag references to the foreign events they list. That pattern is fully covered by Method 2 above and needs no additional convention.

--- a/protocols/nips/decentralized-lists.md
+++ b/protocols/nips/decentralized-lists.md
@@ -1,0 +1,413 @@
+> **Repo metadata — not part of the published NIP text.**
+> **Status:** 🚀 published (update pending)
+> **Canonical:** kind 30817, `d=decentralized-lists` — [NostrHub](https://nostrhub.io/naddr1qvzqqqrcvypzpef89h53f0fsza2ugwdc3e54nfpun5nxfqclpy79r6w8nxsk5yp0qythwumn8ghj7erpwe5kgtnwdaehgu339e3k7mf0qqfkgetrv4h8gunpd35h5ety94kxjum5wv4px7v6)
+> **Last published:** 2026-02-26
+> **Sources:** `feat/communities:DECENTRALIZED_LISTS.md`, reconciled per protocols-directory story 2 (`docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` §5)
+> **Working-copy divergence from the published version (the delta a republish ships):** adds the three-element human-readable description convention on `required`/`allowed`/`recommended`/`disallowed` tags; adds the cross-reference to the [Cross-NIP Compatibility companion](../drafts/decentralized-lists-compat.md); mechanical fixes to example JSON (quoting/commas). The unpublished, unfinished "Backwards Compatibility with Preexisting NIPs" draft section was superseded by the companion and removed.
+
+---
+
+Decentralized Lists
+=====
+
+This NIP defines lists of things that users can create and that anyone can add to. It provides an alternative to NIP-51 for list management. The distinction is that for any given NIP-51 list, the list author has full control over list items, whereas for this NIP, list items are contributed by the community.
+
+We introduce the following event kinds: `9998` and `39998` for _list header declaration_ (a.k.a. _list declaration_), and `9999` and `39999` for _list item declaration_. Whether to use kind `999x` or kind `3999x` depends on whether the declaration author wishes the list or list item to be editable (kind `3999x`) or not (kind `999x`).
+
+_This NIP is agnostic regarding the choice of method or methods for list curation and spam prevention_. (But see below for a brief discussion.)
+
+_See also: [Decentralized Lists: Cross-NIP Compatibility](../drafts/decentralized-lists-compat.md), a companion NIP describing how foreign event kinds can play list-item or list-header roles._
+
+## Declarations of lists and list items
+
+There are two actions: declaration of a list, and declaration of a specific item that belongs to a given list.
+
+### List declaration
+
+Declaration of a list is a kind `9998` (or `39998`) event. It may be referred to as the _list header_.
+
+The list header `must` have the `names` tag. The `names` tag must be followed by two strings: a singular form ("widget") and a plural form ("widgets"), as in the examples below.
+
+Optional tags: `titles`, `slugs`, which also must have a singular form and a plural form, as is the case for the `names` tag.
+
+The list header `should` make use of `required` or `allowed` tags to indicate which child item types are expected. For example: `["required", "p"]` indicates that child item declarations must make use of the `p` tag. Each required or allowed tag must be listed individually, not packed together into a single tag. For example, use `["required", "foo"], ["required", "bar"]` rather than `["required", "foo", "bar"]`.
+
+An optional third element MAY be included on any of the `required`, `allowed`, `recommended`, or `disallowed` tags to provide a brief human-readable description of what the named tag represents. For example: `["required", "p", "Pubkey of the person being endorsed"]`, or `["allowed", "comments", "Optional textual reason"]`. The description is informational only and does not affect validation. Two-element forms remain valid; the third element is purely additive.
+
+If the list header is a kind `39998` replaceable event, it _must_ have a `d` tag as described in [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md).
+
+### Item declaration 
+
+There are two methods to declare an item: the <i>standard</i> method and the <i>nonstandard</i> method. The standard method is recommended for routine use. The nonstandard method may be used for backwards compatibility with other NIPs. The only distinction between these two methods are the event kinds that are used for declaration of an item on a list. Standard declaration of an item on an existing list is a kind `9999` (or `39999`) event. Nonstandard declaration of an item on an existing list is some other kind that is selected for the sake of compatibility with one or more other chosen NIPs. For an example of nonstandard item declaration, see below.
+
+The `z` tag is required by all list item events, whether standard (kind `9999` and `39999`) or nonstandard (some other event kind). It is used as a pointer to the parent list (the list header). If the list header is a kind `9998` event, the `z` tag is the _event id_ of the list header. If the list header is a kind `39998` event, which is a replaceable event and will not have a constant event id, the `z` tag follows the format of an `a` tag: `39998:<list header author pubkey>:<d-tag of the list header>`. Alternatively, if a list header has not been formally declared, the `z` tag value can be replaced with a human readable name of the list, e.g.  `["z", "country"]` and `["t", "Switzerland"]` could be used to add `Switzerland` to the list of countries. However, the _preferred_ practice will be to rely upon formal declaration of the list header.
+
+The list item event `should` have at least one item tag, which is a `p`, `e`, `t`, or `a` tag (others), as indicated by `required` by the parent list declaration.
+
+Optional tags: `name`, `title`, `slug`, `description`, `comments`. Each of these tags is followed by a single string element, as in the examples below.
+
+A single kind `9999` or `39999` event can be used to declare multiple items for a single list (e.g. one z tag and multiple item tags), or a single item that belongs to multiple lists (multiple z tags and a single item tag), or multiple items that all belong to multiple lists (multiple z tags and multiple item tags). However, it is recommended to use a distinct event for each individual item (one z tag, one item tag).
+
+If an item belongs to multiple lists, either multiple list item declaration events can be employed, or there can be a single list item declaration event with multiple `z` tags, one for each list to which it belongs.
+
+The `p`, `e`, `t`, and `a` tags are used in list item declarations when declaring a pubkey, event id, string, or naddr as an item on a list. The parent list declaration event `should` specify which of these tags are expected to be present in their children using the `required`, `allowed`, `recommended` and/or `disallowed` tags.
+
+## Expressions of approval & disapproval of individual list items
+
+Various methods exist for community members to express their approval or disapproval of individual list items. Existing methods include commonly used NIPs such as NIP-25: Reactions, zaps, NIP-56: Reports, etc. This NIP will therefore not introduce any new formalism for this purpose. It is up to personalized trust metric interpreters to decide what these data points mean and how to use them.
+
+As a starting point, it is `recommended` that endorsements or objections to individual list items be handled with existing NIP-25: Reactions. Using this method, endorsement of a list item is a kind 7 event with an `e` tag pointing to the list item declaration and "+" in the content field. Objection is the same but with "-" in the content field.
+
+## Examples
+
+### Example 1: a list of nostr developers
+
+List creation:
+
+```json
+{
+  "kind": 9998,
+  "tags": [
+    ["names", "nostr developer", "nostr developers"],
+    ["description", "This is a list of developers who build within the nostr ecosystem"],
+    ["required", "p"],
+    ["required", "name"]
+  ],
+  "id": "<id_list_of_developers>"
+}
+```
+
+Add a pubkey as an item on the list of developers:
+
+```json
+{
+  "kind": 9999,
+  "tags": [
+    ["z", "<id_list_of_developers>"],
+    ["name", "Derek Ross"],
+    ["p", "3f770d65d3a764a9c5cb503ae123e62ec7598ad035d836e2a810f3877a745b24"]
+  ]
+}
+```
+
+### Example 2: a list of long form articles on hyperinflation:
+
+List creation:
+
+```json
+{
+  "kind": 9998,
+  "tags": [
+    ["names", "long form article on hyperinflation", "long form articles on hyperinflation"],
+    ["description", "This is a list of long form content events on the topic of hyperinflation."],
+    ["required", "a"],
+    ["recommended", "title"]
+  ],
+  "id": "<id_hyperinflation>"
+}
+```
+
+Add an naddr address as an item to the above list:
+
+```json
+{
+  "kind": 9999,
+  "tags": [
+    ["z", "<id_hyperinflation>"],
+    ["a", "naddr1qvzqqqr4gupzq4rqjpyzsnf2z5wgma397sxr382z8mg90l80jf7m3z2k628z9wsrqythwumn8ghj7cnfw33k76twv4ezuum0vd5kzmp0qythwumn8ghj7ct5d3shxtnwdaehgu3wd3skuep0qq3kv6tpwskkxatjwfjkucme946xsefdwd5kcetwwskhg6tdv5khg6rfv4nqnxv6fx"],
+    ["title", "Fiat Currency: The Silent Time Thief"]
+  ]
+}
+```
+
+### Example 3: a list of dog names:
+
+List creation:
+
+```json
+{
+  "kind": 9998,
+  "tags": [
+    ["names", "dog name", "dog names"],
+    ["description", "This is a list of commonly used dog names."],
+    ["required", "t"]
+  ],
+  "id": "<id_dog_names>"
+}
+```
+
+Add a piece of text as an item to the above list:
+
+```json
+{
+  "kind": 9999,
+  "tags": [
+    ["z", "<id_dog_names>"],
+    ["t", "Fido"]
+  ]
+}
+```
+
+### Example 4: A single item on multiple lists
+
+Create a list of dogs and a list of animals:
+
+```json
+{
+  "kind": 9998,
+  "tags": [
+    ["names", "dog", "dogs"],
+    ["description", "This is a list (by name) of individual dogs."],
+    ["required", "t"]
+  ],
+  "id": "<id_dogs>"
+}
+```
+
+```json
+{
+  "kind": 9998,
+  "tags": [
+    ["names", "animal", "animals"],
+    ["description", "This is a list (by name) of individual animals."],
+    ["required", "t"]
+  ],
+  "id": "<id_animals>"
+}
+```
+
+Now add Fido to both of the above lists.
+
+```json
+{
+  "kind": 9999,
+  "tags": [
+    ["z", "<id_dogs>"],
+    ["z", "<id_animals>"],
+    ["t", "Fido"]
+  ]
+}
+```
+
+It is equally valid to split the above item declaration event into two events, one for each list:
+
+```json
+{
+  "kind": 9999,
+  "tags": [
+    ["z", "<id_dogs>"],
+    ["t", "Fido"]
+  ]
+}
+```
+
+```json
+{
+  "kind": 9999,
+  "tags": [
+    ["z", "<id_animals>"],
+    ["t", "Fido"]
+  ]
+}
+```
+
+An alternate and equivalent way to add Fido to these two lists is to provide each list `name` (singular) in place of the list id. In this case, we replace `<id_dogs>` with `dog`, and `<id_animals>` with `animal`:
+
+```json
+{
+  "kind": 9999,
+  "tags": [
+    ["z", "dog"],
+    ["z", "animal"],
+    ["t", "Fido"]
+  ]
+}
+```
+
+The above can be translated: "Fido is a dog" and "Fido is an animal".
+
+However, it is encouraged to use the list id if an appropriate one is known and available.
+
+### Example 5: A list of lists
+
+Declare a list of movie lists, each one corresponding to a different genre.
+
+```json
+{
+  "kind": 9998,
+  "tags": [
+    ["names", "list of good movies in a specific movie genre", "lists of good movies in a specific movie genre"],
+    ["description", "This is a list of lists of good movies in specific movie genres. It will be used to make a composite list of good movies of any genre."],
+    ["required", "e"]
+  ],
+  "id": "<id_list_of_lists_of_movies>"
+}
+```
+
+Now add two items to the above list: a list of comedies and a list of dramas.
+
+```json
+{
+  "kind": 9999,
+  "tags": [
+    ["z", "<id_list_of_lists_of_movies>"],
+    ["e", "<id_list_of_comedies>"],
+    ["e", "<id_list_of_dramas>"]
+  ]
+}
+```
+
+### Example 6: Objection to an item on a list
+
+```json
+{
+  "kind": 7,
+  "content": "-", // or "+" to upvote
+  "tags": [
+    ["e", "<id_declaration_of_list_item>"]
+  ]
+}
+```
+
+### Example 7: Declaration of the List Header using kind 39998 Replaceable Event
+
+```json
+{
+  "kind": 39998,
+  "tags": [
+    ["d", "<d_tag_for_list_of_dogs>"],
+    ["names", "dog", "dogs"],
+    ["required", "t"]
+  ],
+  "id": "<id_for_list_of_dogs>",
+  "author": "<pubkey_for_list_of_dogs>"
+}
+```
+
+```json
+{
+  "kind": 9999,
+  "tags":[
+    ["z", "39998:<pubkey_for_list_of_dogs>:<d_tag_for_list_of_dogs>"],
+    ["t", "Fido"]
+  ]
+}
+```
+
+If the list item is also a replaceable event, it must also have a `d` tag:
+
+```json
+{
+  "kind": 39999,
+  "tags":[
+    ["z", "39998:<pubkey_for_list_of_dogs>:<d_tag_for_list_of_dogs>"],
+    ["d", "<d_tag_for_Fido>"],
+    ["t", "Fido"]
+  ]
+}
+```
+
+## Nonstandard methods to declare a list
+
+The standard method to declare a list of widgets uses a kind `(3)9998` event as the list header:
+
+```json
+{
+  "kind": 9998,
+  "tags": [
+    ["names", "widget", "widgets"],
+    ["description", "Lorem ipsum"],
+    ["required", "t"]
+  ],
+  "id": "<id_lists>"
+}
+```
+
+The nonstandard method to declare a list is to use a kind `(3)9999` event as the list header.
+
+To see how this works, suppose we declare a list of all known lists:
+
+```json
+{
+  "kind": 9998,
+  "tags": [
+    ["names", "list", "lists"],
+    ["description", "This is a list of all the lists that exist within any given datastore"],
+    ["required", "names"]
+  ],
+  "id": "<id_lists>"
+}
+```
+
+From this point forward, we can avoid kind `(3)9998` events in favor of using `<id_lists>` in a kind `(3)9999` event to declare new lists:
+
+```json
+{
+  "kind": 9999,
+  "tags": [
+    ["z", "<id_lists>"],
+    ["names", "dog", "dogs"],
+    ["description", "This is a list (by name) of individual dogs."],
+    ["required", "t"]
+  ],
+  "id": "<id_dogs>"
+}
+```
+
+Alternatively, we can eschew kind `9998` and `39998` events altogether by replacing `["z", "<id_lists>"]` with `["z", "list"]`, as follows:
+
+
+```json
+{
+  "kind": 9999,
+  "tags": [
+    ["z", "list"],
+    ["names", "dog", "dogs"],
+    ["description", "This is a list (by name) of individual dogs."],
+    ["required", "t"]
+  ],
+  "id": "<id_dogs>"
+}
+```
+
+There is a certain elegance in building this NIP entirely around only two event kinds: `9999` and `39999`. However, it is more in line with standard nostr practice to separate list headers from list items by kind. We suggest using `(3)9998` for list header declaration and then experiment with phasing kind `(3)9998` events out entirely if this proves to be a feasible course of action.
+
+## Retrieval of list headers and list items
+
+Retrieval of all canonically-formed lists:
+
+```json
+{
+  "kinds": [9998, 39998]
+}
+```
+
+Retrieval of all lists formed using the nonstandard method:
+
+```json
+{
+  "kinds": [9999, 39999],
+  "#z": ["list", "<id1_lists>", "<id2_lists>", "<id3_lists>", ... ]
+}
+```
+
+Retrieval of all items on the list of dogs:
+
+```json
+{
+  "since": 0,
+  "kinds": [9999, 39999],
+  "#z": ["dog", "<id1_dogs>", "<id2_dogs>",  "<id3_dogs>", ...]
+}
+```
+
+Note that we are searching for multiple `#z` tags to address the possibility of list redundancy, with multiple redundant list declarations used by different communities.
+
+## List curation and spam prevention
+
+List curation refers to questions like the following:
+- Which items should be accepted to a given list?
+- Which items should be excluded from a given list?
+- How can accepted list items be stratified?
+
+A wide variety of methods of varying degrees of sophistication can be imagined. For example, a _personalized trust metric_ could be used to exclude items based on the personalized trust metric of the item contributor. For simplicity, this NIP presumes these methods to be specified elsewhere.


### PR DESCRIPTION
## Summary

Story 2 of the protocols-directory epic: produces the single authoritative, publication-ready working copy of the Decentralized Lists base NIP and its Cross-NIP Compatibility companion under `protocols/`, reconciled from the newer draft on `feat/communities`. The base NIP drops the superseded, unfinished embedded Backwards-Compat section (spun off into the complete companion), keeps the three-element description convention and companion cross-ref, and carries a repo-metadata header stating the exact delta vs. the published NostrHub version (2026-02-26). Ends at "ready to republish" — the republication itself is the author's act.

## Changes

- `protocols/nips/decentralized-lists.md` — reconciled base NIP + metadata header (status 🚀 published (update pending), naddr, last-published, republish delta)
- `protocols/drafts/decentralized-lists-compat.md` — faithful companion copy + header (🧪 pre-NIP, publish-ready)
- `protocols/README.md` — two index rows flipped to working-copy-here
- `engineering-team/stories|reviews/protocols-directory/` — story 2 (Done) + review (PASS, zero findings)

## Test plan

- [x] Machine-diff fidelity audit: base body differs from branch source by exactly 5 flagged mechanical lines; companion by exactly 1 (link retarget)
- [x] 4-dimension independent audit (fidelity, ACs, metadata incl. naddr decode, spec semantics) — zero findings
- [x] `npm test` green; BIBLE.md byte-identical; `feat/communities` untouched
- [ ] After merge: deploy-staging.yml runs.
- [ ] Smoke test on staging.brainstorm.world (Tiers 1/2/5; 3/4 N/A docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)