### PR TITLE
Promote staging → main: communities pre-NIP (story 6)

### DIFF
--- a/docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md
+++ b/docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md
@@ -1,6 +1,6 @@
 # Communities Protocol — Design Handoff
 
-**Status:** 🔴 OPEN — protocol *design* settled (foundations + identity + membership); the remaining open item is **delivery: three-branch reconciliation** (§7), an org decision for the user + Avi + Vinney. **Not yet in the BIBLE.**
+**Status:** 🔴 OPEN — protocol *design* (§1–§6) **ratified into [`protocols/drafts/communities.md`](../protocols/drafts/communities.md)** (protocols-directory story 6, ADR 0004; Resolved Definition extracted earlier via story 5). The remaining open item is **delivery: three-branch reconciliation** (§7), an org decision for the user + Avi + Vinney.
 
 **Created:** 2026-06-05, from a `/discuss` (Product Expert) scoping session.
 **Builds on:** story #31 / ADR 0027 / BIBLE §25 — the `b` / inherit-from tag.

--- a/engineering-team/decisions/protocols-directory/0004-communities-spec.md
+++ b/engineering-team/decisions/protocols-directory/0004-communities-spec.md
@@ -1,0 +1,116 @@
+# ADR 0004 (protocols-directory): Communities pre-NIP — source reconciliation, scope, skeleton
+
+**Status:** Accepted
+**Date:** 2026-06-10
+**Story:** `engineering-team/stories/protocols-directory/6-communities-spec.md`
+
+> Full ADR (not thin): the epic's first synthesis. Inherits ADR 0001's macro pattern (pointer-first discipline, source map, gates) but its substance is the four-family source reconciliation below.
+
+## Context
+
+Story 6 produces `protocols/drafts/communities.md` from four source families of different dates and authority. Orientation established the chronology that drives every decision here:
+
+1. **May 2026** — `feat/communities` branch specs: `COMMUNITY_RECORDS_DLIST.md` (personal records with engine config: `seed`/`weighting_model`/`endorsement_threshold`; `template-source` lineage; NIP-72 wrapping) and `COMMUNITY_ENDORSEMENTS_DLIST.md` (global endorse/veto DList with deterministic d-tags). **Pre-redesign.**
+2. **2026-06-05** — `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` (the capture doc; story-designated **design authority**): no-privileged-center tenet; community = concept; identity = concept identity; **membership = consume the nostr-user-tag**; two-axis sameness; population/ruleset safety split; first-listed-wins ratified. Explicitly supersedes founder-centric framing.
+3. **2026-06-05 → 06-08** — branch ADRs 0029–0040, **post-redesign**: the branch's own response. Classified by a 3-agent sweep (full results in the workflow transcript; verdicts below).
+4. **BIBLE §22** — the community-*reference* machinery: resolution precedence (`grapevine-resolved → firmware-blessed → none`, explicitly *unratified* — Flaw A accepted temporarily), export invariants, Phase A/B record.
+
+### The 12-ADR classification (wire-format inventory)
+
+| ADR | Verdict | Wire content (if any) |
+|---|---|---|
+| 0029 declaration shape | **wire** | CD = kind-39998 concept header: `d`=slug (per-founder), `name`/`description`/`belonging`/`founder`/`topic` tags, type-marker `z`-ref to the `brainstorm-community` concept, forward-compatible `b`-forking; strangler coexistence with the frozen bespoke 39999 records |
+| 0030 membership-from-tags | **mixed** | CD `claims` = list of tag-element a-coords (`39999:<tagAuthor>:<slug>`); assertion shape **a-primary** (`a`=element identity, `e`=provenance only — corrected 2026-06-05); v1 roster gate: `applications ≥ cutoff AND applications > disputes` (count-based) |
+| 0031 roster topology | impl | — |
+| 0032 degraded posting | impl | — |
+| 0033 reply threading | **wire** | kind-1111 (NIP-22): top-level `["a", communityATag]`; replies add `e`(parent)+`k`+`p`, inherit uppercase `A` |
+| 0034 reactions | **wire** | kind-7 (NIP-25) scoped by `A`/`e`/`p`/`k`; `+`/`-` with **latest-per-reactor** aggregation (wire-binding rule) |
+| 0035 live updates | impl | — |
+| 0036 signs of life | impl | — |
+| 0037 notification prefs | impl | — |
+| 0038 notification inbox | **wire (sourcing only)** | derives from existing shapes (vouches `#p`+polarity, replies `e`, posts `#A`); defines no new shapes |
+| 0039 foothold invite | **wire** | kind-39999 invite: `["a",communityATag]`, `["d","invite-<code>"]`, `["p",issuer]`, `z`→`foothold-invite` |
+| 0040 accept foothold | **mixed** | kind-39999 redemption (`"redeem-<code>"`, `z`→`foothold-redemption`) + standard self-tag/vouch assertions per 0030 |
+
+The story's presumption (0031/0032/0037/0038 implementation-side) confirmed, with one correction: 0038's *sourcing rules* reuse wire shapes but define none — implementation-side for the spec.
+
+### Disagreement findings (story rule: surfaced, capture doc authoritative)
+
+- **D1 — Endorsements DList superseded for membership.** The May endorsements layer (endorse/veto items, engine-config-driven aggregation) and the June design (membership = nostr-user-tag, disputes = `polarity:-1`, trust-weighted) solve the same problem incompatibly. Capture doc *and* the branch's own latest (0030) both take the tags route. **Verdict: superseded.** Not ratified into the spec; recorded here and in the spec's header sources line.
+- **D2 — Records layer reframed by strangler coexistence.** The May records spec survives, but as the **deployed coexistence layer** (0029's "frozen bespoke" records), not the go-forward declaration. The CD (kind-39998, 0029) is the declaration wire format. Spec presents both, framed exactly so.
+- **D3 — `founder` field vs the founding tenet.** Capture §1 bans privileged-center *default fields*; 0029 (post-redesign) still carries `founder`. Resolution: the field survives as **informational-only** with normative teeth — "MUST NOT confer any algorithmic privilege" (the records spec's own "no algorithmic privilege" language, promoted to a requirement) — and the tension is flagged in the source map.
+- **D4 — nostr-user-tag shape drift (binding on story 7).** Three variants exist: tags-branch ADR 0001 (`e`-primary), capture doc (`['e', concept]`), communities 0030 (**`a`-primary, `e`-provenance** — the 2026-06-05 correction, load-bearing for communities' `#a` roster reads). This spec's membership section describes the assertion via the story-7 pending marker *and notes the a-primary correction*; **story 7 must reconcile the variants, with 0030's correction as the latest word.**
+- **D5 — Roster rule: deployed vs designed.** 0030's v1 gate is count-based (`applications ≥ cutoff AND applications > disputes`, house PoV); the capture doc's design is GrapeRank-weighted net-assert-vs-dispute per PoV. Both are real (one shipped, one ratified-in-design). The spec states the v1 rule as deployed wire-binding aggregation, states the designed direction, and marks the reconciliation **open** → new worksheet entry.
+
+## Options considered (the §22 scoping question — the story's central call)
+
+### Option A — Spec references §22's resolution model; BIBLE untouched (chosen)
+
+The only §22 content the spec needs is the resolution-precedence *concept* for identity selection — which §22 itself marks unratified (Flaw A "accepted temporarily"; registry "not ratified here"). A pre-NIP must not ratify what its source declines to. The spec's identity section therefore states identity = concept identity, cites the precedence direction non-normatively, and points the canonical-selection question at worksheet W1 (which owns it). **Zero BIBLE edits this story.**
+
+### Option B — Extract a "resolution kernel" from §22, pointer-first rewrite
+
+Rejected: creates a normative home for an explicitly-unratified mechanism, and §22's remaining body (export invariants, Phase A/B) is implementation record that would survive anyway — the rewrite would be ceremony without separation.
+
+### Option C — Fold all of §22 into the spec
+
+Rejected outright: §22 is dominated by Tapestry implementation (firmware passes, materialization invariants, smoke-gate lessons).
+
+## Decision
+
+**Option A**, plus the scope list, skeleton, and treatments below.
+
+### Spec scope (what the inventory marks settled)
+
+The founding tenet (normative principle); community-as-concept and identity-as-concept-identity (incl. powerless referent, bootstrap, two-axis sameness with non-transitivity, population/ruleset split); the CD shape (0029, with D3's informational-founder requirement); membership (claims a-coords; assertion consumption with the story-7 pending marker + D4 note; self-tag vs vouch = `pubkey == p`; disputes; the v1 roster rule as deployed + designed direction marked open per D5; roles as predicates, admin OFF v1); the personal-records coexistence layer (index header, record shape, `template-source` snapshot lineage, NIP-72 `a`-wrapping); posts/threading (0033's kind-1111 layout); reactions (0034's latest-per-reactor rule); foothold invitations (0039/0040 shapes). Security considerations: the live-`b` retroactive-lever caveat with distance-weighted-overlap mitigation and the population/ruleset split as a safety property (capture §3), cross-referencing the inherit-from spec's trust-coupling.
+
+### Skeleton (fixed, 11 headings)
+
+```
+(header: 📝 pre-NIP · in-flight note: feat/communities + feat/pubkey-tagging-target unmerged,
+ three-branch reconciliation OPEN (capture doc §7) · sources: the four families, with
+ COMMUNITY_ENDORSEMENTS_DLIST.md marked superseded-for-membership per this ADR)
+---
+Communities
+=====
+## Founding tenet: no privileged center
+## Relationship to other specs
+## A community is a concept
+## The Community Declaration
+## Sameness: two axes
+## Membership
+## Personal community records (coexistence layer)
+## Posts, threading, and reactions
+## Foothold invitations
+## Security considerations
+## Open questions
+```
+
+"Open questions" is a first-class spec section this time (the story demands open things stay visibly open): three-branch reconciliation (org decision, capture §7); engine-config carriage (D2 residue: where `seed`/`weighting_model`/`threshold` live post-redesign — records? CD? resolved definition?); roster-rule reconciliation (D5); canonical concept identity (→ W1).
+
+### Other treatments
+
+- **Capture doc status line:** updated to "🔴 OPEN — design (§1–§6) ratified into `protocols/drafts/communities.md` (protocols-directory story 6); remaining open item: §7 three-branch reconciliation." Nothing else in that doc changes (its audience is Avi + Vinney).
+- **Worksheet:** two new entries — **W8 engine-config carriage** (D2 residue) and **W9 roster-rule reconciliation** (D5: count-based v1 vs WoT-weighted design; plus capture §5's threshold mechanics) — plus the proactive sweep (W1's §22 refs survive untouched since BIBLE is untouched).
+- **README row 6:** working copy here; source column notes the endorsements spec's supersession.
+- **Story-7 pending marker form:** "specified by the Tags & Taggings pre-NIP (story 7, pending; until then the latest wire word is `feat/communities` ADR 0030's a-primary correction)".
+- **Spec title:** "Communities" (deployment-neutral); "Brainstorm Communities" appears once as the reference deployment's name.
+
+## Consequences
+
+- The settled Communities design gains a single readable home; the genuinely open items become *visible* spec text instead of tribal knowledge.
+- Story 7 inherits a binding instruction (D4) — reconcile the assertion-shape variants with 0030's correction as the latest word.
+- The endorsements layer's supersession is now written down; if Avi's branch still builds on it, the spec surfaces that conversation rather than hiding it.
+- **Firmware reinstall required?** No.
+
+## Implementation notes
+
+- Files: `protocols/drafts/communities.md` (new, per skeleton); `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` (status line only); `protocols/worksheet.md` (+W8, +W9, sweep); `protocols/README.md` (row 6). **BIBLE.md: untouched.**
+- Source map required: spec section → capture-doc §, branch-spec section, or branch ADR (by number), with **D1–D5 each flagged where they shaped prose**.
+- Gates: `npm test`; diff scope = the four files; zero BIBLE diff; dual-normativity sweep (CD shape, roster rule, foothold shapes appear only in the spec); link/anchor checks incl. the two new worksheet anchors.
+
+## Out of scope
+
+- Deciding §7 (three-branch reconciliation), W1, W8, W9.
+- Story 7 (beyond the pending marker + D4 instruction).
+- Any code, branch, or firmware change; publishing.

--- a/engineering-team/reviews/protocols-directory/6-communities-spec.md
+++ b/engineering-team/reviews/protocols-directory/6-communities-spec.md
@@ -1,0 +1,68 @@
+# Review: Story 6 — Communities pre-NIP (synthesis)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-10
+**Diff:** commit `383ebd6e` (4 files, +131/−2: `protocols/drafts/communities.md` new; `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` status line only; `protocols/worksheet.md` +W8/+W9; `protocols/README.md` row 6)
+**Contract:** `protocols-directory` ADR 0004 (full — four-family reconciliation, findings D1–D5, 11-heading skeleton, Option A: BIBLE untouched); story ACs; synthesis traceability rule
+**Method note:** implementation authored in this same session; audit fanned out to 10 independent agents across five dimensions (ADR conformance, boundary, traceability against all four source families via `git show`, references/anchors, term-coverage as first-class per the story), all non-note findings adversarially verified — zero unverified this time (the orchestration null-filter fix from story 5's incident held). Gates run directly by the Reviewer.
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **PASS** (full suite)
+- [x] Playwright — skipped: docs-only
+- [x] Diff scope — exactly the ADR's four files; **BIBLE absent from the commit** (Option A verified); capture-doc change is exactly one replaced line
+- [x] _Lint/typecheck/build not configured — skipped._
+
+## ADR adherence
+
+- [x] Skeleton: exactly the 11 fixed headings; "Open questions" first-class with the ADR's items (a fifth, CD field encodings, added — judged in-scope: it is the spec's own honest-gap marker, noted, accepted).
+- [x] D-resolutions applied in substance: D1 (endorsements omitted from body; supersession in header sources + README row), D2 (coexistence framing), D3 (founder MUST-NOT requirement), D4 (a-primary assertion + story-7 marker), D5 (both roster rules; reconciliation → W9).
+- [x] **AC1/endorsements judgment (explicit):** the story's coverage minimum names the endorsement layer but is qualified by "the wire formats the ADR's inventory marks settled"; ADR D1 marks it superseded. The omission is **contract-conformant**.
+- [x] Capture-doc treatment: status line only; §7 remains open; audience-respecting.
+- [x] W8/W9 per the ADR's definitions, with D2/D5 citations.
+
+## Boundary discipline
+
+- [x] Zero stack machinery; all `z` type-handles deployment-neutralized; "Brainstorm Communities" appears once as the reference deployment's name; generic "observer's trust" phrasing for the designed rule (no GrapeRank-as-pipeline).
+- [x] Dual-normativity: capture doc's full design prose coexists as a *design record* (ADR-like role, now status-marked as ratified-into-spec) — judged acceptable non-normative coexistence; BIBLE §22 verified untouched and non-contradicting.
+
+## Traceability (synthesis rule) — the source map (durable copy, D-flags per row)
+
+| Spec section | Source | D-flag |
+|---|---|---|
+| Founding tenet | capture doc §1, near-verbatim | — |
+| Relationship to other specs | connective + pending marker | **D4** |
+| A community is a concept | capture §3 (identity, bootstrap, safety property) + W1 | — |
+| The Community Declaration | branch ADR 0029 (fields) + 0030 (`claims`); encodings marked "not yet formalized" (0029 verified to contain no literal tag arrays) | **D2** (CD as go-forward), **D3** (founder MUST-NOT) |
+| Sameness: two axes | capture §3 (incl. overlap-coefficient example and non-transitivity — verified sourced) | — |
+| Membership | assertion block verified **exact** vs 0030:50–54 modulo neutralized `z`; claims semantics per 0030; both roster rules faithful (count-based gate verbatim; weighted formula faithful) | **D4**, **D5** |
+| Personal records (coexistence) | records spec (index, fields, `template-source` snapshot rationale, NIP-72 wrap) framed per 0029 | **D2**; engine config → W8 |
+| Posts/threading/reactions | 0033 layout; 0034 latest-per-reactor (verified) | — |
+| Foothold invitations | 0039/0040 shapes, neutralized handles | — |
+| Security considerations | capture §3 (live-`b` lever, distance-weighting, population/ruleset) — verified sourced | **D5** stake (no-veto asymmetry) |
+| Open questions | §7 / W8 / W9 / W1 / encoding gaps — all sourced as open | **D1** recorded in header sources line, not body |
+
+Audit verdict: all normative claims traced; no silent resolution of disagreements; no inventions.
+
+## Findings
+
+Audit: 5 non-note findings raised → 4 confirmed (all minor), 1 refuted, 0 unverified; 2 notes.
+
+### Resolved by this report (no spec change)
+
+1. **Source-map artifact + D-flags** (adr-conformance) — ADR 0004 requires a source map with D1–D5 flagged where they shaped prose; the implementation delivered it in the (ephemeral) gate report, and inline D-codes in a publishable spec would violate the spec's own boundary discipline. Resolution: the source map with per-row D-flags is embedded **above, in this review** — the durable artifact. ADR requirement satisfied; no kickback.
+
+### Blocking (consolidated — one kickback, one file)
+
+2. **Pending-marker wording drift** (communities.md:63) — the Membership section's marker ("wire format owned by…") deviates from the ADR's fixed form used at first instance. Asked change: align to the prescribed form.
+3. **`tag-element` / `a-coordinate` undefined at first use** (:48, :76) — one sourced sentence: a *tag-element* is the kind-39999 tag event itself, addressed by its a-tag form (`39999:<author>:<slug>` — addressing per Tapestry Concepts); "a-coordinate" = that address.
+4. **`influence cutoff` undefined** (:76) — one sourced, deployment-neutral sentence: the minimum trust an asserter must have, from the evaluating observer's point of view, for their assertions to count; preset values are deployment policy (carriage already tracked in W8).
+
+### Non-blocking
+
+1. Posts/replies "both carry the community `a` scope" explicitness — refuted (the quoted layouts state it: top-level `a`, replies inherit uppercase `A`).
+2. The fifth open question (CD encodings) beyond the ADR's four — accepted, see ADR adherence.
+
+## Verdict
+
+**CHANGES_REQUESTED** — solely for the three one-line definitional/consistency fixes above (items 2–4; one file, additive; same species as stories 3 and 5, now caught by the dedicated term-coverage dimension as intended). Everything structural passed on first audit: skeleton, all five D-resolutions in substance, exact assertion-shape fidelity, boundary spotless, zero BIBLE diff, references clean. Converts to PASS on the fix with a targeted re-check.

--- a/engineering-team/reviews/protocols-directory/6-communities-spec.md
+++ b/engineering-team/reviews/protocols-directory/6-communities-spec.md
@@ -65,4 +65,16 @@ Audit: 5 non-note findings raised → 4 confirmed (all minor), 1 refuted, 0 unve
 
 ## Verdict
 
-**CHANGES_REQUESTED** — solely for the three one-line definitional/consistency fixes above (items 2–4; one file, additive; same species as stories 3 and 5, now caught by the dedicated term-coverage dimension as intended). Everything structural passed on first audit: skeleton, all five D-resolutions in substance, exact assertion-shape fidelity, boundary spotless, zero BIBLE diff, references clean. Converts to PASS on the fix with a targeted re-check.
+~~**CHANGES_REQUESTED**~~ → **PASS** (see re-review below)
+
+Initial verdict CHANGES_REQUESTED — solely for the three one-line fixes (items 2–4). Everything structural passed on first audit: skeleton, all five D-resolutions in substance, exact assertion-shape fidelity, boundary spotless, zero BIBLE diff, references clean.
+
+## Re-review (2026-06-10, commit `cee2ed54`)
+
+Targeted re-check of the three passages (+4/−2 lines, one file):
+
+2. Pending marker at Membership intro now matches the ADR's fixed form ("specified by the Tags & Taggings pre-NIP (story 7, pending; until then the latest wire word is…)"). Fixed as asked.
+3. *tag-element* / *a-coordinate* defined in one sourced sentence directly under the assertion block, grounding both in Tapestry Concepts addressing. Fixed as asked.
+4. *influence cutoff* defined inline at its first roster use, deployment-neutral, with preset values left as deployment policy (W8 carriage untouched). Fixed as asked.
+
+`npm test` re-run green. The review converts to **PASS**.

--- a/engineering-team/stories/protocols-directory/6-communities-spec.md
+++ b/engineering-team/stories/protocols-directory/6-communities-spec.md
@@ -1,0 +1,58 @@
+# Story 6: Communities pre-NIP (synthesis)
+
+**Status:** Approved
+**Created:** 2026-06-10
+**Type:** Doc
+**Epic:** protocols-directory — realizes `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` (§4 spec #6, §8 story 6)
+
+## Background
+
+This is the epic's first **synthesis** story: the Communities wire format has no single home to extract from. Four source families exist, of different authority and freshness:
+
+1. **`docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md`** (🔴 OPEN, 2026-06-05) — the Communities Protocol capture doc. Its design is **settled** (§1–§6: no-privileged-center tenet, Resolved Definition as foundation, identity = concept identity, membership = consume the pubkey-tag); its one open item is **§7 delivery: the three-branch reconciliation**, an org decision for the project owner + Avi + Vinney. This is the design authority. Notably, it already declared its general piece (Resolved Definition) ready to extract — which story 5 has since done.
+2. **`feat/communities` branch specs** (read via `git show`, never merged): `COMMUNITY_RECORDS_DLIST.md` (the personal community-record layer — per-user `brainstorm-communities` index, record items with engine config) and `COMMUNITY_ENDORSEMENTS_DLIST.md` (the global signal layer — endorsement/veto items). Mature wire-format documents, already written against the reconciled DList base NIP conventions.
+3. **The branch's communities ADR line** (12 ADRs: declaration shape 0029, membership-from-tags 0030, roster topology 0031, degraded posting 0032, threading/reactions/live-updates/signs-of-life 0033–0036, notifications 0037–0038, foothold invite/accept 0039–0040).
+4. **BIBLE §22** (Community-Reference Model) — the resolution model (`grapevine-resolved → firmware-blessed → none`), Flaw A and its registry exit, and the Phase A/B implementation record.
+
+The synthesis must produce one spec ratifying the settled design without deciding what is genuinely undecided, and without absorbing implementation material that belongs in the BIBLE or the branch.
+
+## User-facing description
+
+As the protocol's designers (and any implementer of a Brainstorm-Communities-compatible client or mirror), I want the settled Communities wire format in one self-contained pre-NIP — the personal-projection model, the record and endorsement event shapes, the membership signal, and the resolution model — so that the design that today lives across an OPEN handoff doc, an unmerged branch, and a BIBLE section can be read, evolved, and eventually published as one document, while the genuinely open questions stay visibly open.
+
+## Acceptance criteria
+
+- [ ] Given a fresh clone of `staging`, when a reader opens `protocols/drafts/communities.md`, then it is a self-contained pre-NIP with a repo-metadata header (status 📝 pre-NIP; the **in-flight-feature note** per `protocols/README.md` — the feature lives on `feat/communities`, unmerged; sources: the four families above) covering, at minimum, the wire formats and models the ADR's inventory marks **settled**: the personal-projection model (records are personal; the community is the convergent overlap), the community-record layer (index header + record item shapes), the global endorsement layer (header addressing forms + endorsement/veto item shape), the membership model (consuming the pubkey-tagging signal), the declaration/affiliation usage of the `b` tag, and the resolution model kernel.
+- [ ] Given the spec, when it touches anything the sources leave genuinely open, then it marks it openly rather than deciding it — **explicitly including** the three-branch reconciliation (capture doc §7, an org decision this story must not make) and the cross-deployment canonical-pubkey question (→ worksheet W1, which the endorsements spec's "well-known pubkey" addressing touches directly).
+- [ ] Given that membership consumes the pubkey-tagging wire format (story 7's territory, tags branch unmerged), when the spec references it, then it uses the established pending-migration pattern: point at the signal's current best source with an explicit "specified by the Tags & Taggings pre-NIP (story 7, pending)" marker, to be repointed by story 7.
+- [ ] Given the spec, when read by a stranger with the prior five specs, then it contains no stack machinery (no Neo4j/endpoints/UI/firmware-install mechanics/GrapeRank pipeline internals; deployment-relative pubkeys handled neutrally per W1 precedent) — and every load-bearing term is defined in the spec or its prerequisite chain (**term-coverage is a first-class review dimension this time**, per the lesson of stories 3 and 5).
+- [ ] Given BIBLE §22 after the change, then its treatment follows the ADR's explicit decision (the central scoping question: §22's community-*reference* machinery overlaps but is not identical to the Communities feature; whatever kernel the spec absorbs becomes pointer-first in §22, whatever stays stays — no dual normativity either way), with §22's number/title/anchor unchanged.
+- [ ] Given `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` after the change, then its status line reflects reality: the design portion (§1–§6) ratified into the spec, §7 (reconciliation) still open — without closing or rewriting a document whose audience includes Avi and Vinney beyond that status-line truth.
+- [ ] Given `protocols/worksheet.md` after the proactive sweep, then no entry claims content that moved, and any new open questions the synthesis surfaces (candidates: the endorsements list's canonical-pubkey addressing vs W1; convergence parameters) are recorded as worksheet entries rather than silently dropped.
+- [ ] Given `protocols/README.md`, then the Communities row links the working copy (story 6 ✅) and the branch files are no longer named as the content's location.
+- [ ] Given the full change, when `npm test` runs, then it passes unchanged; and no BIBLE section other than §22 is modified.
+
+**Traceability rule (extended for synthesis):** every normative statement traces to one of the four source families, with the capture doc authoritative where sources disagree (it is the latest, reconciliation-aware design); disagreements between sources are themselves findings — surfaced in the source map, not silently resolved. Honest gaps marked explicitly.
+
+## Concepts touched
+
+None in the concept-graph sense (no events published, no firmware change, no reinstall). The spec *describes* community records, endorsements, and membership signals riding on kinds already specified upstream.
+
+## Out of scope
+
+- Deciding the three-branch reconciliation (capture doc §7) or anything else the sources leave open.
+- Story 7 (Tags & Taggings) — except the pending-marker cross-reference.
+- Resolving W1; changing any code or branch content; publishing.
+- The notification/inbox ADRs (0037–0038) and roster-read/degraded-posting ADRs (0031–0032) are *presumed* implementation-side — the ADR's inventory confirms or corrects this presumption.
+
+## Open questions
+
+- **Architecture phase?** **Runs full, not thin** — the wire-format inventory across four source families (which of the 12 branch ADRs carry wire format vs implementation; what §22 contributes; where the sources disagree) is precisely an Architect's reconciliation job, and fixing it before prose is what makes the synthesis reviewable.
+- Spec title: "Communities" per the handoff (the branch specs say "Brainstorm Communities") — the ADR proposes; review confirms.
+
+## Linked artifacts
+
+- Design record: `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` §4/§8; design authority: `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` (§1–§6 settled); pattern: `protocols-directory` ADRs 0001–0003
+- ADR: (pending — full run)
+- Test plan: skipped (docs-mode)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/protocols-directory/6-communities-spec.md
+++ b/engineering-team/stories/protocols-directory/6-communities-spec.md
@@ -53,6 +53,6 @@ None in the concept-graph sense (no events published, no firmware change, no rei
 ## Linked artifacts
 
 - Design record: `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` §4/§8; design authority: `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` (§1–§6 settled); pattern: `protocols-directory` ADRs 0001–0003
-- ADR: (pending — full run)
+- ADR: `engineering-team/decisions/protocols-directory/0004-communities-spec.md` (`protocols-directory` ADR 0004, full) — Accepted; disagreement findings D1–D5
 - Test plan: skipped (docs-mode)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/protocols-directory/6-communities-spec.md
+++ b/engineering-team/stories/protocols-directory/6-communities-spec.md
@@ -55,4 +55,4 @@ None in the concept-graph sense (no events published, no firmware change, no rei
 - Design record: `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` §4/§8; design authority: `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` (§1–§6 settled); pattern: `protocols-directory` ADRs 0001–0003
 - ADR: `engineering-team/decisions/protocols-directory/0004-communities-spec.md` (`protocols-directory` ADR 0004, full) — Accepted; disagreement findings D1–D5
 - Test plan: skipped (docs-mode)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/protocols-directory/6-communities-spec.md` — CHANGES_REQUESTED (three one-line definitional/consistency fixes), converts to PASS on fix

--- a/engineering-team/stories/protocols-directory/6-communities-spec.md
+++ b/engineering-team/stories/protocols-directory/6-communities-spec.md
@@ -1,6 +1,6 @@
 # Story 6: Communities pre-NIP (synthesis)
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-10
 **Type:** Doc
 **Epic:** protocols-directory — realizes `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` (§4 spec #6, §8 story 6)
@@ -55,4 +55,4 @@ None in the concept-graph sense (no events published, no firmware change, no rei
 - Design record: `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` §4/§8; design authority: `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` (§1–§6 settled); pattern: `protocols-directory` ADRs 0001–0003
 - ADR: `engineering-team/decisions/protocols-directory/0004-communities-spec.md` (`protocols-directory` ADR 0004, full) — Accepted; disagreement findings D1–D5
 - Test plan: skipped (docs-mode)
-- Review: `engineering-team/reviews/protocols-directory/6-communities-spec.md` — CHANGES_REQUESTED (three one-line definitional/consistency fixes), converts to PASS on fix
+- Review: `engineering-team/reviews/protocols-directory/6-communities-spec.md` — PASS (after three one-line fixes in `cee2ed54`)

--- a/protocols/README.md
+++ b/protocols/README.md
@@ -52,7 +52,7 @@ Migration is in progress — specs land here story by story (see the [design han
 | Tapestry Concepts (DList extensions) | [drafts/tapestry-concepts.md](./drafts/tapestry-concepts.md) | 📝 pre-NIP | **Working copy here** (BIBLE §5/§8/§9 hold implementation detail + pointers) | story 3 ✅ |
 | Class-Thread Membership Tags (`n`, `s`) | [drafts/class-thread-tags.md](./drafts/class-thread-tags.md) | 📝 pre-NIP | **Working copy here** (BIBLE §23 holds implementation + pointer) | story 4 ✅ |
 | Inherit-From & Resolved Definition (`b`) | [drafts/inherit-from.md](./drafts/inherit-from.md) | 📝 pre-NIP | **Working copy here** (BIBLE §25/§26 hold implementation + pointers) | story 5 ✅ |
-| Communities | `drafts/communities.md` | 📝 pre-NIP | [BIBLE §22](../BIBLE.md#22-community-reference-model), `feat/communities:COMMUNITY_RECORDS_DLIST.md`, `feat/communities:COMMUNITY_ENDORSEMENTS_DLIST.md`, communities ADR line | story 6 — pending |
+| Communities | [drafts/communities.md](./drafts/communities.md) | 📝 pre-NIP | **Working copy here** (in-flight feature; BIBLE §22 untouched — see ADR 0004; `COMMUNITY_ENDORSEMENTS_DLIST.md` superseded for membership per ADR 0004 D1) | story 6 ✅ |
 | Tags & Taggings | `drafts/tags.md` | 📝 pre-NIP | `feat/pubkey-tagging-target` branch: ADRs 0001 (profile-tag architecture), 0009 (pin-a-tag); firmware concepts `tag` / `nostr-user-tag` / `tag-pinning` | story 7 — pending |
 
 Branch-path notation: `branch:path` means the file exists at that path on the named (unmerged) branch — read it with `git show <branch>:<path>`. Migration **copies** content from those branches; it never implies merging them.

--- a/protocols/drafts/communities.md
+++ b/protocols/drafts/communities.md
@@ -60,7 +60,7 @@ Overlap alone means "talking about the same thing"; membership alone means "each
 
 ## Membership
 
-Membership is **the pubkey-tagging primitive, consumed** — not a community-specific schema. A membership assertion is a kind 39999 event (wire format owned by the Tags & Taggings pre-NIP, story 7 pending; shape per `feat/communities` ADR 0030's a-primary correction):
+Membership is **the pubkey-tagging primitive, consumed** — not a community-specific schema. A membership assertion is a kind 39999 event — specified by the Tags & Taggings pre-NIP (story 7, pending; until then the latest wire word is `feat/communities` ADR 0030's a-primary correction):
 
 ```
 ["p", "<targetPubkey>"]                    the person being tagged
@@ -70,10 +70,12 @@ Membership is **the pubkey-tagging primitive, consumed** — not a community-spe
 ["polarity", "1" | "-1"]                   apply / dispute
 ```
 
+A *tag-element* is the kind-39999 tag event itself, addressed by its a-tag form (`39999:<author>:<slug>` — addressing per [Tapestry Concepts](./tapestry-concepts.md)); its *a-coordinate* is that address.
+
 - **The community claims the tag, not the reverse.** A CD's `claims` field lists the tag-element a-coordinates (`39999:<tagAuthor>:<slug>`) that count as its membership signal. Many-to-many: one community may claim several tag-elements; one tag-element may feed several communities. The tag itself stays general — no community pointer is baked into it. A newly founded community conventionally auto-claims its founder's own tag-element.
 - **Self-tag vs. vouch** = whether the assertion's author equals its `p` target. **Disputes** = `polarity: -1`.
 - **Roster (v1, as deployed):** candidates are pubkeys carrying any claimed tag-element; the gate is count-based — `applications ≥ cutoff AND applications > disputes`.
-- **Roster (as designed):** per-observer and trust-weighted — `score = Σ over asserters of (observer's trust in asserter × polarity)`, counting only asserters above an influence cutoff, then gated by the resolved definition's threshold. Disputes are weighted, not counted, so "no veto" falls out automatically.
+- **Roster (as designed):** per-observer and trust-weighted — `score = Σ over asserters of (observer's trust in asserter × polarity)`, counting only asserters above an *influence cutoff* — the minimum trust an asserter must hold, from the evaluating observer's point of view, for their assertions to count; preset values are deployment policy — then gated by the resolved definition's threshold. Disputes are weighted, not counted, so "no veto" falls out automatically.
 - *The two roster rules are **not yet reconciled** — tracked as worksheet [W9](../worksheet.md#w9--roster-rule-reconciliation).* Membership is **derived on read** in either rule, never stored.
 - **Roles are predicates over the roster**, defined in the resolved definition: *applicant* (self-tagged, below threshold), *member* (cleared threshold). Admin is **off** in v1. Authoring a CD makes you a definer, not a member — the zoologist who defines "dog" is not a dog.
 

--- a/protocols/drafts/communities.md
+++ b/protocols/drafts/communities.md
@@ -1,0 +1,113 @@
+> **Repo metadata — not part of the spec text.**
+> **Status:** 📝 pre-NIP
+> **Canonical:** not yet published
+> **In flight:** describes a feature in flight on the unmerged branches `feat/communities` (Avi) and `feat/pubkey-tagging-target` (Vinney); the three-branch reconciliation is an OPEN delivery decision — see `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` §7.
+> **Sources:** `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` §1–§6 (design authority, ratified here per protocols-directory story 6 / `protocols-directory` ADR 0004); `feat/communities` ADRs 0029/0030/0033/0034/0039/0040; `feat/communities:COMMUNITY_RECORDS_DLIST.md` (coexistence layer); `feat/communities:COMMUNITY_ENDORSEMENTS_DLIST.md` is **superseded for membership** by the 2026-06-05 redesign (ADR 0004, finding D1) and is not ratified here.
+
+---
+
+Communities
+=====
+
+This NIP defines **communities** as a thin reading of the concept graph specified by [Tapestry Concepts](./tapestry-concepts.md) and [Inherit-From & Resolved Definition](./inherit-from.md): a community is a concept, its definitions are ordinary addressable events, its members are trust-weighted elements, and nothing in the protocol holds privileged power. "Brainstorm Communities" is the reference deployment's name for this design.
+
+## Founding tenet: no privileged center
+
+Every Community Declaration is **its author's own view, resolved from their own point of view**. There is no protocol-level founder, leader, anchor, or canonical roster — and no default field for any of those, because a slot for "leader" makes centralization read as expected.
+
+- Centralization is always a **hard opt-in**, expressed in your own declaration via the `b` tag ("I defer to X"), and **revocable** (re-publish without it).
+- "Canonical" membership is **emergent, never imposed**: when many participants `b`-defer to the same declaration *and* their webs of trust overlap, their resolved rosters converge — and that convergence *is* the community. Any of them can defer out tomorrow.
+- Disagreement is **native**: participants who diverge simply keep, drop, or re-point their deference. There is no global leadership to dispute, so no dispute machinery exists.
+
+Centralization must be built by participants, never assumed by the protocol.
+
+## Relationship to other specs
+
+Communities ride entirely on primitives defined upstream: the addressable kinds and `z` conventions of [Decentralized Lists](../nips/decentralized-lists.md) and [Tapestry Concepts](./tapestry-concepts.md); definitional deference and the resolution algorithm of [Inherit-From & Resolved Definition](./inherit-from.md); and the membership signal of the pubkey-tagging wire format — **specified by the Tags & Taggings pre-NIP (story 7, pending; until then the latest wire word is `feat/communities` ADR 0030's a-primary correction, quoted under "Membership")**. This spec adds only the thin community-specific layer on top.
+
+## A community is a concept
+
+**community = concept; member = element; Community Declaration = concept-definition; `b` = definition-inheritance.**
+
+- **Identity is concept identity, inherited wholesale.** "Which *LFO* is *the* LFO" is the same question as "which `dogs` is *the* dogs." The shared referent is an ordinary community concept (kind 39998) — forkable, trust-rankable, and **powerless**, exactly like any concept. There is no privileged node above the definitions. How independent deployments select a *canonical* concept identity is the open problem tracked as worksheet [W1](../worksheet.md#w1--cross-deployment-concept-identity).
+- **Bootstrap:** a newcomer becomes comparable by pointing at the concept — tagging against it (entering the **population**) and/or `b`-deferring to a declaration in its cluster (adopting a **ruleset**). A first mover gets only a forkable naming advantage: zero protocol power.
+- **Safety property — population and ruleset stay separate.** This is load-bearing, not tidiness: a captured definition-hub can drift cutoffs and roles for its voluntary deferrers, but it **cannot retag people** — the who's-in layer does not move with a rogue rule-hub.
+
+## The Community Declaration
+
+A Community Declaration (CD) is a **kind 39998 concept event**, `d` = community slug (per-author; not deduplicated across authors), publishable and readable directly from relays. Its definition rides in its tags:
+
+| Field | Meaning |
+|---|---|
+| name | display name |
+| description / belonging | what the community is about; who belongs (free prose) |
+| topic | topical tag (repeatable) |
+| founder | **informational only** — MUST NOT confer any algorithmic privilege (see the founding tenet) |
+| type marker | a `z` reference identifying the event as a community declaration, distinguishing it from other kind-39998 headers |
+| `b` | optional deference to a parent declaration ([Inherit-From](./inherit-from.md)) — forking and convergence ride on this |
+| claims | the tag-element coordinates this community consumes as its membership signal (see "Membership"), plus the membership threshold and influence-cutoff preset; resolves through `b`-inheritance like any other definitional field |
+
+*The exact tag spelling of these fields is **not yet formalized** on the wire — the sources fix the field set and semantics but not the byte-level encoding.* A declaration needs no `b` tag: a `b`-less CD is a standalone definition (a root with zero special status); plural roots are normal, and multi-parent deference resolves per the [resolution rule](./inherit-from.md).
+
+## Sameness: two axes
+
+"Same community" is two orthogonal, per-observer, graded measures — and you need the **conjunction**:
+
+1. **Definition overlap** — graded similarity over deference closures (e.g. overlap coefficient), from `0` (unrelated) to `1` (identical).
+2. **Mutual membership** — each party actually a member (below).
+
+Overlap alone means "talking about the same thing"; membership alone means "each in *a* community." Consequence (a feature, stated plainly): overlap-based sameness is **non-transitive** — communities overlap and bleed; they do not partition people into disjoint buckets. Any gating feature must therefore gate against a *specific* declaration's resolved definition (the enforcer's own); there is no global roster.
+
+## Membership
+
+Membership is **the pubkey-tagging primitive, consumed** — not a community-specific schema. A membership assertion is a kind 39999 event (wire format owned by the Tags & Taggings pre-NIP, story 7 pending; shape per `feat/communities` ADR 0030's a-primary correction):
+
+```
+["p", "<targetPubkey>"]                    the person being tagged
+["a", "39999:<tagAuthorPubkey>:<slug>"]    the tag-element applied — stable identity (claim/scan this)
+["e", "<tagEventId>"]                      the element version at apply-time — provenance only
+["z", "<the deployment's nostr-user-tag concept address>"]   assertion type-header
+["polarity", "1" | "-1"]                   apply / dispute
+```
+
+- **The community claims the tag, not the reverse.** A CD's `claims` field lists the tag-element a-coordinates (`39999:<tagAuthor>:<slug>`) that count as its membership signal. Many-to-many: one community may claim several tag-elements; one tag-element may feed several communities. The tag itself stays general — no community pointer is baked into it. A newly founded community conventionally auto-claims its founder's own tag-element.
+- **Self-tag vs. vouch** = whether the assertion's author equals its `p` target. **Disputes** = `polarity: -1`.
+- **Roster (v1, as deployed):** candidates are pubkeys carrying any claimed tag-element; the gate is count-based — `applications ≥ cutoff AND applications > disputes`.
+- **Roster (as designed):** per-observer and trust-weighted — `score = Σ over asserters of (observer's trust in asserter × polarity)`, counting only asserters above an influence cutoff, then gated by the resolved definition's threshold. Disputes are weighted, not counted, so "no veto" falls out automatically.
+- *The two roster rules are **not yet reconciled** — tracked as worksheet [W9](../worksheet.md#w9--roster-rule-reconciliation).* Membership is **derived on read** in either rule, never stored.
+- **Roles are predicates over the roster**, defined in the resolved definition: *applicant* (self-tagged, below threshold), *member* (cleared threshold). Admin is **off** in v1. Authoring a CD makes you a definer, not a member — the zoologist who defines "dog" is not a dog.
+
+## Personal community records (coexistence layer)
+
+The deployed record layer predates the declaration model and coexists with it (two read paths united by the consuming application; founding new communities writes declarations only). Each user maintains one `brainstorm-communities` DList (kind 39998 header, deterministic `d` = `brainstorm-communities`) holding their **personal records**: kind 39999 items, one per community, `d` = `t` = community slug, with `name`/`description`/`image`/`topic`/`language`, **informational-only** `founder`, engine-config fields (`relay`, `seed`, `weighting_model`, `endorsement_threshold` — carriage post-redesign tracked as worksheet [W8](../worksheet.md#w8--engine-config-carriage)), optional NIP-72 wrapping via a bare `a` tag (`34550:<creator>:<d-tag>`), and `template-source` lineage (event-id **snapshot** of the record copied from — deliberately not an a-tag, so later edits by the source do not retarget the lineage).
+
+There is no canonical record of any community anywhere: there are N personal records, and the community **is** their convergent overlap. Joining = publishing your own record (or, in the declaration model, tagging in / deferring); there is no join request and no acceptance.
+
+## Posts, threading, and reactions
+
+- **Posts** are NIP-22 kind `1111` events scoped to a community by `["a", "<community address>"]` (uppercase `A` carries the community scope on replies).
+- **Replies** (one level) add `["e", "<parent post id>", "", "<parent author>"]`, `["k", "1111"]`, and `["p", "<parent author>"]`, inheriting the community's uppercase `A`. The presence or absence of the parent `e` tag is the wire signal distinguishing replies from top-level posts.
+- **Reactions** are NIP-25 kind `7` events carrying `A`/`e`/`p`/`k` scope tags with content `+` (react) or `-` (un-react). The aggregation rule is wire-binding: a post's count = distinct reactors whose **most recent** reaction is `+` (latest-per-reactor; `-` is a removal marker, not a dislike).
+
+## Foothold invitations
+
+A member may extend a **foothold** to a newcomer:
+
+- **Invite:** kind 39999, `d` = `invite-<code>`, with `["a", "<community address>"]`, `["p", "<issuer>"]`, and a `z` type-header naming the deployment's `foothold-invite` concept.
+- **Redemption:** kind 39999, `d` = `redeem-<code>`, same `a`/`p` shape, `z` → the deployment's `foothold-redemption` concept — the recipient's signal that the invite was accepted.
+- **Acceptance effects** are ordinary membership assertions (above): the recipient self-tags, and the issuer vouches, both via the standard assertion shape.
+
+## Security considerations
+
+- **The live-`b` retroactive lever.** Deference tracks future edits ([trust-coupling](./inherit-from.md)), so a dominant declaration holds a retroactive editorial lever over its live deferrers, and a compromised mid-chain declaration can drift a deferrer's community identity (closure shift). Mitigations: (1) the population/ruleset split — a rogue rule-hub cannot retag anyone; (2) making closure-overlap **distance-weighted** (nearer shared ancestors count more) when the sameness metric is refined.
+- **No veto by construction** (designed rule): disputes are trust-weighted, so no single hostile disputer can eject a member; under the deployed count-based rule this property is weaker — one of the W9 reconciliation stakes.
+
+## Open questions
+
+Kept visibly open; this spec decides none of them:
+
+1. **Three-branch reconciliation** (`staging` / `feat/communities` / `feat/pubkey-tagging-target`) — an organizational delivery decision; see `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` §7.
+2. **Engine-config carriage** — where `seed`/`weighting_model`/threshold/cutoff live post-redesign (records? declaration `claims`? resolved definition?) → worksheet [W8](../worksheet.md#w8--engine-config-carriage).
+3. **Roster-rule reconciliation** — deployed count-based vs. designed trust-weighted, plus threshold mechanics (1 vouch vs. N ≥ 2 for safe spaces) → worksheet [W9](../worksheet.md#w9--roster-rule-reconciliation).
+4. **Canonical concept identity across deployments** → worksheet [W1](../worksheet.md#w1--cross-deployment-concept-identity).
+5. **CD field encodings** — the exact tag spelling of the declaration's fields and the `claims` declaration (marked above).

--- a/protocols/worksheet.md
+++ b/protocols/worksheet.md
@@ -67,3 +67,19 @@ Resolved Definition ([inherit-from spec](./drafts/inherit-from.md) § "Scope (v1
 The DList compat companion introduces `item-kind` on list headers to declare which foreign event kinds a list accepts (e.g. kind 34550 NIP-72 communities as list items). Tapestry's concept headers carry their own conventions (`concept-graph` pointer, firmware schemas, `required`/`allowed` declarations). **Do these compose or compete?** E.g.: should Tapestry concept headers declare `item-kind`? Does a foreign-kind item participate in class threads (`n`/`s`) and inheritance (`b`)? Does the firmware JSON-schema mechanism subsume the header's schema-declaration tags or duplicate them?
 
 **Refs:** `feat/communities:DECENTRALIZED_LISTS_COMPAT.md` (`item-kind`, Methods 2/3); BIBLE §5 (concept-graph tag), §7 (firmware schemas); [class-thread-tags spec](./drafts/class-thread-tags.md) § "Security considerations" (ex-BIBLE §23).
+
+## W8 — Engine-config carriage
+
+**Status:** Open · raised 2026-06-10
+
+Brainstorm Communities' membership engine needs configuration: seed pubkeys, a weighting model, a membership threshold, an influence cutoff. The May records layer carries `seed`/`weighting_model`/`endorsement_threshold` as record tags; the post-redesign declaration model (`feat/communities` ADR 0030) rides threshold + cutoff with the CD's `claims` declaration, resolving through `b`-inheritance. **Where does engine config canonically live — personal records, the Community Declaration, the resolved definition, or split across them — and what is its exact wire encoding?** The [communities spec](./drafts/communities.md) marks both the CD field encodings and this carriage question open.
+
+**Refs:** [communities spec](./drafts/communities.md) § "The Community Declaration" / § "Personal community records"; `feat/communities` ADRs 0029/0030; `feat/communities:COMMUNITY_RECORDS_DLIST.md`; protocols-directory ADR 0004 (finding D2 residue).
+
+## W9 — Roster-rule reconciliation
+
+**Status:** Open · raised 2026-06-10
+
+Two membership roster rules exist for Brainstorm Communities: the **deployed v1 rule** (count-based: `applications ≥ cutoff AND applications > disputes`, single PoV) and the **designed rule** (per-observer, trust-weighted: net assert-vs-dispute weighted by the observer's trust in each asserter, influence-cutoff-gated, threshold from the resolved definition — "no veto" falls out). Reconciling them — and settling threshold mechanics (1 vouch vs. N ≥ 2 for safe spaces, capture doc §5) — is open. The security stakes are real: the no-veto property holds only under the weighted rule.
+
+**Refs:** [communities spec](./drafts/communities.md) § "Membership" / § "Security considerations"; `feat/communities` ADR 0030 (both rules); `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` §3/§5; protocols-directory ADR 0004 (finding D5).


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`.

## Bundled

- **#271** — Communities pre-NIP synthesis (protocols-directory story 6, ADR 0004). Docs-only: new spec, capture-doc status line, worksheet +W8/+W9, index row.

## Net production impact

None at runtime — repo markdown only; BIBLE untouched.

## Verification trail

- #271 staging deploy green; smoke Tier 1 stable in minimum 3 polls; Tiers 2/5 all 10 endpoints 200; Tiers 3/4 N/A.
- 10-agent independent audit (zero blockers/unverified) + npm test green at every phase commit.

## Test plan

- [ ] After merge: deploy-brainstorm.yml runs to completion.
- [ ] Smoke test on brainstorm.world (Tiers 1/2/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)