### PR TITLE
chore: clarify Reviewer authors the Gate-5 Status flip

### DIFF
--- a/.claude/skills/direct-feature/SKILL.md
+++ b/.claude/skills/direct-feature/SKILL.md
@@ -55,7 +55,7 @@ Follow the phase workflows in [engineering-team/workflows/](../../../engineering
 2. **Architecture** — spawn `architect`. **Gate 2:** judged. Commit the ADR, journal.
 3. **Test Design** — spawn `tester`; demand the actual failing `npm test` output. **Gate 3:** judged. Commit (`test: failing tests for <slug> (story #<n>)`), journal.
 4. **Implementation** — spawn `implementer`. **Gate 4 (mechanical):** run the full Stage-0 baseline command yourself; confirm `git diff <Gate-3 commit>..HEAD -- test/` is empty. Commit (`impl: <slug> (story #<n>, ADR <NNNN>)`), journal.
-5. **Review** — spawn `reviewer` (fresh context — never the Implementer's). Commit the review file **regardless of verdict** (workflow 5 rule), journal. CHANGES_REQUESTED → route back to the Implementer (counts as a Gate-5 kick-back). PASS → **Gate 5:** judge audits the review artifact; on APPROVE, confirm the story's `**Status:** Done` flip, journal.
+5. **Review** — spawn `reviewer` (fresh context — never the Implementer's). On PASS the Reviewer flips the story's `**Status:** Done` in the review commit as its standard close-out (`workflows/5-review.md`) — **don't instruct it otherwise.** Commit the review file **regardless of verdict** (workflow 5 rule), journal. CHANGES_REQUESTED → route back to the Implementer (counts as a Gate-5 kick-back). PASS → **Gate 5:** judge audits the review artifact; on APPROVE, **verify the Reviewer's `**Status:** Done` flip is present** in the review commit (a missing flip is a Gate-5 kick-back to the Reviewer — the Director never edits the story file), journal.
 
 ### Stage 2 — deploy
 

--- a/engineering-team/roles/director.md
+++ b/engineering-team/roles/director.md
@@ -99,7 +99,7 @@ The judge applies these; you confirm the judge actually applied them. Items mark
 - The review follows `templates/review-checklist.md` — including the **things-tests-can't-catch sweep** (secrets, leftover debug code, security, races) and the **house-rules check** (Concept Graph authority, no new tooling) — each section *demonstrated*, not just present.
 - The review records the Reviewer's **own** test-gate run with actual results — not the Implementer's word.
 - Spec check, ADR check, concept-graph integrity, and scope-creep sweep all present, with file:line refs.
-- Verdict explicit. PASS only if mergeable as-is; on PASS, the story's `**Status:** Done` is flipped in the same review commit and no files are moved (per-story close-out is in place; epic retirement is not yours — see the skill, Stage 3).
+- Verdict explicit. PASS only if mergeable as-is; on PASS, the story's `**Status:** Done` is flipped in the same review commit, **authored by the Reviewer** (`roles/reviewer.md` / `workflows/5-review.md`), and no files are moved (per-story close-out is in place; epic retirement is not yours — see the skill, Stage 3). **The Director never edits the story file — it is outside the Director's lane;** the judge confirms the flip is *present*, and a missing flip is a Gate-5 kick-back to the Reviewer, not a Director edit.
 - A Reviewer CHANGES_REQUESTED routes back to the Implementer and **counts as a KICK_BACK at Gate 5** for the stopping rules.
 - The judge here audits *the review*, not the diff: does the review demonstrate its checks, or merely assert them?
 


### PR DESCRIPTION
## Summary

Docs-only harness clarification (post-mortem from the reputation-info-popup Direction run). Aligns the Director docs with the already-correct Reviewer docs: the **Reviewer** authors the story `**Status:** Done` flip in the review commit; the Director only **verifies** it is present (a missing flip is a Gate-5 kick-back to the Reviewer, never a Director edit). No app code.

## Changes
- `engineering-team/roles/director.md` — Gate-5 rubric clarified
- `.claude/skills/direct-feature/SKILL.md` — Stage 1 step 5 clarified

No change to `roles/reviewer.md` / `workflows/5-review.md` (already correct) or `gate-judge.md`. Goalpost-class clarification, applied post-run and operator-ratified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)