### PR TITLE
docs(book-close): reputation-info-popup audit trail

### DIFF
--- a/engineering-team/audits/reputation-info-popup/audit.md
+++ b/engineering-team/audits/reputation-info-popup/audit.md
@@ -1,0 +1,50 @@
+# Build Audit: Reputation info popup (profile page)
+
+**Book:** `engineering-team/audits/reputation-info-popup/book.md`
+**Date:** 2026-06-14
+**Branch / commit range:** `feat/reputation-info-popup`; feature diff `3a167ab8..e8b9182e` (staging PR [#287](https://github.com/nous-clawds4/tapestry/pull/287)); live on `main` `b4699d58` (prod PR [#288](https://github.com/nous-clawds4/tapestry/pull/288))
+**Provenance:** Acceptance-frame
+**Confidence:** high
+
+> As-built record. The book was run autonomously through the Direction-mode harness (Product Owner → Architect → Tester → Implementer → Reviewer, each judged gate cleared by a blinded gate-judge), deployed to staging, and — on explicit operator direction, post-run — promoted to production. Every acceptance-frame bullet was verified on staging and again on production.
+
+## 1. What shipped
+- An informational popup (a circled-"i" ⓘ control) beside the profile page's **Reputation** section heading that explains, in plain language, that the reputation scores reflect a Web-of-Trust point of view — either the **House** point of view (the instance's default) or the viewer's **Personalized** point of view, depending on which is currently selected — `stories/reputation-info-popup/1-reputation-section-pov-explainer-popup.md`.
+
+## 2. Epics & stories rolled up
+
+### Epic: `reputation-info-popup`
+| Story | Delivered | Status | Review |
+|---|---|---|---|
+| #1 reputation-section-pov-explainer-popup | New `ReputationInfo.jsx` ⓘ-popup (static House/Personalized explainer) rendered in the profile "Reputation" heading | Done | `reviews/reputation-info-popup/1-reputation-section-pov-explainer-popup.md` (PASS) |
+
+## 3. As-built inventory
+*(derived from the diff `3a167ab8..e8b9182e`)*
+- **User-facing:** one new control — a ⓘ button in the `<h3>Reputation</h3>` heading on the profile page (`/user/:pubkey`) that opens a dismissible popup (acknowledgement button + overlay-click to close). New file `ui/src/components/ReputationInfo.jsx` (41 lines); 2-line change to `ui/src/pages/BrainstormProfile.jsx` (import + render in the heading). No CSS change (reuses `.bsp-info-btn` / `.bsp-confirm-overlay` / `.bsp-confirm-box` / `.bsp-confirm-ok`).
+- **Domain:** none. No Concept Graph definitions added or changed (oriented against `web-of-trust` and `graperank`; "House"/"Personalized point of view" are product/UI notions, not graph concepts). No schema change. **No firmware reinstall.**
+- **Data & contracts:** none. No new endpoint, event kind, API route, or stored shape. The component is prop-free and hook-free (no data fetch). The Reputation data path (Meilisearch document fetch, `TRUST_METRICS` grid, `?pov=` resolution) is untouched.
+- **Tests:** new `test/reputation-info-popup.test.js` (16 source-sentinel tests), registered in `test/test.js`.
+
+## 4. Deviations from intent
+The as-built **fully satisfies all six acceptance-frame bullets** (verified on staging and prod). The entries below are intentional interpretation/deferral choices, harvested from the story's `## Deviations`, the ADR's `Consequences`/`Out of scope`, and the story's `Out of scope` — reconciled against the diff. No anchor bullet was relaxed.
+
+| # | Specified (anchor) | Built | Type | Rationale (source) | Product impact | Carry-forward |
+|---|---|---|---|---|---|---|
+| 1 | Frame bullet 1: ⓘ "visually and behaviorally consistent with the existing Verified control" | ⓘ right-aligns at the heading edge (shared `.bsp-info-btn { margin-left:auto }` left in effect; no CSS override added) | interpretation | Story `## Deviations`: maximizes consistency with the Verified ⓘ (also right-aligned in its `.bsp-counts` row) and keeps the change zero-CSS; ADR 0034 authorized either placement | Minor visual: the ⓘ sits at the right edge of the "Reputation" heading rather than snug after the word | Revisit only if a snug placement is later preferred (one-line `.bsp-section h3 .bsp-info-btn { margin-left:0 }`) |
+| 2 | Frame bullet 3: explain House-or-Personalized "depending on which is currently selected" | Static, general copy that does **not** name the *active* PoV | deferred | Book/intake scope decision (operator, 2026-06-14): the dynamic variant would require promoting the resolved `povSuffix` from the fetch effect into render state — explicitly out of scope | Reader learns scores reflect *either* PoV by selection, but the popup doesn't state which is active in the moment | Dynamic "you are viewing the {House\|Personalized} PoV" variant, if wanted |
+| 3 | (interaction pattern) | A second popup skeleton (`ReputationInfo`) duplicates ~25 lines of the `VerificationInfo` open/close/overlay boilerplate | deferred (debt) | ADR 0034 `Consequences`: chose a sibling component (Option A) over generalizing a shared `InfoPopover` primitive, to keep the change additive and avoid touching shipped/tested code | None (internal structure only) | Extract a shared `InfoPopover` primitive when a **third** explainer appears (deliberate refactor story) |
+
+**Undocumented work:** none. Every file in the book diff traces to story #1 / ADR 0034 (the 2 source files, the test file + registration, and the harness artifacts).
+
+## 5. Quality state at close
+- **Test gate at close:** `npm test` → **PASS** (34 suites; the new `reputation-info-popup` suite 16/16; all 33 pre-existing suites unchanged).
+- **Known open issues / accepted bugs:** none.
+- **Debt logged:** the two near-identical popup skeletons (`VerificationInfo` + `ReputationInfo`) — see §4 #3; tracked for an `InfoPopover` extraction once a third explainer exists (ADR 0034 `Consequences`).
+- **Process note (harness, not product):** one Gate-5 kick-back occurred — the Director instructed the Reviewer not to flip the story `Status: Done`, but the pinned Gate-5 rubric requires that flip *in the review commit* and it is outside the Director's edit lane. The blinded judge caught it; it was corrected and re-judged clean. Suggest clarifying in `roles/director.md` (Gate 5) and the `direct-feature` skill that the Reviewer authors the Status flip. (Goalpost-class — applies to the next run, operator-ratified.)
+
+## 6. Carry-forward register
+- [ ] Dynamic "which PoV is active" variant of the popup (from §4 #2 / story `Out of scope`).
+- [ ] Extract a shared `InfoPopover` primitive when a third explainer is added (from §4 #3 / ADR 0034 `Consequences`).
+- [ ] Optional: snug (non-right-aligned) ⓘ placement, if preferred (from §4 #1).
+- [ ] Adjacent, already-open profile-followers follow-ups on the same surface (intake 2026-06-06; `docs/PROFILE_FOLLOWERS_HANDOFF_2026-06-06.md`) — esp. **item 6** (Personalized PoV for the follows/followers *tables*), which is thematically related: this feature explains House-vs-Personalized for the Reputation scores while the tables remain House/Owner-only. PoV consistency across the profile is a natural next consideration.
+- [ ] Ratify the popup copy (it was chosen by the Director under the book's delegation; the product team may want to own the final wording).

--- a/engineering-team/audits/reputation-info-popup/book.md
+++ b/engineering-team/audits/reputation-info-popup/book.md
@@ -1,9 +1,9 @@
 # Book of Work: Reputation info popup (profile page)
 
 **Slug:** reputation-info-popup
-**Status:** Open
+**Status:** Closed
 **Opened:** 2026-06-14
-**Closed:** —
+**Closed:** 2026-06-14
 
 ## Intent anchor
 **Acceptance frame (no PRD)** — the operator's ask, restated and confirmed at kickoff. Completion is *judged* against the bullets below.
@@ -87,7 +87,7 @@ Executed **only on the operator's explicit instruction** after reviewing the HAL
 
 ## Provenance
 - **Mode:** Acceptance-frame
-- **Confidence at close:** *(to be filled by `/close-book`)*
+- **Confidence at close:** high
 
 ## Close artifacts *(filled by `/close-book`)*
 - Build audit: `engineering-team/audits/reputation-info-popup/audit.md`

--- a/engineering-team/audits/reputation-info-popup/completion-report.md
+++ b/engineering-team/audits/reputation-info-popup/completion-report.md
@@ -1,0 +1,47 @@
+# Completion Report — reputation-info-popup
+
+**Book:** `engineering-team/audits/reputation-info-popup/book.md`
+**Epic:** `reputation-info-popup` · **Story #1:** reputation-section-pov-explainer-popup (`**Status:** Done`)
+**Live on:** https://staging.brainstorm.world (PR [#287](https://github.com/nous-clawds4/tapestry/pull/287), merge `e8b9182e`, deploy run [`27483210200`](https://github.com/nous-clawds4/tapestry/actions/runs/27483210200) — success, 1m14s)
+
+This report maps each acceptance-frame bullet to its evidence.
+
+## Acceptance-frame bullets
+
+### 1. The "Reputation" section heading carries a circled-"i" (ⓘ) control, visually/behaviorally consistent with the existing "Verified" info control
+- **Code:** new `ui/src/components/ReputationInfo.jsx` renders `<button className="bsp-info-btn" …>ⓘ</button>` — the same class, glyph, and `type` as the shipped `VerificationInfo.jsx`. Rendered inside the heading in `ui/src/pages/BrainstormProfile.jsx`: `<h3>Reputation<ReputationInfo /></h3>`.
+- **Consistency:** the shared `.bsp-info-btn { margin-left:auto }` is left in effect, so the Reputation ⓘ right-aligns at the heading edge — the same placement behavior as the Verified ⓘ in its `.bsp-counts` row (recorded in the story's `## Deviations`).
+- **Staging evidence:** rendered on https://staging.brainstorm.world/user/c4eabae1be3cf657bc1855ee05e69de9f059cb7a059227168b80b89761cbc4e0?pov=a1420e44 — the ⓘ appears beside "Reputation" (browser `find` located it as the button "Where do these reputation scores come from?" next to the Reputation heading; screenshot captured).
+- **Tests:** T1, T9 in `test/reputation-info-popup.test.js`.
+
+### 2. Activating the control opens a dismissible popup (closes on an acknowledgement button and on dismissing the overlay)
+- **Code:** `useState(open)`; `bsp-confirm-overlay` (overlay `onClick → setOpen(false)`) wrapping `bsp-confirm-box` (`onClick → e.stopPropagation()`); a `bsp-confirm-ok` "Got it" button (`onClick → setOpen(false)`).
+- **Staging evidence:** clicking the ⓘ opened the popup; clicking "Got it" closed it (the dialog was confirmed absent from the page tree after the click).
+- **Tests:** T3 (overlay/box), T4 ("Got it" closes), T5 (overlay closes / inner click does not).
+
+### 3. The popup explains the scores reflect a Web-of-Trust point of view — either the House (default) or the viewer's Personalized PoV, depending on which is selected (general; does not name the active one)
+- **Live DOM extract (staging):** *"Where do these scores come from? These reputation scores reflect a Web of Trust — a point of view on who is trustworthy. The numbers show either the House point of view (this Tapestry instance's default) or your Personalized point of view, depending on which is currently selected. Got it"*
+- **General:** the copy presents House vs Personalized as alternatives ("either … or … depending on which is currently selected") without naming the active PoV.
+- **Tests:** T6 (Web of Trust / point of view), T7 (House + Personalized + either/or + select).
+
+### 4. The explanation is accurate and bounded — no claim about the Following / Verified Followers / Verified Reporters counts elsewhere on the page
+- **Code:** the popup copy mentions none of those counts.
+- **Staging evidence (boundary is real):** on the same profile, the top-of-page "Verified Followers" reads **17,584** (Owner-PoV, Neo4j) while the Reputation grid reads **20,688** (Meili House/Personalized at `?pov=a1420e44`) — distinct sources. The popup is scoped to the Reputation-section scores and makes no PoV claim about the top counts, honoring ADR 0033 §27.
+- **Tests:** T8 (popup names none of the counts), R7 (`BrainstormProfile.jsx` carries no "House (default)" label on the counts).
+
+### 5. Additive and presentational only — no change to how scores are computed/fetched/namespaced/displayed; with the control removed the page behaves exactly as before
+- **Diff scope:** only `ui/src/components/ReputationInfo.jsx` (new) and `ui/src/pages/BrainstormProfile.jsx` (import + render in the heading). No `src/api/**`/backend change; no new dependency, lint, typecheck, or build tooling.
+- **Data path untouched:** the Meili document fetch, `TRUST_METRICS` grid, and `?pov=`/`povSuffix` resolution are unchanged (regression sentinels R1–R3). The shipped verification popover (`VerificationInfo.jsx`, `useVerificationInfo.js`) and `BrainstormReporters.jsx` are not in the diff (R4–R6).
+- **Tests:** full `npm test` 34/34 suites green (the new suite 16/16; all pre-existing suites unchanged).
+
+### 6. Live on staging.brainstorm.world with the staging smoke passing; Tier-4 rendered-UI evidence mandatory
+- **Deploy:** PR #287 merged to `staging` (merge `e8b9182e`); `deploy-staging.yml` run `27483210200` succeeded (1m14s).
+- **Five-tier smoke (https://staging.brainstorm.world):** Tier 1 stability (3 consecutive 200s); Tier 2 sanity (`/`, `/api/assistant/pubkey`, `/user/<pub>` all 200); Tier 3 the served bundle `index-DVyPDYLk.js` contains the feature copy; Tier 4 rendered UI (below); Tier 5 regression (Verified popup intact, no console errors).
+- **Tier-4 evidence:** the live staging profile render described in bullets 1–4 — a 200 on the profile URL, the ⓘ beside "Reputation", and the opened popup containing both "House" and "Personalized" point-of-view wording (DOM extract quoted in bullet 3; screenshots captured). No browser console errors.
+
+## Artifacts
+- Story: `engineering-team/stories/reputation-info-popup/1-reputation-section-pov-explainer-popup.md`
+- ADR: `engineering-team/decisions/reputation-info-popup/0034-reputation-section-pov-explainer-popup.md`
+- Test plan + tests: `…/1-reputation-section-pov-explainer-popup.test-plan.md`, `test/reputation-info-popup.test.js`
+- Review: `engineering-team/reviews/reputation-info-popup/1-reputation-section-pov-explainer-popup.md` (PASS)
+- Decision journal: `engineering-team/audits/reputation-info-popup/journal.md`

--- a/engineering-team/audits/reputation-info-popup/journal.md
+++ b/engineering-team/audits/reputation-info-popup/journal.md
@@ -138,6 +138,14 @@ All five tiers PASS. **Frame bullet 6 satisfied.**
 **Why:** Scope pre-check: `origin/main..origin/staging` carried only the reputation-info-popup feature (nothing unrelated). Opened PR #288 (`staging → main`, https://github.com/nous-clawds4/tapestry/pull/288); paused for explicit confirmation; on the operator's "Ready to merge to main," merged (merge commit `b4699d58`, mergedAt 2026-06-14T08:51:26Z). `deploy-brainstorm.yml` run `27493772719` succeeded (1m22s). Passive five-tier smoke on https://brainstorm.world: Tier 1 stable (3×200); Tier 2 sanity (/, /api/assistant/pubkey, /user/<pub> all 200); Tier 3 prod serves `index-DVyPDYLk.js` containing the Reputation popup copy; Tier 4 rendered live on the c4eabae1 profile (real scores; ⓘ beside "Reputation"; popup with verbatim House/Personalized copy; DOM extract captured; no console errors); Tier 5 regression (Verified popup copy intact). Read-only verification only — no prod mutation.
 **Next:** Re-offer book ratification/close (`/close-book`) to the operator. The feature is now live on staging AND production.
 
+## 2026-06-14T09:40:14Z — Book closed (Reviewer at book scope, operator-ratified)
+**Story/Phase:** reputation-info-popup / Book Close (post-run, normal mode — not a Director action)
+**Decision:** INFO — book ratified Closed by the operator.
+**Judge:** n/a (book-close is human-gated, not judge-gated)
+**Why:** Operator ratified the completion offer and ran `/close-book`. Wrote `audit.md` (as-built record — all six frame bullets satisfied; three documented interpretation/deferral choices; close gate `npm test` PASS, 34 suites) and `prd-seed.md` (reverse-engineered baseline for the product team, confidence high). Flipped `book.md` → `Status: Closed` (Confidence at close: high). Provenance: Acceptance-frame. The return edge to the product team is in place.
+**Carry-forward (see audit §6):** dynamic "which PoV is active" variant; extract a shared `InfoPopover` on a third explainer; PoV consistency across the follows/followers tables (open intake 2026-06-06 item 6); copy ownership by product. **Harness process amendment (goalpost-class, post-run, operator-ratified):** clarify that the Reviewer authors the Gate-5 `Status: Done` flip and reconcile "same review commit" vs the `story: close out` convention — to be drafted and committed separately (not in the book-close commit).
+**Next:** Commit `book-close: reputation-info-popup`; then draft the harness clarification for operator review.
+
 
 
 

--- a/engineering-team/audits/reputation-info-popup/journal.md
+++ b/engineering-team/audits/reputation-info-popup/journal.md
@@ -104,6 +104,14 @@ This conveys all required content, stays general (does not name the active PoV),
 **Caveat:** local Meili is sparse → the Reputation grid shows "No trust scores available" for the test pubkey; the ⓘ renders regardless (it lives in the heading, independent of score data). The definitive Tier-4 with populated scores is the book's mandatory staging evidence (frame bullet 6).
 **Next:** Stage 2.2 — `/cycle-staging`: push `feat/reputation-info-popup`, PR → staging, plain merge, watch `deploy-staging.yml`, five-tier smoke on `staging.brainstorm.world`. Staging is the ceiling; I do not go past it.
 
+## 2026-06-14T00:14:00Z — Stage 2.2 (/cycle-staging) — merged to staging; deploy in progress
+**Story/Phase:** reputation-info-popup #1 / Stage 2 deploy (staging)
+**Decision:** INFO (operational deploy gate, not judged)
+**Judge:** n/a
+**Why:** Preconditions clean (on `feat/reputation-info-popup`, tree clean, 8 commits vs origin/staging). Pushed the branch. Opened PR #287 (https://github.com/nous-clawds4/tapestry/pull/287, base `staging`). Merged with a plain merge (authorized — staging is the ceiling; the Director's reserved boundary is *past* staging, not staging itself). Merge commit `e8b9182e`, mergedAt 2026-06-14T00:14:00Z, state MERGED. `deploy-staging.yml` run `27483210200` (headSha `e8b9182e`) is in progress — watching to completion before the five-tier smoke. This is a frontend-only change; no `neo4j-heavy`/`reconcileAll` task is triggered (read-only smoke only). Note: post-merge journal entries continue to accrue on `feat/`; staging holds the audit trail through the merge commit.
+**Next:** On deploy success → five-tier smoke on staging.brainstorm.world (Tier 4 = the book's MANDATORY Tier-4 evidence: authenticated 200 on a profile URL + screenshot/DOM extract showing the ⓘ beside "Reputation" and the opened popup naming House + Personalized). Then Stage 3 completion report + final judge + offer. Deadline `2026-06-16T23:01:56Z` not passed.
+
+
 
 
 

--- a/engineering-team/audits/reputation-info-popup/journal.md
+++ b/engineering-team/audits/reputation-info-popup/journal.md
@@ -111,6 +111,20 @@ This conveys all required content, stays general (does not name the active PoV),
 **Why:** Preconditions clean (on `feat/reputation-info-popup`, tree clean, 8 commits vs origin/staging). Pushed the branch. Opened PR #287 (https://github.com/nous-clawds4/tapestry/pull/287, base `staging`). Merged with a plain merge (authorized — staging is the ceiling; the Director's reserved boundary is *past* staging, not staging itself). Merge commit `e8b9182e`, mergedAt 2026-06-14T00:14:00Z, state MERGED. `deploy-staging.yml` run `27483210200` (headSha `e8b9182e`) is in progress — watching to completion before the five-tier smoke. This is a frontend-only change; no `neo4j-heavy`/`reconcileAll` task is triggered (read-only smoke only). Note: post-merge journal entries continue to accrue on `feat/`; staging holds the audit trail through the merge commit.
 **Next:** On deploy success → five-tier smoke on staging.brainstorm.world (Tier 4 = the book's MANDATORY Tier-4 evidence: authenticated 200 on a profile URL + screenshot/DOM extract showing the ⓘ beside "Reputation" and the opened popup naming House + Personalized). Then Stage 3 completion report + final judge + offer. Deadline `2026-06-16T23:01:56Z` not passed.
 
+## 2026-06-14T00:21:28Z — Stage 2.2 staging deploy + five-tier smoke — PASS
+**Story/Phase:** reputation-info-popup #1 / Stage 2 deploy (staging)
+**Decision:** INFO (operational deploy gate, not judged)
+**Judge:** n/a
+**Why:** `deploy-staging.yml` run `27483210200` (merge `e8b9182e`) succeeded (conclusion success, 1m14s; "Deploy via SSH" clean). origin/staging now at `e8b9182e` (Merge PR #287). Five-tier smoke on https://staging.brainstorm.world:
+- **Tier 1 (stability):** 3 consecutive 200s on `/`.
+- **Tier 2 (sanity):** `/` 200, `/api/assistant/pubkey` 200, `/user/<c4eabae1>` 200.
+- **Tier 3 (PR-specific):** staging serves the new bundle `index-DVyPDYLk.js`; it contains the Reputation popup title and the House/Personalized copy.
+- **Tier 4 (rendered UI — the book's MANDATORY evidence):** rendered the live staging profile of c4eabae1 (jack mallers) at `?pov=a1420e44` in a real browser. Real reputation scores present (Verification Score 97, Verified Followers 20688). The new ⓘ renders beside the "Reputation" heading; clicking it opens the popup with the **verbatim** copy — DOM extract captured: *"Where do these scores come from? These reputation scores reflect a Web of Trust — a point of view on who is trustworthy. The numbers show either the House point of view (this Tapestry instance's default) or your Personalized point of view, depending on which is currently selected. Got it"*; "Got it" dismisses it (dialog confirmed absent post-click). **No console errors.** AC5 boundary visibly correct: the top-of-page counts (Verified Followers 17,584 — Owner PoV) differ from the Reputation grid (20688 — Meili House/Personalized), and the popup makes no claim about the top counts. Screenshots captured (open popup over the populated Reputation section).
+- **Tier 5 (regression):** the Verified popup copy ("What does \"verification\" mean?") still present in the staging bundle; Verified ⓘ + Reputation grid intact; no console errors.
+All five tiers PASS. **Frame bullet 6 satisfied.**
+**Next:** Stage 3 — write the completion report (bullet-by-bullet frame evidence), spawn the final `gate-judge` to audit it against the acceptance frame, then make the completion offer to the operator (staging is the ceiling — I do not promote to prod or ratify the book).
+
+
 
 
 

--- a/engineering-team/audits/reputation-info-popup/journal.md
+++ b/engineering-team/audits/reputation-info-popup/journal.md
@@ -131,6 +131,14 @@ All five tiers PASS. **Frame bullet 6 satisfied.**
 **Why:** Every acceptance-frame bullet is satisfied and verified on staging by an independent judge plus my own checks; the run is clean (4 judged gates APPROVE + Gate 4 mechanical PASS, 1 Gate-5 kick-back resolved, 0 stopping rules tripped). Per the ceiling, I do NOT promote past staging and I do NOT ratify the book — I offer completion and stop; the operator ratifies via `/close-book`. Audit trail (journal + completion report) pushed to `origin/feat/reputation-info-popup` for durability (post-merge commits weren't in PR #287). Deadline `2026-06-16T23:01:56Z` not passed.
 **Next:** Await operator ratification (`/close-book`). No further Director action; staging is the ceiling.
 
+## 2026-06-14T08:55:30Z — POST-RUN (operator-directed): promoted to production
+**Story/Phase:** reputation-info-popup #1 / post-run promotion
+**Decision:** INFO — **operator-directed, outside the Direction-mode run.** Not a Director action (the Director's ceiling is staging). The operator explicitly instructed prod promotion and gave explicit merge confirmation; I executed it as a normal assistant with the operator as the gate.
+**Judge:** n/a (deploy gates are operational, not judged)
+**Why:** Scope pre-check: `origin/main..origin/staging` carried only the reputation-info-popup feature (nothing unrelated). Opened PR #288 (`staging → main`, https://github.com/nous-clawds4/tapestry/pull/288); paused for explicit confirmation; on the operator's "Ready to merge to main," merged (merge commit `b4699d58`, mergedAt 2026-06-14T08:51:26Z). `deploy-brainstorm.yml` run `27493772719` succeeded (1m22s). Passive five-tier smoke on https://brainstorm.world: Tier 1 stable (3×200); Tier 2 sanity (/, /api/assistant/pubkey, /user/<pub> all 200); Tier 3 prod serves `index-DVyPDYLk.js` containing the Reputation popup copy; Tier 4 rendered live on the c4eabae1 profile (real scores; ⓘ beside "Reputation"; popup with verbatim House/Personalized copy; DOM extract captured; no console errors); Tier 5 regression (Verified popup copy intact). Read-only verification only — no prod mutation.
+**Next:** Re-offer book ratification/close (`/close-book`) to the operator. The feature is now live on staging AND production.
+
+
 
 
 

--- a/engineering-team/audits/reputation-info-popup/journal.md
+++ b/engineering-team/audits/reputation-info-popup/journal.md
@@ -124,6 +124,14 @@ This conveys all required content, stays general (does not name the active PoV),
 All five tiers PASS. **Frame bullet 6 satisfied.**
 **Next:** Stage 3 — write the completion report (bullet-by-bullet frame evidence), spawn the final `gate-judge` to audit it against the acceptance frame, then make the completion offer to the operator (staging is the ceiling — I do not promote to prod or ratify the book).
 
+## 2026-06-14T00:25:39Z — Stage 3: final completion-report judge — APPROVE; completion offered
+**Story/Phase:** reputation-info-popup #1 / Stage 3 (completion)
+**Decision:** APPROVE (completion-report gate) → completion OFFERED (not ratified — operator's call)
+**Judge:** APPROVE, blinding intact (fresh `gate-judge`). Audited the completion report bullet-by-bullet against the acceptance frame and verified each independently: ran `npm test` itself (34/34 suites, new suite 16/16, all pre-existing unchanged); confirmed PR #287 state MERGED at `e8b9182e`; deploy run `27483210200` conclusion success; `https://staging.brainstorm.world/` 200 serving `index-DVyPDYLk.js`, the bundle contains the full Reputation popup copy AND preserves the Verified popup copy (Tier-5 regression intact); the report's quoted DOM extract is verbatim-faithful to source. All six frame bullets pass with verified evidence.
+**Why:** Every acceptance-frame bullet is satisfied and verified on staging by an independent judge plus my own checks; the run is clean (4 judged gates APPROVE + Gate 4 mechanical PASS, 1 Gate-5 kick-back resolved, 0 stopping rules tripped). Per the ceiling, I do NOT promote past staging and I do NOT ratify the book — I offer completion and stop; the operator ratifies via `/close-book`. Audit trail (journal + completion report) pushed to `origin/feat/reputation-info-popup` for durability (post-merge commits weren't in PR #287). Deadline `2026-06-16T23:01:56Z` not passed.
+**Next:** Await operator ratification (`/close-book`). No further Director action; staging is the ceiling.
+
+
 
 
 

--- a/engineering-team/audits/reputation-info-popup/prd-seed.md
+++ b/engineering-team/audits/reputation-info-popup/prd-seed.md
@@ -1,0 +1,51 @@
+# PRD Seed: Reputation explainer (profile point-of-view transparency)
+
+**Mode:** reconstructed from as-built *(no prior PRD)*
+**Build audit:** `engineering-team/audits/reputation-info-popup/audit.md`
+**Anchor:** acceptance frame in `book.md`
+**Confidence:** high *(explicit acceptance frame; small, fully-verified feature)*
+**Date:** 2026-06-14
+
+> A reverse-engineered baseline in the product-team PRD shape, built from what shipped. A strawman for the product team — not a ratified spec. Sections are tagged `[FROM FRAME]` (grounded in the kickoff acceptance frame), `[INFERRED]` (read off the as-built system), or `[UNKNOWN — product input needed]`. Adopt as the starting point for `/discover` on the next phase and validate each section.
+
+## 1. Product vision
+`[FROM FRAME]` Make the reputation numbers on a profile **self-describing**: a reader should be able to learn, in plain language, where the scores come from without leaving the page. `[INFERRED]` The underlying opportunity: the profile shows Web-of-Trust reputation scores that *shift with the selected point of view* (House vs Personalized), and nothing on the page previously explained that — leaving the numbers opaque or easy to misread as a single global truth. `[INFERRED]` This extends an existing pattern: the page already had a "Verified" ⓘ explainer; this brings the same affordance to "Reputation."
+
+## 2. Personas
+`[FROM FRAME / INFERRED]` Story line: *"As someone viewing a public profile page…"* — the primary persona is a **profile visitor** (both authenticated and anonymous), not the profile owner or an operator. They want to understand what the reputation numbers mean and that they reflect a point of view. `[UNKNOWN]` Whether distinct sub-personas (e.g. newcomers vs. power users who already grok the Grapevine) warrant different treatment.
+
+## 3. Scope (as-built)
+`[FROM FRAME]` In scope, shipped:
+- A circled-"i" ⓘ control beside the profile "Reputation" heading, visually/behaviorally consistent with the existing "Verified" control.
+- A dismissible popup (acknowledgement button + overlay-click to close).
+- Static explanatory copy: the scores reflect a Web-of-Trust point of view — either the House (default) or the viewer's Personalized PoV, depending on which is currently selected.
+- Accuracy boundary: the copy is scoped to the Reputation-section scores and makes no claim about the separate Following / Verified Followers / Verified Reporters counts (which are Owner-PoV, a different source).
+- Additive/presentational only — no change to how scores are computed, fetched, namespaced, or displayed.
+
+`[FROM FRAME]` Explicitly **out of scope** this phase: dynamically naming the *active* PoV; any backend/API change; adding the explainer to other pages.
+
+## 4. Domain model
+`[INFERRED]` from the Concept Graph orientation and ADR 0034:
+- **Web of Trust** (`web-of-trust`) — the reputation model; "each user sees a personalized view of the network weighted by the people they trust."
+- **GrapeRank** (`graperank`) — the contextual WoT scoring algorithm behind the Reputation-grid numbers.
+- **House point of view** vs **Personalized point of view** — product/UI notions (NOT modeled as Concept Graph nodes). House = the instance default (its delegated pubkey); Personalized = the viewer's own, selected via the `?pov=` URL parameter. Per BIBLE §27 / ADR 0033, the profile's Meilisearch-sourced Reputation grid is legitimately House/Personalized, whereas the top-of-page counts are **Owner** PoV (Neo4j) — a distinction this feature is careful to preserve.
+
+## 5. Design rules (as-built)
+`[INFERRED]` from the shipped UI + ADR 0034 + review:
+- Info-explainers reuse the shared `bsp-info-btn` trigger + `bsp-confirm-overlay`/`bsp-confirm-box`/`bsp-confirm-ok` ("Got it") popup pattern, tap-to-open and mobile-friendly.
+- A new explainer that needs no instance data is a self-contained, prop-free, hook-free component (no fetch).
+- `[INFERRED]` Placement convention is unsettled: this ⓘ right-aligns at the heading edge (matching the Verified ⓘ's behavior); a "snug after the word" convention was considered but not adopted. `[UNKNOWN]` whether a single placement rule should be standardized for all info-controls.
+
+## 6. Carry-forward & open questions
+*(promoted from build audit §6)*
+- Dynamic "which PoV is active" variant of the popup.
+- Extract a shared `InfoPopover` primitive once a third explainer appears.
+- PoV consistency across the rest of the profile — esp. Personalized PoV for the follows/followers *tables* (open intake 2026-06-06, item 6), which this feature's House-vs-Personalized framing now sits beside.
+- Optional snug ⓘ placement; standardize an info-control placement rule.
+
+## 7. What product must validate
+- [ ] **Copy ownership:** the popup wording was chosen by the engineering Director under the book's delegation. Does the product team want to own/refine the final copy (tone, length, terminology like "Web of Trust" vs "Grapevine")?
+- [ ] **Dynamic PoV naming:** is "explain in general" sufficient, or should the popup state which PoV the viewer is currently seeing? (Deferred this phase.)
+- [ ] **PoV transparency strategy:** should this explainer be part of a broader, consistent treatment of House-vs-Personalized across the whole profile (counts + tables), rather than the Reputation section alone?
+- [ ] **Reach:** should the same explainer appear on other surfaces that show PoV-dependent scores (e.g. `/reporters`, search results)?
+- [ ] `[UNKNOWN]` Success signal: is there any measurable goal (comprehension, reduced confusion) the product team wants to attach, or is this purely a clarity improvement?


### PR DESCRIPTION
## Summary

Docs-only. Lands the post-merge audit trail for the `reputation-info-popup` book on the main line: the build audit and PRD seed (the return edge for the product team), the completion report, the full decision journal, and `book.md` flipped to **Closed**. No app code — these files are not part of the UI build.

## Changes
- `engineering-team/audits/reputation-info-popup/audit.md` (new — as-built record)
- `engineering-team/audits/reputation-info-popup/prd-seed.md` (new — reverse-engineered baseline for product)
- `engineering-team/audits/reputation-info-popup/completion-report.md`, `journal.md`
- `engineering-team/audits/reputation-info-popup/book.md` → Status: Closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)