### PR TITLE
docs: revive search-quality eval harness into a search-quality epic

### DIFF
--- a/engineering-team/decisions/search-quality/0001-search-quality-eval-harness.md
+++ b/engineering-team/decisions/search-quality/0001-search-quality-eval-harness.md
@@ -1,0 +1,166 @@
+# ADR 0001: Architecture for the offline search-quality evaluation harness
+
+**Status:** Accepted
+**Date:** 2026-05-17 · **Revived/re-validated:** 2026-06-16
+**Story:** `engineering-team/stories/search-quality/1-search-quality-eval-harness.md`
+**Epic:** `search-quality`
+
+> **Revival note (2026-06-16).** Authored 2026-05-17 on the local-only branch `feat/search-eval-harness` (never pushed); revived into the `search-quality` epic and renumbered from the flat `decisions/0004-…`. The load-bearing facts below were re-checked against current `main`: the meili proxy `src/api/search/profiles/meili/index.js` → `handleMeiliSearchProfiles` (still the "SINGLE AUTHORITY") ✓; `nostr-search/src/{search,ingest,startup}.js` ✓; the `test-data/` fixture precedent ✓ (now also `dwarves-v2-*`); `.github/workflows/` still all deploy-only (`deploy-brainstorm`, `deploy-communities`, `deploy-magic-carpet`, `deploy-staging`) so a PR-triggered CI workflow remains net-new ✓; the `test/test.js` hand-rolled runner ✓. Two small drifts corrected inline below: the Meili tag and the test-file name. Implementation has not begun.
+
+## Context
+
+Story 1 asks for an offline harness that scores search quality against a
+hand-judged query set, with a measure-and-regression-gate success condition, a
+layered-ready fixture format (v1 scores profile search only), and a v1 Done bar
+of ≥30 hand-judged queries. Relevant facts pulled from the story plus the
+codebase:
+
+- **Two search seams exist.**
+  - `src/api/search/profiles/meili/index.js` → `handleMeiliSearchProfiles`
+    (`GET /api/search/profiles/meili?q&wotPov=house|user&userPubkey`). Its own
+    header comment: *"This proxy is the SINGLE AUTHORITY for POV resolution,
+    filter/sort config, and field namespacing (`wot_<metric>_<suffix>`). The
+    client only sends q, limit, offset, wotPov, userPubkey."*
+  - `nostr-search/src/search.js` (`GET /api/search`) — lower level; expects
+    already-fully-qualified `sort`/`wotFilters` (e.g. `wot_rank_a8ca55ca`) and
+    runs the two-phase scored+backfill merge against Meilisearch directly.
+- **The corpus mutates continuously.** `nostr-search/src/ingest.js` live-ingests
+  kind-0; `nostr-search/src/startup.js` schedules a 24h bulk re-ingest; WoT
+  scores are upserted via `POST /api/load-scores`. A score compared to a baseline
+  is only meaningful against a *fixed* corpus.
+- **Constraints.**
+  - CLAUDE.md / `roles/architect.md`: JS-without-build; *no new
+    lint/typecheck/build tooling without an ADR*. All `.github/workflows/` are
+    deploy-only — a PR-triggered CI workflow is net-new automation.
+  - `test/test.js` is a hand-rolled runner: phase-1 smoke + story suites
+    `test/<slug>.test.js` each exporting `async run() → {pass,fail}`,
+    `require()`d and added to the results list; `process.exit(0|1)`.
+  - `test-data/` (`dwarves-test-data.json`, `mint-dwarves.js`) is the
+    established curated-fixture-dataset precedent.
+- **Concept Graph orientation (three-call pattern, AGENTS.md):** `/summaries`
+  (34 concepts) → `/node/<h>/neighbors` for the two concepts the story names.
+  - `39998:e00ed090…df36:web-of-trust` — ConceptHeader, neighbors `{}`.
+  - `39998:e00ed090…df36:graperank` — ConceptHeader, neighbors `{}`.
+  - No `search` / `relevance` / `evaluation` concept exists. The harness adds
+    and changes **no** concept-graph node or schema.
+
+## Options considered
+
+### Option A — Proxy seam + version-pinned fixture corpus + hand-rolled scorer (chosen)
+
+Drive the eval through `/api/search/profiles/meili` (the real product path).
+Co-version a small curated **fixture corpus** + the gold set; load the corpus
+into an **ephemeral Meilisearch** (`MEILI_URL` override, tag matching
+`docker-compose.yml` — currently `getmeili/meilisearch:v1.12`) for each run.
+Hand-rolled binary-relevance scorer (recall@k + MRR). Ships a PR-triggered CI
+workflow added as a **non-required** check.
+
+- **Pros:** Tests what users actually get (POV resolution + namespacing exercised,
+  not duplicated). Reproducible — score moves only when code/config moves.
+  Hermetic and CI-able. Reuses the `test-data/` fixture precedent. No new runtime
+  dependency; consistent with the hand-rolled `test/test.js` and JS-without-build.
+- **Cons:** Needs the control-panel + nostr-search-api + an ephemeral Meili stood
+  up for a full run. A small corpus is not the production data distribution —
+  v1 measures *ranking logic on a controlled corpus*, explicitly not prod recall.
+
+### Option B — nostr-search-api seam + pinned index snapshot + nDCG
+
+Hit `nostr-search/src/search.js` directly against a pinned Meilisearch dump of
+the real index; graded relevance with nDCG@k.
+
+- **Pros:** Realistic data distribution; nDCG is the ranking gold standard.
+- **Cons:** The harness must re-implement the proxy's `wot_<metric>_<suffix>`
+  namespacing — a fidelity/drift hazard for a quality gate. A real-index dump is
+  750K–2.6M docs / 1.2–5.6 GB RAM — too heavy to version or run in CI. Graded
+  labels materially raise the hand-judging burden against a 30-query v1.
+
+### Option C — Meilisearch-direct + live staging index + wide tolerance
+
+Query Meilisearch directly against the live staging index; absorb data drift
+with a loose tolerance.
+
+- **Pros:** Cheapest to stand up.
+- **Cons:** Bypasses the two-phase WoT merge in `search.js` (doesn't test what
+  ships). A drift-noisy gate on a *trust* metric is worse than none — it trains
+  everyone to ignore it (the Goodhart failure mode AC4 exists to prevent).
+
+## Decision
+
+We chose **Option A**.
+
+The story's acceptance criteria are observer-relative and the proxy is the
+documented single authority for observer resolution; testing below it would
+either bypass observer semantics (B/C) or force the harness to duplicate and
+drift from proxy logic (B). Reproducibility is non-negotiable for a regression
+gate, which kills the live-index options; a small co-versioned fixture corpus is
+the only hermetic, CI-able choice and matches the existing `test-data/` pattern.
+
+Sub-decisions:
+
+- **Metric:** binary relevance, primary metrics **recall@k and MRR**
+  (k configurable, default 10); overall score = mean over queries. Chosen over
+  graded nDCG because it minimizes hand-judging burden for the ≥30-query v1 and
+  is directly auditable (AC4). The gold-entry schema stores an optional `grade`
+  so nDCG can be added later without re-judging.
+- **CI as a *required* gate is deferred.** This ADR authorizes the workflow
+  *file* (satisfying the no-new-tooling-without-ADR rule); promoting it to a
+  merge-blocking required check is a process-contract change tracked in the
+  separate, independently-ratifiable harness-contract ADR — not this story.
+
+## Consequences
+
+- **Enables:** A reproducible, observer-relative search-quality number and an
+  auditable per-query report; a mechanical regression signal; a fixture format
+  ready for the future layered Tag→DList work.
+- **Constrains:** A full eval run requires the local stack + an ephemeral Meili.
+  The fixture corpus becomes a maintained artifact that must evolve with search.
+- **New debt / follow-ups:** The concrete baseline value + tolerance are set
+  post-Implementation (story Open Questions). Promoting the CI check to required,
+  and any production-distribution eval, are explicitly deferred.
+- **Firmware reinstall required?** **No** — verified via the Concept Graph: no
+  concept node or schema is added or changed.
+
+## Implementation notes
+
+Concrete guidance for the Implementer (no production code written here):
+
+- **`nostr-search/eval/score.js`** — pure, dependency-free:
+  `recallAtK(hitPubkeys, judged, k)`, `mrr(hitPubkeys, judged)`,
+  `aggregate(perQuery)`. No framework.
+- **`nostr-search/eval/schema.js`** — `validateGoldEntry(obj)`: requires
+  `query`, `observer`, `judgments`; **accepts and ignores** an optional
+  `layered` object (AC3 — never reject it).
+- **`nostr-search/eval/runner.js`** — `runEval({goldDir, corpusDir, k})`:
+  validate gold, ensure corpus loaded into the target Meili, for each entry
+  `GET ${TAPESTRY_URL}/api/search/profiles/meili?q&wotPov&userPubkey`, collect
+  hit pubkeys, score, write `report.json` + a human-readable per-query report
+  (query, observer, returned results, judged hit/miss — AC4), compare overall to
+  `baseline.json`, `process.exit(0|1)` listing regressed queries (AC2).
+- **`nostr-search/eval/gold/*.json`** — ≥30 hand-judged entries. Schema:
+  `{ id, query, observer:{wotPov, userPubkey?}, judgments:[{pubkey, relevant,
+  grade?}], layered?:{tagLayer?,dlistLayer?} }`.
+- **`nostr-search/eval/corpus/*.json`** + a `mint-*.js`-style loader mirroring
+  the `test-data/` precedent; pinned, co-versioned with the gold set.
+- **`nostr-search/eval/baseline.json`** — `{ metric, baseline, tolerance }`;
+  numbers filled post-Implementation.
+- **`test/search-quality-eval-harness.test.js`** — exports `async run()` →
+  `{pass,fail}`; unit-tests `score.js`, `schema.js` (incl. layered-ignored), and
+  the gate exit logic with synthetic inputs (hermetic — no live stack).
+  Register in `test/test.js`: `require()` + suite line + fold into `overallOk`.
+  (Slug-named, not number-prefixed, per the current `test/` convention.)
+- **`.github/workflows/search-eval.yml`** — PR trigger on `nostr-search/**` and
+  `src/api/search/**`; Meilisearch service container at the tag `docker-compose.yml`
+  uses (**`v1.12`** as of 2026-06-16); load corpus; `node nostr-search/eval/runner.js`.
+  Added **non-required** in v1.
+
+Alternative location considered: a top-level `eval/`. Chose `nostr-search/eval/`
+to co-locate with the search service it measures (mirrors `nostr-search/src/`).
+
+## Out of scope
+
+- The concrete baseline number + tolerance (post-Implementation).
+- Promoting the CI workflow to a required, merge-blocking gate (separate
+  harness-contract ADR, for the operator + Vinney to ratify).
+- A production-distribution / real-index-snapshot eval.
+- Scoring the layered Tag→DList layers (only the *format* is layered-ready).
+- Any label bootstrapping (story explicitly rejected; hand-judged only).

--- a/engineering-team/epics/search-quality.md
+++ b/engineering-team/epics/search-quality.md
@@ -1,0 +1,21 @@
+# Epic: Search Quality
+
+**Status:** Active
+**Provenance:** Revived 2026-06-16 from the local-only branch `feat/search-eval-harness`. The story + ADR were authored 2026-05-17 by the `Clawds4` agent identity on the operator's machine, committed locally, and **never pushed** — they existed nowhere else until this revival. Idea-seeded by a strategy conversation (search quality is judged only by eyeball today); intended in part as something Vinney could evaluate. Pre-dates epic-scoping, so the story/ADR were renumbered into this epic on revival.
+
+## What this is
+The **measurement substrate for search**: an automated, repeatable way to score search-result *quality* so that changes to ranking, WoT weighting, or the search pipeline are caught mechanically rather than by eyeball. v1 is an offline harness that scores **profile** search against a hand-judged gold set; the fixture format is **layered-ready** for the planned Tag→DList WoT search. For a *trust* product, an unmeasured ranking is an integrity risk (regressions in *whose* curation surfaces are otherwise invisible), and this harness is the precondition for safely lengthening agentic-coding autonomy.
+
+## Stories
+`stories/search-quality/`:
+1. **search-quality-eval-harness** — the offline eval harness: a hand-judged gold set (≥30 queries) + a hand-rolled scorer (recall@k + MRR) driven through the real `/api/search/profiles/meili` proxy against a version-pinned fixture corpus; a PASS/FAIL regression gate (non-zero exit + names the regressed queries) and an auditable per-query report; ships a **non-required** PR-triggered CI workflow. *(Planning + Architecture done — revived/ratified 2026-05-17, re-validated 2026-06-16; next phase: Test Design, on operator confirmation.)*
+
+## ADRs
+`decisions/search-quality/` — 0001 (search-quality-eval-harness).
+
+## Related / seeds
+- The eval is **observer-relative** (`web-of-trust` / `graperank`): it scores results *for a given observer*, consistent with the three-PoV model (BIBLE §27). The proxy `src/api/search/profiles/meili/index.js` is the documented single authority for PoV resolution.
+- A separate, independently-ratifiable **harness-contract ADR** ("every feature ships an executable acceptance check") is referenced by ADR 0001 but tracked **outside** this epic — for the operator + Vinney to ratify on their own.
+
+## Deferred (later phases / not v1)
+Concrete baseline value + tolerance (set post-Implementation, once a first run produces numbers); promoting the CI workflow to a required, merge-blocking gate (the separate harness-contract ADR); a production-distribution / real-index-snapshot eval; scoring the layered Tag→DList layers (only the fixture *format* is layered-ready in v1); any label bootstrapping (v1 is hand-judged only, to avoid circularly evaluating WoT search with WoT-derived labels).

--- a/engineering-team/stories/_intake.md
+++ b/engineering-team/stories/_intake.md
@@ -703,3 +703,16 @@ Reference profile: `https://staging.brainstorm.world/user/c4eabae1be3cf657bc1855
 **Priority:** Low (intended primarily as a low-risk shakedown of the Direction-mode autonomous run).
 
 ---
+
+## 2026-06-16 — Feature (REVIVED): offline search-quality evaluation harness
+
+**Not a new request — a revival.** Planning + Architecture for an offline search-quality eval harness were found on the local-only branch `feat/search-eval-harness` during a 2026-06-16 branch-hygiene pass: a story + ADR authored 2026-05-17 by the `Clawds4` agent identity on the operator's machine, committed locally and **never pushed** (existed nowhere else). Git forensics confirmed provenance — authored locally on the operator's machine, not teammate work, not a sync artifact. The original raw request is the **2026-05-17** entry above ("…something that Vinney can evaluate and use himself…"). Revived at the operator's direction.
+
+**What the revival did:**
+- Created a new **`search-quality`** epic and relocated the artifacts into it, renumbered from the pre-epic-scoping flat paths: `stories/7-…` → `stories/search-quality/1-search-quality-eval-harness.md`; `decisions/0004-…` → `decisions/search-quality/0001-search-quality-eval-harness.md`.
+- **Re-validated** the ADR against current `main`: the meili proxy (`…/profiles/meili/index.js` → `handleMeiliSearchProfiles`, still "SINGLE AUTHORITY"), the `nostr-search/src/{search,ingest,startup}.js` seams, the `test-data/` fixture precedent, the all-deploy-only `.github/workflows/` premise, and the `test/test.js` runner all still hold. Two small drifts corrected inline: Meili tag `v1.12.8` → `v1.12` (per current `docker-compose.yml`); test file renamed to the slug convention (`test/search-quality-eval-harness.test.js`).
+
+**Status:** Planning + Architecture ratified (revived/re-validated). **Implementation not started.**
+**Classification:** Feature
+**Strictness:** Standard
+**Phase path:** Test Design → Implementation → Review (Planning + Architecture done — see `epics/search-quality.md` + ADR `search-quality/0001`). **Resume on operator confirmation.**

--- a/engineering-team/stories/search-quality/1-search-quality-eval-harness.md
+++ b/engineering-team/stories/search-quality/1-search-quality-eval-harness.md
@@ -1,0 +1,94 @@
+# Story 1: Offline search-quality evaluation harness
+
+**Status:** Approved
+**Created:** 2026-05-17 · **Revived:** 2026-06-16
+**Type:** Feature
+**Epic:** `search-quality`
+
+> **Provenance & revival.** Authored 2026-05-17 by the `Clawds4` agent identity on the operator's machine and committed to the local-only branch `feat/search-eval-harness` — **never pushed**, so it existed nowhere else. Revived 2026-06-16 into the `search-quality` epic (renumbered from the pre-epic-scoping flat `stories/7-…`). **Re-validated against current `main` on 2026-06-16:** the proxy seam, the two `nostr-search` search seams, the `test-data/` fixture precedent, and the all-deploy-only `.github/workflows/` premise all still hold (see ADR 0001 for the file-by-file recheck). Planning + Architecture are ratified; **implementation has not begun** — resume at Test Design only on operator confirmation.
+
+## Background
+Search quality in this project is currently judged by human eyeball — there is
+no automated, repeatable measure of whether a change to ranking, the WoT
+weighting, or the search pipeline made results better or worse. This makes every
+search-affecting change unfalsifiable without manual spot-checking, and it is the
+binding constraint on (a) safely increasing how much search R&D can run without
+per-decision human approval, and (b) any trustworthy measurement of the planned
+layered Tag→DList WoT search. Because this is a *trust* product, an unmeasured
+search ranking is also an integrity risk: regressions in whose curation surfaces
+are invisible. Affects everyone who changes search (engineers and the agentic
+harness) and, indirectly, every brainstorm.world search user.
+
+## User-facing description
+As an engineer or the engineering-team harness changing anything that affects
+search, I want an automated score of result quality against a fixed, human-judged
+query set, so that a regression is caught mechanically before it ships rather
+than discovered by eyeball or in production.
+
+## Acceptance criteria
+Testable from the outside. Each criterion gets at least one test.
+
+- [ ] Given the committed hand-judged gold set, when the harness is run, then it
+      produces a single overall quality score **and** a per-query breakdown,
+      reporting the search corpus/index reference it ran against.
+- [ ] Given an agreed baseline score and tolerance, when a run's overall score is
+      below baseline beyond tolerance, then the run reports FAIL, exits non-zero,
+      and lists exactly which queries regressed; when at/above baseline it reports
+      PASS and exits zero.
+- [ ] Given a gold-set entry that includes tag-layer and dlist-layer expectation
+      fields, when the harness loads it, then the entry validates and runs
+      (the not-yet-implemented layers are accepted and ignored, never rejected),
+      and the v1 score reflects profile-search results only.
+- [ ] Given a completed run, when an engineer inspects the per-query report, then
+      for each query it shows the query text, the observer/WoT context, the
+      returned results, and which judged-relevant items were hit vs missed —
+      enough to audit *why* the score is what it is.
+- [ ] The harness ships with a seed gold set of **at least 30** hand-judged
+      queries, each carrying its observer context and human relevance labels,
+      committed to the repo.
+
+## Concepts touched
+The Concept Graph API was re-checked during Architecture (ADR 0001): `/summaries`
+returns 34 concepts and **no** `search` / `relevance` / `evaluation` concept
+exists, so search/relevance is not a modeled concept — the harness adds and
+changes no concept-graph node or schema (no firmware reinstall).
+
+- `web-of-trust` — relevance is observer-relative; the eval must score results
+  *for a given observer*, not globally.
+- `graperank` — the trust-scoring whose effect on ranking the harness measures.
+
+## Out of scope
+- **Metric choice and scorer implementation** (nDCG / MRR / recall / etc.) —
+  Architect's decision in ADR 0001 (recall@k + MRR).
+- **How the gate is wired into CI**, including introducing any PR-triggered CI
+  workflow — Architecture + its ADR (this is net-new tooling, gated by the
+  CLAUDE.md "no new tooling without an ADR" rule).
+- **Bootstrapped or auto-generated relevance labels** — explicitly rejected for
+  v1; hand-judged only (avoids circularly evaluating WoT search with WoT-derived
+  labels).
+- **Implementing layered Tag→DList search, or scoring those layers** — only the
+  *fixture format* is layered-ready in v1; scoring is profile-search only.
+- **The engineering-team contract change** (a general "every feature ships an
+  executable acceptance check" rule) — tracked as its own separate,
+  independently-ratifiable ADR; NOT part of this story.
+- **Ongoing baseline governance** — v1 establishes the gate mechanism and one
+  initial agreed baseline; how the baseline is raised over time is deferred.
+- **Merging to staging/main** — originally framed as a draft PR for evaluation;
+  promotion is out of scope for the story.
+
+## Open questions
+Non-blocking for story approval; flagged so they aren't lost:
+
+- The concrete **baseline value and tolerance** can't be fixed until the metric
+  exists and a first run produces numbers — the *mechanism* is in scope now; the
+  *number* is set during/after Implementation.
+- Whether the ~30 seed queries should deliberately target known-weak areas
+  (e.g. the documented Meilisearch panic-class queries) or aim for representative
+  coverage — a labeling-strategy question, resolvable in Test Design.
+
+## Linked artifacts
+- Intake: `engineering-team/stories/_intake.md` — original 2026-05-17 entry + the 2026-06-16 revival entry.
+- ADR: `engineering-team/decisions/search-quality/0001-search-quality-eval-harness.md` — Accepted 2026-05-17 (revived/re-validated 2026-06-16).
+- Separate harness-contract ADR: tracked independently of this story; not a blocker for it.
+- Test plan: (filled after Test Design phase)
+- Review: (filled after Review phase)


### PR DESCRIPTION
## Summary

Revives never-pushed planning work found on the local-only branch `feat/search-eval-harness` (a story + ADR for an offline search-quality evaluation harness, authored 2026-05-17, provenance confirmed local — never on any remote). Relocates it into the current epic-scoped structure as a new `search-quality` epic, re-validated against current `main`. **Docs-only — no code, no user-facing change.** Planning + Architecture are ratified; implementation has not started.

## Changes

- **New epic** `engineering-team/epics/search-quality.md` (with provenance line).
- **Story** `engineering-team/stories/search-quality/1-search-quality-eval-harness.md` — renumbered from flat `stories/7-…`; Status Approved; revival banner; stale ADR-0003 concept ref replaced with the re-confirmed concept-graph fact.
- **ADR** `engineering-team/decisions/search-quality/0001-search-quality-eval-harness.md` — renumbered from flat `0004`; Status Accepted; re-validation note; two drifts fixed inline (Meili tag `v1.12.8→v1.12`; slug-named test file; current workflow set).
- **`engineering-team/stories/_intake.md`** — 2026-06-16 revival entry preserving provenance.

## Test plan

- [ ] After merge: deploy-staging.yml runs.
- [ ] Light smoke on staging.brainstorm.world (Tier 1 stability + Tier 2 sanity + Tier 5 regression). No PR-specific surface — markdown-only, nothing user-facing changed.

## Follow-up

After this merges, the orphan branch `feat/search-eval-harness` will be deleted (its content is now preserved here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)