### PR TITLE
feat: dual-z writer — local z on new tags/taggings (tag-federation Half 2 Part B)

### DIFF
--- a/engineering-team/decisions/tag-federation/0003-dual-z-writer.md
+++ b/engineering-team/decisions/tag-federation/0003-dual-z-writer.md
@@ -1,0 +1,177 @@
+# ADR 0003: Dual-z writer — stamp canonical + local `z` on new tags/taggings (W11 applied)
+
+**Status:** Proposed
+**Date:** 2026-06-17
+**Story:** `engineering-team/stories/tag-federation/3-dual-z-writer.md`
+**Builds on:** ADR-0015 (the `LEGACY_*_PUBKEY` named-exception concepts + the literal `82b75e47…` *coordinate*), ADR-0022 (the `nostr-user-tag` hybrid `e`+`a` parent reference), tag-federation ADR 0001 (Half-1 read-union on the **canonical** z), tag-federation ADR 0002 (the per-concept pointer-`b` seed — the "map" the local z roots against), and `community-reference` ADR 0033 (W11 cloud-formation frame, design-only / resolver-gated).
+**Citation hygiene:** ADR ids are epic-scoped. Cite this as **tag-federation ADR 0003**. Every `82b75e47…` in this ADR is the ADR-0015 legacy *coordinate string* (the canonical-z data literal), **never** a hardcoded signing key. The **local** z is always the *runtime* instance TA (`useConfig().taPubkey`) — never a literal.
+
+## Context
+
+Today a newly created **tag element** (`useProfileTags.createTag`, `ui/src/hooks/useProfileTags.js:103-129`) and a newly published **tagging assertion** (`publishProfileTagAssertion`, `ui/src/utils/publishProfileTag.js:45-81`) each carry exactly **one** `z` tag — the **canonical** z, composed from the ADR-0015 legacy literal:
+
+- `createTag` stamps `['z', TAG_HANDLE]` where `TAG_HANDLE = \`39998:${TA_PUBKEY}:tag\`` and `TA_PUBKEY = '82b75e47…'` (`useProfileTags.js:6-7,114`).
+- `publishProfileTagAssertion` stamps `['z', NOSTR_USER_TAG_HANDLE]` where `NOSTR_USER_TAG_HANDLE = \`39998:${TA_PUBKEY}:nostr-user-tag\`` and `TA_PUBKEY = '82b75e47…'` (`publishProfileTag.js:15-16,71`).
+
+The canonical z makes these events network-visible (Half-1 / ADR 0001 federates and read-unions on `#z = 39998:82b75e47…:<slug>` — see the server read filters `NOSTR_USER_TAG_Z_TAG`/`TAG_Z_TAG` at `src/api/profile-tags/index.js:59-61`, used *only* as `#z` scan keys, never to publish). But the **local** instance's own concept list is keyed on the **local** z, `39998:<thisInstanceTA>:<slug>`, which new events never carry — so each instance's local `nostr-user-tag` list stays empty even as its users tag people. Story 2 (ADR 0002) seeds the local header's pointer-`b` to the canonical header (the "map"); this story makes the **writer** stamp the **local** z so locally-authored activity actually lands in the local list (the "membership").
+
+This is the implementation of **W11** ("cloud formation / multi-z stamping"). The full W11 *protocol practice* (consensus-ranked clouds, rotation, caps) is ratified design-only in `community-reference` ADR 0033 and is **resolver-gated** — out of scope here. This ADR applies W11's **floor**: the rule that a published list item carries its **personal/canonical `z` (required, ≥1)** plus additional `z` stamps, and that **`z` order is not load-bearing** (ADR 0033: "consumers MUST NOT depend on it"). Concretely, for the tag stack: exactly **two** z's — canonical + local.
+
+### Concepts touched (no schema change)
+
+- `tag` / `nostr-user-tag`: gain a second `z` per event. Canonical z = `39998:82b75e47…:<slug>` (unchanged, ADR-0015 literal). Local z = `39998:<runtime taPubkey>:<slug>` (NEW). Both headers already exist in the live graph (`/api/concept-graph/node/39998:82b75e47…:{tag,nostr-user-tag}`); ADR 0002 verified the local header exists and gains the pointer-`b` on reinstall. **No json-schema or property change** — this is purely a wire-tag addition on user-signed events. **No firmware reinstall is required *by this ADR*** (Story 2 already triggers the reinstall for the `b` seeds).
+
+### Constraints
+
+- **Canonical z stays the ADR-0015 literal** (`82b75e47…`) — the named-exception data coordinate that keeps historical activity visible across non-dev deployments. **Local z MUST resolve the runtime instance TA** (`useConfig().taPubkey`, backed by `/api/assistant/pubkey`) — never hardcoded (CLAUDE.md "Per-deployment TA pubkey — NEVER hardcode"; AC-6).
+- **Additive only.** The second z MUST NOT regress the ADR-0022 hybrid `e`+`a` shape (AC-3) or Half-1's canonical-z read-union (AC-4). No migration/backfill of existing single-z events (AC-5).
+- **POV-first / decentralization** (CLAUDE.md): unchanged. A z stamp is membership-in-a-concept, carries zero consensus weight, and gates nothing at write time.
+- **No new lint/build tooling** (JS-without-build). UI is ESM (`ui/package.json:5` → `"type": "module"`); the root test runner is CJS + Playwright — ESM UI utils are not `require()`-able from it (prior-story constraint; see Verification).
+
+## Options considered
+
+The genuinely-open seams are **(a) where/how the local z is added** and **(b) whether to factor the two-coordinate composition into a shared helper**. Two cross-cutting threads also need a decision: **how the writer obtains `taPubkey`** and **the exact stamping rule (W11)**.
+
+### Option A — add the local z inline at each of the two writers; thread `taPubkey` as an explicit function argument (chosen)
+
+`createTag` and `publishProfileTagAssertion` each build the local handle inline next to the existing canonical handle and append a second `['z', …]` entry. The runtime `taPubkey` is read via `useConfig()` at the React layer (the hook `useProfileTags` and the page `Tag.jsx`) and passed **into** the pure writer functions as a new named arg (`localTaPubkey`). The pure functions never call a hook — they stay testable, side-effect-light, and honor the existing "single source of truth for the wire shape" comment block.
+
+- **Pros:** Mirrors exactly how the codebase already does z composition (a per-file `…_HANDLE` const + an inline `['z', HANDLE]` push). The canonical literal stays put as the ADR-0015 exception; only the local handle is computed. Keeping `taPubkey` as a function arg (not a hook call inside the util) preserves the pure-function boundary the ESM-vs-CJS test reality needs (source-contract regex + any pure unit). Two writers, two ~2-line edits, plus arg-threading at the two call sites — small, reviewable, no new module. Both z's are emitted *by construction*, which is exactly what the dev-box degenerate case (below) needs to be testable.
+- **Cons:** The two-coordinate shape (`canonical = literal`, `local = runtime`) is duplicated across the two files. Mitigated: it's two short, identical idioms already living beside three sibling literals (`publishTagPin.js` is the third), and each writer's wire shape is deliberately co-located per the existing file-level doc contract.
+
+### Option B — factor a shared `dualZ(slug, localTaPubkey)` helper into a new util, imported by both writers
+
+A single function returns `[['z', \`39998:82b75e47…:${slug}\`], ['z', \`39998:${localTaPubkey}:${slug}\`]]`.
+
+- **Pros:** DRY; one place defines "two z's, canonical-then-local"; one place to extend if W11's cap grows beyond two (ADR 0033's eventual `k`).
+- **Cons:** Premature. ADR 0033's multi-z cap is resolver-gated and **explicitly deferred** — building the generalized cloud-stamper now would either be a stub or pull resolver concerns into a write-time util that has none. It also **co-locates the ADR-0015 literal with a runtime value in a new shared module**, inviting a future refactor to "unify" them into one runtime lookup — the precise regression the named exception forbids (a reviewer would have to re-derive the split every time). The existing pattern deliberately keeps each writer's wire shape self-contained and commented; a new cross-writer util erodes that. Rejected for now; revisit if/when ADR 0033's resolver lands and a real third stamp appears.
+
+### Option C — read `taPubkey` inside the util via a module-level fetch of `/api/assistant/pubkey`
+
+The util fetches the runtime TA itself, removing the threading.
+
+- **Cons:** Adds a network round-trip and async/caching surface to a pure wire-builder; `ConfigProvider` already fetches `/api/assistant/pubkey` once app-wide (`ui/src/context/ConfigContext.jsx:20-24`) and exposes it via `useConfig()` — re-fetching duplicates that and breaks the pure-function testability. Rejected.
+
+## Decision
+
+**Option A.** Add the local z **inline at each of the two writers**, keeping the canonical z as the unchanged ADR-0015 literal; obtain the runtime `taPubkey` via `useConfig()` at the React layer and **thread it as an explicit `localTaPubkey` argument** into the pure writer functions. No new shared module (Option B deferred to the W11/ADR-0033 resolver work).
+
+### The W11 stamping rule (this story's design deliverable)
+
+For a new **tag element** (kind 39999, `createTag`) and a new **tagging assertion** (kind 39999, `publishProfileTagAssertion`), the event's `tags` array carries **two `z` tags** for its concept:
+
+1. **canonical** — `['z', '39998:82b75e47…:<slug>']` — the ADR-0015 literal; unchanged; the network-identity coordinate Half-1 federates and read-unions on. **Always present (required, ≥1).**
+2. **local** — `['z', '39998:<runtime taPubkey>:<slug>']` — `<runtime taPubkey>` = `useConfig().taPubkey`; NEW; the membership coordinate that lands the event in *this* instance's local concept list.
+
+Both are emitted together, by construction, on every new tag/tagging (they always co-occur). **Ordering is canonical-then-local by convention but is NOT load-bearing** — `z` is a NIP-01 single-character indexed tag, multi-value; relays index each value independently and readers `#z`-scan/union per value (confirmed: every server reader filters on a single `#z` value and unions results — `src/api/profile-tags/index.js:179,237,306,…`; none enumerate or order-compare the writer's z array). The rule is stated generally (the reusable "≥1 personal z + additional z stamps, order-free" convention from ADR 0033), but the **implementation is scoped to the tag writer's two coordinates only** — no cloud, no cap, no rotation (those stay resolver-gated in ADR 0033).
+
+### Open-question resolutions
+
+- **OQ-1 (z ordering & multiplicity):** Order does **not** matter. `z` is NIP-01 multi-value indexed; readers union per-value and are order-insensitive (verified across `src/api/profile-tags/index.js`). We emit **canonical-then-local** purely for diff/readability stability. Multiplicity here is exactly **two** (one canonical + one local); the general W11 cap (>2) is ADR-0033 resolver-gated and out of scope.
+- **OQ-2 (composition with the ADR-0022 hybrid `e`+`a`):** **No collision.** `z` and `a` are different tag names indexing different namespaces. The `a`-coordinate keeps its ADR-0022 author semantics — `['a', '39999:<tagAuthorPubkey>:<slug>']` (kind **39999**, the tag-element *author*'s pubkey) — while the new local z is `['z', '39998:<instanceTA>:<slug>']` (kind **39998**, the *instance* TA). Different kind prefix, different pubkey role, different tag name. The dual-z is purely additive: the assertion writer keeps `d`/`p`/`a`/`e`/`polarity` and its `content` JSON mirror byte-for-byte; we only append one `z` (AC-3).
+- **OQ-3 (writer surface scope):** **Client-only.** The only paths that *publish/sign* kind-39999 tag/tagging events are the two client writers (`publishProfileTagAssertion` and `createTag`). The server `src/api/profile-tags/index.js` references the z handles **solely as `#z` read filters** (`:59-61` consts → `:179/237/306/…` scans); it never signs or publishes a tag/tagging, so there is **no server-side writer to change**. (`publishTagPin.js` `pinTag` is the *tag-pinning* concept, out of this story's scope per AC-1/AC-2 which name tag + tagging only.)
+- **OQ-4 (local-header existence dependency):** The local z assumes `39998:<localTA>:<slug>` exists. **Confirmed:** firmware install materializes the TA-authored local header for each concept (verified live in ADR 0002 — all three local headers exist on this box, e.g. `nostr-user-tag` id `7df925f7…`). Story 2's seeded pointer-`b` is appended **to** that header and does **not** change its address/existence — `b` is an added wire tag on the same header, not a re-keying. So the local z always has a header to join.
+
+## Consequences
+
+**Enables:**
+- New tags/taggings land in the publishing instance's **local** concept list (`39998:<instanceTA>:nostr-user-tag`) while staying network-visible via the canonical z (AC-1, AC-2, AC-4). The dual-z "map" (ADR 0002) + "membership" (this) together make the local `/tapestry` concept browser correct on every instance.
+
+**Constrains / debt:**
+- Two writer files now duplicate the canonical-literal-+-runtime-local idiom (accepted; Option B deferred until ADR-0033's resolver makes a shared multi-z stamper non-premature).
+- The two call sites (`useProfileTags`, `Tag.jsx`) must thread `localTaPubkey`; a future caller that forgets it would drop the local z (no network regression — canonical still ships). Mitigation: a dev-time guard/log when `localTaPubkey` is absent/malformed, mirroring the existing `authorPubkey` guard at `publishProfileTag.js:54-56` (do **not** hard-throw — a missing local TA must not block the canonical publish; AC-5/decentralization).
+- **No migration** (AC-5): old single-z events stay canonical-only and network-visible; they will not retroactively appear in local lists. Accepted per story Out-of-scope.
+
+**Firmware reinstall required?** **No** — no concept/schema/manifest change in *this* ADR (the writer adds a wire tag to user-signed events; the schema is unchanged). The reinstall that seeds the pointer-`b` belongs to Story 2 (ADR 0002).
+
+## Implementation notes
+
+Concrete, file:line-anchored. The Implementer edits two writer files and two call sites; the Tester writes source-contract regex tests (ESM constraint) + Playwright live-verify.
+
+### 1. `ui/src/hooks/useProfileTags.js` — tag-element writer (`createTag`, `:103-129`)
+
+- Add a runtime TA read at the top of the hook: `const { taPubkey } = useConfig();` (import `useConfig` from `../context/ConfigContext`). `ConfigProvider` is mounted app-wide (`ui/src/main.jsx:11`), so this is in-context.
+- In `createTag`, compose the local handle from the runtime value and append the second z. The canonical `TAG_HANDLE` (`:7`, the `82b75e47…` literal) is **unchanged**.
+
+Before (`:112-115`):
+```js
+tags: [
+  ['d', slug],
+  ['z', TAG_HANDLE],
+],
+```
+After:
+```js
+tags: [
+  ['d', slug],
+  ['z', TAG_HANDLE],                          // canonical (ADR-0015 literal) — unchanged
+  ['z', `39998:${taPubkey}:tag`],             // local (runtime instance TA) — W11, tag-federation ADR 0003
+],
+```
+- Guard (non-fatal, mirrors `publishProfileTag.js:54-56`): if `taPubkey` is missing/malformed, skip the **local** z and `console.warn` — never block the canonical publish. (The Tester decides whether to assert the warn path.)
+- Thread `taPubkey` into the assertion writer too — `buildAndPublishAssertion` (`:71-74`) calls `publishProfileTagAssertion`; pass `localTaPubkey: taPubkey` (see §2).
+
+### 2. `ui/src/utils/publishProfileTag.js` — tagging-assertion writer (`publishProfileTagAssertion`, `:45-81`)
+
+- Extend the signature to accept `localTaPubkey`: `publishProfileTagAssertion({ tag, targetPubkey, polarity, localTaPubkey })`.
+- Append the local z **after** the canonical `NOSTR_USER_TAG_HANDLE` (`:16,71`, the `82b75e47…` literal — unchanged). The ADR-0022 `a`/`e`/`d`/`p`/`polarity` lines and the `content` JSON are **untouched** (AC-3).
+
+Before (`:66-73`):
+```js
+tags: [
+  ['d', dTag],
+  ['p', targetPubkey],
+  ['a', tagAddress],
+  ['e', tag.eventId],
+  ['z', NOSTR_USER_TAG_HANDLE],
+  ['polarity', String(polarity)],
+],
+```
+After:
+```js
+tags: [
+  ['d', dTag],
+  ['p', targetPubkey],
+  ['a', tagAddress],
+  ['e', tag.eventId],
+  ['z', NOSTR_USER_TAG_HANDLE],               // canonical (ADR-0015 literal) — unchanged
+  ['z', `39998:${localTaPubkey}:nostr-user-tag`], // local (runtime TA) — W11, tag-federation ADR 0003
+  ['polarity', String(polarity)],
+],
+```
+- Same non-fatal guard: missing/malformed `localTaPubkey` → omit the local z + warn; never block. (The existing `authorPubkey` guard hard-throws because a missing `a` would re-grow the legacy set; a missing *local z* has no such cost — canonical still ships — so it must **not** throw.)
+
+### 3. Call sites — thread the runtime `taPubkey`
+
+- **`ui/src/hooks/useProfileTags.js`** — `buildAndPublishAssertion` (`:71-74`): pass `localTaPubkey: taPubkey` (already read in §1) into `publishProfileTagAssertion`. `applyTag`/`disputeTag`/`createTag` flow through this and through §1; no other change needed in `ProfileTagsSection.jsx` (it consumes the hook's returned callbacks).
+- **`ui/src/pages/Tag.jsx`** — `handleApply`/`handleDispute` (`:~95-103`) call `publishProfileTagAssertion` directly. Add `const { taPubkey } = useConfig();` at the component top and pass `localTaPubkey: taPubkey` in both calls.
+
+### 4. Testability hooks (ESM-vs-CJS reality)
+
+The two writers are ESM under `ui/` and are **not** `require()`-able from the CJS root runner (`package.json:13` → `node test/test.js`) — same constraint as prior tag stories. Therefore:
+- **Source-contract regex tests** (CJS-friendly `readFileSync` over the two files): assert each writer's `tags` array contains **both** a canonical `['z', '39998:82b75e47…:<slug>']` literal/const reference **and** a runtime-composed `['z', \`39998:${…}:<slug>\`]` whose interpolation is `taPubkey`/`localTaPubkey` (not a literal). Assert the canonical literal is still present (no accidental replacement) and the ADR-0022 `a`/`e` lines are intact in `publishProfileTag.js` (AC-3 regression guard). Assert no new `82b75e47…` literal was introduced for the *local* handle (AC-6 anti-hardcode).
+- **Playwright live-verify** (against the running dev stack) per §Verification.
+
+## Verification plan (live, on the dev stack)
+
+1. Log in via NIP-07; create a new tag and/or apply a tagging through the UI (profile chip popover or `/tag/:slug` page).
+2. Fetch the published kind-39999 event from the local relay and assert it carries **two `z` tags**: the canonical `39998:82b75e47…:<slug>` **and** the local `39998:<localTA>:<slug>`; and (for the assertion) that the ADR-0022 `['a','39999:<author>:<slug>']` + `['e',<id>]` shape is intact (AC-3).
+3. Load the local concept list `39998:<localTA>:nostr-user-tag` (the `/tapestry` browser or `/api/profile-tags` `#z`-scan) and confirm the new tagging now appears in it (AC-4) — while remaining network-visible (canonical z).
+
+### ⚠️ Dev-box degenerate-z caveat (important)
+
+On **this dev box the local TA equals the canonical coordinate** (`/api/assistant/pubkey` → `82b75e47…`, verified in ADR 0002). So the two z handles are **identical strings** here — the writer emits `['z','39998:82b75e47…:<slug>']` twice. This is the same self-loop collapse Story 2 flagged. The distinct-value case only manifests on a **non-dev** instance (different runtime TA).
+
+Therefore the test must assert the writer **emits both z coordinates by construction** — i.e. that **two** `['z', …]` entries are produced and that the *second* one is composed from the **runtime `taPubkey` argument** (not a literal) — rather than asserting the two values differ. The source-contract regex (one canonical-literal z + one runtime-interpolated z) proves the mechanism regardless of whether the two resolve equal on this box. A reviewer/Tester verifying on a non-dev TA (or by stubbing `taPubkey` to a different value in a unit harness if/when one exists) would then see two distinct values; on the dev box, "two z entries, second one runtime-sourced" is the assertion of record.
+
+### David verification breadcrumb (AC-7)
+
+The PR description carries the explicit note (consistent with Story 2's "one pointer-`b` per header" breadcrumb): **"each new Tag and Tagging now carries TWO `z` tags — canonical (`82b75e47…`, network identity, unchanged) + local (runtime instance TA, NEW for the local list); existing single-z events are not migrated."** Plus the reversal breadcrumb: removing the second `['z', …]` line from each writer reverts to single-z behavior with no data migration.
+
+## Out of scope
+
+- The full W11 cloud practice — consensus-ranked clouds, rotation, the cap `k`, re-stamping (all resolver-gated in `community-reference` ADR 0033).
+- Migrating/backfilling existing single-z events (AC-5; none).
+- The pointer-`b` seed / manifest / firmware reinstall (Story 2 / ADR 0002).
+- Adding the local z to `tag-pinning` (`publishTagPin.js`) — this story scopes to tag + tagging (AC-1/AC-2); pinning's dual-z, if wanted, is a follow-up.
+- Lazy client self-re-emit of pre-change events to gain the local z (would be the ADR-0022-style optional, eventual path; not built here).

--- a/engineering-team/reviews/tag-federation/3-dual-z-writer.md
+++ b/engineering-team/reviews/tag-federation/3-dual-z-writer.md
@@ -1,0 +1,78 @@
+# Review: Story 3 — Dual-z writer (canonical + local z on new tags/taggings, W11)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-17
+**Epic:** tag-federation (Half 2 — Part B)
+**Branch:** `feat/dual-z-writer` (stacked on `feat/b-tag-primitive`)
+**Diff:** `git diff 548b37bc~1 548b37bc` (implementation commit `548b37bc`)
+**Story:** `engineering-team/stories/tag-federation/3-dual-z-writer.md`
+**ADR:** `engineering-team/decisions/tag-federation/0003-dual-z-writer.md`
+**Test plan:** `engineering-team/stories/tag-federation/3-dual-z-writer.test-plan.md`
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] **Gate 1 — `node test/dual-z-writer.test.js`** → **14 passed, 0 failed.** All 7 prior FAILs flipped green; the 7 baseline PASSes stayed green.
+- [x] **Gate 2a — `node test/nostr-user-tag-hybrid-ea-writer.test.js`** (ADR-0022 e+a regression) → **10 passed, 0 failed.** Proves the hybrid e+a wire shape is intact and the second z is additive.
+- [x] **Gate 2b — `node test/profile-tag-polish.test.js`** → **11 passed, 0 failed.**
+- [x] **Gate 3 — `npm --prefix ui run build`** → **`✓ built in 15.14s`.** Compiles clean. Only output before that is the standard chunk-size advisory (>500 kB), which is a warning, not an error. JSX syntax gate satisfied (`Tag.jsx` is the only changed `.jsx`).
+- [x] **Gate 4 (optional) — `node test/test.js`** → Up through the pin stories all suites green; the **only** red is the documented pre-existing flake `tl-publication-from-pins` → `POST /api/trusted-list/refresh-pinned-tag rejects an unauthenticated call` → "fetch failed" (server-state flake, unrelated to this diff). `dual-z-writer` is registered in the runner (`test/test.js:103,276,472`). No regression attributable to this change. (Concurrent local runs contend on the server port; the standalone suites in Gates 1–3 are the authoritative signal.)
+- [x] _Lint not configured — skipped._
+- [x] _Typecheck not configured — skipped._
+
+## Spec adherence (7 ACs)
+
+- [x] **AC-1 (tag element dual-z):** `useProfileTags.js:124-126` — `createTag` keeps `['z', TAG_HANDLE]` (canonical, unchanged const) and appends `...(hasLocalTa ? [['z', \`39998:${taPubkey}:tag\`]] : [])` (local, runtime-interpolated). Two z entries by construction.
+- [x] **AC-2 (tagging dual-z):** `publishProfileTag.js:80-81` — keeps `['z', NOSTR_USER_TAG_HANDLE]` (canonical) and appends `...(hasLocalTa ? [['z', \`39998:${localTaPubkey}:nostr-user-tag\`]] : [])` (local, runtime).
+- [x] **AC-3 (composes with hybrid e+a — most important regression):** `publishProfileTag.js:61` `tagAddress = \`39999:${tag.authorPubkey}:${tag.slug}\`` unchanged; `['a', tagAddress]` (`:78`) and `['e', tag.eventId]` (`:79`) intact; `content` JSON mirror (`:84-86`) untouched. The local z is appended *after* canonical and *before* `['polarity', …]`, exactly the ADR's "After" block. Gate 2a (10/0) independently confirms the e+a shape is not regressed. The second z is purely additive.
+- [~] **AC-4 (local list populates):** Deferred to deployed-env verification per the ADR/test-plan (live-only, not host-unit-testable). Correctly deferred — see "Things tests can't catch" below. Not a blocker.
+- [x] **AC-5 (no migration / no regression to old events):** No backfill or rewrite of existing events anywhere in the diff. The change is write-time-only on newly-signed events. Confirmed by inspection of all four changed files. (Distinct-value live behavior deferred per below — not a blocker.)
+- [x] **AC-6 (runtime local TA pubkey — anti-hardcode):** Both local z's are template-literal interpolations of the runtime arg (`${taPubkey}` / `${localTaPubkey}`), never a literal. Grep confirms each writer file carries **exactly one** `82b75e47…` occurrence — the pre-existing `const TA_PUBKEY` (`useProfileTags.js:7`, `publishProfileTag.js:15`) — and `Tag.jsx` carries **zero**. No new 64-hex literal introduced. The canonical z is the sanctioned ADR-0015 literal exception; the local z is runtime. CLAUDE.md "never hardcode the TA pubkey" honored.
+- [~] **AC-7 (David verification breadcrumb):** PR-description deliverable, not a code artifact. Outstanding for the eventual PR (the "two z per event, one pointer-`b` per header" note + reversal breadcrumb). Noted as remaining; not a code blocker.
+
+## ADR adherence (Option A + W11 rule)
+
+- [x] **Option A (inline local z at each writer; `taPubkey` threaded as explicit arg):** Implemented exactly. The pure writer `publishProfileTagAssertion` takes `localTaPubkey` as a destructured arg (`:45`) and calls no hook; `createTag` reads `taPubkey` from the hook-level `useConfig()`. No shared `dualZ` helper was introduced (Option B correctly deferred). No module-level `/api/assistant/pubkey` fetch in the util (Option C correctly avoided).
+- [x] **W11 stamping rule:** exactly two z's per event, canonical-then-local, additive. Ordering is by convention only (not load-bearing); the implementation introduces no order dependence.
+- [x] **Non-throwing guard (ADR design decision, user-confirmed):** Both guards are warn+omit via conditional spread. `publishProfileTag.js:67-70` and `useProfileTags.js:115-118` compute `hasLocalTa = /^[0-9a-f]{64}$/.test(… || '')` and, when false, `console.warn` only — the local z is omitted via `...(hasLocalTa ? […] : [])`. **No new throw tied to `localTaPubkey`.** The only throws in `publishProfileTag.js` remain the pre-existing ones: `:29` (publishOrThrow relay-failure), `:47` (`!window.nostr`), `:55` (`authorPubkey`). A missing local z has no network cost — canonical still ships — matching the ADR's rationale for not throwing.
+- [x] **Threading (OQ-3 wiring):** Threaded from **both** call sites. `useProfileTags.js:75` `buildAndPublishAssertion` passes `localTaPubkey: taPubkey` (dep array updated to include `taPubkey`, `:76`); `createTag` dep array also updated (`:140`). `Tag.jsx:98` `handleApply` and `:104` `handleDispute` both pass `localTaPubkey: taPubkey`. No un-threaded call path remains that would silently drop the local z.
+- [x] **React-hooks usage sound:** `useConfig()` is called unconditionally at hook top-level (`useProfileTags.js:23`) and component top-level (`Tag.jsx:44`) — Rules of Hooks satisfied, no conditional/nested call.
+- [x] **No firmware reinstall required by this ADR** (no concept/schema/manifest change — purely a wire-tag addition on user-signed events). Correctly not performed; the pointer-`b` reinstall belongs to Story 2.
+
+## Test-change judgment (Implementer modified a test — scrutinized)
+
+The SOFT non-throw test in `test/dual-z-writer.test.js` was changed from a 220-char-preceding-window heuristic to a precise guard regex `/if\s*\([^)]*\blocalTaPubkey\b[^)]*\)\s*\{[^}]*\bthrow\b/`.
+
+- **(a) Was the original a genuine false-positive?** **Yes.** Adding `localTaPubkey` to the function signature at `publishProfileTag.js:45` places that token ~70 chars before the pre-existing `!window.nostr` throw at `:47` (and within ~220 chars of the `authorPubkey` throw at `:55`). The old window-based heuristic would have matched the *signature's* `localTaPubkey` against an unrelated pre-existing throw and failed — a true false-positive caused precisely by the in-spec signature change, not by any forbidden guard.
+- **(b) Does the refined version still catch a genuine new throw-guard while not false-positiving on the signature?** **Yes.** The function signature is not an `if (…) { … throw }` construct, so it no longer matches. A genuine new hard-throw guard (`if (!localTaPubkey) { throw … }`) still matches and fails. I confirmed the live source has no such guard (the warn+omit branch is `if (!hasLocalTa) { console.warn(...) }` with no throw), and the test PASSes — for the right reason.
+- **(c) Legitimate precision fix or weakened coverage?** **Legitimate precision fix.** It is documented inline in the test comment ("Refined from a crude 220-char-window heuristic… tightened by the Implementer; see review note") and in the implementation commit. It does not weaken real coverage: the test plan already classifies this as a SOFT tripwire (not a positive proof — the positive "warns and still ships canonical" is a live/code-review item). The refinement makes the tripwire *more* targeted (catches the real forbidden pattern, stops flagging the benign signature), not looser. Verdict: acceptable.
+
+## Concept-graph integrity
+- [x] Handles remain `kind:pubkey:slug` form (`39998:<pubkey>:<slug>`, `39999:<pubkey>:<slug>`).
+- [x] No concept definition / schema change → no firmware reinstall required (ADR §"Firmware reinstall required? No"). Correct.
+- [x] No BIBLE re-derivation; the change is a wire-tag append consistent with established patterns.
+
+## Things tests can't catch
+- [x] No secrets introduced. The only 64-hex literals are the pre-existing sanctioned ADR-0015 canonical const (one per writer file).
+- [x] **Dev-box degenerate-z reality:** On this box the runtime TA == canonical (`/api/assistant/pubkey` → `82b75e47…`), so the two z's resolve to identical strings. The source-contract tests correctly assert "two z entries emitted, second runtime-sourced" (the assertion of record per ADR §"Dev-box degenerate-z caveat" + test plan) rather than "values differ." The distinct-value case (AC-4 local-list population, AC-5 no-migration live behavior, and the non-dev distinct-z confirmation) is appropriately deferred to deployed-env verification — the user explicitly chose to leave live testing for whoever merges to a deployed env. **Not a blocker.**
+- [x] `console.warn` lines are intentional dev-time guards per the ADR (warn+omit contract), not leftover debug logging.
+- [x] No commented-out code; comments are the intentional ADR-anchored wire-shape annotations.
+- [x] Error/edge paths: missing/malformed local TA → warn + omit (canonical still ships); the canonical publish is never blocked. Race conditions: N/A (synchronous tag-array construction).
+
+## House rules check
+- [x] Concept Graph API authority respected (no concept redefinition).
+- [x] No new lint/typecheck/build tooling.
+- [x] Per-deployment TA pubkey rule honored: canonical = sanctioned ADR-0015 literal exception; local z = runtime `useConfig().taPubkey`. No `LEGACY_*` const removed.
+
+## Findings
+
+### Blocking
+None.
+
+### Non-blocking
+1. **AC-7 (PR deliverable)** — the David breadcrumb ("each new Tag/Tagging now carries TWO z tags — canonical unchanged + local runtime, NEW for the local list; existing single-z events not migrated" + the reversal breadcrumb: removing the second `['z', …]` line reverts to single-z with no migration) must be carried in the eventual PR description. Tracked, not a code blocker.
+2. **AC-4 / AC-5 live behavior** — local-list population, no-migration confirmation, and the non-dev distinct-z verification remain for deployed-env testing by whoever merges to a non-dev instance. Deferred by explicit user decision; correctly out of the host suite. Tracked, not a blocker.
+
+## Verdict
+**PASS**
+
+The diff implements the ADR's Option A exactly: a purely additive local z stamped at both writers, composed from the runtime instance TA (never hardcoded), threaded from both call sites via top-level `useConfig()`, guarded by warn+omit (no new throw), with the ADR-0022 hybrid e+a shape provably intact (Gate 2a 10/0). All four gates pass (dual-z 14/0, hybrid e+a 10/0, polish 11/0, UI build ✓; the only full-suite red is the documented pre-existing `tl-publication-from-pins` server flake). The Implementer's test change is a legitimate, documented precision fix that removes a real signature-induced false-positive while still catching a genuine forbidden guard. Story 3 should be marked **Done**. Remaining: the AC-7 David breadcrumb for the PR, and AC-4/AC-5 deployed-env verification (both explicitly deferred, neither a code blocker).

--- a/engineering-team/stories/tag-federation/3-dual-z-writer.md
+++ b/engineering-team/stories/tag-federation/3-dual-z-writer.md
@@ -1,7 +1,7 @@
 # Story 3: Dual-z writer — new tags/taggings carry both canonical and local z (W11)
 
 **Epic:** tag-federation (Half 2 — Part B)
-**Status:** Draft
+**Status:** Approved
 **Created:** 2026-06-17
 **Type:** Feature
 

--- a/engineering-team/stories/tag-federation/3-dual-z-writer.md
+++ b/engineering-team/stories/tag-federation/3-dual-z-writer.md
@@ -1,7 +1,7 @@
 # Story 3: Dual-z writer — new tags/taggings carry both canonical and local z (W11)
 
 **Epic:** tag-federation (Half 2 — Part B)
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-17
 **Type:** Feature
 
@@ -21,13 +21,13 @@ As a **user tagging people on my instance**, I want the tags and taggings I crea
 
 ## Acceptance criteria
 
-- [ ] **AC-1 (tag element dual-z):** When a new tag element is created, the published event carries **two** `z` tags: the canonical `39998:82b75e47…:<slug>` **and** the local `39998:<thisInstanceTA>:<slug>`.
-- [ ] **AC-2 (tagging dual-z):** When a new tagging assertion is published, the event carries the same two `z` tags (canonical + local) for its concept.
-- [ ] **AC-3 (composes with hybrid e+a):** The dual-z event still carries the ADR-0022 hybrid `e`+`a` reference shape unchanged — no regression to that wire format; the second z is additive.
-- [ ] **AC-4 (local list populates):** Given a user publishes a new tagging on instance X, when instance X's local concept list (`39998:<X's TA>:nostr-user-tag`) is loaded, then that tagging appears in it — and (per Half 1) it remains visible network-wide as well.
-- [ ] **AC-5 (no migration / no regression to old events):** Existing single-z events are not rewritten; they stay canonical-z-only and remain network-visible. No backfill.
-- [ ] **AC-6 (runtime local TA pubkey):** The local z's `<thisInstanceTA>` is resolved at runtime (never hardcoded) — correct per-deployment on every instance.
-- [ ] **AC-7 (David verification breadcrumb):** The PR carries the explicit "one pointer-`b` per header / two z per event" note to David + the reversal breadcrumb (consistent with Story 2).
+- [x] **AC-1 (tag element dual-z):** When a new tag element is created, the published event carries **two** `z` tags: the canonical `39998:82b75e47…:<slug>` **and** the local `39998:<thisInstanceTA>:<slug>`.
+- [x] **AC-2 (tagging dual-z):** When a new tagging assertion is published, the event carries the same two `z` tags (canonical + local) for its concept.
+- [x] **AC-3 (composes with hybrid e+a):** The dual-z event still carries the ADR-0022 hybrid `e`+`a` reference shape unchanged — no regression to that wire format; the second z is additive.
+- [~] **AC-4 (local list populates):** Given a user publishes a new tagging on instance X, when instance X's local concept list (`39998:<X's TA>:nostr-user-tag`) is loaded, then that tagging appears in it — and (per Half 1) it remains visible network-wide as well. *(Deferred to deployed-env verification — live-only; see review.)*
+- [x] **AC-5 (no migration / no regression to old events):** Existing single-z events are not rewritten; they stay canonical-z-only and remain network-visible. No backfill.
+- [x] **AC-6 (runtime local TA pubkey):** The local z's `<thisInstanceTA>` is resolved at runtime (never hardcoded) — correct per-deployment on every instance.
+- [~] **AC-7 (David verification breadcrumb):** The PR carries the explicit "one pointer-`b` per header / two z per event" note to David + the reversal breadcrumb (consistent with Story 2). *(PR-description deliverable — outstanding for the eventual PR.)*
 
 ## Concepts touched
 
@@ -53,4 +53,4 @@ As a **user tagging people on my instance**, I want the tags and taggings I crea
 - Depends on: `engineering-team/stories/tag-federation/2-per-concept-b-tag-seeds.md` and `…/community-reference/38-…` (Done).
 - ADR: `engineering-team/decisions/tag-federation/0003-dual-z-writer.md`
 - Test plan: `engineering-team/stories/tag-federation/3-dual-z-writer.test-plan.md`
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/tag-federation/3-dual-z-writer.md` (PASS, 2026-06-17)

--- a/engineering-team/stories/tag-federation/3-dual-z-writer.md
+++ b/engineering-team/stories/tag-federation/3-dual-z-writer.md
@@ -52,5 +52,5 @@ As a **user tagging people on my instance**, I want the tags and taggings I crea
 - Epic: `engineering-team/epics/tag-federation.md`. Handoff: `docs/B_TAG_HALF_2_HANDOFF.md` (§4 Story 3, Part 1 — W11). Worksheet: `protocols/worksheet.md` (W11).
 - Depends on: `engineering-team/stories/tag-federation/2-per-concept-b-tag-seeds.md` and `…/community-reference/38-…` (Done).
 - ADR: `engineering-team/decisions/tag-federation/0003-dual-z-writer.md`
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/tag-federation/3-dual-z-writer.test-plan.md`
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/tag-federation/3-dual-z-writer.md
+++ b/engineering-team/stories/tag-federation/3-dual-z-writer.md
@@ -51,6 +51,6 @@ As a **user tagging people on my instance**, I want the tags and taggings I crea
 
 - Epic: `engineering-team/epics/tag-federation.md`. Handoff: `docs/B_TAG_HALF_2_HANDOFF.md` (§4 Story 3, Part 1 — W11). Worksheet: `protocols/worksheet.md` (W11).
 - Depends on: `engineering-team/stories/tag-federation/2-per-concept-b-tag-seeds.md` and `…/community-reference/38-…` (Done).
-- ADR: (filled in after Architecture phase — **the W11 stamping design**)
+- ADR: `engineering-team/decisions/tag-federation/0003-dual-z-writer.md`
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/tag-federation/3-dual-z-writer.test-plan.md
+++ b/engineering-team/stories/tag-federation/3-dual-z-writer.test-plan.md
@@ -1,0 +1,214 @@
+# Test Plan: Story 3 — Dual-z writer (epic tag-federation, Half 2 — Part B)
+
+**Story:** `engineering-team/stories/tag-federation/3-dual-z-writer.md`
+**ADR:** `engineering-team/decisions/tag-federation/0003-dual-z-writer.md`
+**Date:** 2026-06-17
+**Branch:** `feat/dual-z-writer`
+**Test file:** `test/dual-z-writer.test.js` (registered in `test/test.js`)
+
+## Test-level reality (read first)
+
+The two writers under test are **ESM under `ui/`** (`ui/package.json` → `"type": "module"`)
+and are **NOT `require()`-able** from the CJS root runner (`node test/test.js`). This is the
+same constraint every prior tag story hit (`test/tag-read-union.test.js`,
+`test/b-tag-seeds.test.js`, `test/b-tag-primitive.test.js`). Therefore:
+
+- **Runnable-now coverage = SOURCE-CONTRACT regex** over the writer + call-site files
+  (read with `fs.readFileSync`, assert on source text). This proves the *mechanism*:
+  two z entries are emitted by construction, the second composed from the runtime TA arg.
+- **Live behavioral ACs (AC-4, AC-5)** need the running stack + NIP-07 + relay
+  inspection. They are documented below as a **manual/Playwright recipe**, NOT faked.
+- **AC-7** (David PR breadcrumb) is a **PR-description deliverable**, not a test.
+
+### ⚠️ Dev-box degenerate-z caveat (per ADR 0003 §"Dev-box degenerate-z caveat")
+
+On **this dev box** the runtime local TA equals the canonical coordinate
+(`/api/assistant/pubkey` → `82b75e47…`, verified in ADR 0002). So the two z handles
+resolve to **identical strings** here — the writer emits `['z','39998:82b75e47…:<slug>']`
+twice. The distinct-value case **only manifests on a non-dev instance** (different runtime
+TA). Accordingly the **assertion of record** is: *the writer emits **two** `['z', …]` entries
+by construction, the **second** composed from the **runtime `taPubkey`/`localTaPubkey`** arg
+(not a literal)* — NOT "the two values differ". The source-contract regex (one canonical-literal
+z + one runtime-interpolated z + a hard count of exactly two z entries) proves this regardless of
+whether the two resolve equal on this box.
+
+## Coverage map
+
+| Criterion | Test name | Test file | Level |
+|---|---|---|---|
+| AC-1 (tag element dual-z) | `AC-1: createTag … still stamps the canonical z via the TAG_HANDLE const` | `test/dual-z-writer.test.js` | source-contract (runnable-now) |
+| AC-1 (tag element dual-z) | `AC-1: createTag … stamps a NEW local z composed from runtime ${taPubkey} (39998:${taPubkey}:tag)` | `test/dual-z-writer.test.js` | source-contract (runnable-now) |
+| AC-1 + dual-z count | `AC-1 + dual-z-count: createTag … tags array contains EXACTLY two z entries` | `test/dual-z-writer.test.js` | source-contract (runnable-now) |
+| AC-2 (tagging dual-z) | `AC-2: publishProfileTagAssertion still stamps the canonical z via NOSTR_USER_TAG_HANDLE` | `test/dual-z-writer.test.js` | source-contract (runnable-now) |
+| AC-2 (tagging dual-z) | `AC-2: publishProfileTagAssertion stamps a NEW local z composed from runtime ${localTaPubkey} (39998:${localTaPubkey}:nostr-user-tag)` | `test/dual-z-writer.test.js` | source-contract (runnable-now) |
+| AC-2 + dual-z count | `AC-2 + dual-z-count: publishProfileTagAssertion tags array contains EXACTLY two z entries` | `test/dual-z-writer.test.js` | source-contract (runnable-now) |
+| AC-3 (composes with hybrid e+a) | `AC-3: publishProfileTag.js still composes the ADR-0022 hybrid \`a\` coordinate …` | `test/dual-z-writer.test.js` | source-contract (runnable-now) — regression guard |
+| AC-3 (composes with hybrid e+a) | `AC-3: publishProfileTagAssertion tags array still carries BOTH the \`a\` … and \`e\` … lines` | `test/dual-z-writer.test.js` | source-contract (runnable-now) — regression guard |
+| AC-4 (local list populates) | live Playwright/manual recipe (see below) | — | **live-only** (not host-unit-testable) |
+| AC-5 (no migration / network-visible) | live Playwright/manual recipe (see below) | — | **live-only** (not host-unit-testable) |
+| AC-6 (runtime local TA — anti-hardcode) | `AC-6: useProfileTags.js introduces NO new 82b75e47… literal — exactly the one pre-existing canonical const occurrence` | `test/dual-z-writer.test.js` | source-contract (runnable-now) |
+| AC-6 (runtime local TA — anti-hardcode) | `AC-6: publishProfileTag.js introduces NO new 82b75e47… literal — exactly the one pre-existing canonical const occurrence` | `test/dual-z-writer.test.js` | source-contract (runnable-now) |
+| AC-2/AC-3 signature (OQ-3) | `SIGNATURE: publishProfileTagAssertion accepts the new localTaPubkey param …` | `test/dual-z-writer.test.js` | source-contract (runnable-now) |
+| AC-2/AC-3 threading (OQ-3) | `THREADING: useProfileTags.js reads taPubkey via useConfig and passes localTaPubkey …` | `test/dual-z-writer.test.js` | source-contract (runnable-now) |
+| AC-2/AC-3 threading (OQ-3) | `THREADING: Tag.jsx reads taPubkey via useConfig and passes localTaPubkey into both calls` | `test/dual-z-writer.test.js` | source-contract (runnable-now) |
+| Non-throw design (ADR §Consequences) | `SOFT: publishProfileTag.js introduces NO new throw tied to a missing/malformed localTaPubkey …` | `test/dual-z-writer.test.js` | source-contract (runnable-now) — **soft, see limitation** |
+| AC-7 (David breadcrumb) | — | — | **PR-description deliverable**, not a test |
+
+## Notes on specific tests
+
+- **Dual-z-count guard** (the dev-box-degenerate-proof assertion): each writer's `tags`
+  array is extracted by bracket-balancing from its `tags:` opener, then `['z', …]` element
+  openers are counted. Asserting **exactly two** is the assertion of record per the ADR's
+  degenerate-z caveat — we assert two z's are EMITTED, not that their values differ.
+
+- **AC-3 is the most important regression guard.** It asserts the ADR-0022 `tagAddress =
+  \`39999:${tag.authorPubkey}:${tag.slug}\`` composition and both the `['a', tagAddress]`
+  and `['e', tag.eventId]` lines remain intact — i.e. the second z did NOT replace or disturb
+  the hybrid e+a shape. These PASS today (baseline intact); they will FAIL only if the
+  Implementer regresses the wire shape while adding the local z.
+
+- **AC-6 anti-hardcode** counts `82b75e47…` literal occurrences per file and requires
+  **exactly one** (the pre-existing `const TA_PUBKEY` def). canonical = literal (the ADR-0015
+  named exception, allowed); local = runtime (required). A second occurrence = the local z was
+  hardcoded. These PASS today and stay green only if the Implementer composes the local z from
+  the runtime arg.
+
+- **Non-throw SOFT guard — limitation.** This is a regex heuristic: it scans every `throw`
+  and fails if a `localTaPubkey` reference appears within the preceding ~220 chars. It cannot
+  prove the *positive* (that a warn+omit branch exists), only catch an obvious new hard-throw
+  guard tied to the local TA. The positive ("missing local TA warns and still ships the
+  canonical publish") is a **code-review item** and is covered behaviorally only via the live
+  recipe (a publish with a stubbed/absent local TA still lands the canonical z). Treat the SOFT
+  test as a tripwire, not a proof.
+
+## Edge cases
+
+- [x] Second z is **additive**, not a replacement (canonical const reference still present) — AC-1/AC-2 canonical tests + AC-3 e+a guards.
+- [x] No new hardcoded TA literal for the local handle — AC-6 (both files).
+- [x] Exactly two z entries (degenerate-z proof) — dual-z-count tests.
+- [x] Runtime arg threaded from BOTH call sites (hook + page; the page calls twice) — THREADING tests.
+- [x] Writer signature actually accepts the new arg — SIGNATURE test.
+- [x] No new hard-throw on a missing local TA (must warn+omit) — SOFT test (tripwire) + code-review.
+- [ ] **Distinct-value case** (two z's resolve to *different* strings) — **not testable on this dev box** (local TA == canonical). Manifests only on a non-dev instance; see live recipe.
+- [ ] **Local list actually populates** (AC-4) — live-only.
+- [ ] **No migration of old single-z events** (AC-5) — live-only.
+
+## Live Playwright / manual recipe (AC-4, AC-5 — NOT host-unit-testable)
+
+Per ADR 0003 §"Verification plan (live, on the dev stack)". Requires the running dev stack
+(control panel + strfry + Neo4j + Redis in Docker; Concept Graph API at `localhost:8877`) and a
+NIP-07 browser extension logged in. **These are not faked in the host unit suite.**
+
+1. **Emit a dual-z event.** Log in via NIP-07. Create a new tag and/or apply a tagging through
+   the UI (profile chip popover, or the `/tag/:slug` page Apply/Dispute).
+2. **Inspect the published kind-39999 event** on the local relay. Assert it carries **two `z`
+   tags**: the canonical `39998:82b75e47…:<slug>` AND the local `39998:<localTA>:<slug>`. For
+   the **tagging** event, also assert the ADR-0022 `['a','39999:<author>:<slug>']` +
+   `['e',<id>]` shape is intact (AC-3 live confirmation).
+   - **Dev-box note:** on this box `<localTA>` == `82b75e47…`, so the two z values are the
+     **same string** — you will see `['z','39998:82b75e47…:<slug>']` twice. That is the
+     expected degenerate case here; the distinct-value case needs a non-dev TA.
+3. **AC-4 — local list populates.** Load the local concept list
+   `39998:<localTA>:nostr-user-tag` (the `/tapestry` concept browser, or the `/api/profile-tags`
+   `#z`-scan on the local handle) and confirm the new tagging now appears in it — while
+   remaining network-visible via the canonical z.
+   - **Prerequisite:** the local header `39998:<localTA>:nostr-user-tag` must exist (firmware
+     install materializes it; verified live in ADR 0002 — `nostr-user-tag` local header id
+     `7df925f7…` on this box). No reinstall is required *by this story* (the pointer-`b` seed
+     reinstall belongs to Story 2 / ADR 0002).
+4. **AC-5 — no migration.** Confirm a pre-change single-z event is **not** rewritten: it stays
+   canonical-z-only and remains network-visible but does NOT retroactively appear in the local
+   list. (Inspect an event authored before this change; no backfill runs.)
+
+**Non-dev distinct-value verification (optional, off this box):** on an instance whose
+`/api/assistant/pubkey` differs from `82b75e47…`, repeat step 2 and confirm the two z values are
+**distinct** strings — proving the local z genuinely tracks the runtime instance TA (AC-6 live).
+
+## Test infrastructure
+
+- Test framework: Node built-in runner — `node test/test.js` (this suite registered there) or
+  `node test/dual-z-writer.test.js` standalone. No new framework (JS-without-build).
+- Concept Graph API: `localhost:8877` — only needed for the **live recipe** (AC-4/AC-5), not for
+  the source-contract suite.
+- Firmware state: no reinstall required by this story (Story 2 owns the pointer-`b` seed reinstall).
+- Fixtures: none — source-contract tests read the live source files directly.
+
+## How to run
+
+Source-contract suite (runnable now, host-only):
+```
+node test/dual-z-writer.test.js
+```
+Full suite:
+```
+npm test
+```
+Live behavioral (AC-4/AC-5) — manual recipe above against the running dev stack; or Playwright
+via:
+```
+npm run test:playwright
+```
+
+## Verification (red phase)
+
+The new source-contract tests **fail for the right reason** with the current code — the local z
+and the runtime-arg threading do not exist yet (not a typo/import error). Confirmed on
+2026-06-17 on branch `feat/dual-z-writer`:
+
+```
+--- dual-z writer tests (epic tag-federation, Story 3) ---
+  PASS  AC-1: createTag (useProfileTags.js) still stamps the canonical z via the TAG_HANDLE const
+  FAIL  AC-1: createTag (useProfileTags.js) stamps a NEW local z composed from runtime ${taPubkey} (39998:${taPubkey}:tag)
+        createTag's tags array has no runtime-interpolated local z. Expected a second z entry like ['z', `39998:${taPubkey}:tag`] …
+  FAIL  AC-1 + dual-z-count: createTag (useProfileTags.js) tags array contains EXACTLY two z entries
+        … Found 1. tags array was: ['d', slug], ['z', TAG_HANDLE],
+  PASS  AC-2: publishProfileTagAssertion still stamps the canonical z via NOSTR_USER_TAG_HANDLE
+  FAIL  AC-2: publishProfileTagAssertion stamps a NEW local z composed from runtime ${localTaPubkey} (39998:${localTaPubkey}:nostr-user-tag)
+        … has no runtime-interpolated local z …
+  FAIL  AC-2 + dual-z-count: publishProfileTagAssertion tags array contains EXACTLY two z entries
+        … Found 1. …
+  PASS  AC-3: publishProfileTag.js still composes the ADR-0022 hybrid `a` coordinate (39999:${tag.authorPubkey}:${tag.slug})
+  PASS  AC-3: publishProfileTagAssertion tags array still carries BOTH the `a` (tagAddress) and `e` (tag.eventId) lines
+  PASS  AC-6: useProfileTags.js introduces NO new 82b75e47… literal — exactly the one pre-existing canonical const occurrence
+  PASS  AC-6: publishProfileTag.js introduces NO new 82b75e47… literal — exactly the one pre-existing canonical const occurrence
+  FAIL  SIGNATURE: publishProfileTagAssertion accepts the new localTaPubkey param in its destructured signature
+  FAIL  THREADING: useProfileTags.js reads taPubkey via useConfig and passes localTaPubkey into publishProfileTagAssertion
+  FAIL  THREADING: Tag.jsx reads taPubkey via useConfig and passes localTaPubkey into both publishProfileTagAssertion calls
+  PASS  SOFT: publishProfileTag.js introduces NO new throw tied to a missing/malformed localTaPubkey (warn+omit, not throw)
+
+dual-z-writer: 7 passed, 7 failed
+```
+
+The 7 PASSes are intentional baselines/guards that must STAY green through implementation:
+the canonical-z presence (AC-1/AC-2), the ADR-0022 e+a regression guards (AC-3), the
+anti-hardcode literal counts (AC-6), and the non-throw tripwire (SOFT). The 7 FAILs flip green
+once the Implementer adds the local z + threads the runtime arg.
+
+`node --check test/dual-z-writer.test.js` and `node --check test/test.js` both pass.
+```
+```
+
+## Notes for the Implementer
+
+- Two writer edits + two call-site edits, per ADR 0003 §"Implementation notes":
+  - `ui/src/hooks/useProfileTags.js` — `createTag` tags array: append
+    `['z', \`39998:${taPubkey}:tag\`]` after the existing `['z', TAG_HANDLE]`; read
+    `const { taPubkey } = useConfig()` at the top of the hook; thread `localTaPubkey: taPubkey`
+    into `publishProfileTagAssertion` in `buildAndPublishAssertion`.
+  - `ui/src/utils/publishProfileTag.js` — extend the signature to
+    `publishProfileTagAssertion({ tag, targetPubkey, polarity, localTaPubkey })`; append
+    `['z', \`39998:${localTaPubkey}:nostr-user-tag\`]` after the existing
+    `['z', NOSTR_USER_TAG_HANDLE]` (and BEFORE `['polarity', …]`, to match the ADR's after-block).
+    Do NOT touch the `a`/`e`/`d`/`p`/`content` lines (AC-3).
+  - `ui/src/pages/Tag.jsx` — read `const { taPubkey } = useConfig()`; thread
+    `localTaPubkey: taPubkey` into BOTH the `handleApply` and `handleDispute`
+    `publishProfileTagAssertion` calls.
+- **Non-throw guard:** the missing/malformed-localTaPubkey path must `console.warn` and omit the
+  local z — NEVER hard-throw (a missing local z has no cost; the canonical still ships). The
+  existing `authorPubkey` hard-throw is the ONLY throw-guard and must stay. The SOFT test trips
+  if you add a `throw` near a `localTaPubkey` reference.
+- The dual-z-count test requires **exactly two** `['z', …]` entries per writer — do not add a
+  third, and do not drop the canonical.
+- Regexes match a template literal interpolating the runtime var (`\`39998:${taPubkey}:tag\``
+  and `\`39998:${localTaPubkey}:nostr-user-tag\``). Match that shape exactly; the literal pubkey
+  path will (correctly) fail AC-6 and the local-z tests.

--- a/test/dual-z-writer.test.js
+++ b/test/dual-z-writer.test.js
@@ -282,20 +282,17 @@ t('THREADING: Tag.jsx reads taPubkey via useConfig and passes localTaPubkey into
 
 t('SOFT: publishProfileTag.js introduces NO new throw tied to a missing/malformed localTaPubkey (warn+omit, not throw)', () => {
   const src = readSrc(PUBLISH_PROFILE_TAG);
-  // Find any `throw` statement whose preceding ~200 chars reference localTaPubkey — that would
-  // be a NEW hard-throw guard the ADR forbids. (The existing authorPubkey throw is allowed and
-  // does not reference localTaPubkey.)
-  const throwIdxs = [];
-  const re = /throw\b/g;
-  let m;
-  while ((m = re.exec(src)) !== null) throwIdxs.push(m.index);
-  for (const idx of throwIdxs) {
-    const window = src.slice(Math.max(0, idx - 220), idx);
-    assert(!/localTaPubkey/.test(window),
-      'publishProfileTag.js must NOT hard-throw on a missing/malformed localTaPubkey — per ADR 0003 ' +
-      'the guard WARNS and omits the local z so the canonical publish still ships (AC-5/decentralization). ' +
-      'Found a `throw` near a localTaPubkey reference. Use console.warn + omit, not throw.');
-  }
+  // The forbidden pattern is a GUARD: an `if (...)` whose condition tests
+  // localTaPubkey and whose body throws — `if (… localTaPubkey …) { … throw … }`.
+  // (Refined from a crude 220-char-window heuristic, which false-positived on the
+  // function SIGNATURE now containing `localTaPubkey` right before the pre-existing
+  // `!window.nostr`/`authorPubkey` throws. The signature is not a guard. — tightened
+  // by the Implementer; see review note.)
+  const guardThrow = /if\s*\([^)]*\blocalTaPubkey\b[^)]*\)\s*\{[^}]*\bthrow\b/;
+  assert(!guardThrow.test(src),
+    'publishProfileTag.js must NOT hard-throw on a missing/malformed localTaPubkey — per ADR 0003 ' +
+    'the guard WARNS and omits the local z so the canonical publish still ships (AC-5/decentralization). ' +
+    'Found an `if (… localTaPubkey …) { … throw }` guard. Use console.warn + omit, not throw.');
 });
 
 /* ─── Run ─── */

--- a/test/dual-z-writer.test.js
+++ b/test/dual-z-writer.test.js
@@ -1,0 +1,318 @@
+/**
+ * Tests for Story 3 (epic: tag-federation, Half 2 — Part B) — the DUAL-Z WRITER.
+ *
+ * Story: engineering-team/stories/tag-federation/3-dual-z-writer.md
+ * ADR:   engineering-team/decisions/tag-federation/0003-dual-z-writer.md
+ *
+ * Intentionally failing until the two client writers stamp a SECOND `z` (the
+ * local, runtime-TA-composed coordinate) alongside the existing canonical z, and
+ * until the runtime `taPubkey` is threaded into the assertion writer + call sites
+ * (red phase). Today each writer carries exactly ONE z (the canonical literal).
+ *
+ * SCOPE OF THIS FILE — SOURCE-CONTRACT REGEX ONLY (runnable on the host, no live
+ * stack):
+ *   The two writers are ESM under `ui/` (`ui/package.json` → "type":"module") and
+ *   are NOT `require()`-able from this CJS root runner (`node test/test.js`) — the
+ *   same constraint every prior tag story hit (see test/tag-read-union.test.js,
+ *   test/b-tag-seeds.test.js, test/b-tag-primitive.test.js). So the runnable-now
+ *   coverage is SOURCE-CONTRACT regex tests: read the two writer files (+ the two
+ *   call-site files) with fs.readFileSync and assert on their source text.
+ *
+ *   The BEHAVIORAL outcome — AC-4 (a new tagging lands in instance X's local
+ *   concept list `39998:<X's TA>:nostr-user-tag`) and AC-5 (no migration / still
+ *   network-visible) — is NOT host unit-testable: it needs a running stack +
+ *   NIP-07 + relay inspection (ADR 0003 §"Verification plan"). Those ACs are
+ *   documented as a live Playwright/manual recipe in the test plan, NOT faked here.
+ *   AC-7 (David PR breadcrumb) is a PR-description deliverable, not a test.
+ *
+ *   ⚠️ Dev-box degenerate-z caveat (ADR 0003): on THIS box the local TA equals the
+ *   canonical coordinate (`/api/assistant/pubkey` → 82b75e47…), so the two z's
+ *   resolve to IDENTICAL strings here. The assertion of record is therefore "the
+ *   writer emits TWO z entries by construction, the second one composed from the
+ *   RUNTIME taPubkey arg (not a literal)" — NOT "the two values differ". The
+ *   distinct-value case only manifests on a non-dev TA.
+ *
+ * Hand-rolled in the project's existing test style — no new framework (JS-without-build).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+
+const USE_PROFILE_TAGS = 'ui/src/hooks/useProfileTags.js';
+const PUBLISH_PROFILE_TAG = 'ui/src/utils/publishProfileTag.js';
+const TAG_PAGE = 'ui/src/pages/Tag.jsx';
+
+// The ADR-0015 legacy canonical COORDINATE — a data literal (a z-tag value), the
+// sanctioned named exception. The CANONICAL z is allowed to reference this; the
+// LOCAL z must NOT introduce a fresh copy of it (AC-6 anti-hardcode).
+const LEGACY_COORD = '82b75e474dda005e912bcbb910391c60c2b89cc7faf5d3c30b7c59a324973833';
+
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+function readSrc(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf-8'); }
+
+const tests = [];
+function t(name, fn) { tests.push([name, fn]); }
+
+/**
+ * Extract the literal text of the FIRST `tags: [ ... ]` array in a source string
+ * starting at a given offset, balancing brackets. Returns the inner text (between
+ * the outer `[` and its matching `]`). Used to scope assertions to the writer's
+ * tags array (not the whole file).
+ */
+function extractTagsArray(src, fromIndex = 0) {
+  const key = src.indexOf('tags:', fromIndex);
+  assert(key !== -1, 'could not locate a `tags:` array in the source');
+  const open = src.indexOf('[', key);
+  assert(open !== -1, 'could not locate the opening `[` of the `tags:` array');
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === '[') depth++;
+    else if (ch === ']') {
+      depth--;
+      if (depth === 0) return src.slice(open + 1, i);
+    }
+  }
+  throw new Error('unbalanced brackets: could not find the closing `]` of the `tags:` array');
+}
+
+// Count occurrences of a `['z'` element opener inside a tags-array slice.
+function countZEntries(tagsArrayText) {
+  const matches = tagsArrayText.match(/\[\s*['"]z['"]\s*,/g);
+  return matches ? matches.length : 0;
+}
+
+/* ════════════════════════════════════════════════════════════════════════
+   AC-1 (tag element dual-z) — useProfileTags.js `createTag`.
+   The createTag tags array must carry BOTH the canonical z (existing
+   TAG_HANDLE const reference, unchanged) AND a NEW local z composed from a
+   runtime-interpolated `39998:${taPubkey}:tag` template.
+   SOURCE-CONTRACT.
+   ════════════════════════════════════════════════════════════════════════ */
+
+t('AC-1: createTag (useProfileTags.js) still stamps the canonical z via the TAG_HANDLE const', () => {
+  const src = readSrc(USE_PROFILE_TAGS);
+  // Scope to createTag's tags array (createTag builds the only kind-39999 with `['d', slug]`).
+  const fromCreate = src.indexOf('createTag');
+  assert(fromCreate !== -1, 'createTag not found in useProfileTags.js');
+  const tagsArr = extractTagsArray(src, fromCreate);
+  assert(/\[\s*['"]z['"]\s*,\s*TAG_HANDLE\s*\]/.test(tagsArr),
+    `createTag's tags array must still contain the canonical \`['z', TAG_HANDLE]\` (the unchanged ` +
+    `ADR-0015 literal const). The second z must be ADDITIVE — not a replacement. tags array was:\n${tagsArr}`);
+});
+
+t('AC-1: createTag (useProfileTags.js) stamps a NEW local z composed from runtime ${taPubkey} (39998:${taPubkey}:tag)', () => {
+  const src = readSrc(USE_PROFILE_TAGS);
+  const fromCreate = src.indexOf('createTag');
+  const tagsArr = extractTagsArray(src, fromCreate);
+  // A runtime-interpolated local z: ['z', `39998:${taPubkey}:tag`] (template literal
+  // interpolating taPubkey, NOT a hardcoded pubkey).
+  const localZ = /\[\s*['"]z['"]\s*,\s*`39998:\$\{\s*taPubkey\s*\}:tag`\s*\]/;
+  assert(localZ.test(tagsArr),
+    `createTag's tags array has no runtime-interpolated local z. Expected a second z entry ` +
+    "like ['z', `39998:${taPubkey}:tag`] (a template literal interpolating the runtime taPubkey). " +
+    `This is the membership coordinate that lands the new tag in this instance's local concept list ` +
+    `(AC-1). tags array was:\n${tagsArr}`);
+});
+
+t('AC-1 + dual-z-count: createTag (useProfileTags.js) tags array contains EXACTLY two z entries', () => {
+  const src = readSrc(USE_PROFILE_TAGS);
+  const fromCreate = src.indexOf('createTag');
+  const tagsArr = extractTagsArray(src, fromCreate);
+  const n = countZEntries(tagsArr);
+  assert(n === 2,
+    `createTag's tags array must contain exactly TWO \`['z', …]\` entries (canonical + local) — ` +
+    `the dev-box-degenerate-proof assertion of record per ADR 0003 (we assert two z's are EMITTED, ` +
+    `not that their values differ, because on this dev box local TA == canonical so they resolve equal). ` +
+    `Found ${n}. tags array was:\n${tagsArr}`);
+});
+
+/* ════════════════════════════════════════════════════════════════════════
+   AC-2 (tagging dual-z) — publishProfileTag.js `publishProfileTagAssertion`.
+   Must carry BOTH the canonical z (NOSTR_USER_TAG_HANDLE const) AND a NEW
+   local z interpolating `localTaPubkey` (39998:${localTaPubkey}:nostr-user-tag).
+   SOURCE-CONTRACT.
+   ════════════════════════════════════════════════════════════════════════ */
+
+t('AC-2: publishProfileTagAssertion still stamps the canonical z via NOSTR_USER_TAG_HANDLE', () => {
+  const src = readSrc(PUBLISH_PROFILE_TAG);
+  const tagsArr = extractTagsArray(src, src.indexOf('publishProfileTagAssertion'));
+  assert(/\[\s*['"]z['"]\s*,\s*NOSTR_USER_TAG_HANDLE\s*\]/.test(tagsArr),
+    `publishProfileTagAssertion's tags array must still contain the canonical ` +
+    `\`['z', NOSTR_USER_TAG_HANDLE]\` (unchanged ADR-0015 literal const). The second z must be ` +
+    `ADDITIVE. tags array was:\n${tagsArr}`);
+});
+
+t('AC-2: publishProfileTagAssertion stamps a NEW local z composed from runtime ${localTaPubkey} (39998:${localTaPubkey}:nostr-user-tag)', () => {
+  const src = readSrc(PUBLISH_PROFILE_TAG);
+  const tagsArr = extractTagsArray(src, src.indexOf('publishProfileTagAssertion'));
+  const localZ = /\[\s*['"]z['"]\s*,\s*`39998:\$\{\s*localTaPubkey\s*\}:nostr-user-tag`\s*\]/;
+  assert(localZ.test(tagsArr),
+    `publishProfileTagAssertion's tags array has no runtime-interpolated local z. Expected a second ` +
+    "z entry like ['z', `39998:${localTaPubkey}:nostr-user-tag`] (a template literal interpolating the " +
+    `runtime localTaPubkey arg, NOT a hardcoded pubkey). This is the membership coordinate (AC-2). ` +
+    `tags array was:\n${tagsArr}`);
+});
+
+t('AC-2 + dual-z-count: publishProfileTagAssertion tags array contains EXACTLY two z entries', () => {
+  const src = readSrc(PUBLISH_PROFILE_TAG);
+  const tagsArr = extractTagsArray(src, src.indexOf('publishProfileTagAssertion'));
+  const n = countZEntries(tagsArr);
+  assert(n === 2,
+    `publishProfileTagAssertion's tags array must contain exactly TWO \`['z', …]\` entries ` +
+    `(canonical + local) — the dev-box-degenerate-proof assertion of record per ADR 0003 (we assert ` +
+    `two z's are EMITTED, not that their values differ, because on this dev box local TA == canonical). ` +
+    `Found ${n}. tags array was:\n${tagsArr}`);
+});
+
+/* ════════════════════════════════════════════════════════════════════════
+   AC-3 (composes with ADR-0022 hybrid e+a) — REGRESSION GUARD (most important).
+   The second z must NOT have replaced or disturbed the e+a shape. The `a`/`e`
+   lines and the tagAddress = `39999:${tag.authorPubkey}:${tag.slug}` composition
+   must remain intact.
+   SOURCE-CONTRACT.
+   ════════════════════════════════════════════════════════════════════════ */
+
+t('AC-3: publishProfileTag.js still composes the ADR-0022 hybrid `a` coordinate (39999:${tag.authorPubkey}:${tag.slug})', () => {
+  const src = readSrc(PUBLISH_PROFILE_TAG);
+  const tagAddr = /tagAddress\s*=\s*`39999:\$\{\s*tag\.authorPubkey\s*\}:\$\{\s*tag\.slug\s*\}`/;
+  assert(tagAddr.test(src),
+    'publishProfileTag.js must STILL compose the ADR-0022 tagAddress as ' +
+    '`39999:${tag.authorPubkey}:${tag.slug}`. The dual-z change must be additive — it must not ' +
+    'disturb the hybrid e+a parent reference (AC-3 regression guard).');
+});
+
+t('AC-3: publishProfileTagAssertion tags array still carries BOTH the `a` (tagAddress) and `e` (tag.eventId) lines', () => {
+  const src = readSrc(PUBLISH_PROFILE_TAG);
+  const tagsArr = extractTagsArray(src, src.indexOf('publishProfileTagAssertion'));
+  assert(/\[\s*['"]a['"]\s*,\s*tagAddress\s*\]/.test(tagsArr),
+    `publishProfileTagAssertion's tags array must still contain \`['a', tagAddress]\` (ADR-0022 ` +
+    `hybrid parent reference). The second z must not replace it. tags array was:\n${tagsArr}`);
+  assert(/\[\s*['"]e['"]\s*,\s*tag\.eventId\s*\]/.test(tagsArr),
+    `publishProfileTagAssertion's tags array must still contain \`['e', tag.eventId]\` (ADR-0022 ` +
+    `applied-version provenance). The second z must not replace it. tags array was:\n${tagsArr}`);
+});
+
+/* ════════════════════════════════════════════════════════════════════════
+   AC-6 (runtime local TA — anti-hardcode). BOTH files. The LOCAL z handle is
+   composed from a runtime variable (taPubkey / localTaPubkey interpolation), and
+   NO new 82b75e47…-style 64-hex literal was introduced for the local handle. The
+   ONLY allowed 82b75e47… literal is the pre-existing canonical const(s): exactly
+   one per file (TAG_HANDLE / NOSTR_USER_TAG_HANDLE def). canonical = literal
+   (allowed); local = runtime (required).
+   SOURCE-CONTRACT.
+   ════════════════════════════════════════════════════════════════════════ */
+
+t('AC-6: useProfileTags.js introduces NO new 82b75e47… literal — exactly the one pre-existing canonical const occurrence', () => {
+  const src = readSrc(USE_PROFILE_TAGS);
+  const occurrences = (src.match(new RegExp(LEGACY_COORD, 'g')) || []).length;
+  assert(occurrences === 1,
+    `useProfileTags.js must contain the ADR-0015 canonical literal exactly ONCE — the pre-existing ` +
+    `\`const TA_PUBKEY = '82b75e47…'\`. A second occurrence means the LOCAL z was hardcoded instead of ` +
+    `composed from the runtime taPubkey (CLAUDE.md "Per-deployment TA pubkey — NEVER hardcode"; AC-6). ` +
+    `Found ${occurrences} occurrences.`);
+});
+
+t('AC-6: publishProfileTag.js introduces NO new 82b75e47… literal — exactly the one pre-existing canonical const occurrence', () => {
+  const src = readSrc(PUBLISH_PROFILE_TAG);
+  const occurrences = (src.match(new RegExp(LEGACY_COORD, 'g')) || []).length;
+  assert(occurrences === 1,
+    `publishProfileTag.js must contain the ADR-0015 canonical literal exactly ONCE — the pre-existing ` +
+    `\`const TA_PUBKEY = '82b75e47…'\`. A second occurrence means the LOCAL z was hardcoded instead of ` +
+    `composed from the runtime localTaPubkey arg (AC-6 anti-hardcode). Found ${occurrences} occurrences.`);
+});
+
+/* ════════════════════════════════════════════════════════════════════════
+   AC-2/AC-3 signature + threading — the local z is useless if the runtime arg
+   isn't accepted by the writer and threaded from the call sites (OQ-3 wiring).
+   SOURCE-CONTRACT.
+   ════════════════════════════════════════════════════════════════════════ */
+
+t('SIGNATURE: publishProfileTagAssertion accepts the new localTaPubkey param in its destructured signature', () => {
+  const src = readSrc(PUBLISH_PROFILE_TAG);
+  // The signature destructures its single object arg: { tag, targetPubkey, polarity, localTaPubkey }
+  const sig = /publishProfileTagAssertion\s*\(\s*\{[^}]*\blocalTaPubkey\b[^}]*\}\s*\)/;
+  assert(sig.test(src),
+    'publishProfileTagAssertion must extend its destructured signature to accept `localTaPubkey` ' +
+    '(e.g. `publishProfileTagAssertion({ tag, targetPubkey, polarity, localTaPubkey })`). Without the ' +
+    'param the threaded runtime TA never reaches the writer and the local z cannot be composed (OQ-3).');
+});
+
+t('THREADING: useProfileTags.js reads taPubkey via useConfig and passes localTaPubkey into publishProfileTagAssertion', () => {
+  const src = readSrc(USE_PROFILE_TAGS);
+  assert(/useConfig/.test(src) && /taPubkey/.test(src),
+    'useProfileTags.js must read the runtime TA via `useConfig()` and reference `taPubkey` ' +
+    '(the local z source). Neither appears — the runtime TA is not wired in.');
+  // The assertion call site (buildAndPublishAssertion) must thread localTaPubkey (or taPubkey) in.
+  const threaded = /publishProfileTagAssertion\s*\(\s*\{[^}]*\b(?:localTaPubkey|taPubkey)\b[^}]*\}/;
+  assert(threaded.test(src),
+    'useProfileTags.js must thread the runtime TA into publishProfileTagAssertion ' +
+    '(e.g. `publishProfileTagAssertion({ tag, targetPubkey, polarity, localTaPubkey: taPubkey })`). ' +
+    'The local z is dropped if the arg is not threaded (OQ-3 wiring).');
+});
+
+t('THREADING: Tag.jsx reads taPubkey via useConfig and passes localTaPubkey into both publishProfileTagAssertion calls', () => {
+  const src = readSrc(TAG_PAGE);
+  assert(/useConfig/.test(src) && /taPubkey/.test(src),
+    'Tag.jsx must read the runtime TA via `useConfig()` and reference `taPubkey` for its direct ' +
+    'publishProfileTagAssertion calls (handleApply / handleDispute). Neither appears — not wired.');
+  // Both handleApply and handleDispute call publishProfileTagAssertion directly; both must thread the arg.
+  const calls = src.match(/publishProfileTagAssertion\s*\(\s*\{[^}]*\}/g) || [];
+  assert(calls.length >= 2,
+    `Tag.jsx is expected to call publishProfileTagAssertion at least twice (apply + dispute); ` +
+    `found ${calls.length}.`);
+  for (const call of calls) {
+    assert(/\b(?:localTaPubkey|taPubkey)\b/.test(call),
+      'every publishProfileTagAssertion call in Tag.jsx must thread the runtime TA ' +
+      '(`localTaPubkey: taPubkey`). An un-threaded call silently drops the local z (OQ-3). ' +
+      `Offending call:\n${call}`);
+  }
+});
+
+/* ════════════════════════════════════════════════════════════════════════
+   Non-throwing guard (the design choice) — SOFT / source-contract.
+   ADR 0003: a missing/malformed local TA must WARN+omit, NEVER hard-throw
+   (a missing local z has no cost — the canonical still ships). The ONLY
+   throw-guard tied to a pubkey arg is the existing authorPubkey guard; no NEW
+   throw may be introduced for taPubkey/localTaPubkey.
+   See test-plan note on the robustness limitation of this regex.
+   ════════════════════════════════════════════════════════════════════════ */
+
+t('SOFT: publishProfileTag.js introduces NO new throw tied to a missing/malformed localTaPubkey (warn+omit, not throw)', () => {
+  const src = readSrc(PUBLISH_PROFILE_TAG);
+  // Find any `throw` statement whose preceding ~200 chars reference localTaPubkey — that would
+  // be a NEW hard-throw guard the ADR forbids. (The existing authorPubkey throw is allowed and
+  // does not reference localTaPubkey.)
+  const throwIdxs = [];
+  const re = /throw\b/g;
+  let m;
+  while ((m = re.exec(src)) !== null) throwIdxs.push(m.index);
+  for (const idx of throwIdxs) {
+    const window = src.slice(Math.max(0, idx - 220), idx);
+    assert(!/localTaPubkey/.test(window),
+      'publishProfileTag.js must NOT hard-throw on a missing/malformed localTaPubkey — per ADR 0003 ' +
+      'the guard WARNS and omits the local z so the canonical publish still ships (AC-5/decentralization). ' +
+      'Found a `throw` near a localTaPubkey reference. Use console.warn + omit, not throw.');
+  }
+});
+
+/* ─── Run ─── */
+async function run() {
+  console.log('\n--- dual-z writer tests (epic tag-federation, Story 3) ---');
+  let pass = 0, fail = 0;
+  const failures = [];
+  for (const [name, fn] of tests) {
+    try { await fn(); console.log(`  PASS  ${name}`); pass++; }
+    catch (err) { console.log(`  FAIL  ${name}\n        ${err.message}`); failures.push({ name, message: err.message }); fail++; }
+  }
+  console.log(`\ndual-z-writer: ${pass} passed, ${fail} failed`);
+  return { pass, fail, failures };
+}
+
+if (require.main === module) {
+  run().then(({ fail }) => process.exit(fail === 0 ? 0 : 1)).catch((e) => { console.error(e); process.exit(1); });
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -100,6 +100,7 @@ const profileHopsPath = require('./profile-hops-path.test.js');
 const tagReadUnion = require('./tag-read-union.test.js');
 const bTagPrimitive = require('./b-tag-primitive.test.js');
 const bTagSeeds = require('./b-tag-seeds.test.js');
+const dualZWriter = require('./dual-z-writer.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...');
@@ -271,6 +272,9 @@ async function main() {
 
   console.log('\nb-tag-seeds suite:');
   const bTagSeedsResult = await bTagSeeds.run();
+
+  console.log('\ndual-z-writer suite:');
+  const dualZWriterResult = await dualZWriter.run();
 
   console.log('\nTest Results');
   console.log('-------------');
@@ -464,6 +468,9 @@ async function main() {
   console.log(
     `b-tag-seeds suite:                               ${bTagSeedsResult.fail === 0 ? 'PASS' : 'FAIL'} (${bTagSeedsResult.pass} passed, ${bTagSeedsResult.fail} failed)`
   );
+  console.log(
+    `dual-z-writer suite:                             ${dualZWriterResult.fail === 0 ? 'PASS' : 'FAIL'} (${dualZWriterResult.pass} passed, ${dualZWriterResult.fail} failed)`
+  );
 
   const overallOk =
     configOk &&
@@ -541,7 +548,8 @@ async function main() {
     profileHopsPathResult.fail === 0 &&
     tagReadUnionResult.fail === 0 &&
     bTagPrimitiveResult.fail === 0 &&
-    bTagSeedsResult.fail === 0;
+    bTagSeedsResult.fail === 0 &&
+    dualZWriterResult.fail === 0;
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);
   process.exit(overallOk ? 0 : 1);
 }

--- a/ui/src/hooks/useProfileTags.js
+++ b/ui/src/hooks/useProfileTags.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../context/AuthContext';
+import { useConfig } from '../context/ConfigContext';
 import { publishProfileTagAssertion, publishOrThrow } from '../utils/publishProfileTag';
 import { syncPinnedExportsForTag } from '../utils/publishTagPin';
 
@@ -20,6 +21,8 @@ async function nip07Pubkey() {
 
 export default function useProfileTags(targetPubkey, viewerPubkey) {
   const { user, loading: authLoading } = useAuth();
+  // W11 / tag-federation ADR 0003 — the runtime instance TA for the local z.
+  const { taPubkey } = useConfig();
   const [availableTags, setAvailableTags] = useState([]);
   const [applications, setApplications] = useState([]);
   const [disputes, setDisputes] = useState([]);
@@ -69,8 +72,8 @@ export default function useProfileTags(targetPubkey, viewerPubkey) {
   }, [targetPubkey, reloadKey, authLoading, user?.pubkey]);
 
   const buildAndPublishAssertion = useCallback(
-    (tag, polarity) => publishProfileTagAssertion({ tag, targetPubkey, polarity }),
-    [targetPubkey]
+    (tag, polarity) => publishProfileTagAssertion({ tag, targetPubkey, polarity, localTaPubkey: taPubkey }),
+    [targetPubkey, taPubkey]
   );
 
   // Story 21 / ADR 0019 — if the viewer has pinned this tag, keep its
@@ -105,13 +108,22 @@ export default function useProfileTags(targetPubkey, viewerPubkey) {
       const authorPk = await nip07Pubkey();
       const slug = slugify(name);
       if (!slug) throw new Error('Tag name must contain at least one alphanumeric character.');
+      // W11 / tag-federation ADR 0003 — the LOCAL z (runtime instance TA) lands the
+      // new tag element in this instance's own concept list; the canonical z stays
+      // the ADR-0015 literal. Non-fatal: a missing/malformed local TA omits the
+      // local z (canonical still ships) and warns — never blocks the publish.
+      const hasLocalTa = /^[0-9a-f]{64}$/.test(taPubkey || '');
+      if (!hasLocalTa) {
+        console.warn('[useProfileTags.createTag] local TA pubkey missing/malformed — local z omitted (canonical z still published)');
+      }
       const unsigned = {
         kind: 39999,
         pubkey: authorPk,
         created_at: Math.floor(Date.now() / 1000),
         tags: [
           ['d', slug],
-          ['z', TAG_HANDLE],
+          ['z', TAG_HANDLE],                                  // canonical (ADR-0015 literal) — unchanged
+          ...(hasLocalTa ? [['z', `39998:${taPubkey}:tag`]] : []), // local (runtime TA) — W11
         ],
         content: JSON.stringify({
           tag: { slug, name, description: description || '' },
@@ -125,7 +137,7 @@ export default function useProfileTags(targetPubkey, viewerPubkey) {
       // build the `a` coordinate (39999:<authorPubkey>:<slug>).
       return { eventId: signed.id, slug, name, description: description || '', authorPubkey: signed.pubkey };
     },
-    [refetch]
+    [refetch, taPubkey]
   );
 
   const revoke = useCallback(

--- a/ui/src/pages/Tag.jsx
+++ b/ui/src/pages/Tag.jsx
@@ -7,6 +7,7 @@ import TagViewControls from '../components/TagViewControls';
 import TagSomeoneModal from '../components/TagSomeoneModal';
 import PinnedListPanel from '../components/PinnedListPanel';
 import { useAuth } from '../context/AuthContext';
+import { useConfig } from '../context/ConfigContext';
 import { publishProfileTagAssertion } from '../utils/publishProfileTag';
 import { pinTag, defaultCurationMethod, publishNip51ExportForPin, syncPinnedExportsForTag } from '../utils/publishTagPin';
 import useTagDetail from '../hooks/useTagDetail';
@@ -39,6 +40,8 @@ export default function Tag() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { user, login } = useAuth();
+  // W11 / tag-federation ADR 0003 — the runtime instance TA for the local z.
+  const { taPubkey } = useConfig();
   const {
     tag, viewerPin, rows, viewerAssertions, povSuffix, sort, setSort,
     headerLoading, rowsLoading, headerError, rowsError,
@@ -92,13 +95,13 @@ export default function Tag() {
 
   const handleApply = async (targetPubkey) => {
     if (!tag) return;
-    await publishProfileTagAssertion({ tag, targetPubkey, polarity: 1 });
+    await publishProfileTagAssertion({ tag, targetPubkey, polarity: 1, localTaPubkey: taPubkey });
     refetchRows();
     reexportAfterAssertion();
   };
   const handleDispute = async (targetPubkey) => {
     if (!tag) return;
-    await publishProfileTagAssertion({ tag, targetPubkey, polarity: -1 });
+    await publishProfileTagAssertion({ tag, targetPubkey, polarity: -1, localTaPubkey: taPubkey });
     refetchRows();
     reexportAfterAssertion();
   };

--- a/ui/src/utils/publishProfileTag.js
+++ b/ui/src/utils/publishProfileTag.js
@@ -42,7 +42,7 @@ export async function publishOrThrow(signed) {
  * @param {1 | -1} args.polarity — +1 = apply; -1 = dispute.
  * @returns {Promise<object>} the signed event.
  */
-export async function publishProfileTagAssertion({ tag, targetPubkey, polarity }) {
+export async function publishProfileTagAssertion({ tag, targetPubkey, polarity, localTaPubkey }) {
   if (!window.nostr) {
     throw new Error('No NIP-07 extension detected. Install one to publish tags.');
   }
@@ -59,6 +59,15 @@ export async function publishProfileTagAssertion({ tag, targetPubkey, polarity }
   // Hybrid e+a parent reference (ADR-0022): `a` = stable tag identity
   // (consume by #a), `e` = applied-version provenance (retained).
   const tagAddress = `39999:${tag.authorPubkey}:${tag.slug}`;
+  // W11 / tag-federation ADR 0003 — the LOCAL z lands this assertion in the
+  // publishing instance's own concept list. Composed from the RUNTIME instance
+  // TA (never hardcoded; the canonical z keeps the ADR-0015 literal). Non-fatal:
+  // a missing/malformed local TA omits the local z (the canonical z still ships)
+  // and warns — it must NEVER block the publish.
+  const hasLocalTa = /^[0-9a-f]{64}$/.test(localTaPubkey || '');
+  if (!hasLocalTa) {
+    console.warn('[publishProfileTagAssertion] local TA pubkey missing/malformed — local z omitted (canonical z still published)');
+  }
   const unsigned = {
     kind: 39999,
     pubkey: authorPk,
@@ -68,7 +77,8 @@ export async function publishProfileTagAssertion({ tag, targetPubkey, polarity }
       ['p', targetPubkey],
       ['a', tagAddress],
       ['e', tag.eventId],
-      ['z', NOSTR_USER_TAG_HANDLE],
+      ['z', NOSTR_USER_TAG_HANDLE],                       // canonical (ADR-0015 literal) — unchanged
+      ...(hasLocalTa ? [['z', `39998:${localTaPubkey}:nostr-user-tag`]] : []), // local (runtime TA) — W11
       ['polarity', String(polarity)],
     ],
     content: JSON.stringify({


### PR DESCRIPTION
## TL;DR

**The dual-z writer — Part B of Half 2.** Makes every new tag element and tagging assertion stamp a **second `z` tag** (the *local* `39998:<runtime instance TA>:<slug>`) alongside the existing canonical `39998:82b75e47…:<slug>`. The canonical z keeps the event network-visible (Half-1 federates on it); the new local z lands it in **this instance's own concept list** so locally-authored activity actually shows up locally — instead of the local list staying empty while the tags are only visible network-wide.

> **Stacked PR — base is `feat/b-tag-primitive` (PR #310), not `staging`.** Merge this into #310 first, then #310 → staging. Story 3 depends on Story 38 (the b-tag primitive) + Story 2 (the seeds) which live in #310; basing here keeps the diff to Story-3-only.

> **For an AI agent:** read `engineering-team/decisions/tag-federation/0003-dual-z-writer.md` (the W11 design). This completes the dual-z model — #310 ships the **map** (each local concept header → canonical, via the pointer-`b`); this ships the **membership** (new events carry the local z so they join the local list).

---

## What this PR does

Implements `tag-federation` Story 3 / ADR 0003 — the **W11 stamping floor**: a published tag/tagging carries its canonical (required) z **plus** a local z; `z` order is not load-bearing (readers `#z`-union per value). Scoped to the tag stack's two coordinates — no cloud/cap/rotation (those stay resolver-gated in `community-reference` ADR 0033).

### Changelog
- **`ui/src/utils/publishProfileTag.js`** (tagging-assertion writer) — `+localTaPubkey` param; appends a local z `39998:${localTaPubkey}:nostr-user-tag` after the unchanged canonical `NOSTR_USER_TAG_HANDLE`. **Additive** — the ADR-0022 hybrid `e`+`a` shape (`['a', tagAddress]`, `['e', tag.eventId]`, `tagAddress = 39999:${tag.authorPubkey}:${tag.slug}`) is untouched.
- **`ui/src/hooks/useProfileTags.js`** — reads the runtime TA via `useConfig().taPubkey`; threads `localTaPubkey` into the assertion writer; stamps the same local z in `createTag` (the tag-element writer).
- **`ui/src/pages/Tag.jsx`** — reads `taPubkey`; threads `localTaPubkey` into both `handleApply` and `handleDispute`.

### Guarantees
- **Anti-hardcode (AC-6):** the canonical z stays the ADR-0015 literal (the sanctioned named exception); the **local z is composed from the runtime `taPubkey`** — no new pubkey literal introduced (each writer still has exactly one `82b75e47…`, the pre-existing const).
- **Non-fatal guard:** a missing/malformed local TA **warns and omits** the local z (the canonical z still ships) — it never throws/blocks a publish. (Confirmed design choice.)
- **No migration (AC-5):** existing single-z events are not rewritten; they stay canonical-only and network-visible.

---

## Testing
- `test/dual-z-writer.test.js` — **14/0** (source-contract over the two ESM writers + the call sites; registered in `test/test.js`).
- **Regression:** the ADR-0022 hybrid-e+a suite stays **10/0** (the second z is additive, not a replacement); `profile-tag-polish` 11/0.
- **UI builds clean** (vite).

### Live verification deferred to a deployed env
AC-4 (a new tagging lands in the instance's local list) + the **distinct-z** behavior are **not** verified here: on the dev box the local TA *equals* the canonical coordinate (`82b75e47…`), so the two z's resolve to **identical strings** — the source-contract assertion of record is "two z entries emitted, the second runtime-sourced," not "two distinct values." The distinct-value case (and local-list population) manifests only on a **non-dev instance**, so it's left for whoever merges to a deployed env to confirm.

---

## ⚠️ Addendum for David — the dual-z shape

This PR makes each new Tag and Tagging carry **TWO `z` tags**: **canonical** (`82b75e47…`, network identity, unchanged) + **local** (the runtime instance TA, NEW, for the local concept list). Together with #310's **one** `pointer`-`b` per header (local → canonical), that's the full dual-z model: two z's per *event*, one `b` per *concept header*.

This is where your *"the new Tags and Taggings need to have two z-tags in them, not just one"* lands — confirmed. (Open question still flagged in #310: you mentioned *"two b-tags"* on the concepts; we ship **one** pointer-`b` per header per the wire spec — see #310's addendum for the reversal breadcrumb if you want a different shape.)

**Reversal breadcrumb:** removing the second `['z', …]` line from each writer (`publishProfileTag.js`, `useProfileTags.js createTag`) reverts to single-z behavior with no data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
