### PR TITLE
Profile: identity details popover (story profile #37)

### DIFF
--- a/docs/PROFILE_IA_REVIEW_2026-06-16.md
+++ b/docs/PROFILE_IA_REVIEW_2026-06-16.md
@@ -1,0 +1,86 @@
+# Profile page information-architecture review (verified)
+
+**Status:** 🟡 CAPTURED / SET ASIDE — needs further operator discussion before any build. Not scheduled. Resume via `/discuss`.
+**Date:** 2026-06-16
+**Scope surface:** `ui/src/pages/BrainstormProfile.jsx` (route `/user/:pubkey`)
+**Provenance:** Produced by a multi-lens UX review (four perspectives — trust-evaluation job, scannability, nostr-newcomer, mobile — synthesized into one recommendation, then each significant move adversarially pressure-tested against the existing ADRs/comments). This document preserves that work for a later discussion. It is **not** a ratified plan.
+
+This is "Story B" from the 2026-06-16 profile-page conversation. "Story A" (move npub + hex pubkey into a name-adjacent **details-drawer popover**; keep Website + Lightning visible) was approved separately and is being built first; see the `profile` epic. Story B was explicitly deferred by the operator: *"Story B will need significantly further discussion before running with it."*
+
+---
+
+## The dominant finding
+
+The product's whole reason for being — the **trust verdict** — is at the very bottom of the page, rendered as tile #1 of an 11-card grid, visually identical to "GrapeRank Input." A visitor arriving from search to answer *"should I trust this person?"* has to scroll past the bio and identity strings to reach the 0–100 Verification Score that answers it. All four review lenses flagged this independently. Raising the trust signal is the high-value change.
+
+## ⚠️ The correctness gotcha that bounds the headline change (point-of-view mismatch)
+
+The naive fix — "promote the score to a hero directly under the counts row" — **imports a PoV bug**:
+
+- The **counts row** (Following / Verified Followers / Verified Reporters) is sourced from **Neo4j, Owner-PoV** via `useUserCounts` (ADR `profile/0031`, BIBLE §27).
+- The **rank / Verification Score** comes from **Meilisearch, and its PoV depends on `?pov=`** — House (instance default) normally, but the **viewer's Personalized PoV** when `?pov=` is set (resolved at `BrainstormProfile.jsx:84,149–186`).
+
+Floating a big "THE score" flush under the counts can therefore show a number that **disagrees with the Verified Followers count right above it** (two different points of view) with no label explaining why — a credibility regression on a trust engine's flagship number. The counts-row `ⓘ` (`VerificationInfo`) explains the *owner-cutoff* definition and must **not** be re-parented onto a `?pov=`-dependent hero (its copy would become false).
+
+**Verified resolution:** keep the score hero **inside the Reputation section**, under the existing "Reputation" heading whose `ReputationInfo` `ⓘ` already frames scores as "House or your personalized view, whichever is selected." That preserves the PoV framing the under-counts placement would strip. The hero must keep **reading the existing Meili `trustScores['rank']`** — the grid data path is a hard regression boundary (ADR `profile/0031` §Consequences, ADR `profile/0034` §Constraints) — and must round/format the value (it is rendered raw today; a hero sized for a clean two-digit integer degrades on a float/absent value).
+
+---
+
+## Verified recommendation — before → after
+
+**Current order:** Header → Counts → Actions → About → Identity (pubkey, npub, website, lightning) → Reputation (flat 11-card grid).
+
+**Proposed order:**
+1. **Header** — name + the Story-A details-drawer icon (pubkey/npub).
+2. **Counts row** — **untouched** (hard-locked).
+3. **Action buttons** — untouched.
+4. **About.**
+5. **Reputation — promoted up to here**, restructured into two tiers:
+   - **Verification Score as a visible headline** at the top of the section (large, formatted 0–100), staying Meili-sourced under the House/Personalized framing.
+   - a **default-collapsed "details" disclosure** holding the technical internals (GrapeRank influence/average/confidence/input, PageRank, Muters).
+6. **Website + Lightning** — kept **visible and not buried** (a website is a human-legible trust signal); "Identity" heading retired to "Links" **only after** Story A ships. Exact placement is an open decision (see below).
+
+## The moves, with verified verdicts
+
+| Move | Verdict | Note |
+|---|---|---|
+| Promote Verification Score to a headline | ✅ do it — **inside Reputation, not under the counts row** | the PoV gotcha above; keep Meili-sourced; round the value |
+| Move Reputation section up (after About) | ✅ do it — low risk | no ADR fixes its bottom placement (mutable) |
+| Progressive disclosure for grid internals | ✅ do it — **as 2 tiers; do not collapse the whole block** | collapsing everything would hide the headline score too; needs a `tier` field on `TRUST_METRICS` |
+| Grid renders "Verified Followers" **twice** (defect) | ✅ remove **one**, not both | the grid value is Meili-PoV and genuinely diverges from the Owner-PoV counts (prod: 26,711 vs 22,981) — a *different* number, not a dupe. Prefer keeping `verifiedFollowerCount` (line 52), drop `followers` (line 45); disambiguate its tooltip. Already catalogued: 2026-06-06 item 4 |
+| Remove the grid "Reporters" card | ✅ proceed — **with a required test edit** | counts-row is the canonical alarm-bearing home (ADR 0032). BUT regression sentinel **R3** in `test/profile-verified-reporters-count.test.js:156–160` asserts the card must stay → must be updated, and the reversal of ADR 0001's retention noted, or `npm test` goes red |
+| Relabel "Identity"→"Contact" + move to page bottom | ❌ mostly **reject** | premature pre-Story-A; and burying Website under PageRank floats demotes a key trust signal. At most a one-word "Identity"→"Links" rename **after** Story A, keeping the block high |
+| Keep "Muters" in the disclosure only | ✅ | do **not** add a 4th count to the counts row — that breaks the locked parallel three-count set (ADR 0029/0031) |
+
+## Open decisions (must be settled in `/discuss` before planning)
+
+1. **Contact links placement** — leave Website/Lightning where Identity is now (after About, above the trust internals), or elsewhere? Lean: keep them visible and high, not buried.
+2. **Hops** — show alongside the headline score (more legible than GrapeRank) or tuck in the collapsed details? Lean: collapsed.
+3. **Bottom-block heading wording** — "Trust details" / "How this score is computed" / keep "Reputation". Must avoid the style guide's forbidden phrasings; the `ReputationInfo` PoV scope must stay bounded to the grid scores only.
+4. **Sequencing** — confirm Story A ships first (or in the same change), since the Identity relabel and the header drawer both assume it.
+
+## Hard constraints any reorder must respect (mined from ADRs/comments)
+
+Do **not** touch / must preserve (mutable:false):
+- **Counts data source** = Neo4j Owner-PoV via `useUserCounts`; never re-derive from the Meili grid, never substitute raw follower count (ADR `profile/0031`).
+- **Count states** `—` vs `0` vs loading; Verified Reporters: `>0`→link, genuine `0`→neutral non-link, unavailable→`—` ("zero is reassurance") (ADR `verified-reporters/0001`, design guide).
+- **Reporter alarm** red+🚩 only at the popularity-adjusted dynamic threshold `≥ 3 + floor(verifiedFollowers/750)`, never color alone, never replicated onto any promoted element (ADR `profile/0032`).
+- **Counts row** stays a parallel three-count set; **no per-count PoV chip / no 4th count** (ADR 0029/0031, ADR 0033/0034 — counts are Owner-PoV and must not be labeled "House").
+- **`ReputationInfo` popover** scope stays bounded to the Reputation-grid scores; its House/Personalized wording must never bleed onto the counts (ADR `profile/0034`).
+- **Reputation grid data path** (Meili `trustScores`, `?pov=` namespacing) is the **regression boundary** — visual reorder only, no data-path change (ADR 0031/0034).
+- **Canonical user-facing copy** for the reporters feature is verbatim-locked; no rephrasing (style guide; ADR `verified-reporters/0001`).
+- **House rules**: JS-without-build, tokens-only (`bsp-*` classes / CSS custom properties), no new icon library, no new tooling, no firmware reinstall for a presentational reorder.
+
+Sanctioned to change (mutable:true — explicitly invited):
+- **Reputation section vertical position** (no ADR defends the bottom placement).
+- **Grid card order / curation**, incl. removing the duplicate Verified-Followers row (named as a deferred cleanup across ADRs 0029/0030/0031).
+- **`VerificationInfo` physical position** within the counts row.
+
+## Relationship to existing work
+
+- **Absorbs** the 2026-06-06 follow-up item 4 (duplicate "Verified Followers" `TRUST_METRICS` row) into a coherent IA story.
+- **Touches** the Reporters grid card → must update R3 in `test/profile-verified-reporters-count.test.js` and note the ADR `verified-reporters/0001` retention reversal.
+- **Depends on** Story A (the pubkey/npub details drawer) for the Identity→Links relabel; otherwise independent.
+- Will need an **ADR** (touches reputation presentation, the PoV boundary, and a ratified test sentinel) — not a fast-track change.
+
+**Next step:** `/discuss` to settle the four open decisions and confirm the PoV-safe headline placement, then Planning → Architecture (ADR) → Test Design → Implementation → Review.

--- a/engineering-team/decisions/profile/0033-identity-details-popover.md
+++ b/engineering-team/decisions/profile/0033-identity-details-popover.md
@@ -1,0 +1,90 @@
+# ADR 0033: Profile identity details popover
+
+**Status:** Proposed
+**Date:** 2026-06-16
+**Story:** `engineering-team/stories/profile/37-identity-details-popover.md`
+**Epic:** `profile`
+
+## Context
+
+Story 37 moves the **npub** and **hex pubkey** out of the inline Identity section of the profile page into a small, centered, tap-to-open popover triggered by a neutral "more details" control floated to the right of the display name. Website and Lightning stay inline. The control is framed as a "details drawer" that will grow.
+
+Acceptance criteria (quoted, condensed): a neutral non-key glyph control to the right of the name, floated right like the existing info popovers, with an a11y label; tap-to-open/dismiss matching the existing info popovers; the popover shows npub + hex pubkey, each labeled, each with a copy control that copies the **full** value with the page's existing on-copy feedback; npub/pubkey **no longer inline**; Website + Lightning unchanged; the Identity section does **not** render as an empty shell when both website and lud16 are absent; **purely presentational** (same values, same derivation).
+
+**Grounding (this branch — all in the React UI under `ui/`):**
+- Display name: `ui/src/pages/BrainstormProfile.jsx:250` — `<h1 className="bsp-name">{displayName}</h1>`, inside `.bsp-header-info` (`:249`) inside the flex `.bsp-header` (`:236`).
+- Identity section: `BrainstormProfile.jsx:334-365` — a `.bsp-section` with `<h3>Identity</h3>` and a `.bsp-id-grid` of `.bsp-id-row`s: Pubkey hex (`:338-342`, value `shortPubkey(pubkey)` + `<CopyButton value={pubkey}/>`), npub (`:343-349`, guarded by `{npub && …}`, value truncated + `<CopyButton value={npub}/>`), Website (`:350-357`, an `<a className="bsp-id-link">`), Lightning (`:358-363`, `<span>⚡ {profile.lud16}</span>`).
+- `CopyButton`: `BrainstormProfile.jsx:59-75` — `navigator.clipboard.writeText(value)`, swaps `📋`→`✓` for 1.5s. **Used only** at `:341` and `:347` (grep-confirmed) — both move into the popover, so after this change the page no longer references it.
+- `npub` is already derived client-side: `BrainstormProfile.jsx:119-121` (`nip19.npubEncode(pubkey)`, `null` on failure). `pubkey` from `useParams`. No fetch involved.
+- `shortPubkey` helper: `BrainstormProfile.jsx:36-39` — **also used at `:122`** for the displayName fallback, so it must stay in the page.
+- Established info-popover pattern (ADR 0032): `ui/src/components/VerificationInfo.jsx`, `ui/src/components/ReputationInfo.jsx` — a `.bsp-info-btn` trigger owning local `open` state + a `.bsp-confirm-overlay` › `.bsp-confirm-box` popover (overlay-click + "Got it" to dismiss; `stopPropagation` on the box).
+- Relevant CSS (all reusable, tokens-only): `.bsp-info-btn` (`styles.css:4181` — circular 1.75rem bordered button, **`margin-left:auto`** → floats right within a flex row); `.bsp-confirm-overlay/box/title/message/buttons/ok` (`:3668-3724`); `.bsp-id-grid/row/label/value` (`:3441-3462`); `.bsp-copy-btn` (`:3471`); `.bsp-section h3` (`:3422`, already `display:flex`).
+
+Constraints: JS-without-build; **tokens-only** (`bsp-*` classes + CSS custom properties); **no new icon library** (use an existing unicode glyph); tested via `test/test.js` **source-regex sentinels**, not Playwright. No concept/schema/firmware change (npub/pubkey are NIP-19 encodings of the already-known `nostr-user` pubkey; Concept Graph orientation is a no-op here and the local stack was down at design time).
+
+## Options considered
+
+### Component structure
+
+#### Option A — a new self-contained `IdentityDetails` component *(chosen)*
+Mirror `VerificationInfo`/`ReputationInfo`: a new `ui/src/components/IdentityDetails.jsx` taking props `{ pubkey, npub }`, owning its own `open` state, rendering the trigger button + the popover. It reuses `.bsp-info-btn` (trigger), `.bsp-confirm-overlay/box` (popover), and `.bsp-id-*` (the rows, moved verbatim) and renders a `<CopyButton>` per identifier. `CopyButton` is **extracted** to its own `ui/src/components/CopyButton.jsx` (exported) and imported by `IdentityDetails`.
+- **Pros:** matches the page's established self-contained-info-popover pattern exactly (operator's consistency intent); keeps the already-large `BrainstormProfile` from growing; the drawer is a clean unit to grow; removes now-dead `CopyButton` from the page; almost no new CSS (one flex wrapper).
+- **Cons:** two new component files + one small refactor (moving `CopyButton`).
+
+#### Option B — inline the trigger + popover state directly in `BrainstormProfile`
+Add `useState` for open + the trigger/overlay JSX inline in the page.
+- **Pros:** one fewer file.
+- **Cons:** bloats a 438-line component; diverges from the VerificationInfo/ReputationInfo pattern the operator explicitly wants to match; harder to grow; the open/close state pollutes the page. Rejected.
+
+#### Option C — a generic reusable `<Popover>`/drawer primitive, with `IdentityDetails` as one consumer
+- **Pros:** would serve future drawers and the Story-B reorg.
+- **Cons:** over-engineering for one drawer; no such primitive exists today and introducing an abstraction now pre-commits a shape before the second use case is known. Rejected — revisit only if more drawers appear (note for Story B).
+
+### Trigger placement / "float right"
+- **Chosen:** wrap the `<h1 className="bsp-name">` and the `IdentityDetails` trigger in a new flex `.bsp-name-row`; the reused `.bsp-info-btn { margin-left:auto }` floats the trigger to the right edge of the name line — identical mechanism to the `ⓘ` icons in `.bsp-counts` / the Reputation `<h3>`.
+- **Alternative:** make the trigger a direct child of `.bsp-header` (far-right card edge, vertically centered with the avatar). Rejected — detaches the control from the name line; "to the right of the **name**" reads better on the name's own row, and it survives header wrapping on mobile.
+
+### Trigger glyph (neutral, not a key, not `ⓘ`)
+- **Chosen:** horizontal ellipsis **`⋯`** (U+22EF) — the canonical "more / details" affordance, neutral, and signals "this will hold more" (the drawer is designed to grow). Distinct from the `ⓘ` ("explain this concept") already on the page.
+- **Alternative:** a chevron (`▾`/`⌄`) — implies expand/collapse of an inline region, mildly misleading for a modal popover. Available as a low-cost flip; the final glyph is the operator's call and the sentinel will pin whatever we choose.
+
+### CopyButton
+- **Chosen:** extract `CopyButton` to `ui/src/components/CopyButton.jsx` (behavior unchanged, verbatim), import in `IdentityDetails`. Removes dead code from the page and makes it reusable for future drawer fields.
+- **Alternative:** co-locate `CopyButton` inside `IdentityDetails.jsx`. Acceptable and slightly smaller, but less reusable as the drawer grows. Either satisfies the story; chosen the shared file for reuse + dead-code removal.
+
+## Decision
+
+We chose **Option A**: a new self-contained `IdentityDetails` component (props `{ pubkey, npub }`) that reuses the ADR-0032 `.bsp-info-btn` / `.bsp-confirm-*` popover pattern and the `.bsp-id-*` rows, with `CopyButton` extracted to its own shared component. The trigger is a neutral `⋯` glyph floated right via a new `.bsp-name-row` flex wrapper next to `<h1 className="bsp-name">`. The Identity section is made conditional on `profile?.website || profile?.lud16` so it never renders as an empty shell. No backend, data, concept, or firmware change.
+
+This **does not conflict with or supersede** any existing ADR: it reuses ADR 0032's popover pattern, preserves ADR 0030's website-link behavior untouched, and the Identity heading/website/lightning are governed by no ADR. It is the approved sibling of the deferred profile IA reorg ("Story B", `docs/PROFILE_IA_REVIEW_2026-06-16.md`); the "Identity"→"Links" relabel and any further drawer fields are explicitly Story B / out of scope here.
+
+## Consequences
+
+- **Declutters the default profile view** while keeping the identifiers one tap away, in a control that can grow (future fields render as more rows in the same popover).
+- **One small refactor:** `CopyButton` moves to its own file; the page drops its local copy. Behavior is byte-for-byte the same (`📋`→`✓`, 1.5s).
+- **Almost no new CSS:** one rule (`.bsp-name-row`, layout-only, no colors/tokens). Trigger, popover, and rows reuse existing classes — honors tokens-only / no-new-tooling.
+- **Keyboard-dismissal parity, not improvement:** the popover matches the existing info popovers exactly (overlay-click + "Got it"; no Esc/focus-trap). The existing popovers lack those too; adding them here would diverge and is out of scope (a future a11y pass could cover all `.bsp-confirm-*` popovers at once).
+- **Testing (for the Tester):** source-regex sentinels in the established style — e.g. `IdentityDetails.jsx` exists and renders a `.bsp-info-btn` trigger bearing the `⋯` glyph + an `aria-label`, opens a `.bsp-confirm-overlay`/`.bsp-confirm-box`, and renders a `CopyButton` for both `pubkey` and `npub`; `BrainstormProfile.jsx` renders `<IdentityDetails …/>` inside `.bsp-name-row` next to `.bsp-name`, **no longer** renders `<CopyButton value={pubkey/npub}/>` in its body, and gates the Identity `.bsp-section` on `website || lud16`; `CopyButton.jsx` exists and is imported by `IdentityDetails`. No new test harness.
+- **Firmware reinstall?** No.
+- **Follow-ups:** if Story B proceeds, the "Identity"→"Links" relabel and additional drawer fields build on this; if a *second* drawer appears elsewhere, reconsider Option C (a shared popover primitive).
+
+## Implementation notes
+
+Concrete, for the Implementer:
+
+- **`ui/src/components/CopyButton.jsx` (new).** Move the `CopyButton` function from `BrainstormProfile.jsx:59-75` here verbatim; `export default`. No behavior change.
+- **`ui/src/components/IdentityDetails.jsx` (new).** Self-contained, props `{ pubkey, npub }`. Structure mirrors `VerificationInfo.jsx`:
+  - Trigger: `<button type="button" className="bsp-info-btn" aria-label="Show account identifiers" title="Show account identifiers" onClick={() => setOpen(true)}>⋯</button>` (final glyph/label wording tunable; sentinel pins it).
+  - Popover (when `open`): `.bsp-confirm-overlay` (onClick close) › `.bsp-confirm-box` (onClick `stopPropagation`) with a `.bsp-confirm-title` (e.g. `Identifiers`), then a `.bsp-id-grid` reproducing the two rows moved from the page — Pubkey hex (`.bsp-id-label` "Pubkey (hex)" + `.bsp-id-value` showing the truncated form `pubkey.slice(0,12)+'…'+pubkey.slice(-8)` + `<CopyButton value={pubkey}/>`) and, guarded by `{npub && …}`, npub (`.bsp-id-value` `npub.slice(0,20)+'…'+npub.slice(-8)` + `<CopyButton value={npub}/>`) — and a `.bsp-confirm-buttons` with a `.bsp-confirm-ok` "Got it". Truncation is inline here (don't import `shortPubkey`; it stays in the page for `:122`). `CopyButton` receives the **full** value.
+- **`ui/src/pages/BrainstormProfile.jsx`:**
+  - Delete the local `CopyButton` (`:59-75`); add `import CopyButton from '../components/CopyButton';` only if still needed (it is **not** after this change — leave it out) and `import IdentityDetails from '../components/IdentityDetails';`.
+  - Header (`:249-253`): wrap the name in a row — `<div className="bsp-name-row"><h1 className="bsp-name">{displayName}</h1><IdentityDetails pubkey={pubkey} npub={npub} /></div>` — leaving `nip05`/`age` siblings below as today.
+  - Identity section (`:334-365`): remove the Pubkey hex row (`:338-342`) and the npub row (`:343-349`); wrap the whole `.bsp-section` so it renders only when `profile?.website || profile?.lud16`. Keep the `<h3>Identity</h3>` heading (relabel is Story B). Website (`:350-357`) and Lightning (`:358-363`) rows unchanged.
+- **`ui/src/styles.css`:** add one layout rule near the header block (≈`:3382`): `.bsp-name-row { display: flex; align-items: center; gap: 0.5rem; }`. No new color tokens. (`.bsp-info-btn`'s existing `margin-left:auto` does the float.)
+
+## Out of scope
+
+- The Story-B profile IA reorg (Verification-Score headline, Reputation promotion/disclosure, grid de-dup, Reporters-card removal) — `docs/PROFILE_IA_REVIEW_2026-06-16.md`.
+- Renaming/relocating the Identity heading ("Identity"→"Links", Story B); adding any drawer field beyond npub + pubkey.
+- Esc/focus-trap keyboard handling for `.bsp-confirm-*` popovers (a separate a11y pass, if any).
+- Any change to value derivation, the website-link scheme (ADR 0030), or other surfaces.

--- a/engineering-team/decisions/profile/0033-identity-details-popover.md
+++ b/engineering-team/decisions/profile/0033-identity-details-popover.md
@@ -1,6 +1,6 @@
 # ADR 0033: Profile identity details popover
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-06-16
 **Story:** `engineering-team/stories/profile/37-identity-details-popover.md`
 **Epic:** `profile`

--- a/engineering-team/reviews/profile/37-identity-details-popover.md
+++ b/engineering-team/reviews/profile/37-identity-details-popover.md
@@ -1,0 +1,74 @@
+# Review: Story profile #37 — Identity details popover
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-16
+**Diff:** `git diff 8765c447..HEAD` (impl commits `9d5cfd64` + `33731edf`; branch `feat/profile-identity-popover`)
+**Story:** `engineering-team/stories/profile/37-identity-details-popover.md`
+**ADR:** `engineering-team/decisions/profile/0033-identity-details-popover.md`
+**Test plan:** `engineering-team/stories/profile/37-identity-details-popover.test-plan.md`
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **PASS**. New suite `profile-identity-details-popover`: **14 passed, 0 failed**. Every other suite still green (incl. `profile-website-link`, `profile-verified-counts-owner-pov`, `profile-verified-counts-explainer-and-alarm`, `profile-verified-reporters-count`); **no FAIL anywhere; Overall: PASS**. No regression introduced.
+- [x] `npm run test:playwright` — N/A. The Playwright harness is broken (intake 2026-06-06 item 8) and irrelevant here; per ADR 0033 this feature is covered by source-regex sentinels, the established `profile-*` pattern.
+- [x] _Lint not configured — skipped._
+- [x] _Typecheck not configured — skipped._
+- [x] _Build not configured for the runner; the `ui` Vite app compiles (verified live during implementation, see below)._
+
+## Spec adherence
+
+Every acceptance criterion maps to ≥1 passing test (verified against the suite):
+
+- [x] AC1 (control right of name, neutral non-key glyph, floated right) → T2 (`⋯`, not `🔑`/`ⓘ`), T7 (`.bsp-name-row` next to `.bsp-name`), T8 (`.bsp-name-row` CSS). Far-right pinning confirmed live.
+- [x] AC2 (a11y label) → T3 (`aria-label="Show account identifiers"`, `IdentityDetails.jsx:18`).
+- [x] AC3 (tap-to-open/dismiss, consistent) → T4 (`bsp-confirm-overlay`/`box` + `useState`).
+- [x] AC4 (shows npub + pubkey, labelled) → T5 (`Pubkey (hex)` + `npub`, `bsp-id-row`).
+- [x] AC5 (copy each, full value, same feedback) → T1 (CopyButton extracted), T6 (`value={pubkey}`/`value={npub}` — full values).
+- [x] AC6 (no longer inline) → T9 (no local `CopyButton`, no `<CopyButton value={pubkey/npub}>`, no `Pubkey (hex)` in page body).
+- [x] AC7 (Website + Lightning remain) → R1, R2.
+- [x] AC8 (empty Identity section collapses) → T10 (`{(profile?.website || profile?.lud16) && (…)}`, `BrainstormProfile.jsx:317`).
+- [x] AC9 (purely presentational) → T11 (no `fetch` in IdentityDetails), R3 (`nip19.npubEncode` derivation unchanged).
+- [x] No criterion silently dropped; no behavior added beyond the story.
+
+## ADR adherence
+
+- [x] Files changed match ADR 0033's Implementation notes exactly: `ui/src/components/CopyButton.jsx` (new, verbatim extraction), `ui/src/components/IdentityDetails.jsx` (new), `ui/src/pages/BrainstormProfile.jsx` (import + header wrap + Identity-section removal/gate + local CopyButton deleted), `ui/src/styles.css` (`.bsp-name-row`).
+- [x] Layering matches: self-contained `IdentityDetails` mirroring `VerificationInfo`/`ReputationInfo` (chosen Option A); `CopyButton` extracted to a shared component and imported by `IdentityDetails`.
+- [x] No new dependencies; reuses `bsp-info-btn` / `bsp-confirm-*` / `bsp-id-*` and `nip19` already in scope.
+- [x] **Deviation, flagged & sanctioned:** the trigger is pinned to the **far-right edge** (`.bsp-header-info { flex: 1 }`, `styles.css:3366`) rather than immediately adjacent — operator-requested (2026-06-16), recorded in the story's `## Deviations`, and explicitly the alternative ADR 0033 named under "Trigger placement / float right." Not a silent contradiction.
+
+## Concept-graph integrity
+
+- [x] N/A — purely presentational change. No concept/schema touched, no handles introduced, **no firmware reinstall required** (ADR 0033 confirms). npub/pubkey are NIP-19 encodings of the already-known `nostr-user` pubkey, derived client-side as before.
+
+## Things tests can't catch
+
+- [x] No secrets in the diff.
+- [x] No leftover debug logging / `console.log`.
+- [x] No commented-out code; the obsolete "Copy Button" banner + function were cleanly removed from `BrainstormProfile.jsx` (no orphan).
+- [x] `shortPubkey` correctly retained — it's no longer used in the Identity row but is still used for the displayName fallback (`BrainstormProfile.jsx:103`); not wrongly deleted, no dead helper.
+- [x] No dead import: `BrainstormProfile.jsx` does **not** import `CopyButton` (only `IdentityDetails` does) — correct, since the page no longer uses it.
+- [x] `npub` null-guard preserved (`IdentityDetails.jsx:33` `{npub && (…)}`); a null npub omits its row, the pubkey row always renders.
+- [x] `.bsp-header-info { flex: 1 }` has no other consumer (grep: the class is profile-header-only); visually confirmed the name row stretches while nip05/age stay left-aligned.
+- [x] Security: no input-handling/injection surface; clipboard write is the unchanged, already-shipped behavior.
+
+## House rules check
+
+- [x] Concept Graph API authority respected (N/A — no concept work).
+- [x] No new lint/typecheck/build tooling. Tokens-only styling (no new color tokens — `.bsp-name-row` is layout-only; `flex:1` is layout-only). No new icon library — the `⋯` is a plain unicode glyph. JS-without-build honored.
+
+## Findings
+
+### Blocking
+_None._
+
+### Non-blocking
+1. **`ui/src/components/IdentityDetails.jsx:30`** — `pubkey.slice(0, 12)` assumes `pubkey` is defined. It always is on the `/user/:pubkey` route (it's a required `useParams` value), and the prior code made the same assumption (`shortPubkey(pubkey)`, `value={pubkey}`), so this is **no regression**. Optional hardening: a defensive guard if `IdentityDetails` is ever reused off-route. Not required for this story.
+2. **Branch scope** — the branch also carries `21c57e7f` (docs/PROFILE_IA_REVIEW_2026-06-16.md + an intake entry, the parked "Story B" capture). Doc-only, intentional, and out of scope for this story; noted, not a finding against the implementation.
+3. **Keyboard dismissal** — the popover has no Esc/focus-trap, matching the existing `bsp-confirm-*` popovers; ADR 0033 explicitly scopes this out (a future a11y pass could cover all such popovers at once). Not blocking.
+
+### Visual evidence
+Verified live against the running local stack (`tapestry-ui` Vite → proxy `:7778`) during implementation: real profile renders the `⋯` control at the far-right of the header (aligned with the two `ⓘ` icons), the "Identifiers" popover opens with both copyable rows, Website + Lightning remain inline, and the layout holds at mobile (375px). No console errors.
+
+## Verdict
+**PASS** — the diff matches the story, ADR 0033, and the test plan; all 14 sentinels pass with no regression to any other suite; the one deviation is operator-approved and documented; house rules honored. Mergeable as-is; ready for the deploy chain (`cycle-staging`).

--- a/engineering-team/stories/_intake.md
+++ b/engineering-team/stories/_intake.md
@@ -716,3 +716,25 @@ Reference profile: `https://staging.brainstorm.world/user/c4eabae1be3cf657bc1855
 **Classification:** Feature
 **Strictness:** Standard
 **Phase path:** Test Design (scaffold drafted, on the branch) → finish gold set → run/verify → Implementation → Review (Planning + Architecture done — see `epics/search-quality.md` + ADR `search-quality/0001`). **Resume on operator confirmation.**
+
+---
+
+## 2026-06-16 — Feature (DEFERRED — needs discussion): Profile page information-architecture reorder
+
+**Captured, set aside by operator.** Came out of the 2026-06-16 profile-page conversation as "Story B" (sibling to "Story A", the npub/pubkey details-drawer popover, which is being built now under the `profile` epic). Operator: *"Story B will need significantly further discussion before running with it… capture Story B and set it aside for later."* **Do not start without a `/discuss` pass.**
+
+Full verified review (the dominant finding, the per-move verdicts, the open decisions, and the complete constraint list mined from ADRs): **[`docs/PROFILE_IA_REVIEW_2026-06-16.md`](../../docs/PROFILE_IA_REVIEW_2026-06-16.md).** Produced by a multi-lens UX review with each significant move adversarially pressure-tested against the existing profile ADRs.
+
+**The gist:**
+- The product's trust verdict (the 0–100 **Verification Score**) is buried at the very bottom as tile #1 of an 11-card grid. The high-value move is to **promote it to a headline** and **lift the Reputation section up** (after About), with the technical GrapeRank/PageRank internals behind a **default-collapsed disclosure**.
+- **⚠️ PoV gotcha:** the counts row is **Owner-PoV (Neo4j)** while the rank is **Meili, `?pov=`-dependent (House/Personalized)** — so the score hero must stay **inside the Reputation section** (under the `ReputationInfo` framing), **not** floated under the counts row, or it can silently contradict the counts. Grid data path stays the regression boundary; hero reads existing `trustScores['rank']`, rounded.
+- Grid cleanups: drop **one** (not both) duplicate "Verified Followers" card (this **absorbs the 2026-06-06 item 4** above); remove the inert grid "Reporters" card — **but** that requires updating regression sentinel **R3** in `test/profile-verified-reporters-count.test.js:156–160` and noting the ADR `verified-reporters/0001` retention reversal, else `npm test` goes red.
+- The "Identity"→"Links" relabel is **gated on Story A** shipping; do **not** bury Website/Lightning at the page bottom (a website is a human-legible trust signal).
+
+**Open decisions to settle first:** contact-links placement; Hops above-the-fold vs in the disclosure; bottom-block heading wording; confirm Story A sequencing. (Details in the doc.)
+
+**Classification:** Feature (frontend reorder; needs an ADR — touches reputation presentation, the PoV boundary, and a ratified test sentinel).
+**Strictness:** Standard.
+**Phase path:** `/discuss` (settle the open decisions + PoV-safe headline placement) → Planning → Architecture (ADR) → Test Design → Implementation → Review.
+**Priority:** Medium — real UX win, but **deferred pending operator discussion**; not a fast-track change.
+**Depends on:** Story A (pubkey/npub details drawer) for the Identity→Links relabel; otherwise independent. **Related:** 2026-06-06 item 4 (absorbed); ADRs `profile/0029–0032`, `verified-reporters/0001`.

--- a/engineering-team/stories/profile/37-identity-details-popover.md
+++ b/engineering-team/stories/profile/37-identity-details-popover.md
@@ -46,6 +46,9 @@ For the Architect:
 - **Glyph choice:** ellipsis vs chevron (or another neutral "more"/"details" glyph) — pick one consistent with existing iconography. House rule: no new icon library; use an existing unicode glyph.
 - **Empty-Identity-section handling:** confirm the section collapses cleanly when only website/lightning remain and both are absent (see the corresponding acceptance criterion).
 
+## Deviations
+- **Trigger pinned to the far-right edge** (operator preference, 2026-06-16) rather than immediately adjacent to the name (ADR 0033's chosen sub-option). Implemented by adding `flex: 1` to `.bsp-header-info` so `.bsp-name-row` spans the header width and the existing `.bsp-info-btn { margin-left: auto }` floats the `⋯` to the right edge — matching the two `ⓘ` icons. ADR 0033 explicitly listed far-right as the alternative, so this is a sanctioned switch, not a contradiction.
+
 ## Linked artifacts
 - Design context: [`docs/PROFILE_IA_REVIEW_2026-06-16.md`](../../../docs/PROFILE_IA_REVIEW_2026-06-16.md) (the deferred "Story B" sibling).
 - Related ADRs (pattern precedent): `engineering-team/decisions/profile/0032-verified-counts-explainer-and-alarm.md` (the shared information-popover pattern this should stay consistent with), `engineering-team/decisions/profile/0030-profile-website-link-scheme.md` (the website link behavior that must be preserved).

--- a/engineering-team/stories/profile/37-identity-details-popover.md
+++ b/engineering-team/stories/profile/37-identity-details-popover.md
@@ -1,6 +1,6 @@
 # Story 37: Profile identity details popover (move npub + pubkey behind a name-adjacent control)
 
-**Status:** Draft
+**Status:** Approved
 **Created:** 2026-06-16
 **Type:** Feature
 **Epic:** `profile`
@@ -49,7 +49,7 @@ For the Architect:
 ## Linked artifacts
 - Design context: [`docs/PROFILE_IA_REVIEW_2026-06-16.md`](../../../docs/PROFILE_IA_REVIEW_2026-06-16.md) (the deferred "Story B" sibling).
 - Related ADRs (pattern precedent): `engineering-team/decisions/profile/0032-verified-counts-explainer-and-alarm.md` (the shared information-popover pattern this should stay consistent with), `engineering-team/decisions/profile/0030-profile-website-link-scheme.md` (the website link behavior that must be preserved).
-- ADR: (filled in after Architecture phase)
+- ADR: `engineering-team/decisions/profile/0033-identity-details-popover.md` (Proposed)
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)
 

--- a/engineering-team/stories/profile/37-identity-details-popover.md
+++ b/engineering-team/stories/profile/37-identity-details-popover.md
@@ -49,8 +49,8 @@ For the Architect:
 ## Linked artifacts
 - Design context: [`docs/PROFILE_IA_REVIEW_2026-06-16.md`](../../../docs/PROFILE_IA_REVIEW_2026-06-16.md) (the deferred "Story B" sibling).
 - Related ADRs (pattern precedent): `engineering-team/decisions/profile/0032-verified-counts-explainer-and-alarm.md` (the shared information-popover pattern this should stay consistent with), `engineering-team/decisions/profile/0030-profile-website-link-scheme.md` (the website link behavior that must be preserved).
-- ADR: `engineering-team/decisions/profile/0033-identity-details-popover.md` (Proposed)
-- Test plan: (filled in after Test Design phase)
+- ADR: `engineering-team/decisions/profile/0033-identity-details-popover.md` (Accepted)
+- Test plan: `engineering-team/stories/profile/37-identity-details-popover.test-plan.md` (suite `test/profile-identity-details-popover.test.js`, wired into `test/test.js`)
 - Review: (filled in after Review phase)
 
 ## House constraints (carried from intake)

--- a/engineering-team/stories/profile/37-identity-details-popover.md
+++ b/engineering-team/stories/profile/37-identity-details-popover.md
@@ -1,0 +1,58 @@
+# Story 37: Profile identity details popover (move npub + pubkey behind a name-adjacent control)
+
+**Status:** Draft
+**Created:** 2026-06-16
+**Type:** Feature
+**Epic:** `profile`
+
+## Background
+On the main profile page (`/user/:pubkey`), the Identity section currently displays the account's **npub** and **hex pubkey** inline, each with a copy-to-clipboard control, stacked above Website and Lightning. For most visitors most of the time these two long cryptographic strings are noise — they clutter the page with information that only a minority needs, and only occasionally. But when someone *does* need them (to copy an npub, to verify a pubkey), they must be readily reachable and copyable.
+
+This story tucks the two identifiers behind a small, recognizable control placed to the right of the profile display name — opening a popover that shows the npub and hex pubkey with copy-to-clipboard. This declutters the default view while keeping the identifiers one tap away. The control is intentionally framed as a general **"details drawer" that will grow**: future iterations may surface additional account details through the same control, so its affordance should read as "more details," not specifically "keys."
+
+This is the approved, independent first half of the 2026-06-16 profile-page conversation. The broader information-architecture reorder discussed alongside it ("Story B") is **deferred pending further discussion** and captured separately in [`docs/PROFILE_IA_REVIEW_2026-06-16.md`](../../../docs/PROFILE_IA_REVIEW_2026-06-16.md); this story does not depend on it.
+
+## User-facing description
+As someone viewing a profile, I want the account's technical identifiers (npub and pubkey) tucked behind a small control next to the name — rather than shown inline by default — so the page stays uncluttered, while I can still open that control to view and copy them when I need to.
+
+## Acceptance criteria
+Testable from the outside.
+
+- [ ] A control sits immediately to the right of the profile display name, floated/aligned to the right in the manner of the page's existing information popovers, and rendered with a **neutral "more details" glyph** (e.g. an ellipsis or chevron) — **not** a key or other identifier-specific icon.
+- [ ] The control carries an assistive-technology label describing its purpose (e.g. it announces that it reveals the account's identifiers/details), consistent with how the page's existing information controls are labeled.
+- [ ] Activating the control opens a popover, and dismissing it (activating the control again, choosing a close affordance, or dismissing outside the popover) closes it — the same open/close interaction as the page's existing "what does verification mean?" / "reputation" information popovers, and visually consistent with them.
+- [ ] The popover displays the account's **npub** and its **hex pubkey**, each clearly labeled as to which is which.
+- [ ] Each of the npub and the hex pubkey has a copy-to-clipboard control that copies that exact full value (not a truncated form) and gives the same on-copy confirmation feedback used elsewhere on the page.
+- [ ] The npub and hex pubkey are **no longer rendered inline** in the Identity section of the profile body; they appear only via the popover.
+- [ ] Website and Lightning remain displayed in the Identity section exactly as before — present, labeled, and functional (the website link still opens; the lightning address still shows) for profiles that have them.
+- [ ] Given a profile that has **neither** a website **nor** a lightning address, the Identity section does not render as an empty or label-only shell (with the identifiers removed there is nothing left to show, so the section/heading is absent rather than blank).
+- [ ] The change is purely presentational: the npub/pubkey values, the website, and the lightning address shown are the same values, derived the same way, as before this story.
+
+## Concepts touched
+Concept Graph API was unreachable at planning time (`http://localhost:8877`); the Architect should resolve/confirm handles when orienting.
+
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-user` — the account being viewed; the npub and hex pubkey are two encodings of its public key (NIP-19 bech32 vs raw hex).
+- Plain-language: **npub / pubkey identifier encodings** (NIP-19) — the values surfaced in the popover. (Resolve to a concept handle if one exists.)
+
+## Out of scope
+- The broader profile information-architecture reorder — promoting the Verification Score, lifting/collapsing the Reputation section, de-duplicating grid cards, removing the grid Reporters card. All deferred to "Story B" ([`docs/PROFILE_IA_REVIEW_2026-06-16.md`](../../../docs/PROFILE_IA_REVIEW_2026-06-16.md)).
+- Renaming or relocating the Identity section heading (the "Identity" → "Links" relabel is part of Story B and is gated on this story shipping).
+- Adding any further fields to the popover beyond npub + pubkey. The control is *designed* to grow, but this story ships exactly the two identifiers.
+- Any change to how npub/pubkey/website/lightning are fetched, derived, or validated; any backend/API change; any change to other pages or to the user-menu surfaces.
+
+## Open questions
+For the Architect:
+- **Pattern reuse (operator intent):** the operator asked that this be built for maximum consistency with the page's existing information popovers and copy affordance — i.e. reuse the established tap-to-open popover machinery and the existing copy-to-clipboard control rather than introduce a new widget. Confirm the cleanest way to do so within the house constraints below; the trigger glyph differs deliberately (neutral "details" glyph, not the `ⓘ` used by the explainer popovers, to avoid colliding with their "explain this concept" meaning).
+- **Glyph choice:** ellipsis vs chevron (or another neutral "more"/"details" glyph) — pick one consistent with existing iconography. House rule: no new icon library; use an existing unicode glyph.
+- **Empty-Identity-section handling:** confirm the section collapses cleanly when only website/lightning remain and both are absent (see the corresponding acceptance criterion).
+
+## Linked artifacts
+- Design context: [`docs/PROFILE_IA_REVIEW_2026-06-16.md`](../../../docs/PROFILE_IA_REVIEW_2026-06-16.md) (the deferred "Story B" sibling).
+- Related ADRs (pattern precedent): `engineering-team/decisions/profile/0032-verified-counts-explainer-and-alarm.md` (the shared information-popover pattern this should stay consistent with), `engineering-team/decisions/profile/0030-profile-website-link-scheme.md` (the website link behavior that must be preserved).
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)
+
+## House constraints (carried from intake)
+- JS-without-build; **tokens-only** styling (`bsp-*` classes + existing CSS custom properties); **no new icon library**, lint, typecheck, or build tooling (would require its own ADR).
+- Tested via the `test/test.js` Node runner with **source-regex sentinels** (the established profile-UI pattern), **not** Playwright (its harness is currently broken and irrelevant here).

--- a/engineering-team/stories/profile/37-identity-details-popover.md
+++ b/engineering-team/stories/profile/37-identity-details-popover.md
@@ -1,6 +1,6 @@
 # Story 37: Profile identity details popover (move npub + pubkey behind a name-adjacent control)
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-16
 **Type:** Feature
 **Epic:** `profile`
@@ -54,7 +54,7 @@ For the Architect:
 - Related ADRs (pattern precedent): `engineering-team/decisions/profile/0032-verified-counts-explainer-and-alarm.md` (the shared information-popover pattern this should stay consistent with), `engineering-team/decisions/profile/0030-profile-website-link-scheme.md` (the website link behavior that must be preserved).
 - ADR: `engineering-team/decisions/profile/0033-identity-details-popover.md` (Accepted)
 - Test plan: `engineering-team/stories/profile/37-identity-details-popover.test-plan.md` (suite `test/profile-identity-details-popover.test.js`, wired into `test/test.js`)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/profile/37-identity-details-popover.md` — **PASS** (2026-06-16)
 
 ## House constraints (carried from intake)
 - JS-without-build; **tokens-only** styling (`bsp-*` classes + existing CSS custom properties); **no new icon library**, lint, typecheck, or build tooling (would require its own ADR).

--- a/engineering-team/stories/profile/37-identity-details-popover.test-plan.md
+++ b/engineering-team/stories/profile/37-identity-details-popover.test-plan.md
@@ -1,0 +1,73 @@
+# Test Plan: Story profile #37 — Profile identity details popover
+
+**Story:** `engineering-team/stories/profile/37-identity-details-popover.md`
+**ADR:** `engineering-team/decisions/profile/0033-identity-details-popover.md`
+**Date:** 2026-06-16
+**Suite:** `test/profile-identity-details-popover.test.js` (source-regex sentinels, the established `profile-*` pattern; Node runner via `npm test`, **not** Playwright). Wired into `test/test.js`.
+
+## Approach
+
+This is a frontend-only React presentational change with no runtime/data surface, so it is covered by **source-regex sentinels** — the same technique used by `profile-verified-counts-explainer-and-alarm` and the other `profile-*` suites. `T1–T11` are the spec (FAIL before implementation, PASS after); `R1–R3` are regression sentinels (PASS before **and** after) guarding what must not change.
+
+## Coverage map
+
+| Criterion | Test(s) | What it asserts | Level |
+|---|---|---|---|
+| AC1 — control to the right of the name, floated right, neutral non-key glyph | `T2`, `T7`, `T8` | `IdentityDetails` trigger uses `.bsp-info-btn` + the `⋯` glyph (not `🔑`, not `ⓘ`); the page renders `<IdentityDetails>` inside a `.bsp-name-row` right after `.bsp-name`; `styles.css` defines `.bsp-name-row` | source-sentinel |
+| AC2 — accessibility label on the control | `T3` | the trigger button has an `aria-label` | source-sentinel |
+| AC3 — tap-to-open/dismiss popover, consistent with existing info popovers | `T4` | reuses `.bsp-confirm-overlay`/`.bsp-confirm-box` + owns `useState` open/close (the VerificationInfo pattern) | source-sentinel |
+| AC4 — popover shows npub + hex pubkey, each labelled | `T5` | labels `Pubkey (hex)` + `npub`, reusing `.bsp-id-row`/`.bsp-id-label` | source-sentinel |
+| AC5 — each copy-to-clipboard, full value, same feedback | `T1`, `T6` | `CopyButton.jsx` extracted (default export, `navigator.clipboard.writeText`, `📋→✓`); `IdentityDetails` imports it and renders one for **both** `value={pubkey}` and `value={npub}` | source-sentinel |
+| AC6 — identifiers no longer inline in the page body | `T9` | the page no longer defines a local `CopyButton`, no longer renders `<CopyButton value={pubkey/npub}>`, and the `Pubkey (hex)` row is gone | source-sentinel |
+| AC7 — Website + Lightning remain in the Identity section | `R1`, `R2` | `profile.website`→`toExternalUrl`/`bsp-id-link` and `profile.lud16`/`⚡` rows persist | regression |
+| AC8 — Identity section not an empty shell when no website & no lightning | `T10` | the Identity `.bsp-section` is gated on `website \|\| lud16` (a combination absent pre-impl) | source-sentinel |
+| AC9 — purely presentational (same values, same derivation) | `T11`, `R3` | `IdentityDetails` does no `fetch` (props-only); npub still derived via `nip19.npubEncode` | source-sentinel + regression |
+
+Every acceptance criterion maps to at least one test.
+
+## Edge cases
+
+- [x] **Empty Identity section** (no website, no lud16) → `T10` (section must collapse, not render a bare heading).
+- [x] **Wrong glyph** — `T2` explicitly rejects `🔑` (key) and `ⓘ` (the "explain" glyph) so a regression to either is caught, not just the presence of *a* glyph.
+- [x] **Full vs truncated copy** — `T6` pins the copy value to `{pubkey}`/`{npub}` (the full props), not the truncated display string.
+- [x] **False positives from pre-existing strings** — `navigator.clipboard.writeText`, `bsp-info-btn`, `bsp-confirm-*`, `bsp-id-row` all already exist elsewhere, so the new-component sentinels assert them inside the **new** files (absent pre-impl → fail on the existence assertion). The removal sentinels (`T9`) rely on the **old** inline code still being present now, so they fail until it is actually moved.
+- [ ] **npub `null` guard** — `npub` can be `null` if `nip19.npubEncode` throws; the ADR keeps the existing `{npub && …}` guard inside the popover. Not separately sentineled (low value as a source regex); noted for the Implementer/Reviewer.
+
+## Test infrastructure
+
+- Runner: Node built-in via `npm test` (`node test/test.js`). The new suite is registered in `test/test.js` (require + `run()` + results row + `overallOk`).
+- No Concept Graph / firmware / fixtures required (pure source inspection).
+- No new test framework (house rule).
+
+## How to run
+
+```
+npm test
+```
+
+## Verification
+
+Baseline `npm test` was **green (Overall: PASS)** before adding the suite. With the failing suite added (working tree on top of commit `ff3c754f`), on 2026-06-16:
+
+```
+profile-identity-details-popover suite:
+  ✗ T1: CopyButton.jsx is extracted as a standalone component …   ui/src/components/CopyButton.jsx does not exist yet.
+  ✗ T2: IdentityDetails renders a bsp-info-btn trigger with the neutral ⋯ glyph …   ui/src/components/IdentityDetails.jsx does not exist yet.
+  ✗ T3: the IdentityDetails trigger carries an aria-label …   IdentityDetails.jsx does not exist yet.
+  ✗ T4: IdentityDetails opens a bsp-confirm-overlay/bsp-confirm-box popover …   IdentityDetails.jsx does not exist yet.
+  ✗ T5: the popover labels and shows both the hex pubkey and the npub …   IdentityDetails.jsx does not exist yet.
+  ✗ T6: IdentityDetails imports CopyButton and renders one for BOTH pubkey and npub …   IdentityDetails.jsx does not exist yet.
+  ✗ T7: BrainstormProfile renders <IdentityDetails> inside a .bsp-name-row …   BrainstormProfile must import IdentityDetails.
+  ✗ T8: styles.css defines .bsp-name-row …   styles.css must define .bsp-name-row …
+  ✗ T9: BrainstormProfile no longer renders the identifiers inline …   the local CopyButton definition must move …
+  ✗ T10: the Identity section is gated on (website || lud16) …   … must render only when (profile?.website || profile?.lud16) …
+  ✗ T11: IdentityDetails is presentational — no data fetch …   IdentityDetails.jsx does not exist yet.
+  ✓ R1: Website remains in the Identity section (regression) (AC7)
+  ✓ R2: Lightning (lud16) remains in the Identity section (regression) (AC7)
+  ✓ R3: npub is still derived via nip19.npubEncode … (AC9)
+
+profile-identity-details-popover suite:          FAIL (3 passed, 11 failed)
+Overall:                                         FAIL
+```
+
+All 11 spec tests fail for the right reason (feature not implemented); all 3 regression sentinels pass; **no other suite is affected** (only this suite shows FAIL). The Implementer is done when this suite reads `PASS (14 passed, 0 failed)` and Overall returns to PASS.

--- a/test/profile-identity-details-popover.test.js
+++ b/test/profile-identity-details-popover.test.js
@@ -1,0 +1,189 @@
+/**
+ * Story profile #37: Profile identity details popover.
+ * ADR profile/0033. See engineering-team/stories/profile/37-identity-details-popover.test-plan.md
+ *
+ * What ships (ADR 0033):
+ *  - NEW ui/src/components/CopyButton.jsx — the existing copy-to-clipboard button, extracted
+ *    from BrainstormProfile (default export; 📋 → ✓ feedback; navigator.clipboard.writeText).
+ *  - NEW ui/src/components/IdentityDetails.jsx — a self-contained "more details" drawer: a
+ *    .bsp-info-btn trigger bearing the neutral ⋯ glyph (NOT a key, NOT the ⓘ) with an aria-label,
+ *    opening a .bsp-confirm-overlay / .bsp-confirm-box popover that shows the hex pubkey + npub
+ *    (each labelled, each with a CopyButton for the FULL value). Mirrors VerificationInfo.
+ *  - BrainstormProfile.jsx — renders <IdentityDetails pubkey npub/> inside a new .bsp-name-row
+ *    next to .bsp-name; DROPS the inline pubkey/npub Identity rows + its local CopyButton; gates
+ *    the Identity .bsp-section on (website || lud16) so it never renders an empty shell. Website +
+ *    Lightning stay. npub derivation (nip19.npubEncode) unchanged — purely presentational.
+ *  - styles.css — one layout rule: .bsp-name-row (the flex wrapper; .bsp-info-btn margin-left:auto
+ *    floats the trigger right).
+ *
+ * Source-regex sentinels (the profile-* precedent). T1–T11 FAIL pre-implementation and PASS post;
+ * R1–R3 are regression sentinels (PASS before AND after).
+ *
+ * FALSE-POSITIVE AVOIDANCE:
+ *  - `navigator.clipboard.writeText`, `📋`/`✓`, `bsp-info-btn`, `bsp-confirm-overlay`, `bsp-id-row`
+ *    all already exist elsewhere pre-implementation (BrainstormProfile / VerificationInfo). The
+ *    new-component sentinels therefore assert them in the NEW files (CopyButton.jsx /
+ *    IdentityDetails.jsx), which do not exist yet → safeRead() == '' → those tests fail on the
+ *    file-existence assertion, for the right reason.
+ *  - The page-removal sentinels (T9) rely on the OLD inline code still being present pre-impl
+ *    (`function CopyButton`, `<CopyButton value={pubkey}>`, the "Pubkey (hex)" row) — so the
+ *    negations fail now and pass only once the Implementer moves them out.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const COPY    = path.resolve(__dirname, '../ui/src/components/CopyButton.jsx');
+const IDENT   = path.resolve(__dirname, '../ui/src/components/IdentityDetails.jsx');
+const PROFILE = path.resolve(__dirname, '../ui/src/pages/BrainstormProfile.jsx');
+const CSS     = path.resolve(__dirname, '../ui/src/styles.css');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+
+// AC5 — the copy control is extracted to a shared component
+test('T1: CopyButton.jsx is extracted as a standalone component (default export, clipboard write, 📋→✓ feedback) (AC5)', () => {
+  const src = safeRead(COPY);
+  assert(src.length > 0, 'ui/src/components/CopyButton.jsx does not exist yet.');
+  assert(/export\s+default/.test(src), 'CopyButton.jsx must default-export the component.');
+  assert(/navigator\.clipboard\.writeText/.test(src), 'CopyButton must copy via navigator.clipboard.writeText (behavior unchanged).');
+  assert(/✓/.test(src) && /📋/.test(src), 'CopyButton must keep the 📋 → ✓ on-copy feedback.');
+});
+
+// AC1 — the trigger: neutral "more details" glyph, reusing the bsp-info-btn look
+test('T2: IdentityDetails renders a bsp-info-btn trigger with the neutral ⋯ glyph (not a key, not ⓘ) (AC1)', () => {
+  const src = safeRead(IDENT);
+  assert(src.length > 0, 'ui/src/components/IdentityDetails.jsx does not exist yet.');
+  assert(/bsp-info-btn/.test(src), 'the trigger must reuse the bsp-info-btn class (stylistically consistent with the ⓘ popovers).');
+  assert(/⋯/.test(src), 'the trigger glyph must be the neutral ellipsis ⋯ (a "more details" affordance), per ADR 0033.');
+  assert(!/🔑/.test(src), 'the trigger must NOT be a key glyph — this is a general details drawer, not "keys".');
+  assert(!/ⓘ/.test(src), 'the trigger must NOT reuse the ⓘ glyph (it means "explain this concept" elsewhere on the page).');
+});
+
+// AC2 — accessibility label
+test('T3: the IdentityDetails trigger carries an aria-label (AC2)', () => {
+  const src = safeRead(IDENT);
+  assert(src.length > 0, 'IdentityDetails.jsx does not exist yet.');
+  assert(/aria-label/.test(src), 'the trigger button must have an aria-label describing its purpose (assistive tech).');
+});
+
+// AC3 — tap-to-open popover, same machinery as the existing info popovers
+test('T4: IdentityDetails opens a bsp-confirm-overlay/bsp-confirm-box popover with its own open state (AC3)', () => {
+  const src = safeRead(IDENT);
+  assert(src.length > 0, 'IdentityDetails.jsx does not exist yet.');
+  assert(/bsp-confirm-overlay/.test(src) && /bsp-confirm-box/.test(src),
+    'the popover must reuse the bsp-confirm-overlay/bsp-confirm-box pattern (same as VerificationInfo/ReputationInfo).');
+  assert(/useState/.test(src) && /setOpen|open\s*&&/.test(src),
+    'the component must own its open/close state (tap-to-open/dismiss), like the existing info popovers.');
+});
+
+// AC4 — the popover shows both identifiers, each labelled, in the bsp-id row structure
+test('T5: the popover labels and shows both the hex pubkey and the npub, reusing the bsp-id rows (AC4)', () => {
+  const src = safeRead(IDENT);
+  assert(src.length > 0, 'IdentityDetails.jsx does not exist yet.');
+  assert(/Pubkey \(hex\)/.test(src), 'the popover must label the hex pubkey row "Pubkey (hex)".');
+  assert(/npub/.test(src), 'the popover must show/label the npub.');
+  assert(/bsp-id-row/.test(src) && /bsp-id-label/.test(src),
+    'the rows must reuse the bsp-id-row/bsp-id-label structure (consistent with the Identity section they came from).');
+});
+
+// AC5 — a copy control per identifier, copying the FULL value
+test('T6: IdentityDetails imports CopyButton and renders one for BOTH pubkey and npub with the full values (AC5)', () => {
+  const src = safeRead(IDENT);
+  assert(src.length > 0, 'IdentityDetails.jsx does not exist yet.');
+  assert(/import\s+CopyButton/.test(src), 'IdentityDetails must import the shared CopyButton.');
+  assert(/CopyButton[^>]*value=\{pubkey\}/.test(src), 'a CopyButton must copy the FULL pubkey (value={pubkey}).');
+  assert(/CopyButton[^>]*value=\{npub\}/.test(src), 'a CopyButton must copy the FULL npub (value={npub}).');
+});
+
+// AC1 — placement: the trigger sits to the right of the name, inside the .bsp-name-row
+test('T7: BrainstormProfile renders <IdentityDetails> inside a .bsp-name-row next to the display name (AC1)', () => {
+  const src = safeRead(PROFILE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/import\s+IdentityDetails/.test(src), 'BrainstormProfile must import IdentityDetails.');
+  assert(/bsp-name-row[\s\S]{0,220}bsp-name[\s\S]{0,220}IdentityDetails/.test(src),
+    'IdentityDetails must sit inside a .bsp-name-row right after the .bsp-name heading (trigger to the right of the name).');
+});
+
+// AC1 — the float mechanism: a layout rule for .bsp-name-row
+test('T8: styles.css defines .bsp-name-row (the flex wrapper that floats the trigger right) (AC1)', () => {
+  const src = safeRead(CSS);
+  assert(src.length > 0, 'ui/src/styles.css missing — unexpected.');
+  assert(/\.bsp-name-row\s*\{/.test(src),
+    'styles.css must define .bsp-name-row (display:flex … so the reused .bsp-info-btn margin-left:auto floats the trigger right).');
+});
+
+// AC6 — the identifiers are no longer inline in the page body
+test('T9: BrainstormProfile no longer renders the identifiers inline (no local CopyButton, no Pubkey(hex) row) (AC6)', () => {
+  const src = safeRead(PROFILE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(!/function CopyButton/.test(src),
+    'the local CopyButton definition must move to ui/src/components/CopyButton.jsx (no longer defined in the page).');
+  assert(!/CopyButton\s+value=\{pubkey\}/.test(src),
+    'the page body must no longer render <CopyButton value={pubkey}> (it moved into the popover).');
+  assert(!/CopyButton\s+value=\{npub\}/.test(src),
+    'the page body must no longer render <CopyButton value={npub}> (it moved into the popover).');
+  assert(!/Pubkey \(hex\)/.test(src),
+    'the "Pubkey (hex)" Identity row must move out of the page body into the popover.');
+});
+
+// AC8 — the Identity section never renders as an empty shell
+test('T10: the Identity section is gated on (website || lud16) so it never renders empty (AC8)', () => {
+  const src = safeRead(PROFILE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/website[\s\S]{0,30}\|\|[\s\S]{0,30}lud16|lud16[\s\S]{0,30}\|\|[\s\S]{0,30}website/.test(src),
+    'after pubkey/npub move out, the Identity .bsp-section must render only when (profile?.website || profile?.lud16) — otherwise it is an empty shell (AC8). Pre-impl website and lud16 are guarded separately, never combined with ||.');
+});
+
+// AC9 — the new component is presentational (no new data path)
+test('T11: IdentityDetails is presentational — no data fetch (values come from props) (AC9)', () => {
+  const src = safeRead(IDENT);
+  assert(src.length > 0, 'IdentityDetails.jsx does not exist yet.');
+  assert(!/fetch\s*\(/.test(src),
+    'IdentityDetails must be presentational (props in, no fetch) — the values are derived upstream; the change is not a new data path.');
+});
+
+// ===========================================================================
+// REGRESSION SENTINELS (must PASS before AND after implementation)
+// ===========================================================================
+
+test('R1: Website remains in the Identity section (regression) (AC7)', () => {
+  const src = safeRead(PROFILE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/profile\??\.website/.test(src) && /toExternalUrl\(/.test(src) && /bsp-id-link/.test(src),
+    'the Website row (profile.website → toExternalUrl, bsp-id-link) must remain in the Identity section.');
+});
+
+test('R2: Lightning (lud16) remains in the Identity section (regression) (AC7)', () => {
+  const src = safeRead(PROFILE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/profile\??\.lud16/.test(src) && /⚡/.test(src),
+    'the Lightning row (profile.lud16, ⚡) must remain in the Identity section.');
+});
+
+test('R3: npub is still derived via nip19.npubEncode (purely presentational; derivation unchanged) (AC9)', () => {
+  const src = safeRead(PROFILE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/nip19\.npubEncode\(/.test(src),
+    'npub must still be derived client-side via nip19.npubEncode(pubkey) — presentational change, not a new data path.');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -60,6 +60,7 @@ const reputationInfoPopup = require('./reputation-info-popup.test.js');
 const liveFeedReadPath = require('./live-feed-read-path.test.js');
 const liveFeedFeedPage = require('./live-feed-feed-page.test.js');
 const verifiedReportersReportColumns = require('./verified-reporters-report-columns.test.js');
+const profileIdentityDetailsPopover = require('./profile-identity-details-popover.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...\n');
@@ -178,6 +179,9 @@ async function main() {
   console.log('\nverified-reporters-report-columns suite:');
   const verifiedReportersReportColumnsResult = await verifiedReportersReportColumns.run();
 
+  console.log('\nprofile-identity-details-popover suite:');
+  const profileIdentityDetailsPopoverResult = await profileIdentityDetailsPopover.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -292,6 +296,9 @@ async function main() {
   console.log(
     `verified-reporters-report-columns suite:         ${verifiedReportersReportColumnsResult.fail === 0 ? 'PASS' : 'FAIL'} (${verifiedReportersReportColumnsResult.pass} passed, ${verifiedReportersReportColumnsResult.fail} failed)`
   );
+  console.log(
+    `profile-identity-details-popover suite:          ${profileIdentityDetailsPopoverResult.fail === 0 ? 'PASS' : 'FAIL'} (${profileIdentityDetailsPopoverResult.pass} passed, ${profileIdentityDetailsPopoverResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -331,7 +338,8 @@ async function main() {
     reputationInfoPopupResult.fail === 0 &&
     liveFeedReadPathResult.fail === 0 &&
     liveFeedFeedPageResult.fail === 0 &&
-    verifiedReportersReportColumnsResult.fail === 0;
+    verifiedReportersReportColumnsResult.fail === 0 &&
+    profileIdentityDetailsPopoverResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/ui/src/components/CopyButton.jsx
+++ b/ui/src/components/CopyButton.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+
+/**
+ * Copy-to-clipboard button — copies the full `value` via navigator.clipboard and shows a brief
+ * 📋 → ✓ confirmation. Extracted from BrainstormProfile (ADR profile/0033) so the IdentityDetails
+ * drawer (and future copyable fields) can reuse it. Behavior unchanged from the original.
+ */
+export default function CopyButton({ value }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      className="bsp-copy-btn"
+      onClick={() => {
+        navigator.clipboard.writeText(value).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        });
+      }}
+      title="Copy to clipboard"
+    >
+      {copied ? '✓' : '📋'}
+    </button>
+  );
+}

--- a/ui/src/components/IdentityDetails.jsx
+++ b/ui/src/components/IdentityDetails.jsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import CopyButton from './CopyButton';
+
+/**
+ * Account "details drawer" — a neutral ⋯ trigger placed to the right of the profile name that
+ * opens a tap-to-open popover listing the account's identifiers (hex pubkey + npub), each copyable
+ * via the full value. Presentational: the values arrive as props (no fetch). Reuses the
+ * bsp-info-btn / bsp-confirm-* / bsp-id-* patterns (ADR profile/0033, sibling of VerificationInfo /
+ * ReputationInfo). Designed to grow — future account details render as more rows here.
+ */
+export default function IdentityDetails({ pubkey, npub }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="bsp-info-btn"
+        aria-label="Show account identifiers"
+        title="Show account identifiers"
+        onClick={() => setOpen(true)}
+      >⋯</button>
+      {open && (
+        <div className="bsp-confirm-overlay" onClick={() => setOpen(false)}>
+          <div className="bsp-confirm-box" onClick={e => e.stopPropagation()}>
+            <h3 className="bsp-confirm-title">Identifiers</h3>
+            <div className="bsp-id-grid">
+              <div className="bsp-id-row">
+                <span className="bsp-id-label">Pubkey (hex)</span>
+                <code className="bsp-id-value">{pubkey.slice(0, 12)}…{pubkey.slice(-8)}</code>
+                <CopyButton value={pubkey} />
+              </div>
+              {npub && (
+                <div className="bsp-id-row">
+                  <span className="bsp-id-label">npub</span>
+                  <code className="bsp-id-value">{npub.slice(0, 20)}…{npub.slice(-8)}</code>
+                  <CopyButton value={npub} />
+                </div>
+              )}
+            </div>
+            <div className="bsp-confirm-buttons">
+              <button className="bsp-confirm-ok" onClick={() => setOpen(false)}>Got it</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -11,6 +11,7 @@ import ReportModal from '../components/ReportModal';
 import { toExternalUrl } from '../utils/url';
 import VerificationInfo from '../components/VerificationInfo';
 import ReputationInfo from '../components/ReputationInfo';
+import IdentityDetails from '../components/IdentityDetails';
 
 /* ── Verified Reporters alarm thresholds (ADR 0032) ──────
    Alarm (red + icon) only when verifiedReporterCount >= BASE + one "freebie" per
@@ -53,26 +54,6 @@ const TRUST_METRICS = [
   { tag: 'verifiedMuterCount',             label: 'Muters',          icon: '🔇', description: 'Users who muted this profile' },
   { tag: 'verifiedReporterCount',          label: 'Reporters',       icon: '🚩', description: 'Users who reported this profile' },
 ];
-
-/* ── Copy Button ─────────────────────────────────────── */
-
-function CopyButton({ value }) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <button
-      className="bsp-copy-btn"
-      onClick={() => {
-        navigator.clipboard.writeText(value).then(() => {
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1500);
-        });
-      }}
-      title="Copy to clipboard"
-    >
-      {copied ? '✓' : '📋'}
-    </button>
-  );
-}
 
 /* ── Main Component ──────────────────────────────────── */
 
@@ -247,7 +228,10 @@ export default function BrainstormProfile() {
                 </div>
               )}
               <div className="bsp-header-info">
-                <h1 className="bsp-name">{displayName}</h1>
+                <div className="bsp-name-row">
+                  <h1 className="bsp-name">{displayName}</h1>
+                  <IdentityDetails pubkey={pubkey} npub={npub} />
+                </div>
                 {profile?.nip05 && <div className="bsp-nip05">{nip05Verified && '✅ '}{profile.nip05}</div>}
                 {profileAge && <span className="bsp-age">Updated {profileAge}</span>}
               </div>
@@ -331,38 +315,29 @@ export default function BrainstormProfile() {
               </div>
             )}
 
-            {/* Identity */}
-            <div className="bsp-section">
-              <h3>Identity</h3>
-              <div className="bsp-id-grid">
-                <div className="bsp-id-row">
-                  <span className="bsp-id-label">Pubkey (hex)</span>
-                  <code className="bsp-id-value">{shortPubkey(pubkey)}</code>
-                  <CopyButton value={pubkey} />
+            {/* Identity — Website + Lightning. Pubkey/npub live in the IdentityDetails drawer
+                by the name (ADR profile/0033); the section renders only when it has content. */}
+            {(profile?.website || profile?.lud16) && (
+              <div className="bsp-section">
+                <h3>Identity</h3>
+                <div className="bsp-id-grid">
+                  {profile?.website && (
+                    <div className="bsp-id-row">
+                      <span className="bsp-id-label">Website</span>
+                      <a href={toExternalUrl(profile.website)} target="_blank" rel="noopener noreferrer" className="bsp-id-link">
+                        {profile.website.replace(/^https?:\/\//, '').replace(/\/$/, '')}
+                      </a>
+                    </div>
+                  )}
+                  {profile?.lud16 && (
+                    <div className="bsp-id-row">
+                      <span className="bsp-id-label">Lightning</span>
+                      <span className="bsp-id-value">⚡ {profile.lud16}</span>
+                    </div>
+                  )}
                 </div>
-                {npub && (
-                  <div className="bsp-id-row">
-                    <span className="bsp-id-label">npub</span>
-                    <code className="bsp-id-value">{npub.slice(0, 20)}…{npub.slice(-8)}</code>
-                    <CopyButton value={npub} />
-                  </div>
-                )}
-                {profile?.website && (
-                  <div className="bsp-id-row">
-                    <span className="bsp-id-label">Website</span>
-                    <a href={toExternalUrl(profile.website)} target="_blank" rel="noopener noreferrer" className="bsp-id-link">
-                      {profile.website.replace(/^https?:\/\//, '').replace(/\/$/, '')}
-                    </a>
-                  </div>
-                )}
-                {profile?.lud16 && (
-                  <div className="bsp-id-row">
-                    <span className="bsp-id-label">Lightning</span>
-                    <span className="bsp-id-value">⚡ {profile.lud16}</span>
-                  </div>
-                )}
               </div>
-            </div>
+            )}
 
             {/* Reputation */}
             <div className="bsp-section">

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3364,6 +3364,7 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
 }
 .bsp-header-info {
   min-width: 0;
+  flex: 1;
 }
 .bsp-name {
   font-size: 1.5rem;

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3371,6 +3371,11 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   margin: 0;
   line-height: 1.2;
 }
+.bsp-name-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
 .bsp-nip05 {
   font-size: 0.85rem;
   opacity: 0.6;


### PR DESCRIPTION
## Summary

Declutters the main profile page by moving the npub + hex pubkey out of the inline Identity section into a small, centered, tap-to-open **Identifiers** popover, triggered by a neutral `⋯` control pinned to the far-right of the profile name (aligned with the existing ⓘ info icons). Website + Lightning stay inline. The control is framed as a "details drawer" intended to grow. Purely presentational — no data/fetch/backend change. (Engineering harness: story → ADR 0033 → tests → impl → review PASS.)

## Changes

- `ui/src/components/CopyButton.jsx` (new) — copy-to-clipboard button extracted verbatim from BrainstormProfile (default export, reusable).
- `ui/src/components/IdentityDetails.jsx` (new) — the `⋯` trigger + `bsp-confirm-*` popover (reuses `bsp-id-*` rows + CopyButton); shows hex pubkey + npub, each copyable (full value); presentational (props in, no fetch).
- `ui/src/pages/BrainstormProfile.jsx` — render `<IdentityDetails>` in a new `.bsp-name-row` next to the name; drop the inline pubkey/npub rows + the local CopyButton; gate the Identity section on `website || lud16`; keep Website + Lightning.
- `ui/src/styles.css` — `.bsp-name-row` (layout) + `.bsp-header-info { flex: 1 }` so the trigger pins to the far-right edge. Tokens-only.
- Tests: `test/profile-identity-details-popover.test.js` (14 source-regex sentinels) wired into `test/test.js`.
- Docs (parked, out of scope): `docs/PROFILE_IA_REVIEW_2026-06-16.md` + intake entry — the deferred "Story B" profile-IA review, captured for later discussion.

## Test plan

- [x] Local `npm test` → `profile-identity-details-popover` 14/14, no regression, Overall PASS.
- [x] Local visual verification (desktop + mobile, live stack).
- [ ] After merge: deploy-staging.yml runs green.
- [ ] Smoke test staging.brainstorm.world: load a profile (e.g. `/user/b83a28b7…35919450?pov=a1420e44`) → `⋯` control renders far-right of the name; popover opens with copyable npub/pubkey; Website + Lightning remain inline.
- [ ] Regression: counts row, Reputation, and the existing ⓘ popovers unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)