### PR TITLE
feat(feed): link author name + avatar to their profile

### DIFF
--- a/ui/src/pages/BrainstormFeed.jsx
+++ b/ui/src/pages/BrainstormFeed.jsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu from '../components/BrainstormUserMenu';
 import useFeed from '../hooks/useFeed';
@@ -57,23 +58,38 @@ export default function BrainstormFeed() {
 }
 
 // One note entry: avatar (placeholder fallback) + author display name + timestamp + text.
+// The avatar and the display name link to the author's profile (/user/<pubkey>) — an
+// in-app SPA <Link>, the same target the search/follows lists use. When the note has no
+// pubkey (defensive; OK items always carry one) the avatar/name render unlinked so we
+// never emit a /user/ link to nowhere.
 function FeedItem({ item }) {
   const author = item.author || {};
   const displayName = author.displayName || (item.pubkey ? `${item.pubkey.slice(0, 8)}…` : 'Unknown');
   const avatar = author.avatar;
+  const profileHref = item.pubkey ? `/user/${item.pubkey}` : null;
+
+  const avatarEl = avatar ? (
+    <img className="bsp-avatar bsp-feed-avatar" src={avatar} alt="" />
+  ) : (
+    <div className="bsp-avatar bsp-avatar-placeholder bsp-feed-avatar">
+      {displayName.charAt(0).toUpperCase()}
+    </div>
+  );
 
   return (
     <div className="bsp-feed-item">
       <div className="bsp-feed-item-head">
-        {avatar ? (
-          <img className="bsp-avatar bsp-feed-avatar" src={avatar} alt="" />
-        ) : (
-          <div className="bsp-avatar bsp-avatar-placeholder bsp-feed-avatar">
-            {displayName.charAt(0).toUpperCase()}
-          </div>
-        )}
+        {profileHref ? (
+          <Link to={profileHref} className="bsp-feed-author-link" aria-label={`View ${displayName}'s profile`}>
+            {avatarEl}
+          </Link>
+        ) : avatarEl}
         <div className="bsp-feed-item-meta">
-          <div className="bsp-name bsp-feed-name">{displayName}</div>
+          {profileHref ? (
+            <Link to={profileHref} className="bsp-name bsp-feed-name bsp-feed-name-link">{displayName}</Link>
+          ) : (
+            <div className="bsp-name bsp-feed-name">{displayName}</div>
+          )}
           <div className="bsp-feed-time">{formatTimestamp(item.createdAt)}</div>
         </div>
       </div>

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -7236,6 +7236,24 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   overflow-wrap: anywhere;
   word-break: break-word;
 }
+/* Author avatar/name link to the author's profile (/user/<pubkey>). */
+.bsp-feed-author-link {
+  display: inline-flex;
+  flex: none;
+  border-radius: 50%;
+}
+.bsp-feed-author-link:hover {
+  opacity: 0.85;
+}
+.bsp-feed-name-link {
+  color: inherit;
+  text-decoration: none;
+}
+.bsp-feed-name-link:hover {
+  text-decoration: underline;
+  text-decoration-color: rgba(165, 180, 252, 0.5);
+  text-underline-offset: 2px;
+}
 
 .table-pagination {
   display: flex;


### PR DESCRIPTION
## Summary

On the `/feed` page, each kind-1 note's author **display name and avatar** now link to that author's profile at `/user/<pubkey>`, using an in-app react-router SPA `<Link>` — the same navigation target the search and follows lists already use. The timestamp stays unclickable; only the name and avatar navigate.

## Changes

- `ui/src/pages/BrainstormFeed.jsx` — `FeedItem` wraps the avatar and the display name in `<Link to={`/user/${item.pubkey}`}>`. Avatar link carries an `aria-label` (image-only). Notes with no `pubkey` (defensive; OK items always carry one) render **unlinked** so no `/user/` link points to nowhere.
- `ui/src/styles.css` — two small rules: name link inherits text color with a subtle hover underline; avatar link keeps the circular shape with a light hover dim.

## Test plan

- [ ] After merge: deploy-staging.yml runs.
- [ ] Smoke test on staging.brainstorm.world.
- [ ] On `/feed`, clicking an author's name navigates to `/user/<pubkey>`.
- [ ] On `/feed`, clicking an author's avatar navigates to `/user/<pubkey>`.
- [ ] Clicking the timestamp does nothing (not a link).

Verified locally: all 18 `live-feed-feed-page` source tests pass; browser-verified the rendered hrefs, the avatar-placeholder / 8-char fallback-name cases, the no-pubkey unlinked case, and that clicking a name SPA-navigates to `/user/<pubkey>` with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)