### PR TITLE
Reporters: Report Type + Reported (timestamp) columns (verified-reporters #4)

### DIFF
--- a/engineering-team/decisions/verified-reporters/0004-reporters-report-type-and-timestamp-columns.md
+++ b/engineering-team/decisions/verified-reporters/0004-reporters-report-type-and-timestamp-columns.md
@@ -1,0 +1,93 @@
+# ADR 0004: Report Type and Reported (timestamp) columns on the Verified Reporters list
+
+**Status:** Accepted
+**Date:** 2026-06-15
+**Story:** `engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.md`
+**Epic:** `verified-reporters`
+
+## Context
+
+Story 4 adds two report-only columns to `/user/:pubkey/reporters` (`BrainstormReporters.jsx`): **Report Type** (humanized label, default-visible) and **Reported** (relative "time ago", toggle-on), sourced from the neo4j `REPORTS` edge. Default visible columns change from Picture/Name/Rank to **Picture/Report Type/Rank**. The Reported column displays e.g. `3d, 4h, 12m ago` but sorts by the **raw unix integer**; missing values render empty and sort **last in both directions**. The page also shows a **"N reporters, M reports"** summary. No client-side de-duplication.
+
+**Verified facts (this branch):**
+- The membership endpoint `src/api/grapevineInteractions/queries/reportersWithMetrics.js:94-103` runs `MATCH (observee)<-[:REPORTS]-(reporter) WHERE reporter.influence > $cutoff RETURN reporter.<node props>` — **no `DISTINCT`, no aggregation**, so it already returns **one row per matched `REPORTS` edge**. The list is *already* report-centric; binding the relationship to add `report_type`/`timestamp` does **not change row cardinality**.
+- Edges are created with `report_type` as part of the composite MERGE key and `r.timestamp = created_at` (seconds) `ON CREATE` (`apocCypherCommands/apocCypherCommand1_reportsToAddToNeo4j:22-23`, `kind1984EventsToReports.js:95-104`). Multiple distinct report types per pair → multiple edges, by design.
+- `ui/src/hooks/useGrapevineReporters.js:31` passes `json.data` straight through, so new response fields flow to the page rows with no hook change.
+- `DataTable` (`ui/src/components/DataTable.jsx:35-43`) sorts on `a[sortKey] ?? ''` via `String(...).localeCompare(…, {numeric:true})`. It has **no way to (a) sort a column by a value different from what it renders, or (b) put missing values last in both directions** — `?? ''` makes nulls sort *first* ascending. **16 files** consume `DataTable`, so any change must be strictly backward-compatible.
+- No shared time-ago helper exists (≈15 inline copies); all are **single-unit** ("3d ago"), so none matches the required **multi-unit** format anyway.
+- The profile badge is `count(f)` over verified `REPORTS` edges (`calculateVerifiedReporterCounts.sh`) → counts **reports**, not distinct reporters. So today badge ≈ row count; the summary's distinct-reporter figure is new. Relabeling/reconciling the badge is **out of scope** (story).
+
+**Constraints:** JS-without-build (no new lint/typecheck); tokens only; House/owner PoV only (ADR 0002/0003); no concept/firmware change — `report_type`/`timestamp` are runtime Neo4j edge properties, not graph concepts (Concept Graph consulted: 34 concepts, none report-related).
+
+## Options considered
+
+### Option A — Additive: opt-in `sortValue` on DataTable + new pure helpers + bind the relationship *(chosen)*
+- Backend: bind the edge (`<-[rel:REPORTS]-`) and return `rel.report_type AS reportType`, `rel.timestamp AS timestamp`. Cardinality unchanged.
+- `DataTable`: add an **opt-in** per-column `sortValue(row)` accessor. When a column defines it, sort numerically on that value with **missing-always-last** (both directions); otherwise the existing `localeCompare` path runs **byte-for-byte unchanged**. Zero impact on the other 15 consumers.
+- Two new pure utils (`timeAgo.js`, `reportType.js`) — independently unit-testable.
+- Page: two columns, new defaults, summary line, map the two fields into rows.
+- **Pros:** minimal, isolated; honors "no dedup" *by construction* (existing per-edge query); decouples display from sort cleanly; backward-compatible; gives the Tester pure functions to test.
+- **Cons:** a (tiny) generic addition to shared `DataTable`. Mitigated by the opt-in gate.
+
+### Option B — Sort without touching DataTable
+Set the column `key:'timestamp'` (raw int) with a `render` that formats — the existing `localeCompare(numeric)` then sorts on the raw int already. Handle nulls by substituting a sentinel (0 / -Infinity) into the row value.
+- **Pros:** no shared-component change.
+- **Cons:** **fails the nulls-last-in-both-directions AC** — a sentinel sits at one end only, and flipping direction moves it to the wrong end; polluting the raw value also corrupts the displayed cell. Brittle string-compare of integers. Rejected.
+
+### Option C — Bundle the deferred `<GrapevineList>` DRY refactor
+Unify follows/followers/reporters now and add the columns to the shared component.
+- **Cons:** refactors live, prod-adjacent pages — regression risk and scope creep; explicitly deferred by ADR 0002/0003. Rejected; remains the standing follow-up.
+
+## Decision
+**Option A.** Additive, isolated, backward-compatible. The "one row per report, no dedup" requirement falls out of the existing per-edge query for free; the only shared-code change is an opt-in `sortValue` accessor on `DataTable` that leaves every current caller untouched.
+
+## Consequences
+- **Enables** report type + recency per row, raw-integer sorting, and the reporter/report summary.
+- **`DataTable` gains** a small, documented, opt-in sort accessor — useful for future columns; no behavior change unless a column opts in.
+- **Row cardinality is unchanged** vs. today — the page was already one-row-per-edge; we only enrich rows. Any duplicate-edge bug in neo4j stays visible (intended).
+- **Badge vs. summary:** today the profile badge counts edges (≈ reports = M). The summary's "N reporters" is new context, and the page is forward-compatible if the badge is later redefined. Badge unchanged here.
+- **Two new util files** (multi-unit time-ago, report-type label) — deliberately *not* a refactor of the ~15 inline single-unit helpers (different format, out of scope; note as follow-up).
+- **Firmware reinstall required?** No.
+
+## Implementation notes
+
+**Backend — `src/api/grapevineInteractions/queries/reportersWithMetrics.js`:**
+- Cypher: `MATCH (observee:NostrUser {pubkey:$observee})<-[rel:REPORTS]-(reporter:NostrUser) WHERE reporter.influence > $cutoff RETURN reporter.pubkey AS pubkey, …existing node props…, rel.report_type AS reportType, rel.timestamp AS timestamp`.
+- In the `.map`, add `reportType: r.get('reportType') ?? null` and `timestamp: toInt(r.get('timestamp'))` (neo4j Integer → JS number; seconds). `count: data.length` unchanged.
+
+**New `ui/src/utils/timeAgo.js`** — `export function formatTimeAgo(unixSeconds, now = Math.floor(Date.now()/1000))`:
+- Missing/non-finite input → `''`.
+- `delta = max(0, now - unixSeconds)` seconds; decompose into y(365d)/d/h/m (integer); **drop all zero units**, take the **3 most-significant** remaining, join with `, `, append `' ago'` → e.g. `3d, 4h, 12m ago`, `2y, 14d, 3h ago`, `45m ago`.
+- Sub-minute (no non-zero unit) → `'0m ago'`.
+
+**New `ui/src/utils/reportType.js`** — `export function humanizeReportType(t)`: `''` if falsy; optional override map (empty for now, e.g. future `csam → CSAM`); else capitalize first letter (`spam → Spam`, `impersonation → Impersonation`).
+
+**`ui/src/components/DataTable.jsx`** — in the `sorted` memo, look up the active column (`columns.find(c => c.key === sortKey)`); if it has a `sortValue` function, sort via that accessor with missing-always-last + numeric compare; else the **existing** path verbatim. Add `columns` to the memo deps. Document `sortValue` in the JSDoc.
+```js
+const col = columns.find(c => c.key === sortKey);
+const accessor = col && typeof col.sortValue === 'function' ? col.sortValue : null;
+if (accessor) {
+  return [...filtered].sort((a, b) => {
+    const av = accessor(a), bv = accessor(b);
+    if (av == null && bv == null) return 0;
+    if (av == null) return 1;      // missing last, regardless of sortDir
+    if (bv == null) return -1;
+    return sortDir === 'asc' ? av - bv : bv - av;
+  });
+}
+// …unchanged localeCompare path…
+```
+
+**`ui/src/pages/BrainstormReporters.jsx`:**
+- Import `formatTimeAgo`, `humanizeReportType`.
+- `ALL_COLUMNS`: add `{ key:'reportType', label:'Report Type', render: v => humanizeReportType(v) }` and `{ key:'timestamp', label:'Reported', sortValue: row => row.timestamp, render: v => (v == null ? '' : formatTimeAgo(v)) }`. (Order them after `name` so the chooser reads naturally.)
+- `DEFAULT_VISIBLE`: `{ picture:true, reportType:true, rank:true, name:false, timestamp:false, npub:false, hops:false, verified*Count:false }`.
+- `rows` memo: add `reportType: f.reportType ?? null`, `timestamp: (f.timestamp == null ? null : Number(f.timestamp))`. Keep the default rank-desc sort.
+- **Summary line** (when `rows.length > 0`): `reportCount = rows.length`; `reporterCount = new Set(rows.map(r => r.pubkey)).size`; render `"<N> reporter(s), <M> report(s)"` (correct singular/plural) below the PoV line. Computed from the full `rows` (independent of the search box). Optional `.bsp-follows-summary` class in `ui/src/styles.css`.
+- Build: `npm run build` in `ui/`.
+
+## Out of scope
+- Changing/relabeling the profile count badge (counts edges today); reconciling badge vs. summary.
+- Refactoring the ~15 inline time-ago helpers; the `<GrapevineList>` DRY unification (standing follow-up).
+- Filtering/grouping by report type (Phase 2 breakdown); pile-on (Phase 3); personalized PoV.
+- Live-ticking the "ago" text; absolute-time tooltips.

--- a/engineering-team/reviews/verified-reporters/4-reporters-report-type-and-timestamp-columns.md
+++ b/engineering-team/reviews/verified-reporters/4-reporters-report-type-and-timestamp-columns.md
@@ -1,0 +1,61 @@
+# Review: Story verified-reporters #4 — Report Type and Reported (timestamp) columns
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-15
+**Diff:** `git diff staging...HEAD` (impl commit `7dc23dad`)
+**Story:** `engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.md`
+**ADR:** `engineering-team/decisions/verified-reporters/0004-reporters-report-type-and-timestamp-columns.md`
+**Test plan:** `engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.test-plan.md`
+
+Method: manual file-by-file audit + an adversarial multi-lens pass (4 independent reviewers — logic/edge-cases, regression to the 16 `DataTable` consumers, ADR/AC conformance, backend/data-flow — each finding then adversarially refuted). 1 finding raised, 1 confirmed (non-blocking), 0 blocking.
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **PASS**. All 38 suites green; `verified-reporters-report-columns` **26/26**; Overall **PASS**.
+- [x] `npm run build` (ui/) — **clean** (only the pre-existing generic chunk-size warning).
+- [~] `npm run test:playwright` — **not run** (live-stack/browser); the supplementary `tests/brainstorm/profile-verified-reporters-columns.spec.js` is a staging-smoke spec, consistent with Story 3's precedent.
+- [x] _Lint not configured — skipped._
+- [x] _Typecheck not configured — skipped._
+- [x] Local endpoint smoke: new bound-relationship Cypher executes → `200` + correct contract; invalid observee → `400`; page route → `200`. (Local DB unseeded — populated render is a staging check.)
+
+## Spec adherence
+- [x] Every acceptance criterion has a passing test (coverage map in the test plan; T1–T22 + R1–R4).
+  - Default cols Picture/Report Type/Rank → `DEFAULT_VISIBLE` (T20) + Playwright chooser check; column ORDER in `ALL_COLUMNS` (picture, name, reportType, rank, timestamp, …) renders the visible set left-to-right as Picture · Report Type · Rank ✓.
+  - Report Type humanized (T8/T17); Reported "ago" multi-unit (T1–T4/T18); sort by raw unix int (T13/T18); missing → empty + sort-last-both-directions (T6/T9/T14/T19); one row per edge / no dedup (T12/integration lens); "N reporters, M reports" summary (T21).
+- [x] No criterion silently dropped.
+- [x] No behavior added beyond the story (diff is exactly the authorized files; no scope creep).
+
+## ADR adherence
+- [x] Files changed match ADR 0004 §Implementation notes precisely (utils, DataTable opt-in accessor, endpoint binding, page columns/defaults/summary, optional CSS class).
+- [x] Layering respected: pure utils stay pure (no DOM/React imports), `DataTable` change is opt-in and additive, endpoint change is additive.
+- [x] No new dependencies; no concept/firmware change (runtime Neo4j edge properties only). **Firmware reinstall: not required** ✓.
+- [x] Deviation logged: the Implementer's `## Deviations` note (comment reworded to avoid the `/\bDISTINCT\b/i` guard) is present and accurate.
+
+## Concept-graph integrity
+- [x] No concept definitions touched; `report_type`/`timestamp` are runtime edge properties, not graph concepts. Handles elsewhere unchanged.
+- [x] No firmware reinstall needed; no BIBLE.md re-derivation.
+
+## Things tests can't catch
+- [x] No secrets committed (neo4j password was redacted in transient shell output; nothing in the diff).
+- [x] No leftover `console.log`/debug; no commented-out code.
+- [x] Input validation intact: endpoint still 64-hex-validates `observee` (400) and enforces the Neo4j deadline (504); Story-2 contract `count:data.length` + `observer:'owner'` preserved (R3).
+- [x] Edge cases: `formatTimeAgo` clamps future/negative to `0m ago`, returns `''` for null/NaN; `toInt(r.get('timestamp'))` is null-safe for edges created before the `ON CREATE SET r.timestamp` line; `humanizeReportType` returns `''` for falsy. Sort accessor returns fixed ±1 for nulls *before* the asc/desc flip → missing-last holds both directions (verified by trace).
+- [x] No race/concurrency surface introduced.
+- [x] Regression to the other 15 `DataTable` consumers: none. The accessor branch is gated on a column declaring `sortValue` (none of them do), so the default `localeCompare(numeric)` path is byte-identical (T15). Adding `columns` to the `sorted` memo deps is harmless — `filtered` already depended on `columns`, so `sorted` already recomputed on a `columns` change; no new render loop.
+
+## House rules check
+- [x] Concept Graph API authority respected (no concept work).
+- [x] No new lint/typecheck/build tooling.
+
+## Findings
+
+### Blocking
+_None._
+
+### Non-blocking
+1. **`ui/src/pages/BrainstormReporters.jsx:142-145`** — Misleading comment, **confirmed by adversarial verification**. The comment says the summary "explains why the row count can exceed the profile badge." But the badge (`verifiedReporterCount`) is `count(f)` over REPORTS edges with no `DISTINCT` (`src/algos/follows-mutes-reports/calculateVerifiedReporterCounts.sh:13-18`; fallback `src/api/export/users/queries/userdata.js:398`), so **badge = M = `reportCount` = `rows.length`** (the page returns one row per edge with the same cutoff). The value that is ≤ the badge is the distinct-**reporter** count **N** (`reporterCount`), not the row count. The rendered numbers are correct; only the comment inverts the relationship — and it contradicts ADR 0004's own correct statement ("the profile badge counts edges (≈ reports = M); the summary's 'N reporters' is new context"). *Asked change (optional, pre-deploy): reword the comment to "…the distinct-reporter count (N) can be lower than the report/row count (M), which equals the profile badge" (or similar). Comment-only; no behavioral impact.*
+2. **`ui/src/pages/BrainstormReporters.jsx` `loadVisible`** — Observation, not a defect. Returning visitors with a saved `bsp-reporters-columns` pref get `{ ...DEFAULT_VISIBLE, ...saved }`, so they see Picture · **Name** · Report Type · Rank (Report Type added, their Name retained); only first-time/reset visitors get the exact Picture · Report Type · Rank default. This matches the AC (scoped to "first-time visitor with no saved column preference") and is the more considerate migration. No change requested.
+3. **`ui/src/utils/timeAgo.js`** — Observation. Uses a 365-day year / 24-hour day approximation (documented in the JSDoc). Acceptable for a relative-time label; no change requested.
+
+## Verdict
+**PASS** — the diff matches the story, the ADR, and the test plan; all quality gates I ran are clean; coverage is complete; no blocking issues. The one confirmed finding is a misleading (non-behavioral) code comment that contradicts the ADR; correcting it before deploy is recommended but not required for merge.

--- a/engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.md
+++ b/engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.md
@@ -46,5 +46,5 @@ Testable from the outside (input → expected behavior).
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/verified-reporters/0004-reporters-report-type-and-timestamp-columns.md` (Accepted)
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.test-plan.md` (suite `test/verified-reporters-report-columns.test.js` + Playwright `tests/brainstorm/profile-verified-reporters-columns.spec.js`)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.md
+++ b/engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.md
@@ -44,6 +44,9 @@ Testable from the outside (input → expected behavior).
 ## Open questions
 - None blocking. (Cardinality of `REPORTS` edges is intentionally not gated on — the table mirrors whatever the graph returns. Membership-endpoint behavior confirmed: binding the relationship to return its properties adds per-report fields without changing which reporters appear.)
 
+## Deviations
+- **Implementer (2026-06-15):** worded the `reportersWithMetrics.js` comment to avoid the literal token "distinct" — the T12 no-dedup guard matches `/\bDISTINCT\b/i` case-insensitively over the whole source, so prose using "distinct"/"No DISTINCT" tripped it even though the Cypher has none. Behavior unchanged; comment now says "no de-duplication / aggregation" and "more than one report type".
+
 ## Linked artifacts
 - ADR: `engineering-team/decisions/verified-reporters/0004-reporters-report-type-and-timestamp-columns.md` (Accepted)
 - Test plan: `engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.test-plan.md` (suite `test/verified-reporters-report-columns.test.js` + Playwright `tests/brainstorm/profile-verified-reporters-columns.spec.js`)

--- a/engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.md
+++ b/engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.md
@@ -1,0 +1,50 @@
+# Story 4: Report Type and Timestamp columns on the Verified Reporters list
+
+**Status:** Approved
+**Created:** 2026-06-15
+**Type:** Feature
+**Epic:** `verified-reporters` · **Book:** `engineering-team/audits/verified-reporters/book.md`
+
+## Background
+The Verified Reporters list page (`/user/:pubkey/reporters`, Story 3) shows *who* reported an account, sorted by Rank. Unlike follows or mutes, a NIP-56 report carries two facts the table currently throws away: **what kind** of report it is (`report_type`) and **when** it was filed (`timestamp`). Both already live on the neo4j `REPORTS` relationship between reporter and reported account; the list query just doesn't surface them. Exposing them lets an observer weigh a warning by its nature ("spam" vs "impersonation") and its recency. This is the epic's deferred Phase-2 "report-type breakdown," scoped here to *surfacing type and time per row* (not filtering/grouping).
+
+This story makes the list **report-centric**: one row per report rather than one per distinct reporter (the user's explicit choice). A reporter who filed more than one report against the account therefore appears once per report. This relaxes Story 3's "rows = verified-reporter count" expectation by design. To keep that distinction legible rather than confusing, the page shows a summary line — e.g. **"8 reporters, 10 reports"** — so an observer who notices the row count differs from the profile's Verified Reporters count understands why. The profile count badge itself is not changed by this story.
+
+**Decision — no client-side de-duplication.** The table faithfully renders one row per `REPORTS` edge returned by the query; it does not merge or de-duplicate rows. Eliminating genuine duplicates (e.g. two identical "Alice reports Bob of impersonation" edges) is neo4j's responsibility. If duplicates leak through today — or multi-report support isn't fully in place yet — surfacing them here is *intended*: the table becomes a faithful 1:1 mirror of the graph, which makes any such bug visible rather than hiding it.
+
+## User-facing description
+As someone weighing a report-based warning on an account, I want to see what type each report is and how long ago it was filed — and to sort by recency — so that I can judge the nature and freshness of the signal, not just who raised it. I also want the page to tell me how many distinct reporters versus how many reports it represents, so a count that differs from the profile badge isn't confusing.
+
+## Acceptance criteria
+Testable from the outside (input → expected behavior).
+
+- [ ] Given a first-time visitor with no saved column preference, when the reporters page loads, the **default visible columns are Picture, Report Type, and Rank** (Name is no longer visible by default); **Name, Reported, and the previously-available columns remain selectable** in the column chooser, and toggling persists as before.
+- [ ] Given a row whose report has a `report_type`, the **Report Type** cell shows a humanized label (e.g. `spam` → "Spam", `impersonation` → "Impersonation", `other` → "Other").
+- [ ] Given the time column (header **"Reported"**) and a row whose report has a `timestamp`, the cell shows the elapsed time as a relative "time ago" string in years/days/hours/minutes, e.g. `3d, 4h, 12m ago`.
+- [ ] Given the table sorted by the **Reported** column, rows are ordered by the **raw unix timestamp integer** (numeric), not by the displayed "ago" text — newest-first and oldest-first both order correctly.
+- [ ] Given a row whose report has **no `report_type`**, the Report Type cell renders **empty** (no "undefined", no error). Given a row with **no `timestamp`**, the Reported cell renders empty, and such rows **sort below all rows that have a timestamp, in both ascending and descending order**.
+- [ ] Given a reporter who has filed more than one report against the account, the table shows **one row per report** (each with its own type and timestamp). The table performs **no client-side de-duplication or merging** — it renders one row per `REPORTS` edge the query returns.
+- [ ] Given a non-empty list, the page shows a **summary of distinct reporters and total reports**, e.g. **"8 reporters, 10 reports"** (distinct reporter pubkeys vs. total report rows), with correct singular/plural; when every reporter has exactly one report the two numbers are equal.
+- [ ] The Follows and Followers list pages still default to Picture / Name / Rank — they are unaffected.
+
+## Concepts touched
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-user` — nostr user (the reported account and each reporter row).
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:web-of-trust` — web of trust (the point of view the list reflects).
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:graperank` — graperank (the Rank shown per row).
+- *(not modeled as a named concept)* the `REPORTS` relationship and its `report_type` / `timestamp` properties — Architect to resolve against the neo4j data model.
+
+## Out of scope
+- Changing the profile **Verified Reporters count badge** or its semantics (Story 1). The badge counts distinct reporters under PoV; this report-centric list may show more rows. The summary line explains the difference; the badge is not reconciled or altered here.
+- Filtering, grouping, or a breakdown UI by report type (later); pile-on discounting (Phase 3).
+- The Follows / Followers pages and any shared count behavior beyond leaving them unchanged.
+- Personalized / customer point of view — list stays House/owner, consistent with the epic.
+- Absolute-time tooltips, seconds granularity, or localized date formatting — relative years/days/hours/minutes only.
+- Client-side de-duplication of report rows (see Background decision).
+
+## Open questions
+- None blocking. (Cardinality of `REPORTS` edges is intentionally not gated on — the table mirrors whatever the graph returns. Membership-endpoint behavior confirmed: binding the relationship to return its properties adds per-report fields without changing which reporters appear.)
+
+## Linked artifacts
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.md
+++ b/engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.md
@@ -1,6 +1,6 @@
 # Story 4: Report Type and Timestamp columns on the Verified Reporters list
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-15
 **Type:** Feature
 **Epic:** `verified-reporters` · **Book:** `engineering-team/audits/verified-reporters/book.md`
@@ -50,4 +50,4 @@ Testable from the outside (input → expected behavior).
 ## Linked artifacts
 - ADR: `engineering-team/decisions/verified-reporters/0004-reporters-report-type-and-timestamp-columns.md` (Accepted)
 - Test plan: `engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.test-plan.md` (suite `test/verified-reporters-report-columns.test.js` + Playwright `tests/brainstorm/profile-verified-reporters-columns.spec.js`)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/verified-reporters/4-reporters-report-type-and-timestamp-columns.md` — **PASS** (2026-06-15)

--- a/engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.md
+++ b/engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.md
@@ -45,6 +45,6 @@ Testable from the outside (input → expected behavior).
 - None blocking. (Cardinality of `REPORTS` edges is intentionally not gated on — the table mirrors whatever the graph returns. Membership-endpoint behavior confirmed: binding the relationship to return its properties adds per-report fields without changing which reporters appear.)
 
 ## Linked artifacts
-- ADR: (filled in after Architecture phase)
+- ADR: `engineering-team/decisions/verified-reporters/0004-reporters-report-type-and-timestamp-columns.md` (Accepted)
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.test-plan.md
+++ b/engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.test-plan.md
@@ -1,0 +1,87 @@
+# Test Plan: Story verified-reporters #4 — Report Type and Reported (timestamp) columns
+
+**Story:** `engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.md`
+**ADR:** `engineering-team/decisions/verified-reporters/0004-reporters-report-type-and-timestamp-columns.md`
+**Date:** 2026-06-15
+
+## Approach
+Two tiers, in one node suite `test/verified-reporters-report-columns.test.js` (wired into `test/test.js`), plus one supplementary Playwright spec.
+
+1. **Real behavioral unit tests (executed)** for the two NEW pure helpers. `ui/` is an ES-module package (`"type":"module"`), so the CJS harness loads them via dynamic `import()` and asserts **actual output** — `formatTimeAgo` (the `3d, 4h, 12m ago` format + every edge case) and `humanizeReportType` (NIP-56 token → friendly label). This is where the subtle display behavior lives, so it gets genuine execution, not regex.
+2. **Source-regex sentinels** for the parts the CJS harness cannot execute (ESM React + the Express handler) — the endpoint relationship-binding, the shared `DataTable` opt-in accessor, and the page (columns, defaults, summary, row fields). This matches the established precedent (`test/verified-reporters-list-page.test.js`, `…-membership-data.test.js`).
+3. **Supplementary Playwright spec** `tests/brainstorm/profile-verified-reporters-columns.spec.js` — verifies the browser-rendered **column chooser** (the new default set is checkable even on a zero-reporter account, since the chooser renders above the table). The populated path (ago-format cells, raw-integer sort, the summary line) is a documented manual/fixture check, exactly as Story 3 handled its populated path.
+
+**False-positive trap handled:** `BrainstormFollowers.jsx` already has a "Verified Reporters" *column* (`verifiedReporterCount`) and the word "reporters"; the reporters page already says "reported". Every new sentinel targets strings/keys absent pre-implementation — `formatTimeAgo`, `humanizeReportType`, `key:'reportType'`, label `'Reported'`, `sortValue`, `new Set(` (distinct-reporter summary), and the new `DEFAULT_VISIBLE` (`reportType:true` / `name:false`).
+
+## Coverage map
+| Criterion (story AC) | Test(s) | Level |
+|---|---|---|
+| Default columns = Picture/Report Type/Rank; Name & Reported toggleable | T20 (DEFAULT_VISIBLE), Playwright (chooser checked-state) | source-regex + e2e |
+| Column chooser keeps Name/Reported/others selectable | T18 (Reported col exists), Playwright (both options visible) | source-regex + e2e |
+| Report Type cell = humanized label | T8 (spam→Spam, impersonation→Impersonation, …), T17 (page wires humanizeReportType) | unit + source-regex |
+| Reported cell = relative "ago" (y/d/h/m), e.g. `3d, 4h, 12m ago` | T1–T4 (format), T18 (page wires formatTimeAgo) | unit + source-regex |
+| Sort Reported by RAW unix integer (not "ago" text) | T13 (sortValue accessor), T18 (column declares sortValue) | source-regex |
+| Missing report_type/timestamp → empty cell | T6 (formatTimeAgo→""), T9 (humanizeReportType→""), T19 (page render `== null ? ''`) | unit + source-regex |
+| Missing timestamps sort LAST in both directions | T14 (fixed `return 1`/`-1` before asc/desc flip) | source-regex |
+| One row per report; NO client-side de-dup | T12 (query: no DISTINCT/aggregation), T22 (rows carry per-edge fields), Playwright manual note | source-regex + manual |
+| "N reporters, M reports" summary | T21 (distinct via `new Set` over pubkeys + "reports" label) | source-regex |
+| report_type + timestamp sourced from the REPORTS edge | T10 (bind `[rel:REPORTS]`), T11 (RETURN report_type/timestamp + toInt) | source-regex |
+| Follows/Followers pages unaffected | R1 (followers defaults), R2 (follows defaults) | regression |
+
+## Edge cases
+- [x] `formatTimeAgo`: 3-unit truncation (T2), interior-zero drop (T3), single unit (T4), sub-minute/zero → `0m ago` (T5), missing/NaN → `""` (T6), future timestamp clamps to `0m ago` (T7).
+- [x] `humanizeReportType`: NIP-56 set incl. `unspecified` (T8), empty/null → `""` (T9).
+- [x] Sort: missing-last in **both** directions (T14); the existing `localeCompare(numeric)` path preserved for the other 15 `DataTable` consumers (T15).
+- [x] Endpoint stays one-row-per-edge (no `DISTINCT`/`collect`/`count`) so duplicate-edge bugs remain visible (T12); Story-2 contract `count:data.length` + `observer:'owner'` intact (R3); hook unchanged (R4).
+- [ ] Populated browser path — ago-format cells, raw-integer header sort, the "N reporters, M reports" line, multi-row-per-reporter — documented manual/fixture check (most accounts have 0 verified reporters); Playwright covers the chooser/defaults on a zero account.
+
+## Test infrastructure
+- Framework: Node built-in runner (`node test/test.js`) for the deterministic suite (wired in `test/test.js`); Playwright (`npm run test:playwright`) for the supplementary spec. No new frameworks.
+- Pure-helper tests load `ui/src/utils/timeAgo.js` and `ui/src/utils/reportType.js` via dynamic `import()` (ui is `type:module`); they must be **import-safe** (pure, no side-effect imports).
+- Concept Graph API: not required (no concept/graph/firmware change).
+- Live stack: only the Playwright spec needs a running instance with the UI **built** (`npm run build` in `ui/`). Base URL `BRAINSTORM_BASE_URL` or `http://localhost:7778`; fresh browser context (empty localStorage) so `DEFAULT_VISIBLE` applies.
+- Fixtures: Playwright uses Jack Dorsey (`82341f88…be6a2`) as a scores-loaded, 0-verified-reporters account (chooser renders; empty table).
+
+## How to run
+```
+npm test                       # deterministic node suites (incl. this one)
+npm run test:playwright        # supplementary browser spec (needs a built, running instance)
+```
+
+## Verification
+The new node suite fails with the current code (20 feature tests fail; **6 guard/regression tests pass** — T12 no-dedup guard, T15 preserved-sort-path guard, and R1–R4 for the untouched follows/followers pages, endpoint contract, and hook). Every other suite in `npm test` remains PASS. Confirmed via `npm test` on 2026-06-15 at commit `5bcad648`:
+
+```
+verified-reporters-report-columns suite:
+  ✗ T1: formatTimeAgo renders the multi-unit headline format "3d, 4h, 12m ago" (AC: Reported display)
+        ui/src/utils/timeAgo.js must exist and export `formatTimeAgo(unixSeconds, now?)` … absent pre-implementation.
+  ✗ T2: formatTimeAgo shows the 3 most-significant units (years..minutes), dropping the rest
+  ✗ T3: formatTimeAgo drops zero-valued units (interior zeros are not shown)
+  ✗ T4: formatTimeAgo renders a single unit when only one is non-zero ("3d ago")
+  ✗ T5: formatTimeAgo renders "0m ago" for sub-minute and zero deltas (minute is the smallest unit)
+  ✗ T6: formatTimeAgo returns "" for missing/invalid input (AC: absent timestamp → empty cell)
+  ✗ T7: formatTimeAgo clamps future timestamps to "0m ago" (no negative durations)
+  ✗ T8: humanizeReportType converts NIP-56 tokens to friendly labels (spam → Spam, impersonation → Impersonation)
+  ✗ T9: humanizeReportType returns "" for missing/empty input (AC: absent report_type → empty cell)
+  ✗ T10: the query BINDS the :REPORTS relationship (so its properties can be returned)
+  ✗ T11: the query RETURNs report_type + timestamp and the handler maps them (timestamp via toInt)
+  ✓ T12: the query does NOT de-duplicate or aggregate — one row per REPORTS edge is preserved
+  ✗ T13: DataTable supports an opt-in per-column `sortValue` accessor (sort by a raw value, decoupled from render)
+  ✗ T14: DataTable sorts missing values LAST regardless of direction
+  ✓ T15: DataTable PRESERVES the existing localeCompare(numeric) path for all other columns (regression — 16 consumers)
+  ✗ T16: the page imports the two new helpers (formatTimeAgo, humanizeReportType)
+  ✗ T17: the page defines a Report Type column (key reportType, label "Report Type", humanized render)
+  ✗ T18: the page defines a Reported column (key timestamp, label "Reported", sortValue + formatTimeAgo render)
+  ✗ T19: the Reported cell renders empty for a missing timestamp (AC: absent field → empty cell)
+  ✗ T20: DEFAULT_VISIBLE is Picture/Report Type/Rank — Name and Reported are NOT default
+  ✗ T21: the page shows a "N reporters, M reports" summary (distinct reporters via Set, total reports = rows)
+  ✗ T22: each row carries reportType + timestamp from the hook data
+  ✓ R1: BrainstormFollowers default columns are untouched — still Picture/Name/Rank, no reportType
+  ✓ R2: BrainstormFollows default columns are untouched — still Picture/Name/Rank
+  ✓ R3: the endpoint keeps the Story-2 contract — count:data.length and observer:'owner'
+  ✓ R4: useGrapevineReporters is unchanged — still fetches the reporters endpoint and passes data through
+
+verified-reporters-report-columns suite:              FAIL (6 passed, 20 failed)
+```
+
+The 6 green tests are the guards that must hold before **and** after implementation: T12 (no `DISTINCT`/aggregation → one row per edge), T15 (the default `localeCompare(numeric)` sort path stays intact for the other 15 `DataTable` consumers), and R1–R4. The 20 `✗` fail because the feature is unimplemented — the util modules, the relationship binding, the `sortValue` accessor, and the page columns/defaults/summary are absent — not from a typo or import error; the pure-helper tests report the missing module explicitly. Every other suite remains PASS (full run: all 37 prior suites green, Overall FAIL solely due to this intentionally-failing suite).

--- a/src/api/grapevineInteractions/queries/reportersWithMetrics.js
+++ b/src/api/grapevineInteractions/queries/reportersWithMetrics.js
@@ -5,7 +5,8 @@
  *
  * Lists the VERIFIED users who NIP-56-reported <observee>, with the owner's
  * GrapeRank metrics read straight from each reporter's NostrUser node: influence
- * (→ rank), hops, and the three verified counts. v1 is OWNER/HOUSE POV ONLY.
+ * (→ rank), hops, and the three verified counts — plus each REPORTS edge's own
+ * report_type + timestamp (story #4 / ADR 0004). v1 is OWNER/HOUSE POV ONLY.
  * Customer observers are deferred: their scores live on NostrUserWotMetricsCard
  * (see ADR 0026 §Decision and userdata.js:40-85), so a non-owner `observer` is 400.
  *
@@ -91,15 +92,21 @@ function handleGetGrapevineReporters(req, res) {
     // Owner/House POV: the metrics ARE each reporter's own NostrUser node GrapeRank
     // properties. Only VERIFIED reporters (influence above the cutoff) are returned —
     // the inverse of the count query. No NostrUserWotMetricsCard join in v1.
+    // Bind the REPORTS edge (rel) so its per-report properties — report_type and
+    // timestamp — come back alongside the reporter's node metrics (story #4 / ADR 0004).
+    // One row per REPORTS edge (no de-duplication / aggregation here), so a reporter who
+    // filed more than one report type appears once per report — report-centric, by design.
     const cypherQuery = `
-      MATCH (observee:NostrUser {pubkey: $observee})<-[:REPORTS]-(reporter:NostrUser)
+      MATCH (observee:NostrUser {pubkey: $observee})<-[rel:REPORTS]-(reporter:NostrUser)
       WHERE reporter.influence > $cutoff
       RETURN reporter.pubkey AS pubkey,
              reporter.influence AS influence,
              reporter.hops AS hops,
              reporter.verifiedFollowerCount AS verifiedFollowerCount,
              reporter.verifiedMuterCount AS verifiedMuterCount,
-             reporter.verifiedReporterCount AS verifiedReporterCount
+             reporter.verifiedReporterCount AS verifiedReporterCount,
+             rel.report_type AS reportType,
+             rel.timestamp AS timestamp
     `;
 
     const queryStartMs = Date.now();
@@ -112,7 +119,9 @@ function handleGetGrapevineReporters(req, res) {
             hops: toInt(r.get('hops')),
             verifiedFollowerCount: toInt(r.get('verifiedFollowerCount')),
             verifiedMuterCount: toInt(r.get('verifiedMuterCount')),
-            verifiedReporterCount: toInt(r.get('verifiedReporterCount'))
+            verifiedReporterCount: toInt(r.get('verifiedReporterCount')),
+            reportType: r.get('reportType') ?? null,
+            timestamp: toInt(r.get('timestamp'))
           }))
           .filter(row => row.pubkey);
 

--- a/test/test.js
+++ b/test/test.js
@@ -59,6 +59,7 @@ const profileVerifiedCountsExplainerAndAlarm = require('./profile-verified-count
 const reputationInfoPopup = require('./reputation-info-popup.test.js');
 const liveFeedReadPath = require('./live-feed-read-path.test.js');
 const liveFeedFeedPage = require('./live-feed-feed-page.test.js');
+const verifiedReportersReportColumns = require('./verified-reporters-report-columns.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -174,6 +175,9 @@ async function main() {
   console.log('\nlive-feed-feed-page suite:');
   const liveFeedFeedPageResult = await liveFeedFeedPage.run();
 
+  console.log('\nverified-reporters-report-columns suite:');
+  const verifiedReportersReportColumnsResult = await verifiedReportersReportColumns.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -285,6 +289,9 @@ async function main() {
   console.log(
     `live-feed-feed-page suite:                       ${liveFeedFeedPageResult.fail === 0 ? 'PASS' : 'FAIL'} (${liveFeedFeedPageResult.pass} passed, ${liveFeedFeedPageResult.fail} failed)`
   );
+  console.log(
+    `verified-reporters-report-columns suite:         ${verifiedReportersReportColumnsResult.fail === 0 ? 'PASS' : 'FAIL'} (${verifiedReportersReportColumnsResult.pass} passed, ${verifiedReportersReportColumnsResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -323,7 +330,8 @@ async function main() {
     profileVerifiedCountsExplainerAndAlarmResult.fail === 0 &&
     reputationInfoPopupResult.fail === 0 &&
     liveFeedReadPathResult.fail === 0 &&
-    liveFeedFeedPageResult.fail === 0;
+    liveFeedFeedPageResult.fail === 0 &&
+    verifiedReportersReportColumnsResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/test/verified-reporters-report-columns.test.js
+++ b/test/verified-reporters-report-columns.test.js
@@ -1,0 +1,321 @@
+/**
+ * Story verified-reporters #4: Report Type + Reported (timestamp) columns on the
+ * Verified Reporters list page.
+ * ADR 0004 (verified-reporters). See
+ * engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.test-plan.md
+ *
+ * TWO TIERS in this one suite:
+ *
+ *  A. REAL behavioral unit tests (executed) for the two NEW pure helpers —
+ *     ui/src/utils/timeAgo.js (formatTimeAgo) and ui/src/utils/reportType.js
+ *     (humanizeReportType). ui/ is an ES module package ("type":"module"), so the
+ *     CJS harness loads them via dynamic import(). Pre-implementation the files do
+ *     not exist, so loadEsm() returns null and T1–T9 FAIL with a descriptive message;
+ *     once written, they execute and assert the actual output (e.g. "3d, 4h, 12m ago").
+ *
+ *  B. SOURCE-REGEX sentinels for the endpoint, the shared DataTable, and the page —
+ *     ESM React that the CJS harness cannot execute (the established precedent:
+ *     test/verified-reporters-list-page.test.js). T10–T22 FAIL now (the additive
+ *     changes are absent) and PASS once implemented per ADR 0004.
+ *
+ *  R1–R4 are REGRESSION sentinels — they PASS before AND after (they guard the
+ *  untouched follows/followers pages, the preserved DataTable default sort path, the
+ *  Story-2 endpoint contract, and the unchanged reporters hook).
+ *
+ * FALSE-POSITIVE AVOIDANCE: BrainstormFollowers.jsx already contains a "Verified
+ * Reporters" COLUMN (verifiedReporterCount) and the word "reporters"; the reporters
+ * page already says "reported". Every new sentinel targets strings/keys that do NOT
+ * exist pre-implementation — formatTimeAgo, humanizeReportType, key:'reportType',
+ * label 'Reported', sortValue, `new Set(` for the distinct-reporter summary, and the
+ * new DEFAULT_VISIBLE (reportType:true / name:false).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+const TIMEAGO    = path.resolve(__dirname, '../ui/src/utils/timeAgo.js');
+const REPORTTYPE = path.resolve(__dirname, '../ui/src/utils/reportType.js');
+const HANDLER    = path.resolve(__dirname, '../src/api/grapevineInteractions/queries/reportersWithMetrics.js');
+const DATATABLE  = path.resolve(__dirname, '../ui/src/components/DataTable.jsx');
+const PAGE       = path.resolve(__dirname, '../ui/src/pages/BrainstormReporters.jsx');
+const FOLLOWERS  = path.resolve(__dirname, '../ui/src/pages/BrainstormFollowers.jsx');
+const FOLLOWS    = path.resolve(__dirname, '../ui/src/pages/BrainstormFollows.jsx');
+const HOOK       = path.resolve(__dirname, '../ui/src/hooks/useGrapevineReporters.js');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+async function loadEsm(absPath) {
+  try { return await import(pathToFileURL(absPath).href); }
+  catch { return null; }
+}
+
+// A fixed "now" so the relative-time assertions are deterministic.
+const NOW = 1_700_000_000;
+const MIN = 60, HOUR = 3600, DAY = 86400, YEAR = 365 * DAY;
+
+// ===========================================================================
+// A. PURE HELPERS — executed (real behavior), ui ESM via dynamic import
+// ===========================================================================
+
+test('T1: formatTimeAgo renders the multi-unit headline format "3d, 4h, 12m ago" (AC: Reported display)', async () => {
+  const mod = await loadEsm(TIMEAGO);
+  assert(mod && typeof mod.formatTimeAgo === 'function',
+    'ui/src/utils/timeAgo.js must exist and export `formatTimeAgo(unixSeconds, now?)` (ADR 0004 §Impl). It is absent pre-implementation.');
+  const got = mod.formatTimeAgo(NOW - (3 * DAY + 4 * HOUR + 12 * MIN), NOW);
+  assert(got === '3d, 4h, 12m ago', `expected "3d, 4h, 12m ago", got "${got}"`);
+});
+
+test('T2: formatTimeAgo shows the 3 most-significant units (years..minutes), dropping the rest', async () => {
+  const mod = await loadEsm(TIMEAGO);
+  assert(mod && typeof mod.formatTimeAgo === 'function', 'ui/src/utils/timeAgo.js must export formatTimeAgo.');
+  const got = mod.formatTimeAgo(NOW - (2 * YEAR + 14 * DAY + 3 * HOUR + 5 * MIN), NOW);
+  assert(got === '2y, 14d, 3h ago', `with y/d/h/m all present, expected the top 3 → "2y, 14d, 3h ago", got "${got}"`);
+});
+
+test('T3: formatTimeAgo drops zero-valued units (interior zeros are not shown)', async () => {
+  const mod = await loadEsm(TIMEAGO);
+  assert(mod && typeof mod.formatTimeAgo === 'function', 'ui/src/utils/timeAgo.js must export formatTimeAgo.');
+  const got = mod.formatTimeAgo(NOW - (1 * DAY + 5 * MIN), NOW); // 1d 0h 5m
+  assert(got === '1d, 5m ago', `the 0h unit must be dropped → "1d, 5m ago", got "${got}"`);
+});
+
+test('T4: formatTimeAgo renders a single unit when only one is non-zero ("3d ago")', async () => {
+  const mod = await loadEsm(TIMEAGO);
+  assert(mod && typeof mod.formatTimeAgo === 'function', 'ui/src/utils/timeAgo.js must export formatTimeAgo.');
+  const got = mod.formatTimeAgo(NOW - 3 * DAY, NOW);
+  assert(got === '3d ago', `expected "3d ago", got "${got}"`);
+});
+
+test('T5: formatTimeAgo renders "0m ago" for sub-minute and zero deltas (minute is the smallest unit)', async () => {
+  const mod = await loadEsm(TIMEAGO);
+  assert(mod && typeof mod.formatTimeAgo === 'function', 'ui/src/utils/timeAgo.js must export formatTimeAgo.');
+  assert(mod.formatTimeAgo(NOW - 30, NOW) === '0m ago', `30s ago should render "0m ago", got "${mod.formatTimeAgo(NOW - 30, NOW)}"`);
+  assert(mod.formatTimeAgo(NOW, NOW) === '0m ago', `a zero delta should render "0m ago", got "${mod.formatTimeAgo(NOW, NOW)}"`);
+});
+
+test('T6: formatTimeAgo returns "" for missing/invalid input (AC: absent timestamp → empty cell)', async () => {
+  const mod = await loadEsm(TIMEAGO);
+  assert(mod && typeof mod.formatTimeAgo === 'function', 'ui/src/utils/timeAgo.js must export formatTimeAgo.');
+  for (const bad of [null, undefined, NaN]) {
+    const got = mod.formatTimeAgo(bad, NOW);
+    assert(got === '', `a missing/invalid timestamp (${String(bad)}) must render "" (empty cell), got "${got}"`);
+  }
+});
+
+test('T7: formatTimeAgo clamps future timestamps to "0m ago" (no negative durations)', async () => {
+  const mod = await loadEsm(TIMEAGO);
+  assert(mod && typeof mod.formatTimeAgo === 'function', 'ui/src/utils/timeAgo.js must export formatTimeAgo.');
+  const got = mod.formatTimeAgo(NOW + 5000, NOW);
+  assert(got === '0m ago', `a future timestamp must clamp to "0m ago", got "${got}"`);
+});
+
+test('T8: humanizeReportType converts NIP-56 tokens to friendly labels (spam → Spam, impersonation → Impersonation)', async () => {
+  const mod = await loadEsm(REPORTTYPE);
+  assert(mod && typeof mod.humanizeReportType === 'function',
+    'ui/src/utils/reportType.js must exist and export `humanizeReportType(token)` (ADR 0004 §Impl). It is absent pre-implementation.');
+  const cases = { spam: 'Spam', impersonation: 'Impersonation', nudity: 'Nudity', other: 'Other', unspecified: 'Unspecified' };
+  for (const [tok, label] of Object.entries(cases)) {
+    const got = mod.humanizeReportType(tok);
+    assert(got === label, `humanizeReportType("${tok}") should be "${label}", got "${got}"`);
+  }
+});
+
+test('T9: humanizeReportType returns "" for missing/empty input (AC: absent report_type → empty cell)', async () => {
+  const mod = await loadEsm(REPORTTYPE);
+  assert(mod && typeof mod.humanizeReportType === 'function', 'ui/src/utils/reportType.js must export humanizeReportType.');
+  for (const bad of ['', null, undefined]) {
+    const got = mod.humanizeReportType(bad);
+    assert(got === '', `a missing report_type (${String(bad)}) must render "" (empty cell), got "${got}"`);
+  }
+});
+
+// ===========================================================================
+// B. ENDPOINT — reportersWithMetrics.js surfaces report_type + timestamp per edge
+// ===========================================================================
+
+test('T10: the query BINDS the :REPORTS relationship (so its properties can be returned)', () => {
+  const src = safeRead(HANDLER);
+  assert(src.length > 0, 'reportersWithMetrics.js missing — unexpected (Story 2 created it).');
+  assert(/\[\s*[A-Za-z_]\w*\s*:REPORTS\s*\]/.test(src),
+    'the Cypher must bind the REPORTS edge to a variable (e.g. `<-[rel:REPORTS]-`) so rel.report_type / rel.timestamp can be RETURNed. Today it is the anonymous `[:REPORTS]` — bind it (ADR 0004 §Impl).');
+});
+
+test('T11: the query RETURNs report_type + timestamp and the handler maps them (timestamp via toInt) (AC: Report Type & Reported data)', () => {
+  const src = safeRead(HANDLER);
+  assert(src.length > 0, 'reportersWithMetrics.js missing — unexpected.');
+  assert(/\.report_type\s+AS\s+reportType/i.test(src),
+    'the Cypher RETURN must surface the edge property `rel.report_type AS reportType` (ADR 0004 §Impl).');
+  assert(/\.timestamp\s+AS\s+timestamp/i.test(src),
+    'the Cypher RETURN must surface the edge property `rel.timestamp AS timestamp` (ADR 0004 §Impl).');
+  assert(/r\.get\(\s*['"]reportType['"]\s*\)/.test(src),
+    'the record .map must read reportType (r.get("reportType")) into each row.');
+  assert(/toInt\(\s*r\.get\(\s*['"]timestamp['"]\s*\)\s*\)/.test(src),
+    'the record .map must read timestamp through toInt (neo4j Integer → JS number, unix seconds): toInt(r.get("timestamp")).');
+});
+
+test('T12: the query does NOT de-duplicate or aggregate — one row per REPORTS edge is preserved (AC: one row per report, no dedup)', () => {
+  const src = safeRead(HANDLER);
+  assert(src.length > 0, 'reportersWithMetrics.js missing — unexpected.');
+  assert(!/\bDISTINCT\b/i.test(src),
+    'the query must NOT add DISTINCT — the page is report-centric (one row per REPORTS edge). De-dup is neo4j\'s job; collapsing here would hide duplicate-edge bugs (ADR 0004 Decision).');
+  assert(!/\bcollect\s*\(/i.test(src) && !/count\s*\(\s*[A-Za-z_]/.test(src),
+    'the query must NOT aggregate reporters (no collect()/count() over the edge) — that would merge multiple reports into one row.');
+});
+
+// ===========================================================================
+// C. DATATABLE — opt-in sortValue accessor with missing-last, existing path kept
+// ===========================================================================
+
+test('T13: DataTable supports an opt-in per-column `sortValue` accessor (sort by a raw value, decoupled from render) (AC: sort by raw timestamp)', () => {
+  const src = safeRead(DATATABLE);
+  assert(src.length > 0, 'DataTable.jsx missing — unexpected.');
+  assert(/sortValue/.test(src),
+    'DataTable must honor a per-column `sortValue` accessor so the Reported column can sort by the raw unix integer while rendering "ago" text (ADR 0004 §Impl). Absent today.');
+});
+
+test('T14: DataTable sorts missing values LAST regardless of direction (AC: empty timestamps sort to the bottom both ways)', () => {
+  const src = safeRead(DATATABLE);
+  assert(src.length > 0, 'DataTable.jsx missing — unexpected.');
+  assert(/==\s*null/.test(src),
+    'the sortValue path must detect missing values (== null) to push them last.');
+  assert(/return\s+1\b/.test(src) && /return\s+-1\b/.test(src),
+    'missing values must return a FIXED order (e.g. `return 1` / `return -1`) BEFORE the asc/desc flip, so they always sort to the bottom in BOTH directions (ADR 0004 §Impl). The current localeCompare path has no such branch.');
+});
+
+test('T15: DataTable PRESERVES the existing localeCompare(numeric) path for all other columns (regression — 16 consumers)', () => {
+  const src = safeRead(DATATABLE);
+  assert(src.length > 0, 'DataTable.jsx missing — unexpected.');
+  assert(/localeCompare\([\s\S]*?numeric:\s*true/.test(src),
+    'the default (no-sortValue) sort path must remain String(...).localeCompare(..., {numeric:true}) so the other 15 DataTable consumers are byte-for-byte unaffected (ADR 0004 Option A).');
+});
+
+// ===========================================================================
+// D. PAGE — BrainstormReporters: columns, defaults, summary, row fields
+// ===========================================================================
+
+test('T16: the page imports the two new helpers (formatTimeAgo, humanizeReportType)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx missing — unexpected (Story 3 created it).');
+  assert(/utils\/timeAgo/.test(src) && /formatTimeAgo/.test(src),
+    'the page must import formatTimeAgo from ../utils/timeAgo (ADR 0004 §Impl).');
+  assert(/utils\/reportType/.test(src) && /humanizeReportType/.test(src),
+    'the page must import humanizeReportType from ../utils/reportType (ADR 0004 §Impl).');
+});
+
+test('T17: the page defines a Report Type column (key reportType, label "Report Type", humanized render)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx missing — unexpected.');
+  assert(/key:\s*['"]reportType['"]/.test(src), 'ALL_COLUMNS must include a column with key:"reportType".');
+  assert(/Report Type/.test(src), 'the Report Type column must be labeled "Report Type".');
+  assert(/humanizeReportType\s*\(/.test(src), 'the Report Type cell must render via humanizeReportType(...) (friendly label).');
+});
+
+test('T18: the page defines a Reported column (key timestamp, label "Reported", sortValue + formatTimeAgo render)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx missing — unexpected.');
+  assert(/key:\s*['"]timestamp['"]/.test(src), 'ALL_COLUMNS must include a column with key:"timestamp".');
+  assert(/['"]Reported['"]/.test(src), 'the timestamp column must be labeled "Reported".');
+  assert(/sortValue/.test(src), 'the Reported column must declare a `sortValue` accessor (sort by the raw unix integer).');
+  assert(/formatTimeAgo\s*\(/.test(src), 'the Reported cell must render via formatTimeAgo(...) ("ago" text).');
+});
+
+test('T19: the Reported cell renders empty for a missing timestamp (AC: absent field → empty cell)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx missing — unexpected.');
+  assert(/==\s*null\s*\?\s*''/.test(src),
+    'a missing timestamp must render "" (e.g. `v == null ? \'\' : formatTimeAgo(v)`), not "undefined"/"NaN ago" (ADR 0004 §Impl).');
+});
+
+test('T20: DEFAULT_VISIBLE is Picture/Report Type/Rank — Name and Reported are NOT default (AC: default columns change)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx missing — unexpected.');
+  const m = src.match(/const\s+DEFAULT_VISIBLE\s*=\s*\{[\s\S]*?\}/);
+  assert(m, 'DEFAULT_VISIBLE object not found in BrainstormReporters.jsx.');
+  const block = m[0];
+  assert(/picture:\s*true/.test(block), 'DEFAULT_VISIBLE.picture must be true.');
+  assert(/reportType:\s*true/.test(block), 'DEFAULT_VISIBLE.reportType must be true (Report Type is now a default column).');
+  assert(/rank:\s*true/.test(block), 'DEFAULT_VISIBLE.rank must be true.');
+  assert(/name:\s*false/.test(block), 'DEFAULT_VISIBLE.name must be false — Name is dropped from the default view (still toggleable).');
+  assert(/timestamp:\s*false/.test(block), 'DEFAULT_VISIBLE.timestamp must be false — Reported is available but not shown by default.');
+});
+
+test('T21: the page shows a "N reporters, M reports" summary (distinct reporters via Set, total reports = rows) (AC: summary line)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx missing — unexpected.');
+  assert(/new Set\(/.test(src),
+    'the summary must count DISTINCT reporters via `new Set(...)` over the row pubkeys (this is how N differs from M; absent today).');
+  assert(/new Set\([\s\S]{0,60}pubkey/.test(src),
+    'the distinct-reporter Set must be built from the row pubkeys (e.g. new Set(rows.map(r => r.pubkey))).');
+  assert(/\breports\b/.test(src),
+    'the summary must render the "reports" label (the "M reports" half of "N reporters, M reports").');
+});
+
+test('T22: each row carries reportType + timestamp from the hook data', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormReporters.jsx missing — unexpected.');
+  assert(/reportType:/.test(src), 'the rows builder must set reportType on each row (from the endpoint field).');
+  assert(/timestamp:/.test(src), 'the rows builder must set timestamp on each row (from the endpoint field).');
+});
+
+// ===========================================================================
+// R. REGRESSION SENTINELS (must PASS before AND after implementation)
+// ===========================================================================
+
+test('R1: BrainstormFollowers default columns are untouched — still Picture/Name/Rank, no reportType (regression)', () => {
+  const src = safeRead(FOLLOWERS);
+  assert(src.length > 0, 'BrainstormFollowers.jsx missing — unexpected.');
+  const m = src.match(/const\s+DEFAULT_VISIBLE\s*=\s*\{[\s\S]*?\}/);
+  assert(m, 'followers DEFAULT_VISIBLE not found.');
+  assert(/name:\s*true/.test(m[0]),
+    'the followers page must STILL default Name on (Picture/Name/Rank). The reporters default change must not bleed into followers.');
+  assert(!/reportType/.test(m[0]),
+    'the followers DEFAULT_VISIBLE must not gain a reportType column.');
+});
+
+test('R2: BrainstormFollows default columns are untouched — still Picture/Name/Rank (regression)', () => {
+  const src = safeRead(FOLLOWS);
+  assert(src.length > 0, 'BrainstormFollows.jsx missing — unexpected.');
+  const m = src.match(/const\s+DEFAULT_VISIBLE\s*=\s*\{[\s\S]*?\}/);
+  assert(m, 'follows DEFAULT_VISIBLE not found.');
+  assert(/name:\s*true/.test(m[0]),
+    'the follows page must STILL default Name on (Picture/Name/Rank).');
+});
+
+test('R3: the endpoint keeps the Story-2 contract — count:data.length and observer:\'owner\' (regression)', () => {
+  const src = safeRead(HANDLER);
+  assert(src.length > 0, 'reportersWithMetrics.js missing — unexpected.');
+  assert(/count\s*:\s*data\.length/.test(src),
+    'the additive change must not break `count: data.length` (Story 2 / ADR 0002).');
+  assert(/observer\s*:\s*['"]owner['"]/.test(src),
+    "the response must still report observer:'owner' (v1 House/owner PoV).");
+});
+
+test('R4: useGrapevineReporters is unchanged — still fetches the reporters endpoint and passes data through (regression)', () => {
+  const src = safeRead(HOOK);
+  assert(src.length > 0, 'useGrapevineReporters.js missing — unexpected.');
+  assert(/get-grapevine-reporters/.test(src),
+    'the hook must still call /api/get-grapevine-reporters (new fields flow through json.data — no hook change needed, ADR 0004).');
+  assert(/setData\(/.test(src),
+    'the hook must still surface the endpoint data array unchanged.');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/tests/brainstorm/profile-verified-reporters-columns.spec.js
+++ b/tests/brainstorm/profile-verified-reporters-columns.spec.js
@@ -1,0 +1,63 @@
+/**
+ * Playwright behavioral check for story verified-reporters #4 / ADR 0004: the
+ * Report Type + Reported (timestamp) columns and the new default column set on the
+ * /user/:pubkey/reporters page.
+ * See engineering-team/stories/verified-reporters/4-reporters-report-type-and-timestamp-columns.test-plan.md
+ *
+ * SUPPLEMENTARY + LIVE-DATA DEPENDENT (mirrors profile-verified-reporters-list.spec.js).
+ * The deterministic coverage is the node suite test/verified-reporters-report-columns.test.js
+ * (pure-function behavior + source sentinels, no stack dependency). This spec verifies the
+ * browser-rendered column chooser, which source-regex can only approximate.
+ *
+ * Preconditions / fragility:
+ *   - A reachable Brainstorm instance (BRAINSTORM_BASE_URL or http://localhost:7778) with
+ *     the change BUILT into the UI (`npm run build` in ui/).
+ *   - The Columns ▾ chooser renders even on an account with ZERO verified reporters (it sits
+ *     above the table/empty-state), so the DEFAULT column set is verifiable without populated
+ *     data. A fresh browser context (empty localStorage) is required so DEFAULT_VISIBLE applies
+ *     rather than a saved 'bsp-reporters-columns' preference — Playwright gives each test one.
+ *
+ * Not run pre-implementation (the columns/defaults do not exist yet); exercised at the
+ * staging smoke after the feature deploys.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = process.env.BRAINSTORM_BASE_URL || 'http://localhost:7778';
+// Scores loaded, expected 0 verified reporters → empty state, but the Columns menu still renders.
+const ZERO_PUBKEY = '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2';
+
+const reportersUrl = (pk) => `${BASE_URL}/user/${pk}/reporters`;
+const colOption = (page, label) =>
+  page.locator('label.bsp-follows-colopt', { hasText: label }).locator('input[type="checkbox"]');
+
+test.describe('Story verified-reporters #4 — report-type & timestamp columns', () => {
+  test('the column chooser offers both new columns: "Report Type" and "Reported"', async ({ page }) => {
+    await page.goto(reportersUrl(ZERO_PUBKEY));
+    await page.getByRole('button', { name: /columns/i }).click();
+    await expect(page.locator('label.bsp-follows-colopt', { hasText: 'Report Type' })).toBeVisible();
+    await expect(page.locator('label.bsp-follows-colopt', { hasText: 'Reported' })).toBeVisible();
+  });
+
+  test('by default Report Type is shown and Name is hidden (default columns = Picture/Report Type/Rank)', async ({ page }) => {
+    await page.goto(reportersUrl(ZERO_PUBKEY));
+    await page.getByRole('button', { name: /columns/i }).click();
+    // New default set: Report Type on, Rank on, Name off, Reported off (toggleable).
+    await expect(colOption(page, 'Report Type')).toBeChecked();
+    await expect(colOption(page, 'Rank')).toBeChecked();
+    await expect(colOption(page, 'Name')).not.toBeChecked();
+    await expect(colOption(page, 'Reported')).not.toBeChecked();
+  });
+
+  // MANUAL / FIXTURE-DEPENDENT (documented, like the list spec's populated-path note). These
+  // need an account that actually has verified reporters under the House PoV at smoke time —
+  // most accounts have zero. To verify on such an account's /reporters page:
+  //   1. Report Type cells show a humanized label (e.g. "Spam", "Impersonation"); empty when absent.
+  //   2. Toggle "Reported" on: cells read relative time, e.g. "3d, 4h, 12m ago"; empty when absent.
+  //   3. Click the "Reported" header: rows order by the RAW unix timestamp (newest/oldest), NOT
+  //      lexicographically by the "ago" text; rows with no timestamp sit at the bottom in BOTH
+  //      sort directions.
+  //   4. The summary line reads "<N> reporters, <M> reports" — N = distinct people, M = rows; when
+  //      a reporter filed multiple distinct report types they appear as multiple rows (no de-dup),
+  //      so M can exceed N. Entry point: the profile's "Verified Reporters" count links here.
+});

--- a/ui/src/components/DataTable.jsx
+++ b/ui/src/components/DataTable.jsx
@@ -3,7 +3,11 @@ import { useState, useMemo, useEffect } from 'react';
 /**
  * Reusable sortable data table.
  * @param {Object} props
- * @param {Array<{key: string, label: string, render?: Function}>} props.columns
+ * @param {Array<{key: string, label: string, render?: Function, sortValue?: Function}>} props.columns
+ *   A column may declare an optional `sortValue(row)` accessor: when present, that
+ *   column sorts by the returned raw value (numerically), decoupled from what `render`
+ *   displays, with missing values (null/undefined) always sorted last in both
+ *   directions. Columns without it keep the default string/localeCompare sort.
  * @param {Array<Object>} props.data
  * @param {Function} props.onRowClick - Optional row click handler
  * @param {string} props.emptyMessage
@@ -34,13 +38,27 @@ export default function DataTable({ columns, data, onRowClick, emptyMessage = 'N
 
   const sorted = useMemo(() => {
     if (!sortKey) return filtered;
+    const col = columns.find(c => c.key === sortKey);
+    const accessor = col && typeof col.sortValue === 'function' ? col.sortValue : null;
+    if (accessor) {
+      // Opt-in: sort by a raw value (e.g. a unix timestamp) decoupled from what the
+      // cell renders, with missing values always last regardless of direction.
+      return [...filtered].sort((a, b) => {
+        const av = accessor(a);
+        const bv = accessor(b);
+        if (av == null && bv == null) return 0;
+        if (av == null) return 1;
+        if (bv == null) return -1;
+        return sortDir === 'asc' ? av - bv : bv - av;
+      });
+    }
     return [...filtered].sort((a, b) => {
       const av = a[sortKey] ?? '';
       const bv = b[sortKey] ?? '';
       const cmp = String(av).localeCompare(String(bv), undefined, { numeric: true });
       return sortDir === 'asc' ? cmp : -cmp;
     });
-  }, [filtered, sortKey, sortDir]);
+  }, [filtered, sortKey, sortDir, columns]);
 
   // Pagination (opt-in via pageSize). Reset to the first page whenever the
   // underlying set changes so we never strand the user on a now-empty page.

--- a/ui/src/pages/BrainstormReporters.jsx
+++ b/ui/src/pages/BrainstormReporters.jsx
@@ -6,6 +6,8 @@ import BrainstormUserMenu from '../components/BrainstormUserMenu';
 import DataTable from '../components/DataTable';
 import useGrapevineReporters from '../hooks/useGrapevineReporters';
 import VerificationInfo from '../components/VerificationInfo';
+import { formatTimeAgo } from '../utils/timeAgo';
+import { humanizeReportType } from '../utils/reportType';
 
 /* ── Helpers ──────────────────────────────────────────── */
 
@@ -22,7 +24,8 @@ const PAGE_SIZE = 50;
 // the pages do not clobber each other's column-visibility prefs.
 const STORAGE_KEY = 'bsp-reporters-columns';
 
-// Column definitions + default visibility (pic/name/rank shown; the rest hidden).
+// Column definitions + default visibility (pic/report-type/rank shown; the rest hidden).
+// Report Type and Reported are report-only (NIP-56) — they have no follows/mutes analogue.
 const ALL_COLUMNS = [
   { key: 'picture', label: '', sortable: false, render: (_v, row) => (
     row.picture
@@ -30,7 +33,11 @@ const ALL_COLUMNS = [
       : <div className="bsp-follows-avatar bsp-follows-avatar-ph">{(row.name || '?')[0].toUpperCase()}</div>
   ) },
   { key: 'name', label: 'Name', render: v => v || '—' },
+  { key: 'reportType', label: 'Report Type', render: v => humanizeReportType(v) },
   { key: 'rank', label: 'Rank', render: v => (v == null ? '—' : v) },
+  // Displays relative "ago" text but sorts by the raw unix integer (sortValue);
+  // a missing timestamp renders an empty cell and sorts last in both directions.
+  { key: 'timestamp', label: 'Reported', sortValue: row => row.timestamp, render: v => (v == null ? '' : formatTimeAgo(v)) },
   { key: 'npub', label: 'npub', render: v => <code className="bsp-follows-npub">{shortNpub(v)}</code> },
   { key: 'hops', label: 'Hops', render: v => (v == null ? '—' : v) },
   { key: 'verifiedFollowerCount', label: 'Verified Followers', render: v => (v == null ? '—' : v) },
@@ -38,7 +45,8 @@ const ALL_COLUMNS = [
   { key: 'verifiedReporterCount', label: 'Verified Reporters', render: v => (v == null ? '—' : v) },
 ];
 const DEFAULT_VISIBLE = {
-  picture: true, name: true, rank: true,
+  picture: true, reportType: true, rank: true,
+  name: false, timestamp: false,
   npub: false, hops: false,
   verifiedFollowerCount: false, verifiedMuterCount: false, verifiedReporterCount: false,
 };
@@ -109,6 +117,8 @@ export default function BrainstormReporters() {
         verifiedFollowerCount: f.verifiedFollowerCount,
         verifiedMuterCount: f.verifiedMuterCount,
         verifiedReporterCount: f.verifiedReporterCount,
+        reportType: f.reportType ?? null,
+        timestamp: f.timestamp == null ? null : Number(f.timestamp),
       };
     });
     // Default sort: Rank (credibility), descending — most credible reporters first.
@@ -128,6 +138,13 @@ export default function BrainstormReporters() {
   }, [rows, search]);
 
   const columns = useMemo(() => ALL_COLUMNS.filter(c => visible[c.key]), [visible]);
+
+  // Report-centric summary: each row is one report, so the row count is the number of
+  // reports while distinct pubkeys are the number of reporters. Showing both ("8
+  // reporters, 10 reports") explains why the row count can exceed the profile badge.
+  // Derived from the full row set, independent of the search box.
+  const reportCount = rows.length;
+  const reporterCount = useMemo(() => new Set(rows.map(r => r.pubkey)).size, [rows]);
 
   return (
     <div className="bsp-page">
@@ -151,6 +168,11 @@ export default function BrainstormReporters() {
         <p className="bsp-follows-subtitle">Verified users who have reported this account.</p>
         {/* v1 data is Owner-PoV (Neo4j), so the owner's web of trust is the honest attribution (ADR 0031). */}
         <p className="bsp-follows-pov">Relative to the owner's web of trust.</p>
+        {rows.length > 0 && (
+          <p className="bsp-follows-summary">
+            {reporterCount} {reporterCount === 1 ? 'reporter' : 'reporters'}, {reportCount} {reportCount === 1 ? 'report' : 'reports'}
+          </p>
+        )}
 
         {/* Controls: search + columns toggle */}
         <div className="bsp-follows-controls">

--- a/ui/src/pages/BrainstormReporters.jsx
+++ b/ui/src/pages/BrainstormReporters.jsx
@@ -139,9 +139,10 @@ export default function BrainstormReporters() {
 
   const columns = useMemo(() => ALL_COLUMNS.filter(c => visible[c.key]), [visible]);
 
-  // Report-centric summary: each row is one report, so the row count is the number of
-  // reports while distinct pubkeys are the number of reporters. Showing both ("8
-  // reporters, 10 reports") explains why the row count can exceed the profile badge.
+  // Report-centric summary: each row is one report (one REPORTS edge). reportCount (M) is
+  // the number of reports; reporterCount (N) is the number of distinct reporters, so N <= M.
+  // The profile badge also counts edges, so it tracks M (≈ the row count, modulo Meili/Neo4j
+  // refresh skew) — showing "N reporters, M reports" makes the people-vs-reports gap explicit.
   // Derived from the full row set, independent of the search box.
   const reportCount = rows.length;
   const reporterCount = useMemo(() => new Set(rows.map(r => r.pubkey)).size, [rows]);

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -4172,6 +4172,8 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
 /* Reporters list: description + point-of-view attribution lines (verified-reporters #3). */
 .bsp-follows-subtitle { margin: 0.35rem 0 0; font-size: 0.9rem; opacity: 0.7; }
 .bsp-follows-pov { margin: 0.4rem 0 0; font-size: 0.82rem; opacity: 0.6; }
+/* Reporter/report tally — "8 reporters, 10 reports" (verified-reporters #4). */
+.bsp-follows-summary { margin: 0.4rem 0 0; font-size: 0.82rem; opacity: 0.75; }
 /* Verification explainer popover: owner identity row (profile #36 / ADR 0032). */
 .bsp-verification-owner { display: flex; align-items: center; gap: 0.5rem; margin: 0.25rem 0 0.5rem; }
 /* Verified Reporters alarm icon (shown only above the dynamic threshold). */

--- a/ui/src/utils/reportType.js
+++ b/ui/src/utils/reportType.js
@@ -1,0 +1,23 @@
+/**
+ * NIP-56 report-type label formatting. Pure — no DOM/React imports (kept
+ * unit-testable from node; the verified-reporters #4 suite imports it directly).
+ */
+
+// Special-case labels that differ from a plain capitalization. Empty for now; add
+// entries here if a token needs a non-capitalized display (e.g. an acronym).
+const REPORT_TYPE_LABELS = {};
+
+/**
+ * Convert a NIP-56 report_type token (e.g. "spam", "impersonation") to a friendly,
+ * human-readable label ("Spam", "Impersonation"). Unknown tokens are capitalized
+ * as-is. Missing/empty input yields "" (caller renders an empty cell).
+ *
+ * @param {string} token - raw report_type from the REPORTS edge
+ * @returns {string} friendly label, or "" for missing/empty input
+ */
+export function humanizeReportType(token) {
+  if (!token) return '';
+  if (REPORT_TYPE_LABELS[token]) return REPORT_TYPE_LABELS[token];
+  const s = String(token);
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/ui/src/utils/timeAgo.js
+++ b/ui/src/utils/timeAgo.js
@@ -1,0 +1,34 @@
+/**
+ * Relative "time ago" formatting. Pure — no DOM/React imports (kept unit-testable
+ * from node; the verified-reporters #4 suite imports it directly).
+ */
+
+const MIN = 60, HOUR = 3600, DAY = 86400, YEAR = 365 * DAY;
+
+/**
+ * Format a unix timestamp (SECONDS) as a compact, multi-unit relative string,
+ * e.g. "3d, 4h, 12m ago". Shows the 3 most-significant non-zero units among
+ * years / days / hours / minutes (minute is the smallest unit); zero-valued units
+ * are dropped. Sub-minute and future timestamps render "0m ago".
+ *
+ * @param {number} unixSeconds - report time as unix SECONDS (nostr created_at)
+ * @param {number} [now] - current time in unix seconds (injectable for tests)
+ * @returns {string} e.g. "2y, 14d, 3h ago" / "45m ago" / "0m ago"; "" for missing/invalid input
+ */
+export function formatTimeAgo(unixSeconds, now = Math.floor(Date.now() / 1000)) {
+  if (unixSeconds == null || !Number.isFinite(Number(unixSeconds))) return '';
+
+  let rem = Math.max(0, Math.floor(now - Number(unixSeconds)));
+  const units = [['y', Math.floor(rem / YEAR)]];
+  rem %= YEAR;
+  units.push(['d', Math.floor(rem / DAY)]); rem %= DAY;
+  units.push(['h', Math.floor(rem / HOUR)]); rem %= HOUR;
+  units.push(['m', Math.floor(rem / MIN)]);
+
+  const parts = units
+    .filter(([, v]) => v > 0)   // drop zero-valued units
+    .slice(0, 3)                // 3 most-significant remaining
+    .map(([u, v]) => `${v}${u}`);
+
+  return `${parts.length ? parts.join(', ') : '0m'} ago`;
+}


### PR DESCRIPTION
## Summary

Adds two report-only columns to the Verified Reporters list page (`/user/:pubkey/reporters`), sourced from the neo4j `REPORTS` edge: **Report Type** (humanized NIP-56 label) and **Reported** (relative "time ago"). Default visible columns change to **Picture · Report Type · Rank** (Name still toggleable). The Reported column displays e.g. `3d, 4h, 12m ago` but sorts by the **raw unix integer**, with missing timestamps sorting last in both directions. A **"N reporters, M reports"** summary line distinguishes distinct reporters from total reports. The list is report-centric — one row per `REPORTS` edge, no client-side de-duplication.

Story verified-reporters #4 / ADR 0004. Full Plan → Architecture → Tests → Implementation → Review cycle; review PASS.

## Changes

- `ui/src/utils/timeAgo.js` (new) — `formatTimeAgo`: multi-unit relative time, drops zero units, top-3, `0m ago` floor, `""` for missing.
- `ui/src/utils/reportType.js` (new) — `humanizeReportType`: friendly NIP-56 label, `""` for missing.
- `ui/src/components/DataTable.jsx` — opt-in per-column `sortValue` accessor (numeric, missing-last both directions); existing `localeCompare` path unchanged (other 15 consumers unaffected).
- `src/api/grapevineInteractions/queries/reportersWithMetrics.js` — bind the `REPORTS` edge; return `report_type` + `timestamp` per row (one row per edge, no `DISTINCT`).
- `ui/src/pages/BrainstormReporters.jsx` — Report Type + Reported columns, new `DEFAULT_VISIBLE`, summary line, per-row fields.
- `ui/src/styles.css` — `.bsp-follows-summary`.
- Tests: `test/verified-reporters-report-columns.test.js` (26 tests) wired into `test/test.js`; Playwright `tests/brainstorm/profile-verified-reporters-columns.spec.js`.

## Test plan

- [ ] After merge: deploy-staging.yml runs.
- [ ] Smoke test on staging.brainstorm.world.
- [ ] Load `/user/eab0e756…91f4f/reporters`: confirm default columns are Picture/Report Type/Rank, Report Type cells show humanized labels, the "N reporters, M reports" summary appears.
- [ ] Toggle "Reported" on: cells show relative "ago" text; sorting by Reported orders by recency (raw timestamp).
- [ ] Regression: Follows/Followers list pages still default to Picture/Name/Rank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)