### PR TITLE
Promote staging → main: /whats-open roll-up + OPEN.md ledger (docs/tooling-only)

### DIFF
--- a/.claude/commands/close-book.md
+++ b/.claude/commands/close-book.md
@@ -24,10 +24,10 @@ You are entering **Book Close** — a milestone phase of the Tapestry engineerin
 - Be honest about confidence. A reconstructed, no-anchor close is a low-confidence hypothesis — say so in the header, don't dress it up.
 - Engineering authors both artifacts under `engineering-team/`. Never write into `product-team/`.
 
-**Gate (mandatory):** After writing both artifacts and flipping the book to Closed, ask:
+**Gate (mandatory):** After writing both artifacts, flipping the book to Closed, and sweeping any small / cross-cutting loose ends into the root [`OPEN.md`](OPEN.md) ledger (workflow step 9), ask:
 
 > Book closed. Audit + {addendum|seed} are ready for the product team to scope the next phase. Anything to correct before I commit?
 
-**Per-phase commit:** Commit audit + feedback doc + updated `book.md` together: `git commit -m "book-close: <book-slug>"`.
+**Per-phase commit:** Commit audit + feedback doc + updated `book.md` + any `OPEN.md` rows together: `git add engineering-team/audits/<book-slug> OPEN.md && git commit -m "book-close: <book-slug>"`.
 
 $ARGUMENTS

--- a/.claude/commands/whats-open.md
+++ b/.claude/commands/whats-open.md
@@ -1,0 +1,26 @@
+---
+description: Roll up everything still open across the repo, from any session — derived from the tracking surfaces plus the OPEN.md ledger. Read-only.
+---
+
+You are producing a **unified "what's still open" report** across the whole repo, spanning every session — bugs, features, protocol changes, doc updates, and small cleanups alike. Read-only: do not change any file or close anything.
+
+## Steps
+
+1. Run the deterministic roll-up and read its output:
+   ```bash
+   bash scripts/whats-open.sh
+   ```
+   It scans: the `OPEN.md` ledger (homeless/cross-cutting items), `🔴 OPEN` handoffs, open books, intake entries with no `PICKED UP`/`RESOLVED` marker (heuristic), `protocols/worksheet.md`, open PRs, and unmerged feature branches.
+
+2. Add the judgment the script can't:
+   - **Triage the intake heuristic.** The script flags intake entries lacking a done-marker, but some are partially done or stale. Open `engineering-team/stories/_intake.md` for any that look ambiguous and say what's actually open.
+   - **Cross-reference.** If an `OPEN.md` ledger row or an open book is already covered by a handoff or PR, note it once, not twice.
+   - **Flag stale.** Anything whose context implies it should already be closed (e.g. a handoff whose verification window has long passed) — call it out as "review status."
+
+3. Present a single report grouped by **type** (bug · feature · protocol · docs · cleanup · meta), each item one line with its source surface and a pointer. Lead with anything stale or surprising. Keep it scannable — this is a status read, not a plan.
+
+## Boundaries
+- **Read-only.** Do not edit `OPEN.md`, flip statuses, or close items here — surface them. Updating the ledger happens at session-end / `/close-book`, not in this report.
+- Don't invent items; report only what the surfaces actually show. If a surface is empty, say so.
+
+$ARGUMENTS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,9 @@ Before starting work, read all four:
 - [BIBLE.md](./BIBLE.md) — architecture, protocol, data model, API, design decisions (universal, fork-agnostic)
 - [OPERATIONS.md](./OPERATIONS.md) — brainstorm.world deployment: branches, CI/CD, droplets, gotchas
 
-**Also check at session start:**
+**Also check at session start** — or just run **`/whats-open`** (alias: `bash scripts/whats-open.sh`) for a unified roll-up of everything still open across sessions, derived from all the surfaces below plus the ledger:
 
+- [`OPEN.md`](./OPEN.md) — the single ledger for **small / cross-cutting open items that have no other surface** (one-off cleanups, "does BIBLE need a note about what we just built?" decisions, follow-ups too small for a handoff doc, a branch to delete). The surfaces below hold the larger triaged work; `/whats-open` rolls them all together. **Write discipline:** whenever you end a session with such a loose end, add a row here (and flip it to `DONE` when handled) so the next session — any session — sees it.
 - [`docs/*HANDOFF*.md`](./docs/) — session continuity notes. Each handoff doc starts with a `**Status:**` line: `🔴 OPEN` = work hasn't been picked up; `✅ ADDRESSED / SUPERSEDED` = the follow-on work has shipped (the body is preserved for historical context, no action needed). Always scan for `OPEN` handoffs before starting fresh work — a previous session may have left specific instructions for the new one.
 - [`engineering-team/stories/_intake.md`](./engineering-team/stories/_intake.md) — queued-but-unplanned work catalog. See [engineering-team/README.md](./engineering-team/README.md) for the format. Scan before opening a fresh feature request — there's often a relevant entry already triaged.
 - [`protocols/README.md`](./protocols/README.md) — index of every protocol spec we author (published Custom NIPs, local pre-NIPs) with per-spec status, plus [`protocols/worksheet.md`](./protocols/worksheet.md) for open protocol problems. Check before any protocol/NIP/wire-format work — the spec's status and current source of truth are recorded there.

--- a/OPEN.md
+++ b/OPEN.md
@@ -1,0 +1,30 @@
+# Open Items Ledger
+
+The single home for **small or cross-cutting open items that have no other surface** — one-off cleanups, "should we update BIBLE?" decisions, follow-ups too small for a handoff doc, anything that would otherwise be remembered only by the session that noticed it.
+
+**This is NOT the whole backlog.** Big, triaged work lives in its proper surface, and those are *derived* into one view by [`scripts/whats-open.sh`](scripts/whats-open.sh) / the `/whats-open` command:
+
+| Kind of open work | Lives in |
+|---|---|
+| Triaged-but-unbuilt features / bugs / refactors | [`engineering-team/stories/_intake.md`](engineering-team/stories/_intake.md) |
+| Session-to-session "I left this open" notes | `docs/*HANDOFF*.md` (`**Status:** 🔴 OPEN`) |
+| Per-book deferred scope | `engineering-team/audits/<slug>/audit.md` §6 + `prd-seed.md` §7 |
+| Open protocol problems | [`protocols/worksheet.md`](protocols/worksheet.md) |
+| In-flight code | open PRs / unmerged branches (git) |
+| **Small / cross-cutting / homeless items** | **this file** |
+
+Run **`/whats-open`** (or `bash scripts/whats-open.sh`) for the unified roll-up across all of the above plus this ledger.
+
+## How to use this ledger
+- Add a row when you finish a session with a small loose end that has no other home. Keep it one line; link to detail if it has any.
+- Flip **Status** to `DONE` (don't delete) when handled — the closed rows are the audit trail.
+- **Type:** `bug` · `feature` · `protocol` · `docs` · `cleanup` · `meta`.
+- **Opened / Done:** ISO date + the session/book/PR that raised or resolved it.
+
+## Items
+
+| # | Type | Item | Opened | Status | Done | Pointer |
+|---|---|---|---|---|---|---|
+| 1 | cleanup | Review/flip the stale handoff status: `docs/POST_TIMEOUT_FIX_COMPLETION_HANDOFF_2026-05-26.md` is still `🔴 OPEN`, but its "24–48h passive-verification window" (late May 2026) is long past — confirm the verification held and flip to `✅ ADDRESSED`, or capture whatever remains. | 2026-06-14 | OPEN | — | the handoff doc |
+| 2 | cleanup | Delete the merged branches `feat/reputation-info-popup` and `chore/clarify-gate5-status-flip`. | 2026-06-14 (reputation-info-popup) | DONE | 2026-06-14 | branches deleted; remotes were auto-deleted on merge |
+| 3 | docs | Decide whether BIBLE needs a `reputation-info-popup` entry. | 2026-06-14 (reputation-info-popup) | DONE | 2026-06-14 | No — it's a UI explainer, not architecture / protocol / data-model / API; out of BIBLE's scope. Recorded here so the judgment isn't lost. |

--- a/engineering-team/workflows/6-book-close.md
+++ b/engineering-team/workflows/6-book-close.md
@@ -33,10 +33,11 @@ Both are **engineering-authored and live under `engineering-team/`.** The produc
 6. **Write the feedback doc** (addendum or seed) — promote deviations and the carry-forward register into product-facing framing. Recommendations are *input*, not decisions.
 7. **Run the gate** at close: `npm test`; record the result in the audit.
 8. **Flip the book to Closed.** Set `**Status:** Closed`, fill the close-artifact links and confidence in `book.md`.
-9. **Gate:** "Book closed. Audit + {addendum|seed} written to `audits/<book-slug>/`. Ready for the product team to scope the next phase. Anything to correct?"
+9. **Sweep loose ends to `OPEN.md`.** Any small / cross-cutting follow-up this book leaves that has no other home — a one-off cleanup, a "does BIBLE need a note?" decision, a branch to delete — gets a row in the root [`OPEN.md`](../../OPEN.md) ledger so it isn't lost. (Larger deferred scope already lives in the audit's §6 carry-forward; link it, don't duplicate it.)
+10. **Gate:** "Book closed. Audit + {addendum|seed} written to `audits/<book-slug>/`. Ready for the product team to scope the next phase. Anything to correct?"
 
 ## Per-phase commit
-Commit the audit, feedback doc, and updated `book.md` together: `git add engineering-team/audits/<book-slug> && git commit -m "book-close: <book-slug>"`.
+Commit the audit, feedback doc, updated `book.md`, and any `OPEN.md` ledger rows together: `git add engineering-team/audits/<book-slug> OPEN.md && git commit -m "book-close: <book-slug>"`.
 
 ## Book retirement
 Like epics, a closed book's folder moves under `audits/done/<book-slug>/` once the next phase has ingested it (one `git mv` on the directory). Everything outside `done/` is live; everything under it is shipped and read-only by convention.

--- a/scripts/whats-open.sh
+++ b/scripts/whats-open.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# whats-open.sh — one unified roll-up of open work across the repo, from ANY session.
+#
+# It DERIVES the view from the tracking surfaces that are already machine-readable
+# (OPEN handoffs, open books, un-picked-up intake, protocol worksheet, open PRs,
+# unmerged branches). The OPEN.md ledger is the home for small / cross-cutting
+# items that have no other surface. Together they answer "what's still open?"
+#
+# Runnable solo (`bash scripts/whats-open.sh`) or via the `/whats-open` command,
+# which runs this and then adds triage/prioritization. See OPEN.md and CLAUDE.md.
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+REPO="nous-clawds4/tapestry"
+hr() { printf '\n──────── %s ────────\n' "$1"; }
+
+hr "OPEN.md ledger — small / cross-cutting items (the homeless ones)"
+if [ -f OPEN.md ]; then
+  grep -E '^\|' OPEN.md | grep -iE '\|[[:space:]]*OPEN[[:space:]]*\|' || echo "  (no OPEN rows in the ledger)"
+else
+  echo "  (OPEN.md not found)"
+fi
+
+hr "🔴 OPEN handoffs — docs/*HANDOFF*.md"
+any=0
+for f in docs/*HANDOFF*.md; do
+  [ -e "$f" ] || continue
+  # 🔴 on a Status line = OPEN (✅ = addressed/superseded). Match the marker, not the
+  # word, since the convention varies: "🔴 OPEN" vs bolded "🔴 **OPEN**".
+  if grep -qi 'Status:.*🔴' "$f"; then
+    any=1; printf "  %s\n      %s\n" "$f" "$(grep -m1 -i 'Status:' "$f" | sed 's/\*\*//g' | cut -c1-150)"
+  fi
+done
+[ "$any" = 0 ] && echo "  (none open)"
+
+hr "Open books — engineering-team/audits/*/book.md (Status: Open)"
+any=0
+for f in engineering-team/audits/*/book.md; do
+  [ -e "$f" ] || continue
+  grep -qiE '^\*\*Status:\*\*[[:space:]]*Open' "$f" && { any=1; echo "  $(basename "$(dirname "$f")")"; }
+done
+[ "$any" = 0 ] && echo "  (none open)"
+
+hr "Intake entries with no PICKED UP / RESOLVED marker — heuristic, review manually"
+awk '
+  /^## 20[0-9][0-9]-/ { if (h != "" && !d) print "  " h; h=$0; d=0 }
+  /PICKED UP|RESOLVED/ { d=1 }
+  END { if (h != "" && !d) print "  " h }
+' engineering-team/stories/_intake.md 2>/dev/null || echo "  (intake not found)"
+
+hr "Protocol worksheet — protocols/worksheet.md (open problems)"
+if [ -f protocols/worksheet.md ]; then
+  grep -nE '^\s*[-*#].*\bW[0-9]+\b' protocols/worksheet.md | grep -viE 'done|resolved|closed|✅|ratified' | head -15 || echo "  (none flagged open — see worksheet)"
+else
+  echo "  (worksheet not found)"
+fi
+
+hr "Open PRs"
+if command -v gh >/dev/null 2>&1; then
+  gh pr list --repo "$REPO" --state open --json number,title,baseRefName \
+    --jq '.[] | "  #\(.number) → \(.baseRefName): \(.title)"' 2>/dev/null || echo "  (gh error)"
+  [ -z "$(gh pr list --repo "$REPO" --state open --json number --jq '.[].number' 2>/dev/null)" ] && echo "  (none)"
+else
+  echo "  (gh not available — skip)"
+fi
+
+hr "Unmerged feature branches vs origin/main (candidate cleanup)"
+git fetch -q origin 2>/dev/null || true
+# Exclude the long-lived sandbox branches (per CLAUDE.md autonomy ceiling) — they are not "to close".
+git branch -r --no-merged origin/main 2>/dev/null \
+  | grep -vE 'origin/(HEAD|main|staging|feature-magic-carpet|feat/communities|feat/curate|feat/pubkey-tagging-target)' \
+  | sed 's/^/  /' | head -40
+[ -z "$(git branch -r --no-merged origin/main 2>/dev/null | grep -vE 'origin/(HEAD|main|staging|feature-magic-carpet|feat/communities|feat/curate|feat/pubkey-tagging-target)')" ] && echo "  (none)"
+
+printf '\nDerived from the tracking surfaces. Small/cross-cutting items with no other home belong in OPEN.md; everything else lives in its surface and is linked from there.\n'


### PR DESCRIPTION
## Summary
Promotes the cross-session open-work tracking (PR #292) to main. **Docs/tooling-only** — no app code; `scripts/whats-open.sh` is a dev/ops helper, not part of the build. Production deploy is a no-op rebuild, zero user-visible impact.

## Bundled
- **#292** — `/whats-open` roll-up command + `scripts/whats-open.sh`, the `OPEN.md` ledger, and the CLAUDE.md / book-close wiring.

## Test plan
- [ ] After merge: deploy-brainstorm.yml runs (no-op rebuild).
- [ ] Sanity: brainstorm.world still 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)