### PR TITLE
Profile: follows-hops path page + HOPS link activation (story profile #39)

### DIFF
--- a/engineering-team/decisions/profile/0035-profile-hops-path.md
+++ b/engineering-team/decisions/profile/0035-profile-hops-path.md
@@ -1,0 +1,91 @@
+# ADR 0035: Follows-hops path page + HOPS link activation
+
+**Status:** Proposed
+**Date:** 2026-06-17
+**Story:** `engineering-team/stories/profile/39-profile-hops-path.md`
+
+## Context
+
+Story #39 builds the click-through page for the HOPS stat from #38 (ADR 0034) and activates the link. The page shows the hop count *and the actual shortest FOLLOWS path* from the source (logged-in viewer, else the Owner) to the viewed profile, as a vertical column of profile cards (pic, name, Owner-PoV rank), ordered source→target, with a re-roll button that swaps in a random one of the equally-short paths.
+
+Established facts (verified against source on this branch, which has #38):
+
+- **#38 endpoint** `GET /api/get-follows-hops` ([follows-hops.js](src/api/export/users/queries/follows-hops.js)) returns the hop **count** via `shortestPath … RETURN length(p)`. The pooled-driver helper `runCypher(cypher, params, txConfig)` ([neo4j-driver.js:53](src/lib/neo4j-driver.js)) takes an optional transaction-timeout config (added by ADR 0034). Auth middleware allows unauthenticated reads by default; gated paths are an allowlist matched by `path.includes(...)` ([auth.js:304](src/middleware/auth.js)).
+- **Sibling list pages** are route objects in `createBrowserRouter` ([App.jsx:111-122](ui/src/App.jsx)) → `BrainstormFollows`/`BrainstormFollowers`/`BrainstormReporters`. The list-page convention ([BrainstormReporters.jsx](ui/src/pages/BrainstormReporters.jsx)): page chrome `bsp-page` / `bsp-top-bar` / `bsp-content` / `bsp-follows-header`; **pic/name from `/api/profiles?pubkeys=<csv>`** batched ≤50 ([:96](ui/src/pages/BrainstormReporters.jsx)); **rank = `Math.round(influence * 100)`** ([:115](ui/src/pages/BrainstormReporters.jsx)); avatar class `bsp-follows-avatar`; row click → `/user/<pubkey>`.
+- **Owner-PoV influence** is a `NostrUser` node property (the owner GrapeRank pass writes `influence`/`average`/`confidence`/`input` onto nodes), so a path query over `nodes(p)` can return each node's `influence` directly — no extra round-trip for rank.
+- `BrainstormProfile.jsx` (staging) renders the #38 HOPS stat as a **non-link** `<span className="bsp-count">` between Verified Followers and Verified Reporters.
+
+No concept/schema change (additive) → **firmware reinstall N/A**. Concept Graph (`:8877`) unreachable (stale local stack — OPEN.md #6).
+
+## Options considered
+
+### Option A — One new endpoint returning up to N shortest paths; client renders one and re-rolls client-side *(chosen)*
+
+`GET /api/get-follows-hops-paths?source=&target=` runs **one** `allShortestPaths` query (cap 20, `LIMIT N`) returning up to N equally-short paths, each as an ordered `[{pubkey, influence}]`. The page shows one path, derives the count from it, shows the re-roll button iff `paths.length > 1`, and re-rolls by picking a random index **client-side** (no re-query). Pic/name come from a batched `/api/profiles` call; rank = `Math.round(influence*100)`.
+
+**Pros:** one round-trip for the whole feature; re-roll is instant and free (no repeated expensive query); count and path are inherently consistent (same query); reuses the `/api/profiles` + influence→rank conventions; `LIMIT N` + the `runCypher` timeout bound the cost.
+**Cons:** the single up-front query is `allShortestPaths` (costlier than `shortestPath`); the random pick samples among the first N paths Neo4j returns, not a uniform draw over all of them; one new endpoint + a small payload of up to N paths.
+
+### Option B — Fast first path (`shortestPath`) for display + lazy `allShortestPaths` only on first re-roll
+
+Show one path fast via a `shortestPath`-returns-nodes endpoint (≈ #38 cost); fetch the all-paths set lazily only if the user clicks re-roll.
+**Pros:** fast initial render even if `allShortestPaths` is slow; pays the expensive query only when needed.
+**Cons:** two endpoints + two query shapes; the re-roll button's visibility needs the path count up front anyway (so we'd still pay something up front, or hide the button until the lazy fetch resolves — awkward UX). More moving parts. **Deferred fallback** if staging profiling shows Option A's up-front `allShortestPaths` is too slow.
+
+### Option C — Server-side random path per re-roll
+
+Each re-roll is a fresh server call returning a random shortest path.
+**Cons:** re-runs the expensive `allShortestPaths` (or an `ORDER BY rand()`) on **every** re-roll — bad latency and DB cost. Rejected.
+
+## Decision
+
+**Option A.** One endpoint, one query, client-side re-roll. It is the simplest design that satisfies all ACs, keeps count/path consistent, makes re-roll instant, and bounds cost with `LIMIT` + a transaction timeout. If staging profiling shows the up-front `allShortestPaths` is too slow for common pairs, fall back to Option B (recorded above). This ADR does not change #38's `/api/get-follows-hops` contract; the stat keeps using it.
+
+## Consequences
+
+- **Enables** the path page and link activation; reuses #38's source rule, the `runCypher` timeout, and the list-page enrichment conventions.
+- **`allShortestPaths` cost.** It can be materially more expensive than `shortestPath`, and the number of equally-short paths can blow up for highly-connected pairs. Mitigations: `LIMIT N` (Neo4j stops after N), a transaction **timeout** (~3 s; on timeout → `{success:false}` → "unavailable", never a false path), and the cap-20 bound. `truncated:true` is returned when ≥N paths exist so the UI can say "a random one of N+". **Validate on staging** (local graph is stale/near-empty — OPEN.md #6); if too slow, take Option B.
+- **Re-roll fairness:** random among the first N returned shortest paths, not a uniform draw over all — acceptable per the story ("a random one"); documented, not hidden.
+- **New public endpoint:** exposes only follow-path structure + already-public rank — no sensitive data. Must **not** be added to any auth gate (`get-follows-hops-paths` contains no gated substring).
+- **Minimal new CSS** for the vertical card column (the sibling pages use a `DataTable`, not a card stack) — a small, bounded addition; reuse `bsp-follows-avatar` and page chrome.
+- **Firmware reinstall:** No.
+
+## Implementation notes
+
+**Backend**
+
+- **New** `src/api/export/users/queries/follows-hops-paths.js` — `handleGetFollowsHopsPaths(req, res)`:
+  - read/validate `source`, `target` as 64-char lowercase hex → else `400 {success:false, error}` (mirror #38).
+  - **self-view** (`source === target`): run `MATCH (a:NostrUser {pubkey:$src}) RETURN a.influence AS influence` and respond `{success:true, hops:0, paths:[[{pubkey:source, influence:<influence|null>}]], truncated:false}` (single card; if the node is absent, still return one card with `influence:null`).
+  - else run, via `runCypher(CYPHER, {src,tgt}, { timeout: HOPS_PATHS_QUERY_TIMEOUT_MS })` (~3000 ms):
+    ```cypher
+    MATCH p = allShortestPaths((a:NostrUser {pubkey: $src})-[:FOLLOWS*..20]->(b:NostrUser {pubkey: $tgt}))
+    RETURN [n IN nodes(p) | { pubkey: n.pubkey, influence: n.influence }] AS nodes
+    LIMIT 25
+    ```
+    (cap `20` and `LIMIT 25` are **literals** — Neo4j can't parameterize var-length bounds; pubkeys are bound params.)
+    - `rows.length === 0` → `{success:true, hops:null, paths:[]}` (∞).
+    - else → `paths = rows.map(r => r.nodes)`; `hops = paths[0].length - 1`; `truncated = (rows.length === 25)`; respond `{success:true, hops, paths, truncated}`.
+  - `catch` → `{success:false, error: err.message}`.
+- `src/api/export/users/index.js` — re-export `handleGetFollowsHopsPaths`.
+- `src/api/index.js` — register `app.get('/api/get-follows-hops-paths', users.handleGetFollowsHopsPaths)` near the other `users.*` routes. Do **not** add to any auth gate.
+
+**Frontend**
+
+- **New** `ui/src/hooks/useFollowsHopsPaths.js` — async, AbortController-scoped (mirror `useFollowsHops`): fetch `/api/get-follows-hops-paths?source=&target=`; return `{ hops, paths, truncated, noPath, loading, error }` where `noPath = success && paths.length === 0 && hops === null`.
+- **New** `ui/src/pages/BrainstormFollowsHops.jsx` (mirror `BrainstormReporters` chrome):
+  - `useParams()` → `pubkey` (target); `useAuth()` → `user`; `useConfig()` → `ownerPubkey`; `source = user?.pubkey || ownerPubkey`.
+  - `useFollowsHopsPaths(source, pubkey)`.
+  - `selectedIndex` state (default 0). **Re-roll** button → set a random index in `[0, paths.length)` (prefer ≠ current); render iff `paths.length > 1`.
+  - **Enrich**: gather unique pubkeys across all returned paths, batch `/api/profiles?pubkeys=<csv>` (≤50/chunk, as BrainstormReporters does); `name = display_name||name||shortNpub`, `picture`; `rank = influence == null ? null : Math.round(influence*100)`.
+  - **Render**: a header (back-link to `/user/:pubkey`, title e.g. "Follow hops"); a count line consistent with #38's tooltip copy (`"<target> is N hop(s) away from <source> by follows."` / `"There is no follow path from <source> to <target>."` / self-view `0`); the selected path as a vertical column of cards (each card a `<Link to={/user/<pubkey>}>` with avatar + name + rank); the re-roll button; loading/error/no-path/self-view states (reuse `bsp-follows-skeleton`/`bsp-trust-unavailable`/`bsp-empty` patterns).
+- `ui/src/App.jsx` — import `BrainstormFollowsHops`; add route `{ path: '/user/:pubkey/follows-hops', element: <BrainstormFollowsHops /> }` next to the sibling routes ([:111-122](ui/src/App.jsx)).
+- `ui/src/pages/BrainstormProfile.jsx` — **activate the link**: change the #38 HOPS `<span className="bsp-count …">` to `<Link to={`/user/${pubkey}/follows-hops`} className={`bsp-count bsp-count-link${followsHopsLoading ? ' bsp-count-loading' : ''}`} title={hopsTitle}>` … `</Link>` — a link in **all** states (finite/0/∞); keep the value + tooltip.
+- `ui/src/styles.css` — add minimal classes for the path-card column (e.g. `.bsp-hops-path`, `.bsp-hops-card`, `.bsp-hops-card-rank`), reusing `.bsp-follows-avatar`.
+
+## Out of scope
+- Changing #38's `/api/get-follows-hops` count contract.
+- Listing all paths at once / pagination (one path + re-roll only).
+- Uniform sampling over *all* shortest paths when there are more than `N` (we sample among the first N; `truncated` flags it).
+- A fast-first-path split (Option B) unless staging profiling forces it.
+- The two-"Hops" PoV reconciliation (OPEN.md #7).

--- a/engineering-team/reviews/profile/39-profile-hops-path.md
+++ b/engineering-team/reviews/profile/39-profile-hops-path.md
@@ -1,0 +1,62 @@
+# Review: Story 39 — Follows-hops path page + HOPS link activation
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-17
+**Diff:** `git diff origin/staging...HEAD` (impl commit `fd157eab`)
+**Story:** `engineering-team/stories/profile/39-profile-hops-path.md`
+**ADR:** `engineering-team/decisions/profile/0035-profile-hops-path.md`
+**Test plan:** `engineering-team/stories/profile/39-profile-hops-path.test-plan.md`
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `test/profile-hops-path.test.js` (isolated) — **27 passed, 0 failed**.
+- [x] Related suites green — `profile-follows-hops` 25/0, `profile-identity-details-popover` 14/0, `trusted-list-pin-publish-blockers` 11/0.
+- [x] `cd ui && npm run build` — **succeeds**.
+- [x] _Full `npm test` `Overall` is **not** a valid gate locally_: several tags-feature `-publish`/concept-graph/Meili suites fail because the stale local stack has no tags runtime (0 `nostr-user-tag` in concept-graph, 0 `tagHits` in Meili). Confirmed unrelated to #39 — the diff touches **zero** tag source (see scope). Green on staging CI.
+- [x] _Lint / typecheck — not configured._
+
+## Spec adherence (story #39 ACs)
+
+- [x] **Link activation** — [BrainstormProfile.jsx:269](ui/src/pages/BrainstormProfile.jsx) the #38 `<span>` is now `<Link to={`/user/${pubkey}/follows-hops`} className="bsp-count bsp-count-link …">` in **all** states; inner value/label + tooltip preserved.
+- [x] **Count, #38-consistent** — [BrainstormFollowsHops.jsx:78-82](ui/src/pages/BrainstormFollowsHops.jsx): `"<target> is N hop(s) away from <source> by follows."` with `hops === 1 ? '' : 's'`; ∞ copy matches #38. Count derived from the path (`hops = paths[0].length - 1` server-side), so it can't disagree.
+- [x] **Path as cards** — [:130-145](ui/src/pages/BrainstormFollowsHops.jsx): vertical `.bsp-hops-path` column, one card per node in path order (source→target), each with avatar + name + rank.
+- [x] **Per-card rank = Owner-PoV** — `node.influence == null ? '—' : Math.round(node.influence * 100)` ([:134](ui/src/pages/BrainstormFollowsHops.jsx)) — the `BrainstormReporters` convention; `influence` is the Owner-PoV node property returned by the query.
+- [x] **Cards link to profiles** — each card is `<Link to={`/user/${node.pubkey}`}>` ([:136](ui/src/pages/BrainstormFollowsHops.jsx)).
+- [x] **No-path (∞) state** — `noPath` branch shows no cards and a "no follow path" message ([:125-127](ui/src/pages/BrainstormFollowsHops.jsx)); backend `{hops:null, paths:[]}` ([follows-hops-paths.js:60](src/api/export/users/queries/follows-hops-paths.js)).
+- [x] **Self-view** — backend short-circuits `source === target` to a single-node path (`hops:0`), via a single-node `MATCH`, **not** `allShortestPaths` ([follows-hops-paths.js:44-53](src/api/export/users/queries/follows-hops-paths.js)); one card, re-roll hidden (paths.length 1).
+- [x] **Re-roll** — `<button>` gated on `paths.length > 1` ([:146](ui/src/pages/BrainstormFollowsHops.jsx)); `reroll()` picks a random index ≠ current ([:37-42](ui/src/pages/BrainstormFollowsHops.jsx)); `selectedIndex` resets on new `paths` ([:35](ui/src/pages/BrainstormFollowsHops.jsx)). Label honestly notes `(of 25+)` when `truncated`.
+- [x] **Graceful failure** — `error` branch shows a non-misleading "couldn't compute" message ([:119-123](ui/src/pages/BrainstormFollowsHops.jsx)); ∞ is keyed on `noPath`, never on error — no false path.
+
+## ADR 0035 adherence
+
+- [x] One endpoint `GET /api/get-follows-hops-paths`; `allShortestPaths((a)-[:FOLLOWS*..20]->(b)) … LIMIT 25` ([follows-hops-paths.js:30-33](src/api/export/users/queries/follows-hops-paths.js)) — cap **20** and `LIMIT 25` are **literals**; pubkeys are **bound** params `$src`/`$tgt`.
+- [x] `runCypher(…, { timeout: 3000 })` reuses the #38 `txConfig` timeout.
+- [x] 3-state contract exactly as specified; client re-rolls **client-side** over the returned set (no re-query).
+- [x] Enrichment via batched `/api/profiles` (chunks of 50) + influence→rank — as specified.
+- [x] Public endpoint — `0` occurrences of `get-follows-hops-paths` in `src/middleware/auth.js`; falls through to read-only `next()`.
+- [x] No change to #38's `/api/get-follows-hops` contract (regression `R3` confirms it stays registered).
+
+## Concept-graph integrity
+- [x] No concept/schema change → **firmware reinstall N/A**. No handles in code.
+
+## Things tests can't catch
+- [x] No secrets / debug logging (the single `console.error` in the handler catch is legitimate) / commented-out code.
+- [x] Input validated at the boundary (64-hex → 400); no injection (bound params, literal cap/LIMIT).
+- [x] `reroll()` while-loop terminates for `paths.length > 1`; `selectedPath = paths[selectedIndex] || []` ([:84](ui/src/pages/BrainstormFollowsHops.jsx)) guards a stale index between a `paths` change and the reset effect (at worst a one-frame empty, no crash).
+- [x] Profile enrichment is cancellable + tolerant of partial failure (mirrors `BrainstormReporters`).
+- [x] Scope: only the 8 expected files; no over-reach.
+
+## House rules check
+- [x] No new lint/typecheck/build tooling. Minimal new CSS (`.bsp-hops-*`), reuses `.bsp-follows-avatar` and page chrome.
+
+## Findings
+
+### Blocking
+_None._
+
+### Non-blocking
+1. **[BrainstormFollowsHops.jsx:107-127](ui/src/pages/BrainstormFollowsHops.jsx)** — in the ∞ case, the no-path message appears twice: as the count line (*"There is no follow path from X to Y."*) and as the empty-state body (*"No follow path within reach…"*). Harmless and both convey the same thing, but consolidating to one would be tidier. Optional.
+2. **Required deploy-time check (staging):** the real path **values** — a finite N path of N+1 cards, a `truncated` 25+ case, and re-roll producing a *different* path — cannot be exercised on the stale/near-empty local graph (OPEN.md #6). The data-independent paths (self-view→single card `hops:0`, validation→400, no-path→∞) were verified locally. Verify the populated-graph behavior on **staging** during the deploy.
+
+## Verdict
+**PASS** — the diff matches story #39, ADR 0035, and the test plan; the `profile-hops-path` suite (27/27) and all related suites pass; UI builds; no blocking issues. Deploy-time follow-up: verify real path rendering + re-roll on **staging**.

--- a/engineering-team/stories/profile/39-profile-hops-path.md
+++ b/engineering-team/stories/profile/39-profile-hops-path.md
@@ -1,0 +1,64 @@
+# Story 39: Follows-hops path page + HOPS link activation
+
+**Status:** Draft
+**Created:** 2026-06-17
+**Type:** Feature
+
+## Background
+Story #38 added the **HOPS** stat to the profile counts row — the directed FOLLOWS hop distance from the source (logged-in viewer, else the instance Owner) to the viewed profile — but deliberately shipped it as a **non-link** because its destination page didn't exist yet. This story builds that page and activates the link.
+
+The number alone says *how far*; this page shows *the actual route*. Seeing the chain of people that connects you (or the Owner) to someone — "Alice → Charlie → Bob" — makes an abstract distance concrete and explorable. It depends on #38 (the HOPS stat and the live shortest-path computation), which is on `staging`.
+
+## User-facing description
+As someone viewing a profile, I want to click the HOPS stat and see the actual shortest follow-path connecting the source (me, or the Owner) to this person — as a vertical chain of profile cards — and be able to re-roll to a different equally-short path, so that I can understand and explore *how* we're connected, not just how far.
+
+## Acceptance criteria
+Testable from the outside. Each criterion gets at least one test.
+
+- [ ] **Link activation.** On the profile page, the HOPS stat is now a clickable link to `/user/:pubkey/follows-hops` (it was a non-link `<span>` in #38). It is clickable in **all** states — finite count, 0 (self-view), and ∞.
+- [ ] **Count, consistent with #38.** The page shows the hop count from the source (logged-in viewer's pubkey, else the Owner) to the viewed profile, using the same live computation and source rule as #38: a finite N, **∞** when there is no path within the cap, **0** for self-view.
+- [ ] **Path as cards.** Given a finite path of length N, the page renders **N+1** profile cards in a single vertical column, **ordered source→target, top to bottom** (e.g. N=2 → Alice / Charlie / Bob). Each card shows the person's **profile picture, name, and Owner-PoV rank** (the Verification Score, always from the Owner's perspective regardless of who the source is).
+- [ ] **Path matches the count.** The number of FOLLOWS steps between the shown cards equals the displayed hop count (a length-N path renders exactly N+1 cards).
+- [ ] **Cards link to profiles.** Clicking any card navigates to that person's profile (`/user/<pubkey>`).
+- [ ] **No-path state.** When there is no path within the cap (∞), the page shows the count as ∞ and a clear *"There is no follow path from &lt;source&gt; to &lt;target&gt;"* message, with **no** path cards and **no** re-roll button.
+- [ ] **Self-view.** When source == target (0 hops), the page shows a single card (that person) and **no** re-roll button.
+- [ ] **Re-roll.** When more than one shortest path of the minimal length exists, a re-roll button is shown; clicking it replaces the displayed path with a **randomly selected** one of the shortest paths.
+- [ ] **Re-roll hidden when nothing to roll.** When only one shortest path exists (or in the self-view / no-path cases), the re-roll button is **not** shown.
+- [ ] **Graceful failure.** If the path lookup errors or times out, the page is unaffected structurally and shows a non-misleading unavailable state — it does **not** falsely render a path or ∞.
+
+## Concepts touched
+Concept Graph API (`http://localhost:8877`) likely unreachable (stale local stack — OPEN.md #6); named in plain language for the Architect to resolve handles.
+
+- **NostrUser** — each node along the path (source, intermediates, target).
+- **FOLLOWS** — the directed edges the path traverses (the only relationship used).
+- **rank** — the Owner-PoV Verification Score shown on each card.
+- **Owner** — `BRAINSTORM_OWNER_PUBKEY`, the source when logged out, and the PoV for the per-card rank.
+
+## Requester-directed constraints (settled decisions — not PO design)
+Decided by the requester this session; the Architect should honor rather than re-open:
+
+- **Adapt the `shortestPath` Cypher to return the path's nodes** (the sequence along `p`) — e.g. the first returned path — instead of `count`/`length`. The displayed count stays consistent with #38.
+- **Re-roll uses `allShortestPaths`** (all distinct paths of the minimal length); the button picks a random one. ("one out of the count(p) paths.")
+- **Hop cap = 20**, same as #38.
+- **Per-card rank is the Owner-PoV rank from Neo4j.**
+- **Source selection = same as #38**: logged-in viewer's pubkey, else the Owner. Target = the viewed profile.
+
+## Out of scope
+- Changing #38's HOPS stat semantics or its `/api/get-follows-hops` count contract beyond what activation needs.
+- Pagination / listing of *all* paths at once — only one path is shown at a time, plus the re-roll.
+- Performance tuning of `allShortestPaths` at cap 20 on the prod-scale graph — flagged for the Architect (it can be materially more expensive than `shortestPath`; likely needs a bounded approach / timeout, as #38 did). 
+- The two-"Hops" PoV reconciliation (OPEN.md #7).
+
+## Open questions
+Resolved during planning:
+- **Route:** `/user/:pubkey/follows-hops` (matches the `/follows`, `/followers`, `/reporters` siblings).
+- **∞ clickable?** Yes — always clickable; the page shows the no-path state.
+- **Cards clickable?** Yes — each links to `/user/<pubkey>`.
+- **Re-roll visibility?** Hidden when ≤1 shortest path (and in self-view / no-path).
+- **Card order:** source at top, target at bottom.
+
+## Linked artifacts
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)
+- Depends on: `engineering-team/stories/profile/38-profile-follows-hops.md` (HOPS stat + `/api/get-follows-hops`), ADR 0034.

--- a/engineering-team/stories/profile/39-profile-hops-path.md
+++ b/engineering-team/stories/profile/39-profile-hops-path.md
@@ -1,6 +1,6 @@
 # Story 39: Follows-hops path page + HOPS link activation
 
-**Status:** Draft
+**Status:** Done
 **Created:** 2026-06-17
 **Type:** Feature
 
@@ -60,5 +60,5 @@ Resolved during planning:
 ## Linked artifacts
 - ADR: `engineering-team/decisions/profile/0035-profile-hops-path.md`
 - Test plan: `engineering-team/stories/profile/39-profile-hops-path.test-plan.md`
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/profile/39-profile-hops-path.md` — **PASS** (2026-06-17)
 - Depends on: `engineering-team/stories/profile/38-profile-follows-hops.md` (HOPS stat + `/api/get-follows-hops`), ADR 0034.

--- a/engineering-team/stories/profile/39-profile-hops-path.md
+++ b/engineering-team/stories/profile/39-profile-hops-path.md
@@ -58,7 +58,7 @@ Resolved during planning:
 - **Card order:** source at top, target at bottom.
 
 ## Linked artifacts
-- ADR: (filled in after Architecture phase)
+- ADR: `engineering-team/decisions/profile/0035-profile-hops-path.md`
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)
 - Depends on: `engineering-team/stories/profile/38-profile-follows-hops.md` (HOPS stat + `/api/get-follows-hops`), ADR 0034.

--- a/engineering-team/stories/profile/39-profile-hops-path.md
+++ b/engineering-team/stories/profile/39-profile-hops-path.md
@@ -59,6 +59,6 @@ Resolved during planning:
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/profile/0035-profile-hops-path.md`
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/profile/39-profile-hops-path.test-plan.md`
 - Review: (filled in after Review phase)
 - Depends on: `engineering-team/stories/profile/38-profile-follows-hops.md` (HOPS stat + `/api/get-follows-hops`), ADR 0034.

--- a/engineering-team/stories/profile/39-profile-hops-path.test-plan.md
+++ b/engineering-team/stories/profile/39-profile-hops-path.test-plan.md
@@ -1,0 +1,78 @@
+# Test Plan: Story 39 — Follows-hops path page + HOPS link activation
+
+**Story:** `engineering-team/stories/profile/39-profile-hops-path.md`
+**ADR:** `engineering-team/decisions/profile/0035-profile-hops-path.md`
+**Date:** 2026-06-17
+
+## Approach
+
+Two layers, matching the profile feature-family convention (#33–#38):
+
+1. **Primary — source-regex sentinels** in `test/profile-hops-path.test.js` (wired into `test/test.js`, run by `npm test`). Each test `fs.readFileSync`s an implementation file and asserts the spec via regex. No DB / React harness (local neo4j is stale/near-empty, OPEN.md #6). Pins the 3-state contract, the self-view short-circuit, `allShortestPaths` + cap-20/`LIMIT 25` literals + bound params, the path-as-cards rendering, rank = `Math.round(influence*100)`, re-roll gating, link activation, and the public-endpoint guard.
+2. **Supplementary — live-data Playwright spec** in `tests/brainstorm/profile-hops-path.spec.js` (not run pre-implementation; exercised on staging). Asserts the activated link + that the page renders a path of profile cards — structure, not specific people/N (data-dependent).
+
+## Coverage map
+
+| Criterion (story AC) | Test(s) | Level |
+|---|---|---|
+| Link activation (HOPS → page, all states) | `T23` (+ spec test 1) | sentinel (+ Playwright) |
+| Route registered | `T22` | sentinel |
+| Count, consistent with #38 | `T8` (derived from path), `T21` (copy) | sentinel |
+| Path as cards (N+1, source→target, pic/name/rank) | `T5`, `T16`, `T17`, `T18` | sentinel |
+| Cards link to /user/<pubkey> | `T16` (+ spec test 2) | sentinel (+ Playwright) |
+| No-path (∞) state | `T7` (backend), `T20` (page) | sentinel |
+| Self-view → single card, short-circuit | `T3` | sentinel |
+| Re-roll present when >1 path | `T19` | sentinel |
+| Re-roll hidden when ≤1 / self-view / no-path | `T19` (`paths.length > 1` gate) | sentinel |
+| Graceful failure (error/timeout → unavailable, not false path/∞) | `T2`, `T6`, `T9`, `T13` | sentinel |
+| `allShortestPaths` + cap 20 + `LIMIT 25` literals, bound params | `T4`, `T6` | sentinel |
+| Owner-PoV rank = `Math.round(influence*100)` | `T5` (influence returned), `T17` | sentinel |
+| Public endpoint (not gated) | `R4` | guard |
+| `runCypher` 3rd-arg timeout reused | `T6` | sentinel |
+| Endpoint registered + exported | `T10`, `T11` | sentinel |
+| Hook contract | `T12`, `T13` | sentinel |
+
+## Test inventory
+
+**Failing pre-implementation (T1–T23)** — backend handler `T1`–`T9`; route/export `T10`/`T11`; hook `T12`/`T13`; page `T14`–`T21`; route `T22`; link activation `T23`.
+
+**Regression / guard (pass before AND after)** — `R1` HOPS stays between Verified Followers and Verified Reporters (#38 placement preserved); `R2` sibling counters/links intact; `R3` #38's `/api/get-follows-hops` still registered; `R4` `/api/get-follows-hops-paths` absent from `src/middleware/auth.js` (stays public).
+
+## Edge cases covered
+
+- [x] Self-view (`source === target`) → single-node path, `hops:0`, no `allShortestPaths`, no re-roll (`T3`, `T19`).
+- [x] No path vs error are **distinct** (`T7` `{hops:null,paths:[]}` vs `T9` `{success:false}`) — ∞ never shown for a failure.
+- [x] Count derived from the actual path so count and path can't disagree (`T8`).
+- [x] `allShortestPaths` cost bounded by `LIMIT 25` + timeout; `truncated` flag (`T4`, `T8`, `T6`).
+- [x] Malformed input → 400 (`T2`); endpoint stays public (`R4`).
+- [x] #38 not broken — its endpoint and the HOPS placement persist (`R1`, `R3`).
+
+## Not covered here (deferred / by design)
+
+- Real path **values** (actual people, finite N, ∞, re-roll variety) — data-dependent; verified on **staging** via the Playwright spec + manual check (local graph is stale/near-empty — OPEN.md #6).
+- Uniform sampling fairness across all shortest paths (we sample among the first 25; `truncated` flags it).
+
+## Test infrastructure
+
+- Node built-in runner via `npm test`; Playwright for the supplementary spec. No new framework.
+- Concept Graph / firmware: not required by the sentinel suite (no concept/schema change).
+
+## How to run
+
+```
+npm test                     # primary sentinel suite (+ all suites)
+npm run test:playwright      # supplementary browser spec (needs a running instance)
+```
+
+## Verification
+
+Confirmed pre-implementation on 2026-06-17 (working tree atop commit `bd707170`):
+
+```
+profile-hops-path suite:                         FAIL (4 passed, 23 failed)
+```
+
+- Isolated run: `T1`–`T23` ✗ (each with a spec-describing message, e.g. "expected a new handler at src/api/export/users/queries/follows-hops-paths.js"); `R1`–`R4` ✓.
+- **Related suites stay green:** `profile-follows-hops` 25/25, `profile-identity-details-popover` 14/14, `trusted-list-pin-publish-blockers` 11/11.
+
+**Note — unrelated local-env failures (NOT a #39 regression):** the full `npm test` also shows several **tags-feature** suites failing (`profile-tags*`, `pin-a-tag*`, `tl-publication*`, `most-pinned*`, concept-graph / Meili / firmware live tests). These fail because the **stale local stack lacks the tags runtime** — confirmed: the local concept-graph returns 0 `nostr-user-tag` matches (firmware not installed) and Meili returns 0 `tagHits`. They are green on staging CI (that's how tags shipped) and are independent of #39: the #39 diff touches only `test/test.js` (suite wiring) and the two new `profile-hops-path` test files — **zero** tag/concept/Meili/publish source. During #39 implementation/review, judge success by the `profile-hops-path` suite + the related suites above, not the full `Overall` (which the local tag-env failures will keep red until the stack is refreshed or those are verified on staging).

--- a/src/api/export/users/index.js
+++ b/src/api/export/users/index.js
@@ -8,6 +8,7 @@ const { handleGetProfileScores } = require('./queries/get-profile-scores');
 const { handleGetNip56Profiles } = require('./queries/nip56-profiles');
 const { handleGetUserData, handleGetUserCounts } = require('./queries/userdata');
 const { handleGetFollowsHops } = require('./queries/follows-hops');
+const { handleGetFollowsHopsPaths } = require('./queries/follows-hops-paths');
 const { handleGetNetworkProximity } = require('./queries/proximity');
 const { handleGetNpubFromPubkey } = require('./queries/get-npub-from-pubkey');
 const { handleGetPubkeyFromNpub } = require('./queries/get-pubkey-from-npub');
@@ -22,6 +23,7 @@ module.exports = {
     handleGetUserData,
     handleGetUserCounts,
     handleGetFollowsHops,
+    handleGetFollowsHopsPaths,
     handleGetNetworkProximity,
     handleGetNpubFromPubkey,
     handleGetPubkeyFromNpub

--- a/src/api/export/users/queries/follows-hops-paths.js
+++ b/src/api/export/users/queries/follows-hops-paths.js
@@ -1,0 +1,81 @@
+/**
+ * Follows-hops PATHS query handler (story profile #39, ADR 0035).
+ *
+ * GET /api/get-follows-hops-paths?source=<hex>&target=<hex>
+ *
+ * Returns up to 25 equally-short directed FOLLOWS paths (cap 20) from `source`
+ * to `target`, each an ordered list of nodes [{pubkey, influence}] — the data
+ * for the follows-hops path page. Owner-PoV `influence` (a NostrUser node
+ * property) lets the client render each card's rank (Math.round(influence*100)).
+ * Public read (no auth). Companion to the #38 count endpoint /api/get-follows-hops.
+ *
+ * Three-state contract (as ADR 0034/0035):
+ *   { success:true, hops:<int>, paths:[[{pubkey,influence},...],...], truncated }
+ *       path(s) found (incl. self-view: hops 0, one single-node path)
+ *   { success:true, hops:null, paths:[] }   no path within cap        → UI renders ∞
+ *   { success:false, error }                bad input / lookup error / timeout → UI "—"
+ *
+ * FOLLOWS is directed; the cap 20 and LIMIT 25 are literals (Neo4j cannot
+ * parameterize a variable-length bound); the pubkeys are bound parameters.
+ */
+
+const { runCypher } = require('../../../../lib/neo4j-driver');
+
+// Per-query deadline. allShortestPaths at cap 20 on the prod-scale graph must be
+// bounded so a view never hangs; on timeout we degrade to "—", not a false path.
+const HOPS_PATHS_QUERY_TIMEOUT_MS = 3000;
+
+const HEX64 = /^[0-9a-f]{64}$/;
+
+// All equally-short directed FOLLOWS paths (cap 20), bounded to 25 paths.
+const CYPHER =
+  'MATCH p = allShortestPaths((a:NostrUser {pubkey: $src})-[:FOLLOWS*..20]->(b:NostrUser {pubkey: $tgt})) ' +
+  'RETURN [n IN nodes(p) | { pubkey: n.pubkey, influence: n.influence }] AS nodes ' +
+  'LIMIT 25';
+
+// Single-node lookup for the self-view "path" — its Owner-PoV influence (card rank).
+const SELF_CYPHER = 'MATCH (a:NostrUser {pubkey: $src}) RETURN a.influence AS influence';
+
+async function handleGetFollowsHopsPaths(req, res) {
+  const source = (req.query.source || '').trim();
+  const target = (req.query.target || '').trim();
+
+  if (!HEX64.test(source) || !HEX64.test(target)) {
+    return res.status(400).json({
+      success: false,
+      error: 'source and target must each be a 64-character hex pubkey',
+    });
+  }
+
+  try {
+    // Self-view: a node is 0 hops from itself — a single-card "path", no traversal.
+    if (source === target) {
+      const rows = await runCypher(SELF_CYPHER, { src: source }, { timeout: HOPS_PATHS_QUERY_TIMEOUT_MS });
+      const influence = rows.length ? (rows[0].influence ?? null) : null;
+      return res.json({
+        success: true,
+        hops: 0,
+        paths: [[{ pubkey: source, influence }]],
+        truncated: false,
+      });
+    }
+
+    const rows = await runCypher(CYPHER, { src: source, tgt: target }, { timeout: HOPS_PATHS_QUERY_TIMEOUT_MS });
+    if (rows.length === 0) {
+      // No directed FOLLOWS path within the cap.
+      return res.json({ success: true, hops: null, paths: [] });
+    }
+    const paths = rows.map(r => r.nodes);
+    return res.json({
+      success: true,
+      hops: paths[0].length - 1,
+      paths,
+      truncated: rows.length === 25,
+    });
+  } catch (error) {
+    console.error('Error computing follows-hops paths:', error);
+    return res.json({ success: false, error: error.message });
+  }
+}
+
+module.exports = { handleGetFollowsHopsPaths };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -198,6 +198,7 @@ async function register(app) {
     app.get('/api/get-user-data', users.handleGetUserData);
     app.get('/api/get-user-counts', users.handleGetUserCounts);
     app.get('/api/get-follows-hops', users.handleGetFollowsHops);
+    app.get('/api/get-follows-hops-paths', users.handleGetFollowsHopsPaths);
     app.get('/api/get-network-proximity', users.handleGetNetworkProximity);
     app.get('/api/get-npub-from-pubkey', users.handleGetNpubFromPubkey);
     app.get('/api/get-pubkey-from-npub', users.handleGetPubkeyFromNpub);

--- a/test/profile-hops-path.test.js
+++ b/test/profile-hops-path.test.js
@@ -1,0 +1,277 @@
+/**
+ * Story #39 (profile epic): Follows-hops path page + HOPS link activation.
+ * ADR 0035. See engineering-team/stories/profile/39-profile-hops-path.test-plan.md
+ *
+ * Builds the click-through page for the #38 HOPS stat and activates its link.
+ * New endpoint GET /api/get-follows-hops-paths returns up to 25 equally-short
+ * FOLLOWS paths (each an ordered [{pubkey, influence}]); the page renders one
+ * path as a vertical column of profile cards (pic, name, Owner-PoV rank =
+ * Math.round(influence*100)) and a re-roll button (shown only when >1 path).
+ * 3-state contract (as ADR 0034): paths / no-path (∞) / error.
+ *
+ * SOURCE-REGEX SENTINELS — the profile-family convention (#33–#38): no DB, no
+ * React harness (local neo4j is stale/near-empty, OPEN.md #6). Browser behavior
+ * is covered by the supplementary spec tests/brainstorm/profile-hops-path.spec.js.
+ *
+ * T* must FAIL pre-implementation and PASS post-implementation.
+ * R* are regression/guard sentinels — they must PASS both before and after.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const HANDLER     = path.resolve(__dirname, '../src/api/export/users/queries/follows-hops-paths.js');
+const USERS_INDEX = path.resolve(__dirname, '../src/api/export/users/index.js');
+const API_INDEX   = path.resolve(__dirname, '../src/api/index.js');
+const AUTH        = path.resolve(__dirname, '../src/middleware/auth.js');
+const HOOK        = path.resolve(__dirname, '../ui/src/hooks/useFollowsHopsPaths.js');
+const PAGE        = path.resolve(__dirname, '../ui/src/pages/BrainstormFollowsHops.jsx');
+const APP         = path.resolve(__dirname, '../ui/src/App.jsx');
+const PROFILE     = path.resolve(__dirname, '../ui/src/pages/BrainstormProfile.jsx');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+function countOf(src, re) { return (src.match(re) || []).length; }
+function countsLabelIndex(src, label) {
+  const re = new RegExp('bsp-count-label"[^>]*>\\s*' + label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const m = src.match(re);
+  return m ? m.index : -1;
+}
+
+// ── Backend: GET /api/get-follows-hops-paths handler ──
+
+test('T1: a follows-hops-paths handler module exists and exports handleGetFollowsHopsPaths', () => {
+  const src = safeRead(HANDLER);
+  assert(src.length > 0, 'expected a new handler at src/api/export/users/queries/follows-hops-paths.js (does not exist yet).');
+  assert(/handleGetFollowsHopsPaths/.test(src) && /module\.exports/.test(src),
+    'the handler must define and export handleGetFollowsHopsPaths (mirror handleGetFollowsHops).');
+});
+
+test('T2: the handler validates 64-hex source/target and 400s with {success:false} (graceful failure)', () => {
+  const src = safeRead(HANDLER);
+  assert(/\{\s*64\s*\}/.test(src), 'must validate pubkeys are 64-char hex (a `{64}` length check).');
+  assert(/\.status\(\s*400\s*\)[\s\S]{0,250}success:\s*false/.test(src),
+    'malformed/missing source or target must 400 with {success:false} (→ UI unavailable, not a false path).');
+});
+
+test('T3: the handler short-circuits source===target to a single-node path with hops:0 (no allShortestPaths) (AC self-view)', () => {
+  const src = safeRead(HANDLER);
+  assert(/(source|src)\s*===\s*(target|tgt)|(target|tgt)\s*===\s*(source|src)/.test(src),
+    'must special-case source === target (self-view is a single-node path, not a 1+-hop traversal).');
+  assert(/hops:\s*0\b/.test(src),
+    'self-view must return {success:true, hops:0, paths:[[{pubkey, influence}]]} — one card, computed WITHOUT allShortestPaths.');
+});
+
+test('T4: the handler uses DIRECTED allShortestPaths over FOLLOWS, cap 20, LIMIT 25 (AC path + re-roll set + bound)', () => {
+  const src = safeRead(HANDLER);
+  assert(/allShortestPaths\s*\(/.test(src),
+    'the re-roll set requires allShortestPaths (all equally-short paths), not a single shortestPath.');
+  assert(/:FOLLOWS\*[0-9]?\.\.20\]\s*->/.test(src),
+    'the traversal must be DIRECTED and capped at 20: `-[:FOLLOWS*..20]->` (literal cap; directionality preserved).');
+  assert(/LIMIT\s+25\b/.test(src),
+    'must bound the returned paths with a literal `LIMIT 25` (cost control; Neo4j stops after 25).');
+});
+
+test('T5: the handler returns each path as ordered nodes(p) with pubkey AND Owner-PoV influence', () => {
+  const src = safeRead(HANDLER);
+  assert(/nodes\(\s*p\s*\)/.test(src),
+    'must return the ordered nodes of the path (nodes(p)), not length/count — this IS the path.');
+  assert(/pubkey/.test(src) && /influence/.test(src),
+    'each path node must carry { pubkey, influence } so the client can render name/pic (via /api/profiles) and rank (Math.round(influence*100)).');
+});
+
+test('T6: the handler binds the pubkeys as params and passes a numeric query timeout to runCypher', () => {
+  const src = safeRead(HANDLER);
+  assert(/runCypher\s*\(/.test(src), 'must execute via the pooled Bolt helper runCypher (ADR 0034), not cypher-shell.');
+  assert(/\$src|\$source/.test(src) && /\$tgt|\$target/.test(src),
+    'pubkeys must be BOUND params ($src/$tgt), not interpolated (the cap/LIMIT are literals; user input is never interpolated).');
+  assert(/runCypher\s*\([\s\S]{0,500}\btimeout\s*:/.test(src),
+    'must pass a transaction config with a numeric `timeout:` — allShortestPaths at cap 20 must be deadline-bounded.');
+});
+
+test('T7: no-path-within-cap maps to {success:true, hops:null, paths:[]} (AC ∞)', () => {
+  const src = safeRead(HANDLER);
+  assert(/hops:\s*null/.test(src) && /paths:\s*\[\s*\]/.test(src),
+    'when allShortestPaths returns no rows, respond {success:true, hops:null, paths:[]} — the UI renders ∞ with no cards.');
+});
+
+test('T8: hops is derived from the path length (paths[0].length - 1) and a truncated flag is set from the LIMIT', () => {
+  const src = safeRead(HANDLER);
+  assert(/length\s*-\s*1/.test(src),
+    'the count must be derived from the actual path: paths[0].length - 1 (count and path can never disagree).');
+  assert(/truncated/.test(src) && /25/.test(src),
+    'must set `truncated` (true when 25 paths were returned, i.e. there may be more) so the UI can say "a random one of 25+".');
+});
+
+test('T9: a query error/timeout is caught and returned as {success:false} (graceful failure, NOT a false path/∞)', () => {
+  const src = safeRead(HANDLER);
+  assert(/catch\s*\([\s\S]{0,300}success:\s*false/.test(src),
+    'an error/timeout must be caught → {success:false, error} so the UI shows "unavailable", never a false path or ∞.');
+});
+
+// ── Backend: route + export ──
+
+test('T10: GET /api/get-follows-hops-paths is registered to handleGetFollowsHopsPaths', () => {
+  const src = safeRead(API_INDEX);
+  assert(/app\.get\(\s*['"]\/api\/get-follows-hops-paths['"]/.test(src),
+    'src/api/index.js must register app.get(\'/api/get-follows-hops-paths\', ...).');
+  assert(/handleGetFollowsHopsPaths/.test(src), 'the route must be wired to users.handleGetFollowsHopsPaths.');
+});
+
+test('T11: handleGetFollowsHopsPaths is re-exported from src/api/export/users/index.js', () => {
+  const src = safeRead(USERS_INDEX);
+  assert(/handleGetFollowsHopsPaths/.test(src), 'src/api/export/users/index.js must re-export handleGetFollowsHopsPaths.');
+});
+
+// ── Frontend: hook ──
+
+test('T12: a useFollowsHopsPaths hook exists, default-exported, fetching the endpoint with AbortController', () => {
+  const src = safeRead(HOOK);
+  assert(/export default function useFollowsHopsPaths/.test(src), 'useFollowsHopsPaths must be the default export.');
+  assert(/\/api\/get-follows-hops-paths\?source=/.test(src) && /target=/.test(src),
+    'the hook must fetch `/api/get-follows-hops-paths?source=${source}&target=${target}`.');
+  assert(/AbortController/.test(src), 'the hook must use an AbortController (its own async lifecycle, non-blocking).');
+});
+
+test('T13: the hook exposes hops/paths/truncated/noPath/loading/error, with noPath from a successful empty result', () => {
+  const src = safeRead(HOOK);
+  for (const field of ['hops', 'paths', 'truncated', 'noPath', 'loading', 'error']) {
+    assert(new RegExp('\\b' + field + '\\b').test(src), `the hook must expose \`${field}\`.`);
+  }
+  assert(/\.length\s*===\s*0|length === 0/.test(src) && /===\s*null/.test(src) && /success/.test(src),
+    'noPath must derive from a SUCCESSFUL empty result (success && paths.length === 0 && hops === null) — so ∞ is never shown for an error.');
+});
+
+// ── Frontend: page ──
+
+test('T14: a BrainstormFollowsHops page exists, default-exported', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'expected a new page at ui/src/pages/BrainstormFollowsHops.jsx.');
+  assert(/export default function BrainstormFollowsHops/.test(src), 'the page must be default-exported as BrainstormFollowsHops.');
+});
+
+test('T15: the page resolves source = logged-in viewer else Owner, and calls useFollowsHopsPaths(source, target)', () => {
+  const src = safeRead(PAGE);
+  assert(/useConfig/.test(src) && /useAuth/.test(src), 'the page must use useAuth (viewer) and useConfig (ownerPubkey).');
+  assert(/user\?\.pubkey/.test(src) && /ownerPubkey/.test(src),
+    'source must be `user?.pubkey || ownerPubkey` (logged-in viewer; else the Owner) — same rule as #38.');
+  assert(/useFollowsHopsPaths\(/.test(src), 'the page must call useFollowsHopsPaths(source, target).');
+});
+
+test('T16: the page renders the path as profile cards that link to /user/<pubkey> (AC path-as-cards + card links)', () => {
+  const src = safeRead(PAGE);
+  assert(/\.map\(/.test(src), 'the path must be rendered by mapping over its nodes (one card per node).');
+  assert(countOf(src, /to=\{`\/user\//g) >= 2 || /to=\{`\/user\/\$\{[^}]*pubkey[^}]*\}`\}/.test(src),
+    'each card must be a <Link to={`/user/${...}`}> (clicking a card navigates to that profile) — distinct from the back-link.');
+  assert(/bsp-follows-avatar|bsp-hops-card|bsp-hops-path/.test(src),
+    'cards must show an avatar (reuse bsp-follows-avatar or a bsp-hops-* card class).');
+});
+
+test('T17: each card shows the Owner-PoV rank = Math.round(influence*100) (AC per-card rank)', () => {
+  const src = safeRead(PAGE);
+  assert(/Math\.round/.test(src) && /influence\s*\*\s*100/.test(src),
+    'rank must be Math.round(influence*100) from the path node\'s Owner-PoV influence — the same derivation as BrainstormReporters.');
+});
+
+test('T18: the page enriches name/pic via /api/profiles (AC card name + picture)', () => {
+  const src = safeRead(PAGE);
+  assert(/\/api\/profiles\?pubkeys=/.test(src),
+    'the page must fetch profile name/pic via /api/profiles?pubkeys=<csv> (batched), as the sibling list pages do.');
+});
+
+test('T19: a re-roll button is rendered ONLY when more than one shortest path exists (AC re-roll + hidden when ≤1)', () => {
+  const src = safeRead(PAGE);
+  assert(/paths\.length\s*>\s*1/.test(src),
+    'the re-roll button must be gated on `paths.length > 1` — hidden for a single path, self-view, and no-path.');
+  assert(/<button/i.test(src), 'there must be a re-roll <button>.');
+});
+
+test('T20: the no-path (∞) state shows a "no follow path" message keyed on noPath, with no cards (AC ∞ state)', () => {
+  const src = safeRead(PAGE);
+  assert(/noPath/.test(src), 'the page must branch on the hook\'s `noPath`.');
+  assert(/There is no follow path from /.test(src),
+    'the no-path state must show "There is no follow path from <source> to <target>" (consistent with #38).');
+});
+
+test('T21: the page shows the hop count, consistent with #38 copy ("…hop(s) away…by follows") (AC count)', () => {
+  const src = safeRead(PAGE);
+  assert(/by follows/.test(src) && / away from /.test(src),
+    'the count line must read like #38: "<target> is N hop(s) away from <source> by follows."');
+  assert(/hop\$\{[^}]*'s'|'hop'\s*:\s*'hops'|'hops'\s*:\s*'hop'/.test(src),
+    'singular/plural: "1 hop" vs "N hops".');
+});
+
+// ── Frontend: route ──
+
+test('T22: App.jsx imports BrainstormFollowsHops and registers /user/:pubkey/follows-hops', () => {
+  const src = safeRead(APP);
+  assert(/import\s+BrainstormFollowsHops\s+from/.test(src), 'App.jsx must import the BrainstormFollowsHops page.');
+  assert(/\/user\/:pubkey\/follows-hops/.test(src), 'App.jsx must register the route /user/:pubkey/follows-hops.');
+});
+
+// ── Frontend: HOPS link activation on the profile page ──
+
+test('T23: the HOPS stat on the profile page is now a <Link> to /user/${pubkey}/follows-hops, enclosing the Hops label (AC link activation)', () => {
+  const src = safeRead(PROFILE);
+  const linkIdx = src.indexOf('/user/${pubkey}/follows-hops');
+  assert(linkIdx !== -1,
+    'the HOPS counter must link to `/user/${pubkey}/follows-hops` (was a non-link <span> in #38).');
+  const hopsIdx = countsLabelIndex(src, 'Hops');
+  assert(hopsIdx !== -1 && hopsIdx > linkIdx,
+    'the follows-hops Link must open BEFORE the Hops counts-row label (it wraps it).');
+  const between = src.slice(linkIdx, hopsIdx);
+  assert(!between.includes('</Link>'),
+    'the Hops label must sit INSIDE the follows-hops <Link> (no closing </Link> between the link and the label).');
+  assert(/bsp-count-link/.test(between),
+    'the activated HOPS counter must carry the bsp-count-link affordance class.');
+});
+
+// ── Regression / guard sentinels (must PASS before AND after) ──
+
+test('R1: the HOPS counter stays placed between Verified Followers and Verified Reporters (#38 placement preserved)', () => {
+  const src = safeRead(PROFILE);
+  const vf = countsLabelIndex(src, 'Verified Followers');
+  const hops = countsLabelIndex(src, 'Hops');
+  const vr = countsLabelIndex(src, 'Verified Reporters');
+  assert(hops !== -1 && vf !== -1 && vr !== -1, 'the Verified Followers / Hops / Verified Reporters counts-row labels must all exist.');
+  assert(vf < hops && hops < vr, `HOPS must remain between Verified Followers and Verified Reporters (VF=${vf}, HOPS=${hops}, VR=${vr}).`);
+});
+
+test('R2: the existing sibling counters/links remain intact (regression)', () => {
+  const src = safeRead(PROFILE);
+  assert(/\/user\/\$\{pubkey\}\/follows\b/.test(src), 'Following → /follows must remain.');
+  assert(/\/user\/\$\{pubkey\}\/followers/.test(src), 'Verified Followers → /followers must remain.');
+  assert(/\/user\/\$\{pubkey\}\/reporters/.test(src), 'Verified Reporters → /reporters must remain.');
+});
+
+test('R3: the #38 /api/get-follows-hops endpoint is still registered (built on, not broken) (regression)', () => {
+  const src = safeRead(API_INDEX);
+  assert(/app\.get\(\s*['"]\/api\/get-follows-hops['"]/.test(src),
+    'the #38 count endpoint /api/get-follows-hops must remain registered.');
+});
+
+test('R4 (guard): /api/get-follows-hops-paths is NOT added to any auth gate — must stay publicly readable', () => {
+  const src = safeRead(AUTH);
+  assert(!/get-follows-hops-paths/.test(src),
+    'the new endpoint must remain public (logged-out viewers use the Owner source). It must NOT appear in any allowlist in src/middleware/auth.js.');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try {
+      await t.fn();
+      console.log(`  ✓ ${t.name}`);
+      pass++;
+    } catch (err) {
+      console.log(`  ✗ ${t.name}`);
+      console.log(`      ${err.message}`);
+      fail++;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -96,6 +96,7 @@ const liveFeedFeedPage = require('./live-feed-feed-page.test.js');
 const verifiedReportersReportColumns = require('./verified-reporters-report-columns.test.js');
 const profileIdentityDetailsPopover = require('./profile-identity-details-popover.test.js');
 const profileFollowsHops = require('./profile-follows-hops.test.js');
+const profileHopsPath = require('./profile-hops-path.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...');
@@ -256,6 +257,9 @@ async function main() {
 
   console.log('\nprofile-follows-hops suite:');
   const profileFollowsHopsResult = await profileFollowsHops.run();
+
+  console.log('\nprofile-hops-path suite:');
+  const profileHopsPathResult = await profileHopsPath.run();
 
   console.log('\nTest Results');
   console.log('-------------');
@@ -437,6 +441,9 @@ async function main() {
   console.log(
     `profile-follows-hops suite:                      ${profileFollowsHopsResult.fail === 0 ? 'PASS' : 'FAIL'} (${profileFollowsHopsResult.pass} passed, ${profileFollowsHopsResult.fail} failed)`
   );
+  console.log(
+    `profile-hops-path suite:                         ${profileHopsPathResult.fail === 0 ? 'PASS' : 'FAIL'} (${profileHopsPathResult.pass} passed, ${profileHopsPathResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -510,7 +517,8 @@ async function main() {
     liveFeedFeedPageResult.fail === 0 &&
     verifiedReportersReportColumnsResult.fail === 0 &&
     profileIdentityDetailsPopoverResult.fail === 0 &&
-    profileFollowsHopsResult.fail === 0;
+    profileFollowsHopsResult.fail === 0 &&
+    profileHopsPathResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/tests/brainstorm/profile-hops-path.spec.js
+++ b/tests/brainstorm/profile-hops-path.spec.js
@@ -1,0 +1,59 @@
+/**
+ * Playwright behavioral check for story #39 / ADR 0035: the HOPS click-through page
+ * and the activated HOPS link.
+ * See engineering-team/stories/profile/39-profile-hops-path.test-plan.md
+ *
+ * SUPPLEMENTARY + LIVE-DATA DEPENDENT (mirrors the #33/#38 specs). The deterministic
+ * coverage is the node suite test/profile-hops-path.test.js (no stack dependency).
+ * This spec verifies the browser-rendered link activation + page that source-regex
+ * can only approximate.
+ *
+ * Preconditions / fragility:
+ *   - A reachable instance (BRAINSTORM_BASE_URL or http://localhost:7778) with the
+ *     change deployed AND a populated FOLLOWS graph (the local stack is stale/near-empty
+ *     per OPEN.md #6 — run against STAGING).
+ *   - Logged-out: the path source is the Owner. The exact path / card count is
+ *     data-dependent, so this spec asserts STRUCTURE (link activates, page renders a
+ *     path of cards, cards link to profiles), not specific people or a specific N.
+ *
+ * Not run pre-implementation (the page/link don't exist yet); exercised at the staging
+ * smoke after the feature deploys.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = process.env.BRAINSTORM_BASE_URL || 'http://localhost:7778';
+// Jack Dorsey — reachable in the FOLLOWS graph from the Owner (owner→jack = 1 on staging).
+const PUBKEY = '04c915daefee38317fa734444acee390a8269fe5810b2241e5e6dd343dfbecc9';
+
+test.describe('Story 39 — follows-hops path page + HOPS link activation', () => {
+  test('the HOPS counter on the profile page is now a link to the follows-hops page', async ({ page }) => {
+    await page.goto(`${BASE_URL}/user/${PUBKEY}`);
+    const counts = page.locator('.bsp-counts');
+    await expect(counts).toBeVisible();
+
+    // The HOPS counter is now an anchor (was a plain span in #38).
+    const hopsLink = counts.getByRole('link', { name: /Hops/i });
+    await expect(hopsLink).toHaveCount(1);
+    await expect(hopsLink).toHaveAttribute('href', new RegExp(`/user/${PUBKEY}/follows-hops`));
+  });
+
+  test('the follows-hops page renders a path of profile cards that link to profiles', async ({ page }) => {
+    await page.goto(`${BASE_URL}/user/${PUBKEY}/follows-hops`);
+
+    // The page loads (back link to the profile present).
+    await expect(page.getByRole('link', { name: /Back to profile/i })).toBeVisible();
+
+    // For a connected pair (owner→jack), at least one card with a link to a /user/ profile renders.
+    // (Exact people / card count are data-dependent — assert structure, not specifics.)
+    const userLinks = page.locator('a[href*="/user/"]');
+    expect(await userLinks.count(), 'the path should render at least one profile card linking to /user/<pubkey>').toBeGreaterThan(0);
+
+    // The page should not have thrown — a known heading/landmark is present.
+    await expect(page.locator('.bsp-content, .bsp-page').first()).toBeVisible();
+  });
+
+  // The re-roll button only appears when more than one shortest path exists between the
+  // chosen pair, and the specific path/people are data-dependent — so the re-roll behavior
+  // and the ∞/self-view states are left as manual/staging checks against known fixtures.
+});

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -68,6 +68,7 @@ import BrainstormProfile from './pages/BrainstormProfile';
 import BrainstormFollows from './pages/BrainstormFollows';
 import BrainstormFollowers from './pages/BrainstormFollowers';
 import BrainstormReporters from './pages/BrainstormReporters';
+import BrainstormFollowsHops from './pages/BrainstormFollowsHops';
 import BrainstormSettings from './pages/BrainstormSettings';
 import BrainstormPersonalization from './pages/BrainstormPersonalization';
 import BrainstormHowSearchWorks from './pages/BrainstormHowSearchWorks';
@@ -119,6 +120,10 @@ const router = createBrowserRouter([
   {
     path: '/user/:pubkey/reporters',
     element: <BrainstormReporters />,
+  },
+  {
+    path: '/user/:pubkey/follows-hops',
+    element: <BrainstormFollowsHops />,
   },
   {
     path: '/settings',

--- a/ui/src/hooks/useFollowsHopsPaths.js
+++ b/ui/src/hooks/useFollowsHopsPaths.js
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook: up to 25 equally-short directed FOLLOWS paths from `source` to `target`
+ * via GET /api/get-follows-hops-paths (story profile #39, ADR 0035). Its own
+ * AbortController-scoped fetch — never blocks render.
+ *
+ * Returns { hops, paths, truncated, noPath, loading, error }:
+ *   - hops:      number (0..20) when a path exists; null otherwise
+ *   - paths:     array of paths, each an ordered [{pubkey, influence}]; [] when none
+ *   - truncated: true when 25 paths were returned (there may be more)
+ *   - noPath:    true ONLY for a confirmed no-path-within-cap (success && hops===null && paths empty) → render ∞
+ *   - error:     set on a failed lookup (!success / fetch error) → render "—" (NOT ∞)
+ */
+export default function useFollowsHopsPaths(source, target) {
+  const [hops, setHops] = useState(null);
+  const [paths, setPaths] = useState([]);
+  const [truncated, setTruncated] = useState(false);
+  const [noPath, setNoPath] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!source || !target) {
+      setHops(null); setPaths([]); setTruncated(false); setNoPath(false); setLoading(false); setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true); setNoPath(false); setError(null);
+
+    fetch(`/api/get-follows-hops-paths?source=${source}&target=${target}`, { signal: controller.signal })
+      .then(r => r.json())
+      .then(json => {
+        if (json?.success) {
+          const ps = json.paths || [];
+          setHops(json.hops);
+          setPaths(ps);
+          setTruncated(!!json.truncated);
+          // Confirmed no path within cap → ∞ (distinct from an error).
+          setNoPath(json.hops === null && ps.length === 0);
+        } else {
+          setHops(null); setPaths([]); setTruncated(false); setNoPath(false);
+          setError(json?.error || 'Hop path unavailable');
+        }
+      })
+      .catch(err => {
+        if (err.name === 'AbortError') return;
+        setHops(null); setPaths([]); setTruncated(false); setNoPath(false);
+        setError(err.message || 'Hop path unavailable');
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [source, target]);
+
+  return { hops, paths, truncated, noPath, loading, error };
+}

--- a/ui/src/pages/BrainstormFollowsHops.jsx
+++ b/ui/src/pages/BrainstormFollowsHops.jsx
@@ -1,0 +1,156 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { nip19 } from 'nostr-tools';
+import { useAuth } from '../context/AuthContext';
+import { useConfig } from '../context/ConfigContext';
+import BrainstormUserMenu from '../components/BrainstormUserMenu';
+import useFollowsHopsPaths from '../hooks/useFollowsHopsPaths';
+
+/* ── Helpers ──────────────────────────────────────────── */
+
+function safeNpub(pubkey) {
+  try { return nip19.npubEncode(pubkey); } catch { return pubkey; }
+}
+function shortNpub(npub) {
+  if (!npub) return '—';
+  return npub.length > 20 ? `${npub.slice(0, 12)}…${npub.slice(-6)}` : npub;
+}
+
+const PROFILE_CHUNK = 50;
+
+/* ── Main component ──────────────────────────────────── */
+
+export default function BrainstormFollowsHops() {
+  const { pubkey } = useParams();
+  const { user, login, logout } = useAuth();
+  const { ownerPubkey } = useConfig();
+
+  // Source = the logged-in viewer, else the instance Owner (same rule as #38).
+  const source = user?.pubkey || ownerPubkey;
+
+  const { hops, paths, truncated, noPath, loading, error } = useFollowsHopsPaths(source, pubkey);
+
+  // Which of the equally-short paths is shown. Reset whenever the path set changes.
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  useEffect(() => { setSelectedIndex(0); }, [paths]);
+
+  const reroll = () => {
+    if (paths.length <= 1) return;
+    let i = selectedIndex;
+    while (i === selectedIndex) i = Math.floor(Math.random() * paths.length);
+    setSelectedIndex(i);
+  };
+
+  // Batch-load names/pics for every pubkey across all paths (so re-roll is instant),
+  // plus source + target for the count-line copy. /api/profiles caps at 50/request.
+  const allPubkeys = useMemo(() => {
+    const s = new Set();
+    paths.forEach(p => p.forEach(n => s.add(n.pubkey)));
+    if (pubkey) s.add(pubkey);
+    if (source) s.add(source);
+    return [...s];
+  }, [paths, pubkey, source]);
+
+  const [profiles, setProfiles] = useState({});
+  useEffect(() => {
+    if (allPubkeys.length === 0) { setProfiles({}); return; }
+    let cancelled = false;
+    (async () => {
+      for (let i = 0; i < allPubkeys.length && !cancelled; i += PROFILE_CHUNK) {
+        const batch = allPubkeys.slice(i, i + PROFILE_CHUNK);
+        try {
+          const r = await fetch(`/api/profiles?pubkeys=${batch.join(',')}`);
+          const j = await r.json();
+          if (!cancelled && j?.profiles) setProfiles(prev => ({ ...prev, ...j.profiles }));
+        } catch { /* tolerate partial profile failures */ }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [allPubkeys]);
+
+  const nameFor = (pk) => {
+    const p = profiles[pk] || {};
+    return p.display_name || p.name || shortNpub(safeNpub(pk));
+  };
+  const targetName = nameFor(pubkey);
+  const sourceName = source ? nameFor(source) : 'the source';
+
+  const countLine = noPath
+    ? `There is no follow path from ${sourceName} to ${targetName}.`
+    : (hops != null
+        ? `${targetName} is ${hops} hop${hops === 1 ? '' : 's'} away from ${sourceName} by follows.`
+        : null);
+
+  const selectedPath = paths[selectedIndex] || [];
+
+  return (
+    <div className="bsp-page">
+      {/* Top bar */}
+      <div className="bsp-top-bar">
+        <a href="/" className="bsp-logo">
+          <img src="/brainstorm.svg" alt="" className="bsp-logo-img" />
+        </a>
+        <div className="bsp-auth">
+          <BrainstormUserMenu user={user} login={login} logout={logout} />
+        </div>
+      </div>
+
+      <div className="bsp-content">
+        {/* Header + back link */}
+        <div className="bsp-follows-header">
+          <Link to={`/user/${pubkey}`} className="bsp-back-link">← Back to profile</Link>
+          <h1 className="bsp-follows-title">Follow hops</h1>
+        </div>
+        <p className="bsp-follows-pov">Ranks are relative to the owner's web of trust.</p>
+
+        {/* Count line */}
+        {!loading && !error && countLine && (
+          <p className="bsp-follows-summary">{countLine}</p>
+        )}
+
+        {/* Body */}
+        {loading && (
+          <div className="bsp-reporters-skeleton" aria-label="Loading path">
+            <div className="bsp-skeleton-row" />
+            <div className="bsp-skeleton-row" />
+            <div className="bsp-skeleton-row" />
+          </div>
+        )}
+        {error && !loading && (
+          <div className="bsp-trust-unavailable">
+            <span className="bsp-trust-icon">🔒</span>
+            <span>Couldn't compute the follow path right now. Try again in a moment.</span>
+          </div>
+        )}
+        {!loading && !error && noPath && (
+          <div className="bsp-empty">No follow path within reach. This account isn't connected by follows from {sourceName}.</div>
+        )}
+        {!loading && !error && !noPath && selectedPath.length > 0 && (
+          <>
+            <div className="bsp-hops-path">
+              {selectedPath.map((node, i) => {
+                const p = profiles[node.pubkey] || {};
+                const name = nameFor(node.pubkey);
+                const rank = node.influence == null ? '—' : Math.round(node.influence * 100);
+                return (
+                  <Link key={`${node.pubkey}-${i}`} to={`/user/${node.pubkey}`} className="bsp-hops-card">
+                    {p.picture
+                      ? <img src={p.picture} alt="" className="bsp-follows-avatar" onError={e => { e.target.style.display = 'none'; }} />
+                      : <div className="bsp-follows-avatar bsp-follows-avatar-ph">{(name || '?')[0].toUpperCase()}</div>}
+                    <span className="bsp-hops-card-name">{name}</span>
+                    <span className="bsp-hops-card-rank" title="Verification Score (owner PoV)">{rank}</span>
+                  </Link>
+                );
+              })}
+            </div>
+            {paths.length > 1 && (
+              <button type="button" className="bsp-follows-colbtn bsp-hops-reroll" onClick={reroll}>
+                ↻ Show a different path{truncated ? ' (of 25+)' : ` (of ${paths.length})`}
+              </button>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -263,13 +263,13 @@ export default function BrainstormProfile() {
                 <span className="bsp-count-value">{fmtCount(verifiedFollowerCount)}</span>
                 <span className="bsp-count-label">Verified Followers</span>
               </Link>
-              {/* Follows-hops (story #38, ADR 0034): live shortestPath source→profile, cap 20.
-                  Non-link for now — the destination page is deferred. ∞ = no path within cap;
-                  "—" = unavailable (error/timeout) or loading; keyed on the hook's noPath. */}
-              <span className={`bsp-count${followsHopsLoading ? ' bsp-count-loading' : ''}`} title={hopsTitle}>
+              {/* Follows-hops (story #38, ADR 0034; link activated #39, ADR 0035): live
+                  shortestPath source→profile, cap 20. Links to the path page in ALL states.
+                  ∞ = no path within cap; "—" = unavailable (error/timeout) or loading. */}
+              <Link to={`/user/${pubkey}/follows-hops`} className={`bsp-count bsp-count-link${followsHopsLoading ? ' bsp-count-loading' : ''}`} title={hopsTitle}>
                 <span className="bsp-count-value">{hopsDisplay}</span>
                 <span className="bsp-count-label">Hops</span>
-              </span>
+              </Link>
               {/* Verified Reporters → /user/:pubkey/reporters. Always a <Link> when >0; a
                   genuine 0 is neutral and not a link; "—" when unavailable; dimmed "—" while
                   loading. The red + 🚩 alarm shows ONLY past the dynamic threshold

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -7146,6 +7146,17 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   font-weight: 600;
 }
 .bsp-follows-npub { font-size: 0.8rem; opacity: 0.85; }
+/* Follows-hops path page (story #39, ADR 0035): a vertical chain of profile cards. */
+.bsp-hops-path { display: flex; flex-direction: column; gap: 0.5rem; max-width: 480px; }
+.bsp-hops-card {
+  display: flex; align-items: center; gap: 0.75rem;
+  padding: 0.6rem 0.85rem; border-radius: 10px;
+  background: rgba(127, 127, 127, 0.08); text-decoration: none; color: inherit;
+}
+.bsp-hops-card:hover { background: rgba(127, 127, 127, 0.16); }
+.bsp-hops-card-name { flex: 1; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bsp-hops-card-rank { opacity: 0.8; font-variant-numeric: tabular-nums; }
+.bsp-hops-reroll { margin-top: 1rem; }
 .bsp-empty { padding: 2rem; text-align: center; opacity: 0.7; }
 /* Skeleton loader for list pages (verified-reporters #3 / ADR 0003) — a designed
    placeholder, never a bare spinner. */


### PR DESCRIPTION
## Summary

Builds the click-through page for the #38 **HOPS** stat and activates its link. The page shows the hop count from the source (logged-in viewer, else the Owner) to the viewed profile **and the actual shortest FOLLOWS path** as a vertical chain of profile cards (pic, name, Owner-PoV rank), with a re-roll button that swaps in a random one of the equally-short paths. Story profile #39, ADR 0035. Built on #38 (already on staging).

## Changes

- **NEW** `src/api/export/users/queries/follows-hops-paths.js` — `GET /api/get-follows-hops-paths?source=&target=`. Validates 64-hex pubkeys (400); self-view short-circuit → single-node path (`hops:0`); else `allShortestPaths((a:NostrUser {pubkey:$src})-[:FOLLOWS*..20]->(b:NostrUser {pubkey:$tgt})) … LIMIT 25` via the pooled driver with a 3s timeout. Returns up to 25 ordered `[{pubkey,influence}]` paths + a `truncated` flag. 3-state: `{paths}` / `{hops:null,paths:[]}` (∞) / `{success:false}` (unavailable). Public (un-gated).
- `src/api/index.js` + `src/api/export/users/index.js` — register/export the endpoint.
- **NEW** `ui/src/hooks/useFollowsHopsPaths.js` — async AbortController hook (`{hops,paths,truncated,noPath,loading,error}`).
- **NEW** `ui/src/pages/BrainstormFollowsHops.jsx` — the `/user/:pubkey/follows-hops` page: vertical profile-card chain (cards link to `/user/<pubkey>`, rank = `round(influence*100)`), re-roll button when >1 path, ∞/self-view/loading/error states; pic/name via batched `/api/profiles`.
- `ui/src/App.jsx` — route registered.
- `ui/src/pages/BrainstormProfile.jsx` — the HOPS stat is now a `<Link>` to the page (all states).
- `ui/src/styles.css` — minimal `.bsp-hops-*` card-column styles.
- Tests: `test/profile-hops-path.test.js` (27 sentinels, wired into `test/test.js`) + Playwright spec; story/ADR 0035/test-plan/review (PASS).

## Test plan

- [ ] After merge: `deploy-staging.yml` runs.
- [ ] Smoke test on staging.brainstorm.world (stability, sanity, regression).
- [ ] **Link activation:** HOPS counter on `/user/<pubkey>` is now an anchor → `/user/<pubkey>/follows-hops`.
- [ ] **Real path values** (couldn't verify locally — stale graph): `/user/<jack>/follows-hops` renders the owner→jack card chain (owner→jack = 1 in #38 → 2 cards); `GET /api/get-follows-hops-paths` returns real `paths` for a connected pair, `{hops:0}` single-node for self-view, `{hops:null,paths:[]}` for unconnected, 400 for bad input. Bundle ships `get-follows-hops-paths`.
- [ ] Re-roll button appears only when >1 shortest path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)