### PR TITLE
Promote staging → main: tags pre-NIP + epic completion (story 7)

### DIFF
--- a/docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md
+++ b/docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md
@@ -1,6 +1,6 @@
 # Protocols Directory — Design Handoff
 
-**Status:** 🔴 OPEN
+**Status:** ✅ ADDRESSED — all seven stories of the protocols-directory epic shipped (2026-06-10); [`protocols/`](../protocols/README.md) is live with every spec as its working copy. Body preserved for historical context. Residuals tracked elsewhere: the NostrHub republish (the author's act — see the DLists row in `protocols/README.md`), worksheet W1–W10, and the three-branch reconciliation (`docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` §7).
 **Date:** 2026-06-09
 **Origin:** Planning session with the project owner (author of the Decentralized Lists Custom NIP). Scoped via `/discuss`-style conversation; execution is Protocol-Spec docs-mode work (see `engineering-team/workflows/protocol-spec-workflow.md`).
 **Owner sign-offs so far:** repo-root location ✅ · directory structure ✅ · the migration map below reviewed in conversation ✅ (final ratification happens per-story).

--- a/engineering-team/decisions/protocols-directory/0005-tags-spec.md
+++ b/engineering-team/decisions/protocols-directory/0005-tags-spec.md
@@ -1,0 +1,87 @@
+# ADR 0005 (protocols-directory): Tags & Taggings pre-NIP — family framing, D4 reconciliation, skeleton
+
+**Status:** Accepted
+**Date:** 2026-06-10
+**Story:** `engineering-team/stories/protocols-directory/7-tags-spec.md`
+
+> Full ADR — the epic finale: a two-branch synthesis (tags branch wire formats × the communities branch's correction) plus the family framing the owner delegated at the story gate.
+
+## Context
+
+Story 7 produces `protocols/drafts/tags.md` from the `feat/pubkey-tagging-target` branch (ADRs 0001/0009, firmware concepts `tag`/`nostr-user-tag`/`tag-pinning`, the three publishers), under two inherited obligations: ADR 0004's **D4** (reconcile the assertion-shape variants, `feat/communities` ADR 0030's a-primary correction as the latest word) and the communities spec's two pending markers. Fresh verification this phase: the deployed assertion publisher (`publishProfileTag.js` on the tags branch) emits exactly `['d','p','e','z','polarity']` — **no `a` tag** — so the deployed shape and the 0030-corrected shape genuinely differ on the wire today. The pin publisher's curation defaults verified (`observer`, `method: 'nip85:rank'`, `cutoff`, `includeScoreInTL`).
+
+## Decision
+
+### (1) Family framing (per the owner's gate guidance, recorded in the story)
+
+The spec opens with **"The taggings family"**: a *tagging* is an assertion that a target belongs to a tag — a family whose **deployed instance** is `nostr-user-tag` (pubkey targets) and whose **planned siblings** are `nostr-event-tag` (event targets; kinds 39998/39999 first) with `dlist-tag` envisioned as a subset of `nostr-event-tag` (actively desired). The family tree is presented as **design direction sourced to the owner's ratified guidance** — explicitly non-normative beyond the deployed instance; no wire format is invented for unbuilt siblings. The **rename question** (`nostr-user-tag` → `nostr-user-tagging`?) is marked open and **wire-impactful**: the slug is embedded in `z` handles on user-signed history, so a rename is a concept-migration decision (the W1/legacy-literal lesson), never a documentation edit. Family naming + expansion gets a new worksheet entry, **W10**.
+
+### (2) D4 reconciliation — honest, in spec text
+
+The Taggings section presents:
+
+- **Normative shape (a-primary):** `d` (deterministic), `p` = target pubkey, **`a` = the tag-element's a-coordinate (stable identity — what consumers claim/scan)**, `e` = tag event id at apply-time (provenance only), `z` = the deployment's `nostr-user-tag` concept address, `polarity`. Source: `feat/communities` ADR 0030 (the 2026-06-05 correction), matching the shape the communities spec quotes.
+- **Deployed variant note (wire-status information, not a footnote):** the tags branch's live publishers emit `d/p/e/z/polarity` **without `a`** (tags-branch ADR 0001 shape); 0030 expects existing assertions to be backfilled with `a` and records its correction as "pending the tags branch owner's confirmation." Until confirmation + backfill, readers needing completeness must union `#a` and legacy `#e` lookups. Status presented exactly so.
+
+### (3) Spec skeleton (fixed, 9 headings)
+
+```
+(repo-metadata header: 📝 pre-NIP · in-flight note: feat/pubkey-tagging-target (Vinney), unmerged,
+ live at tags.brainstorm.world · sources: tags-branch ADRs 0001/0009 + firmware concepts;
+ feat/communities ADR 0030 (assertion-shape correction); epic handoff §6)
+---
+Tags & Taggings
+=====
+## The taggings family            (deployed instance vs planned siblings; rename open → W10)
+## Relationship to other specs    (rides on DList + Tapestry Concepts; consumed by Communities)
+## Tag definitions                (kind 39999, z→tag concept, d=slug, content {tag:{slug,name,description}})
+## Taggings (assertions)          (normative a-primary shape; deployed-variant note; d-tag convention
+                                   profile-tag-<slug>-<target8>-<asserter8>; replaceability = latest-wins
+                                   per (author, target, slug))
+## Polarity                       ("1"/"-1"; v1 buckets ≥0.5 applied / ≤−0.5 disputed; reserved middle → W3)
+## Pins                           (z→tag-pinning; dual e+a reference → W4; curation-method fields
+                                   observer/method/cutoff/includeScoreInTL; d-tag tag-pin-<slug>-<author8>-<viewer8>)
+## Unpinning                      (NIP-09 kind-5; pin-exists ⇒ pinned)
+## Event tagging (planned)        (39998/39999 targets first; explicitly not yet specified; family tree pointer)
+## Open questions                 (W3 polarity arc; W4 e-vs-a; W10 family naming/rename; deployed-variant
+                                   reconciliation status; cross-deployment concept identity → W1)
+```
+
+Out of the spec (boundary, per the epic handoff's original analysis): the Trusted-List (kind 30392) publication pipeline, pinned-tab UI, "most pinned" aggregation, PoV read filtering, the `tl-pin-*` d-tag layer, and the ADR 0015 legacy-literal exception (BIBLE/branch history; all `z` handles deployment-neutral with the W1 pointer).
+
+### (4) Communities-spec repoints
+
+Both markers — the Relationship sentence and the Membership intro — become plain references to `[Tags & Taggings](./tags.md)`, parentheticals retired; the Membership intro gains "(deployed-variant status noted there)" so the communities reader still discovers the backfill caveat.
+
+### (5) Worksheet treatment
+
+- **W3 / W4:** refs gain the spec as owning context (`[tags spec](./drafts/tags.md)` § Polarity / § Pins, alongside the existing branch-ADR refs).
+- **New W10 — Taggings family naming & expansion:** the owner's guidance quoted; the rename's wire impact; handle decisions for `nostr-event-tag`/`dlist-tag`; relationship to the event-tagging rollout. Refs: the spec § family, story 7's gate record, handoff §6.
+- Proactive sweep for anything else.
+
+### (6) README final state
+
+Row 7 → working copy (story 7 ✅). The index preamble's "Migration is in progress…" paragraph is replaced with the completed framing: the initial migration (stories 1–7) is complete; every spec lives here as the working copy; the status column tracks publication state. Flagged as the story's allowed small edit.
+
+## Options considered
+
+The one real fork was **where the deployed-variant note lives**: spec text (chosen — it is wire-status information an implementer needs to read events correctly today) vs. source-map-only (rejected: hides a live read-completeness hazard) vs. resolving silently to a-primary (rejected outright: falsifies the wire and pre-empts Vinney's pending confirmation).
+
+## Consequences
+
+- The epic's migration completes: no wire format left homeless; the communities spec's dependency closes.
+- The D4 union-read guidance gives implementers a correct path *today* while the backfill decision stays Vinney's.
+- W10 inherits the family/rename program — including the `dlist-tag` ambition — as a tracked protocol question rather than chat history.
+- **Firmware reinstall required?** No.
+
+## Implementation notes
+
+- Files: `protocols/drafts/tags.md` (new, per skeleton); `protocols/drafts/communities.md` (two marker repoints); `protocols/worksheet.md` (W3/W4 refs, +W10, sweep); `protocols/README.md` (row 7 + preamble). **BIBLE.md: zero diff.**
+- Source map required (spec section → tags-branch ADR/publisher/firmware lines, 0030, handoff §6), with the D4 presentation and any survey-vs-source corrections flagged.
+- Gates: `npm test`; four-file diff scope; zero BIBLE diff; link/anchor checks incl. the W10 anchor and the repointed communities links; dual-normativity sweep (assertion shape now lives in tags spec as normative — communities spec's quoted block must read as *consumption* of it, not a second normative home; verify the framing).
+
+## Out of scope
+
+- Resolving W1/W3/W4/W10; Vinney's backfill confirmation; any rename migration.
+- Event-tagging wire format; TL pipeline; code/firmware changes; publishing.
+- Epic close-out (the PROTOCOLS_DIRECTORY_DESIGN_HANDOFF status flip and `/close-book` belong to the epic-completion step after this story ships, not to this story).

--- a/engineering-team/reviews/protocols-directory/7-tags-spec.md
+++ b/engineering-team/reviews/protocols-directory/7-tags-spec.md
@@ -1,0 +1,50 @@
+# Review: Story 7 — Tags & Taggings pre-NIP (synthesis — epic finale)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-10
+**Diff:** commit `e7b4efe8` (4 files, +118/−6: `protocols/drafts/tags.md` new; `protocols/drafts/communities.md` marker repoints; `protocols/worksheet.md` W3/W4 refs + W10; `protocols/README.md` row 7 + completed-migration preamble)
+**Contract:** `protocols-directory` ADR 0005 (full — family framing, D4 honest reconciliation, 9-heading skeleton, four-file scope, zero BIBLE diff); story ACs; synthesis traceability rule
+**Method note:** implementation authored in this same session; audit fanned out to 8 independent agents across five dimensions (ADR conformance, boundary, traceability against both branches via `git show`, references/anchors, term-coverage first-class), all non-note findings adversarially verified.
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **PASS** (full suite)
+- [x] Playwright — skipped: docs-only
+- [x] Diff scope — exactly the ADR's four files; BIBLE absent from the commit; zero stale story-7 pending markers tree-wide
+- [x] _Lint/typecheck/build not configured — skipped._
+
+## ADR adherence
+
+- [x] Skeleton: exactly the 9 fixed headings, in order.
+- [x] Family framing: deployed instance vs planned siblings cleanly separated; **no wire format invented** for `nostr-event-tag`/`dlist-tag`; rename marked open + wire-impactful; W10's quote of the owner's gate guidance verified **verbatim** against the story record.
+- [x] D4 presentation per contract: normative a-primary shape (verified tag-by-tag vs `feat/communities` ADR 0030); deployed-variant note **in spec text** (verified truthful vs `publishProfileTag.js` — no `a` emitted); union-read guidance; pending-confirmation status stated.
+- [x] Treatments: both communities markers repointed with the breadcrumb; W3/W4 refs updated; README row 7 + preamble graduated to migration-complete (all seven rows ✅ — verified true).
+
+## Boundary discipline
+
+- [x] Zero stack machinery (no UI/TL-pipeline/`tl-pin`/Meili/PoV/endpoints/function names); zero hex pubkeys; the legacy literal absent; all three `z` handles deployment-neutral with the W1 pointer.
+- [x] Dual normativity: the communities spec's assertion block now reads explicitly as consumption ("specified by Tags & Taggings… the shape consumed here"); worksheet entries point, don't restate.
+
+## Traceability (synthesis rule)
+
+- [x] Tag definitions vs the branch builder; assertion d-tag formula + content payload vs `publishProfileTag.js`; pin block + curation fields vs `publishTagPin.js` + ADR 0009; polarity buckets vs ADR 0001; unpinning vs ADR 0009; family tree vs the gate record (direction only). All verified at source; no survey-vs-source corrections needed.
+- [x] The one raised traceability "blocker" — that the normative shape lists `a` while the deployed publisher omits it — was **refuted** by its adversarial verifier: presenting the corrected shape as normative *with* the deployed-variant disclosure is the ADR's explicit D4 decision (the rejected alternative was falsifying toward the deployed shape); the spec's disclosure makes the wire status truthful.
+
+## Findings
+
+Audit: 3 non-note findings raised → **0 confirmed, 3 refuted, 0 unverified**; 17 confirmatory notes.
+
+### Blocking
+
+None — the epic's first first-pass PASS.
+
+### Non-blocking
+
+1. Normative-`a` vs deployed-publisher tension — refuted (ADR-sanctioned D4 presentation; see Traceability).
+2. Polarity "absent means apply" vs the shape listing `polarity` — refuted (the shape shows the tag's form; the prose defines absent-tag semantics; standard spec practice, both sourced to ADR 0001).
+3. Union-read guidance actionability — refuted (adequate: `#a` by coordinate, legacy `#e` by the tag-element's event ids, both derivable from the spec's own definitions).
+4. Notes for the eventual publication pass (no action now): `nip85:rank` is an identifier-by-convention (the spec says so); "the deployment's concept address" is the established chain-wide phrasing whose underlying question is W1.
+
+## Verdict
+
+**PASS** — first-pass, no kickback. The migration is complete: all seven specs live in `protocols/` as working copies, the communities dependency is closed, and the D4 reconciliation gives implementers a truthful read of the wire today while leaving the backfill decision where it belongs.

--- a/engineering-team/stories/protocols-directory/7-tags-spec.md
+++ b/engineering-team/stories/protocols-directory/7-tags-spec.md
@@ -1,0 +1,57 @@
+# Story 7: Tags & Taggings pre-NIP (synthesis — epic finale)
+
+**Status:** Approved
+**Created:** 2026-06-10
+**Type:** Doc
+**Epic:** protocols-directory — realizes `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` (§4 spec #7, §6, §8 story 7)
+
+## Background
+
+The Tags feature (live at tags.brainstorm.world, built on the unmerged `feat/pubkey-tagging-target` branch) ships three wire formats, all kind-39999 DList items distinguished by which concept their `z` tag references: **tag definitions** ("Podcaster is a tag"), **taggings** ("Avi is a Podcaster", with apply/dispute polarity), and **pins** ("I pin Podcaster into my curated set", with curation parameters), plus NIP-09 kind-5 unpinning. Their normative sources are the tags branch's ADRs 0001 (profile-tag architecture) and 0009 (pin-a-tag) and the firmware concepts `tag`/`nostr-user-tag`/`tag-pinning` — surveyed in full at this epic's outset. The tagging primitive is now **load-bearing beyond its home feature**: Communities membership consumes it (story 6), and two pending markers in the communities spec await this story.
+
+This story carries inherited obligations from the epic:
+
+1. **The D4 reconciliation** (`protocols-directory` ADR 0004): three assertion-shape variants exist — the tags branch's deployed `e`-primary shape (ADR 0001), the capture doc's sketch, and `feat/communities` ADR 0030's **`a`-primary / `e`-provenance correction** (2026-06-05, load-bearing for community roster reads, and itself marked "pending Vinney's one-line confirm"). The spec reconciles with the correction as the latest word — **honestly**: the normative shape is a-primary, with the variant history and the pending-confirmation status recorded, not silently resolved.
+2. **Repoint the communities spec's two pending markers** to this spec, retiring "story 7, pending".
+3. **The legacy z-tag pubkey exception stays out** (tags-branch ADR 0015 / BIBLE territory): all `z` handles deployment-neutral, with the canonical-identity question pointed at worksheet W1.
+4. **W3 (polarity valence arc) and W4 (`e` vs. `a` references)** are this spec's pre-assigned open questions — it points at them rather than resolving them.
+5. **Event-tagging is planned, not specified**: targets of kinds 39998/39999 are next per the epic handoff §6 — the spec carries an explicitly-planned section, not invented wire format.
+
+## User-facing description
+
+As the protocol's designers (and any implementer of tagging — including the Communities consumers that now depend on it), I want the tag/tagging/pin wire formats in one self-contained pre-NIP with the assertion-shape reconciliation stated honestly, so that the primitive Vinney built, the correction the communities work needs, and the curation layer all read as one document — completing the protocols/ migration with no wire format left homeless.
+
+## Acceptance criteria
+
+- [ ] Given a fresh clone of `staging`, when a reader opens `protocols/drafts/tags.md`, then it is a self-contained pre-NIP with a repo-metadata header (📝 pre-NIP; in-flight note naming `feat/pubkey-tagging-target` and the live deployment; sources: tags-branch ADRs 0001/0009, the firmware concept definitions, `feat/communities` ADR 0030 for the reconciliation, epic handoff §6) covering at minimum: the tag-definition wire format; the tagging (assertion) wire format **reconciled per D4** with the variant history and pending-confirmation status visible; polarity semantics (apply/dispute values, the v1 bucketing, the reserved middle interval → worksheet W3); the pin wire format including curation-parameter semantics and its dual `e`+`a` reference; kind-5 unpinning; the deterministic d-tag conventions for assertions and pins; and a **planned** event-tagging section (kinds 39998/39999 targets first) explicitly marked as not yet specified.
+- [ ] Given the spec, when read by a stranger with the prior six specs, then it contains no stack machinery (no UI tabs, no Trusted-List publication pipeline, no Meili/PoV internals, no endpoint paths) and **no deployment pubkeys** — every `z` type-handle deployment-neutral with the W1 pointer; the legacy-literal exception is not mentioned (it is BIBLE/ADR history).
+- [ ] Given `protocols/drafts/communities.md`, when its two former story-7 pending markers are followed, then both point at the new spec with the pending parentheticals retired, and the assertion shape quoted there remains consistent with the new spec's normative shape.
+- [ ] Given `protocols/worksheet.md` after the proactive sweep, then W3 and W4 cite the new spec as the owning context (refs updated), no entry claims content that moved, and any new open questions the synthesis surfaces are recorded as entries.
+- [ ] Given `protocols/README.md`, then the Tags & Taggings row links the working copy (story 7 ✅), and — all seven rows now done — the index preamble's migration-in-progress framing is updated to the completed state (small allowed edit, flagged).
+- [ ] Given the full change, when `npm test` runs, then it passes unchanged; and `BIBLE.md` has zero diff (tags content never lived there; the ADR 0015 exception stays untouched on its branch).
+- [ ] Term coverage is a first-class review dimension (carried from story 6); every load-bearing term is defined in the spec or its prerequisite chain.
+
+**Traceability rule (synthesis):** every normative statement traces to tags-branch ADRs 0001/0009, the firmware concept definitions, `feat/communities` ADR 0030 (for the reconciled shape), or the epic handoff §6; the D4 variant disagreement is surfaced in the spec text itself (it is wire-status information an implementer needs), not just the source map. Honest gaps marked explicitly.
+
+## Concepts touched
+
+None modified (no events, no firmware change, no reinstall). The spec *describes* the `tag`/`nostr-user-tag`/`tag-pinning` concept family; their firmware definitions on the tags branch are sources, not targets.
+
+## Out of scope
+
+- Resolving W1, W3, W4, or the D4 pending-confirmation (Vinney's call).
+- Specifying event-tagging wire format (planned section only).
+- The Trusted-List (kind 30392) publication pipeline and all feature behavior (BIBLE/branch territory).
+- Any code, branch, or firmware change; publishing.
+
+## Open questions
+
+- **Naming — resolved at the gate: (c), delegated to the ADR, with the owner's directional guidance recorded verbatim:** *"we will have a parent concept of taggings, with nostr-user-tag (should we change it to nostr-user-tagging?) and nostr-event-tag as sibling concepts; maybe even dlist-tag as a subset of nostr-event-tag, with dlist-tag being something we would very much like to start using."* The ADR frames the family accordingly; it must not invent wire format for the unbuilt siblings, and it must treat any concept-slug *rename* as wire-impactful (slugs are embedded in `z` handles on signed history) — a migration decision to mark open, not a docs decision to make.
+- **Architecture phase?** Runs full — the D4 two-branch reconciliation and the family framing are real design calls.
+
+## Linked artifacts
+
+- Design record: `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` §4/§6/§8; inherited instruction: `protocols-directory` ADR 0004 finding D4; pattern: ADRs 0001–0004
+- ADR: (pending — full run)
+- Test plan: skipped (docs-mode)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/protocols-directory/7-tags-spec.md
+++ b/engineering-team/stories/protocols-directory/7-tags-spec.md
@@ -52,6 +52,6 @@ None modified (no events, no firmware change, no reinstall). The spec *describes
 ## Linked artifacts
 
 - Design record: `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` §4/§6/§8; inherited instruction: `protocols-directory` ADR 0004 finding D4; pattern: ADRs 0001–0004
-- ADR: (pending — full run)
+- ADR: `engineering-team/decisions/protocols-directory/0005-tags-spec.md` (`protocols-directory` ADR 0005, full) — Accepted
 - Test plan: skipped (docs-mode)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/protocols-directory/7-tags-spec.md
+++ b/engineering-team/stories/protocols-directory/7-tags-spec.md
@@ -1,6 +1,6 @@
 # Story 7: Tags & Taggings pre-NIP (synthesis — epic finale)
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-10
 **Type:** Doc
 **Epic:** protocols-directory — realizes `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` (§4 spec #7, §6, §8 story 7)
@@ -54,4 +54,4 @@ None modified (no events, no firmware change, no reinstall). The spec *describes
 - Design record: `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` §4/§6/§8; inherited instruction: `protocols-directory` ADR 0004 finding D4; pattern: ADRs 0001–0004
 - ADR: `engineering-team/decisions/protocols-directory/0005-tags-spec.md` (`protocols-directory` ADR 0005, full) — Accepted
 - Test plan: skipped (docs-mode)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/protocols-directory/7-tags-spec.md` — PASS (first-pass, no kickback)

--- a/protocols/README.md
+++ b/protocols/README.md
@@ -43,7 +43,7 @@ Spec headers also record: **canonical external URL** (naddr for NostrHub Custom 
 
 ## Spec index
 
-Migration is in progress — specs land here story by story (see the [design handoff](../docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md) §8 for the plan). Until a spec's migration story has run, **its listed source location remains the source of truth** and the planned file does not exist yet.
+The initial migration (protocols-directory epic, stories 1–7) is **complete** — every spec below lives here as its working copy. The Status column tracks each spec's publication state; "Content lives today" records provenance and any external divergence (e.g. a published NostrHub version pending republication).
 
 | Spec | File | Status | Content lives today | Migration |
 |---|---|---|---|---|
@@ -53,7 +53,7 @@ Migration is in progress — specs land here story by story (see the [design han
 | Class-Thread Membership Tags (`n`, `s`) | [drafts/class-thread-tags.md](./drafts/class-thread-tags.md) | 📝 pre-NIP | **Working copy here** (BIBLE §23 holds implementation + pointer) | story 4 ✅ |
 | Inherit-From & Resolved Definition (`b`) | [drafts/inherit-from.md](./drafts/inherit-from.md) | 📝 pre-NIP | **Working copy here** (BIBLE §25/§26 hold implementation + pointers) | story 5 ✅ |
 | Communities | [drafts/communities.md](./drafts/communities.md) | 📝 pre-NIP | **Working copy here** (in-flight feature; BIBLE §22 untouched — see ADR 0004; `COMMUNITY_ENDORSEMENTS_DLIST.md` superseded for membership per ADR 0004 D1) | story 6 ✅ |
-| Tags & Taggings | `drafts/tags.md` | 📝 pre-NIP | `feat/pubkey-tagging-target` branch: ADRs 0001 (profile-tag architecture), 0009 (pin-a-tag); firmware concepts `tag` / `nostr-user-tag` / `tag-pinning` | story 7 — pending |
+| Tags & Taggings | [drafts/tags.md](./drafts/tags.md) | 📝 pre-NIP | **Working copy here** (in-flight feature on `feat/pubkey-tagging-target`) | story 7 ✅ |
 
 Branch-path notation: `branch:path` means the file exists at that path on the named (unmerged) branch — read it with `git show <branch>:<path>`. Migration **copies** content from those branches; it never implies merging them.
 

--- a/protocols/drafts/communities.md
+++ b/protocols/drafts/communities.md
@@ -23,7 +23,7 @@ Centralization must be built by participants, never assumed by the protocol.
 
 ## Relationship to other specs
 
-Communities ride entirely on primitives defined upstream: the addressable kinds and `z` conventions of [Decentralized Lists](../nips/decentralized-lists.md) and [Tapestry Concepts](./tapestry-concepts.md); definitional deference and the resolution algorithm of [Inherit-From & Resolved Definition](./inherit-from.md); and the membership signal of the pubkey-tagging wire format — **specified by the Tags & Taggings pre-NIP (story 7, pending; until then the latest wire word is `feat/communities` ADR 0030's a-primary correction, quoted under "Membership")**. This spec adds only the thin community-specific layer on top.
+Communities ride entirely on primitives defined upstream: the addressable kinds and `z` conventions of [Decentralized Lists](../nips/decentralized-lists.md) and [Tapestry Concepts](./tapestry-concepts.md); definitional deference and the resolution algorithm of [Inherit-From & Resolved Definition](./inherit-from.md); and the membership signal of the pubkey-tagging wire format — specified by [Tags & Taggings](./tags.md). This spec adds only the thin community-specific layer on top.
 
 ## A community is a concept
 
@@ -60,7 +60,7 @@ Overlap alone means "talking about the same thing"; membership alone means "each
 
 ## Membership
 
-Membership is **the pubkey-tagging primitive, consumed** — not a community-specific schema. A membership assertion is a kind 39999 event — specified by the Tags & Taggings pre-NIP (story 7, pending; until then the latest wire word is `feat/communities` ADR 0030's a-primary correction):
+Membership is **the pubkey-tagging primitive, consumed** — not a community-specific schema. A membership assertion is a kind 39999 event — specified by [Tags & Taggings](./tags.md) (deployed-variant status noted there); the shape consumed here:
 
 ```
 ["p", "<targetPubkey>"]                    the person being tagged

--- a/protocols/drafts/tags.md
+++ b/protocols/drafts/tags.md
@@ -1,0 +1,104 @@
+> **Repo metadata — not part of the spec text.**
+> **Status:** 📝 pre-NIP
+> **Canonical:** not yet published
+> **In flight:** describes a feature in flight on the unmerged branch `feat/pubkey-tagging-target` (Vinney), live at tags.brainstorm.world.
+> **Sources:** tags-branch ADRs 0001 (profile-tag architecture) and 0009 (pin-a-tag) plus the branch's publishers and firmware concepts `tag`/`nostr-user-tag`/`tag-pinning` (extracted per protocols-directory story 7, `protocols-directory` ADR 0005); `feat/communities` ADR 0030 (the a-primary assertion-shape correction, per ADR 0004 finding D4); epic handoff §6 (the planned event-tagging direction).
+
+---
+
+Tags & Taggings
+=====
+
+This NIP defines **tags** (community-creatable categories — "Podcaster is a tag") and **taggings** (assertions that a target belongs to a tag — "Avi is a Podcaster"), plus a personal **pinning** layer for curating tags. All three ride on the kinds and conventions of [Decentralized Lists](../nips/decentralized-lists.md) and [Tapestry Concepts](./tapestry-concepts.md), as kind-39999 items distinguished by which concept their `z` tag references.
+
+## The taggings family
+
+A *tagging* is an assertion that a **target** belongs to a tag. The family is organized by target type:
+
+- **`nostr-user-tag`** — targets are **pubkeys**. The deployed instance, and the only member specified in this document.
+- **`nostr-event-tag`** *(planned)* — targets are **events**, beginning with kinds 39998/39999 (DList headers and items).
+- **`dlist-tag`** *(envisioned)* — a subset of `nostr-event-tag` for DList objects specifically; an actively desired next step.
+
+This family tree is ratified design direction (the protocol author's, recorded in this epic's story 7); only the deployed instance below is normative. Whether the deployed concept should be *renamed* (e.g. `nostr-user-tag` → `nostr-user-tagging`) is open — and **wire-impactful**, since the concept slug is embedded in `z` handles on user-signed history; renames are concept migrations, never documentation edits. The family's naming and expansion are tracked as worksheet [W10](../worksheet.md#w10--taggings-family-naming--expansion).
+
+## Relationship to other specs
+
+Tags and taggings are ordinary kind-39999 DList items per [Tapestry Concepts](./tapestry-concepts.md): each carries a `z` tag naming the deployment's `tag`, `nostr-user-tag`, or `tag-pinning` concept address (how independent deployments agree on those concept identities is worksheet [W1](../worksheet.md#w1--cross-deployment-concept-identity)). The tagging assertion is **consumed by [Communities](./communities.md)** as its membership signal — community declarations claim tag-elements, and rosters derive from the assertions that apply them.
+
+## Tag definitions
+
+A tag is created as a kind `39999` event joining the deployment's `tag` concept:
+
+```json
+{
+  "kind": 39999,
+  "tags": [
+    ["d", "<slug>"],
+    ["z", "<the deployment's tag concept address>"]
+  ],
+  "content": "{\"tag\":{\"slug\":\"<slug>\",\"name\":\"<name>\",\"description\":\"<description>\"}}"
+}
+```
+
+`d` is the tag's slug (e.g. `podcaster`); the content payload mirrors it with the display name and description. The tag event — the **tag-element** — is addressable at `39999:<author>:<slug>` (its *a-coordinate*); anyone may create tags, and tags by different authors with the same slug are distinct elements.
+
+## Taggings (assertions)
+
+A tagging is a kind `39999` event asserting that a pubkey belongs to a tag. **Normative shape** (a-primary, per the 2026-06-05 correction):
+
+```
+["d", "profile-tag-<tagSlug>-<targetPubkey[0:8]>-<asserterPubkey[0:8]>"]
+["p", "<targetPubkey>"]                    the person being tagged
+["a", "39999:<tagAuthorPubkey>:<slug>"]    the tag-element applied — stable identity (consumers claim/scan this)
+["e", "<tagEventId>"]                      the tag-element's version at apply-time — provenance only
+["z", "<the deployment's nostr-user-tag concept address>"]
+["polarity", "1" | "-1"]                   apply / dispute
+```
+
+with a content payload mirroring the key tags (`{"nostrUserTag":{"taggedPubkey":…,"tagEventId":…}}`).
+
+**Replaceability — latest wins.** The deterministic `d` tag gives each asserter exactly one live stance per (target, tag slug): republishing at the same address replaces the prior assertion, including flips between apply and dispute.
+
+**Deployed variant (wire-status an implementer needs today).** The live publishers on the deploying branch emit `d/p/e/z/polarity` **without** the `a` tag — the original shape — and the a-primary correction (made on the communities side, where `#a` roster scans depend on it) is recorded there as *pending the tags branch owner's confirmation*, with existing assertions expected to be backfilled with `a`. Until that confirmation and backfill, a reader needing completeness MUST union `#a` lookups with legacy `#e` lookups against the tag-element's event ids. The `e`-vs-`a` reference question in general is worksheet [W4](../worksheet.md#w4--e-vs-a-for-parent-tag-references).
+
+## Polarity
+
+`polarity` is `"1"` (apply) or `"-1"` (dispute); an absent tag means apply. v1 interpretation buckets values: `≥ 0.5` counts as applied, `≤ −0.5` as disputed, and the open interval between is **reserved** for a future graded-valence arc and not counted in v1. The graded semantics are undesigned — worksheet [W3](../worksheet.md#w3--polarity-valence-arc).
+
+## Pins
+
+A pin is a kind `39999` event by which a viewer opts a tag into their personal curated set:
+
+```
+["d", "tag-pin-<tagSlug>-<tagAuthorPubkey[0:8]>-<viewerPubkey[0:8]>"]
+["e", "<tagEventId>"]                      the tag-element version being pinned
+["a", "39999:<tagAuthorPubkey>:<slug>"]    the tag-element's stable address — survives the author's edits
+["z", "<the deployment's tag-pinning concept address>"]
+["curation-method", "<stringified JSON, see below>"]
+```
+
+with a content payload mirroring them (`{"tagPinning":{"tagEventId":…,"curationMethod":…}}`). The **dual reference** is deliberate: `e` pins the specific version seen at pin-time; `a` tracks the tag through its author's later edits (the general `e`-vs-`a` question is [W4](../worksheet.md#w4--e-vs-a-for-parent-tag-references)).
+
+**Curation parameters.** The `curation-method` value is stringified JSON carrying the pin's curation intent:
+
+```json
+{ "observer": "<viewerPubkey>", "method": "nip85:rank", "cutoff": 1, "includeScoreInTL": true }
+```
+
+— the observing pubkey, a ranking-method identifier, a rank cutoff, and whether derived scores are included in downstream published lists. Further method identifiers may be introduced by convention.
+
+## Unpinning
+
+Unpinning is a standard NIP-09 kind-`5` deletion of the pin event. Reader semantics are existence-based: a live pin event means pinned; its absence (or deletion) means not pinned.
+
+## Event tagging (planned)
+
+Tagging **events** — beginning with kinds 39998/39999, i.e. DList headers and items — is the family's next step (see "The taggings family"). Its wire format is **not yet specified**: target reference form, concept handles, and polarity carriage for event targets are all open until the `nostr-event-tag` design lands. This section exists so the family's direction is visible; nothing here is normative.
+
+## Open questions
+
+1. **Family naming & expansion** — the rename question and the `nostr-event-tag`/`dlist-tag` handles → worksheet [W10](../worksheet.md#w10--taggings-family-naming--expansion).
+2. **The deployed-variant reconciliation** — the a-primary correction's pending confirmation and the `a`-backfill of existing assertions (the union-read guidance above stands until then).
+3. **Polarity's graded arc** → [W3](../worksheet.md#w3--polarity-valence-arc).
+4. **`e` vs. `a` reference precedence** (assertions and pins) → [W4](../worksheet.md#w4--e-vs-a-for-parent-tag-references).
+5. **Cross-deployment concept identity** for the `tag`/`nostr-user-tag`/`tag-pinning` handles → [W1](../worksheet.md#w1--cross-deployment-concept-identity).

--- a/protocols/worksheet.md
+++ b/protocols/worksheet.md
@@ -34,7 +34,7 @@ Our specs are steadily claiming single-char (NIP-01 relay-indexed) tag letters: 
 
 Tagging events carry `polarity` `"1"` (apply) or `"-1"` (dispute); v1 semantics bucket `>= 0.5` as applied and `<= -0.5` as disputed, deliberately reserving the open interval `(-0.5, 0.5)` for a future graded-valence arc (GrapeRank-style weights in `[-1, +1]`). **The graded semantics are undesigned**: what does a 0.3 mean, who interprets it, and does the bucketing rule belong in the Tags spec or in trust-metric-interpreter territory?
 
-**Refs:** tags-branch ADR 0001 (polarity wire format + v1 buckets); tags-branch follow-ups (valence arc deferred); handoff doc §6.
+**Refs:** [tags spec](./drafts/tags.md) § "Polarity"; tags-branch ADR 0001 (polarity wire format + v1 buckets); tags-branch follow-ups (valence arc deferred); handoff doc §6.
 
 ## W4 — `e` vs. `a` for parent-tag references
 
@@ -42,7 +42,7 @@ Tagging events carry `polarity` `"1"` (apply) or `"-1"` (dispute); v1 semantics 
 
 Tagging and pin events reference the tag they apply/pin by `e` (event id — pins a specific version) and/or `a` (address — survives the author's edits). The tags branch flagged this choice for re-evaluation in its own follow-ups: replaceable events make `e`-references go stale, while `a`-references change meaning under the author's later edits. **Which reference (or which combination, with what precedence) should the spec mandate, and does the answer differ for taggings vs. pins?**
 
-**Refs:** tags-branch ADRs 0001/0009 + follow-ups; the same question shape appears in the DList compat companion (Method 2 mandates `a` for items pointing at kind-34550 events because they're replaceable; Method 3 rides on `z` tags instead).
+**Refs:** [tags spec](./drafts/tags.md) § "Taggings (assertions)" / § "Pins"; tags-branch ADRs 0001/0009 + follow-ups; the same question shape appears in the DList compat companion (Method 2 mandates `a` for items pointing at kind-34550 events because they're replaceable; Method 3 rides on `z` tags instead).
 
 ## W5 — `REFERENCES` publishing semantics
 
@@ -83,3 +83,11 @@ Brainstorm Communities' membership engine needs configuration: seed pubkeys, a w
 Two membership roster rules exist for Brainstorm Communities: the **deployed v1 rule** (count-based: `applications ≥ cutoff AND applications > disputes`, single PoV) and the **designed rule** (per-observer, trust-weighted: net assert-vs-dispute weighted by the observer's trust in each asserter, influence-cutoff-gated, threshold from the resolved definition — "no veto" falls out). Reconciling them — and settling threshold mechanics (1 vouch vs. N ≥ 2 for safe spaces, capture doc §5) — is open. The security stakes are real: the no-veto property holds only under the weighted rule.
 
 **Refs:** [communities spec](./drafts/communities.md) § "Membership" / § "Security considerations"; `feat/communities` ADR 0030 (both rules); `docs/COMMUNITIES_PROTOCOL_DESIGN_HANDOFF.md` §3/§5; protocols-directory ADR 0004 (finding D5).
+
+## W10 — Taggings family naming & expansion
+
+**Status:** Open · raised 2026-06-10
+
+The taggings family ([tags spec](./drafts/tags.md) § "The taggings family") has one deployed member and a ratified direction, recorded from the protocol author at story 7's gate: *"we will have a parent concept of taggings, with nostr-user-tag (should we change it to nostr-user-tagging?) and nostr-event-tag as sibling concepts; maybe even dlist-tag as a subset of nostr-event-tag, with dlist-tag being something we would very much like to start using."* Open: (1) the **rename** of `nostr-user-tag` — wire-impactful, since the slug rides in `z` handles on user-signed history (a concept migration, same class as the W1 legacy-literal lessons); (2) the **handles and hierarchy** for `nostr-event-tag` and `dlist-tag` (parent/sibling/subset structure as concepts); (3) sequencing against the event-tagging rollout (kinds 39998/39999 targets first, per the epic handoff §6).
+
+**Refs:** [tags spec](./drafts/tags.md) § "The taggings family" / § "Event tagging (planned)"; story 7 gate record (`engineering-team/stories/protocols-directory/7-tags-spec.md` § Open questions); `docs/PROTOCOLS_DIRECTORY_DESIGN_HANDOFF.md` §6.


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`. Completes the protocols-directory epic: all seven specs live in `protocols/` as working copies.

## Bundled

- **#273** — Tags & Taggings pre-NIP (story 7, ADR 0005) + the epic handoff's ✅ ADDRESSED flip. Docs-only.

## Net production impact

None at runtime — repo markdown only; BIBLE untouched.

## Verification trail

- #273 staging deploy green; smoke Tier 1 stable; Tiers 2/5 all 10 endpoints 200; Tiers 3/4 N/A.
- 8-agent audit: zero confirmed findings (first-pass PASS); npm test green at every phase commit.

## Test plan

- [ ] After merge: deploy-brainstorm.yml runs to completion.
- [ ] Smoke test on brainstorm.world (Tiers 1/2/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)