### PR TITLE
feat(feed): per-note actions menu + /event placeholder

### DIFF
--- a/engineering-team/reviews/live-feed/3-feed-note-actions-menu.md
+++ b/engineering-team/reviews/live-feed/3-feed-note-actions-menu.md
@@ -1,0 +1,75 @@
+# Review: feed note actions menu (conversational / non-harness)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-18
+**Diff:** `git --no-pager diff --cached` on branch `feat/feed-note-actions-menu` (staged, uncommitted)
+**Nature:** Conversational UI change. No formal story / ADR / test plan — those gates are skipped by design. Audited the diff directly for correctness, pattern consistency, accessibility, security, and edge cases.
+
+## Scope of the diff
+- `ui/src/components/NoteActionsMenu.jsx` (new) — "⋯" kebab menu per feed note: Copy Note Link, Copy Note ID (nevent), Copy Note ID (event id), Tag Event (transient "not yet supported").
+- `ui/src/utils/clipboard.js` (new) — `copyText` helper extracted from `PinnedListPanel.jsx`.
+- `ui/src/pages/BrainstormEvent.jsx` (new) — `/event` placeholder echoing `?nevent=` / `?id=`.
+- `ui/src/pages/BrainstormFeed.jsx` — wires `<NoteActionsMenu>` into `FeedItem`.
+- `ui/src/App.jsx` — registers `/event` route.
+- `ui/src/styles.css` — menu + event-page CSS.
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **Suite-level: relevant suites PASS; overall FAIL is pre-existing/environmental, NOT caused by this diff.**
+  - The two suites covering the surface this diff touches both pass: `live-feed-feed-page` (18/18), `live-feed-read-path` (23/23).
+  - The overall `FAIL` comes entirely from live-service integration suites (`profile-tags`, `tag-detail-publish`, `tag-index-publish`, `pin-a-tag`, `tl-publication-from-pins`, `concept-graph /summaries`, …) that report `fetch failed` / Meili / strfry errors. None of these reference any changed file (verified: `grep -rln "NoteActionsMenu|utils/clipboard|BrainstormEvent" test/` → NONE). They are environmental (test DB / service wiring), independent of a pure client-side nav/clipboard change.
+- [ ] `npm run test:playwright` — not run. No Playwright spec exists for this surface and the Implementer browser-verified the interaction manually (menu open/close, aria-expanded, all 4 actions, mobile 375px, zero console errors). Acceptable for a conversational UI change with no e2e harness.
+- [x] _Lint not configured — skipped._
+- [x] _Typecheck not configured — skipped._
+- [x] _Build not configured — skipped._
+
+## Correctness
+
+- **nevent encoding** — `nip19.neventEncode({ id, author })` and `{ id }` both verified against `ui/node_modules/nostr-tools`: round-trip correct, and invalid hex throws (caught by the `try/catch` → `nevent = null`). Correct.
+- **copyLink URL** — `${window.location.origin}/event?nevent=${nevent}`. Origin is correct; nevent is bech32 (`[a-z0-9]` only) so no URL-encoding needed. The `/event` reader matches (`params.get('nevent')`). Round-trips correctly.
+- **No-id guard** — `if (!eventId) return null` renders no dead menu. Matches the Implementer's claim.
+- **No-pubkey path** — falls to `{ id }`-only nevent; still copyable. Correct.
+
+## Pattern consistency
+
+- **Click-outside / open-state** — mirrors `BrainstormUserMenu.jsx:14–20` exactly (same `mousedown` listener, same cleanup in the effect return). No listener leak: the effect has `[]` deps and removes its own listener on unmount.
+- **Multiple menus** — each `FeedItem` mounts its own `NoteActionsMenu` instance with independent `open` state. Opening menu B fires menu A's outside-`mousedown` handler (B's button is outside A's `menuRef`), closing A. Net effect is correct single-open-at-a-time behavior. No shared-state bug.
+- **clipboard.js extraction** — byte-for-byte identical logic to `PinnedListPanel.jsx:54–72` (secure-context fast path + `execCommand` textarea fallback). Faithful extraction.
+
+## Architecture invariants (CLAUDE.md)
+
+- **TA pubkey** — no hardcode; no TA pubkey usage at all (`grep 82b75e47|[0-9a-f]{64}` → NONE in new files). N/A and clean.
+- **POV-first / decentralized-first / filter-at-view-time** — N/A. Pure client-side nav + clipboard; no read scoping, no write gating, no per-POV storage.
+
+## Security
+
+- **XSS in `/event` echo** — `{identifier}` is rendered as a React text child inside `<code>`; React escapes it. No `dangerouslySetInnerHTML` in any new file (verified). The identifier is display-only — never `decode`d, fetched, or interpolated into a URL/DOM sink. Safe.
+- **Secrets / debug** — none. No `console.*`, `debugger`, TODO/FIXME, or commented-out code in the new files.
+
+## Accessibility
+
+- Kebab button: `aria-label="Note actions"`, `aria-haspopup="menu"`, `aria-expanded={open}`, `title`. Dropdown `role="menu"`, items `role="menuitem"`, flash `role="status"`. Good baseline. (Arrow-key roving / Escape-to-close are absent — see NICE-TO-HAVE.)
+
+## Findings
+
+### BLOCKER
+None.
+
+### SHOULD-FIX
+None.
+
+### NICE-TO-HAVE
+1. **`ui/src/components/PinnedListPanel.jsx:54–72`** — now-duplicated `copyText`. The extraction into `utils/clipboard.js` was intentionally not back-applied to PinnedListPanel to avoid scope creep, which is a defensible call for this change. But the duplication is now load-bearing (two copies that must stay in sync). Recommend a tiny follow-up to have `PinnedListPanel` import from `utils/clipboard` and delete its local copy. Not blocking — file it as an OPEN.md / `_intake.md` cleanup row.
+2. **`ui/src/components/NoteActionsMenu.jsx` (menu)** — no Escape-to-close and no arrow-key navigation within the `role="menu"`. The ARIA roles imply keyboard menu semantics that aren't fully wired. Click-outside + tab-away work, so it's usable; full menu keyboard support is a polish item, and `BrainstormUserMenu` (the model) doesn't implement it either, so this is consistent with the house baseline.
+
+### NIT
+1. **`ui/src/components/NoteActionsMenu.jsx:50`** — `setTimeout(() => setFlash(null), 1600)` is unguarded against unmount. This matches the established house pattern (`CopyButton.jsx:16`, `PinnedListPanel.jsx:87`, `settings/Index.jsx`, `RelaySettings.jsx`), and `useFeed` does not poll so feed items don't churn under the user; React 18 no longer warns on setState-after-unmount. No action needed.
+2. **`ui/src/pages/BrainstormEvent.jsx`** — inline `style={{…}}` on the content wrapper and headings rather than CSS classes (the identifier line correctly uses classes). Minor inconsistency on a deliberately-throwaway placeholder. Fine to leave.
+
+## Route placement
+`/event` is registered in the public route group (`App.jsx:149–152`), immediately after `/feed` and before the `/tapestry` admin tree — correct placement for a public, login-free page reachable from the feed's Copy Note Link.
+
+## Verdict
+**PASS**
+
+The diff is correct, faithfully follows the `BrainstormUserMenu` interaction pattern, introduces no security/secret/TA-pubkey issues, respects all architecture invariants, and is mergeable as-is. The overall `npm test` FAIL is pre-existing environmental breakage in live-service integration suites unrelated to this client-side change; the feed suites that cover the touched surface pass. No story file exists to mark Done (conversational change). The two NICE-TO-HAVE items (dedupe PinnedListPanel's `copyText`, menu keyboard polish) are non-blocking follow-ups.

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -79,6 +79,7 @@ import Tags from './pages/Tags';
 import Pins from './pages/Pins';
 import PinRedirect from './components/PinRedirect';
 import BrainstormFeed from './pages/BrainstormFeed';
+import BrainstormEvent from './pages/BrainstormEvent';
 import NotFound from './pages/NotFound';
 const router = createBrowserRouter([
   {
@@ -144,6 +145,10 @@ const router = createBrowserRouter([
   {
     path: '/feed',
     element: <BrainstormFeed />,
+  },
+  {
+    path: '/event',
+    element: <BrainstormEvent />,
   },
   {
     path: '/developers',

--- a/ui/src/components/NoteActionsMenu.jsx
+++ b/ui/src/components/NoteActionsMenu.jsx
@@ -1,0 +1,100 @@
+import { useState, useEffect, useRef } from 'react';
+import { nip19 } from 'nostr-tools';
+import { copyText } from '../utils/clipboard';
+
+/**
+ * Per-note actions menu for a single kind-1 feed note: a "⋯" kebab button that
+ * opens a dropdown of copy/share actions. Modeled on BrainstormUserMenu's
+ * click-to-toggle + click-outside-close pattern.
+ *
+ * Actions:
+ *  - Copy Note Link        → an absolute URL to this instance's /event page,
+ *                            carrying the note's nevent (?nevent=<nevent>).
+ *  - Copy Note ID (nevent) → the bech32 nevent (id + author), portable across clients.
+ *  - Copy Note ID (event id) → the raw 32-byte hex event id.
+ *  - Tag Event             → not yet wired; shows a transient "not yet supported" line.
+ *
+ * Self-contained: derives the nevent client-side from item.id (+ item.pubkey as the
+ * author hint) and copies via the shared clipboard helper. Renders nothing if the
+ * note has no id (defensive; OK feed items always carry one).
+ */
+export default function NoteActionsMenu({ item }) {
+  const [open, setOpen] = useState(false);
+  const [flash, setFlash] = useState(null); // transient feedback line, e.g. "Link copied"
+  const menuRef = useRef(null);
+
+  // Close on click outside (the BrainstormUserMenu convention).
+  useEffect(() => {
+    function handleClick(e) {
+      if (menuRef.current && !menuRef.current.contains(e.target)) setOpen(false);
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  const eventId = item?.id || null;
+  // nevent embeds the event id and (when known) the author, so the link/id resolve
+  // even on clients that didn't index this note from our default relays.
+  let nevent = null;
+  if (eventId) {
+    try {
+      nevent = nip19.neventEncode(item.pubkey ? { id: eventId, author: item.pubkey } : { id: eventId });
+    } catch { nevent = null; }
+  }
+
+  // No id ⇒ nothing to copy/share; don't render a dead menu.
+  if (!eventId) return null;
+
+  function flashMsg(msg) {
+    setFlash(msg);
+    setTimeout(() => setFlash(null), 1600);
+  }
+
+  async function doCopy(value, label) {
+    if (!value) { flashMsg(`${label} unavailable`); return; }
+    try {
+      await copyText(value);
+      flashMsg(`${label} copied`);
+    } catch {
+      flashMsg('Copy failed');
+    }
+  }
+
+  function copyLink() {
+    if (!nevent) { flashMsg('Link unavailable'); return; }
+    doCopy(`${window.location.origin}/event?nevent=${nevent}`, 'Link');
+  }
+
+  return (
+    <div className="bsp-note-menu" ref={menuRef}>
+      <button
+        type="button"
+        className="bsp-note-menu-btn"
+        onClick={() => setOpen(o => !o)}
+        aria-label="Note actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title="Note actions"
+      >
+        ⋯
+      </button>
+      {open && (
+        <div className="bsp-note-menu-dropdown" role="menu">
+          <button type="button" className="bsp-note-menu-item" role="menuitem" onClick={copyLink}>
+            Copy Note Link
+          </button>
+          <button type="button" className="bsp-note-menu-item" role="menuitem" onClick={() => doCopy(nevent, 'nevent')}>
+            Copy Note ID (nevent)
+          </button>
+          <button type="button" className="bsp-note-menu-item" role="menuitem" onClick={() => doCopy(eventId, 'Event ID')}>
+            Copy Note ID (event id)
+          </button>
+          <button type="button" className="bsp-note-menu-item" role="menuitem" onClick={() => flashMsg('Tag Event is not yet supported')}>
+            Tag Event
+          </button>
+          {flash && <div className="bsp-note-menu-flash" role="status">{flash}</div>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/BrainstormEvent.jsx
+++ b/ui/src/pages/BrainstormEvent.jsx
@@ -1,0 +1,46 @@
+import { useSearchParams } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import BrainstormUserMenu from '../components/BrainstormUserMenu';
+
+/**
+ * Placeholder for the public single-event view (/event). Reachable from the feed's
+ * per-note "Copy Note Link" action, which builds /event?nevent=<nevent>. The page
+ * also accepts ?id=<hex> so either identifier resolves once the real view is built.
+ *
+ * Front-end only and intentionally minimal: it confirms the route is live and echoes
+ * back the identifier it received. The actual event rendering is a work in progress.
+ */
+export default function BrainstormEvent() {
+  const { user, login, logout } = useAuth();
+  const [params] = useSearchParams();
+  const nevent = params.get('nevent');
+  const id = params.get('id');
+  const identifier = nevent || id || null;
+
+  return (
+    <div className="bsp-page">
+      {/* Top bar */}
+      <div className="bsp-top-bar">
+        <a href="/" className="bsp-logo">
+          <img src="/brainstorm.svg" alt="" className="bsp-logo-img" />
+        </a>
+        <div className="bsp-auth">
+          <BrainstormUserMenu user={user} login={login} logout={logout} />
+        </div>
+      </div>
+
+      <div className="bsp-content" style={{ maxWidth: 680, margin: '0 auto', padding: '2rem 1.5rem' }}>
+        <h1 style={{ fontSize: '1.5rem', marginBottom: '1rem' }}>Event</h1>
+        <p style={{ lineHeight: 1.7, fontSize: '0.95rem', opacity: 0.85 }}>
+          This is a placeholder page — the single-event view is a work in progress.
+        </p>
+        {identifier && (
+          <p className="bsp-event-identifier">
+            <span className="bsp-event-identifier-label">{nevent ? 'nevent' : 'event id'}:</span>{' '}
+            <code className="bsp-event-identifier-value">{identifier}</code>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/BrainstormFeed.jsx
+++ b/ui/src/pages/BrainstormFeed.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu from '../components/BrainstormUserMenu';
+import NoteActionsMenu from '../components/NoteActionsMenu';
 import useFeed from '../hooks/useFeed';
 
 /**
@@ -92,6 +93,8 @@ function FeedItem({ item }) {
           )}
           <div className="bsp-feed-time">{formatTimestamp(item.createdAt)}</div>
         </div>
+        {/* Per-note actions (copy link / id, tag) — floats to the top-right of the entry. */}
+        <NoteActionsMenu item={item} />
       </div>
       <div className="bsp-feed-text">{item.content}</div>
     </div>

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -7254,6 +7254,77 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   text-decoration-color: rgba(165, 180, 252, 0.5);
   text-underline-offset: 2px;
 }
+/* Per-note actions menu (the "⋯" kebab + dropdown), top-right of each feed entry. */
+.bsp-note-menu {
+  position: relative;
+  margin-left: auto;
+  flex: none;
+  align-self: flex-start;
+}
+.bsp-note-menu-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted, #94a3b8);
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+  padding: 0.1rem 0.5rem;
+  border-radius: 6px;
+}
+.bsp-note-menu-btn:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-primary, #e2e8f0);
+}
+.bsp-note-menu-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 210px;
+  background: var(--bg-secondary, #1a1a2e);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  z-index: 50;
+  padding: 0.25rem;
+  display: flex;
+  flex-direction: column;
+}
+.bsp-note-menu-item {
+  background: none;
+  border: none;
+  color: var(--text-primary, #e2e8f0);
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  border-radius: 6px;
+  white-space: nowrap;
+}
+.bsp-note-menu-item:hover {
+  background: rgba(99, 102, 241, 0.15);
+}
+.bsp-note-menu-flash {
+  font-size: 0.75rem;
+  color: #a5b4fc;
+  padding: 0.45rem 0.75rem 0.3rem;
+  margin-top: 0.25rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+/* /event placeholder — the echoed identifier line. */
+.bsp-event-identifier {
+  margin-top: 1.25rem;
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+.bsp-event-identifier-label {
+  opacity: 0.8;
+}
+.bsp-event-identifier-value {
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 0.8rem;
+  word-break: break-all;
+  overflow-wrap: anywhere;
+}
 
 .table-pagination {
   display: flex;

--- a/ui/src/utils/clipboard.js
+++ b/ui/src/utils/clipboard.js
@@ -1,0 +1,28 @@
+/**
+ * Copy text to the clipboard, with a fallback for non-secure contexts
+ * (http:// on a LAN IP) and older browsers where navigator.clipboard is
+ * unavailable. Resolves on success, rejects if every path fails.
+ *
+ * Mirrors the copyText helper that PinnedListPanel.jsx defines locally; extracted
+ * here so other surfaces (e.g. the feed note-actions menu) can reuse the same
+ * robust behavior instead of the bare navigator.clipboard call.
+ */
+export function copyText(text) {
+  if (navigator.clipboard && window.isSecureContext) {
+    return navigator.clipboard.writeText(text);
+  }
+  return new Promise((resolve, reject) => {
+    try {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.setAttribute('readonly', '');
+      ta.style.position = 'fixed';
+      ta.style.top = '-9999px';
+      document.body.appendChild(ta);
+      ta.select();
+      const ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      if (ok) resolve(); else reject(new Error('copy command rejected'));
+    } catch (e) { reject(e); }
+  });
+}


### PR DESCRIPTION
## Summary

Adds a per-note **actions menu** to each kind-1 note on `/feed` and a public **`/event` placeholder page**. The `⋯` menu floats top-right of each note and is modeled on `BrainstormUserMenu`'s click-to-toggle + click-outside-close dropdown.

Menu actions:
- **Copy Note Link** → `<origin>/event?nevent=<nevent>`
- **Copy Note ID (nevent)** → bech32 nevent (id + author)
- **Copy Note ID (event id)** → raw 32-byte hex event id
- **Tag Event** → not yet wired; shows a transient "not yet supported" line

`nevent` is derived client-side via `nip19.neventEncode`. Copies use a shared `copyText` helper extracted to `ui/src/utils/clipboard.js` (robust non-secure-context fallback). The `/event` page reads `?nevent=`/`?id=` and echoes the identifier — the real single-event view is a follow-up.

## Changes

- `ui/src/components/NoteActionsMenu.jsx` (new) — the kebab menu
- `ui/src/utils/clipboard.js` (new) — extracted clipboard helper
- `ui/src/pages/BrainstormEvent.jsx` (new) — `/event` placeholder
- `ui/src/pages/BrainstormFeed.jsx` — wires the menu into `FeedItem`
- `ui/src/App.jsx` — registers the public `/event` route (beside `/feed`)
- `ui/src/styles.css` — menu + event-page styles
- `engineering-team/reviews/live-feed/3-feed-note-actions-menu.md` — review (PASS)

## Test plan

- [ ] After merge: deploy-staging.yml runs.
- [ ] Smoke test on staging.brainstorm.world.
- [ ] On `/feed`, each note shows a `⋯` button top-right; clicking opens the 4-option menu.
- [ ] Copy Note Link / nevent / event id each copy the expected value.
- [ ] Tag Event shows the "not yet supported" indicator (no clipboard write).
- [ ] `/event?nevent=…` and `/event?id=…` render the placeholder + echoed identifier.

Verified locally in-browser: all 4 actions copy correct values, aria-expanded toggles, edge cases (no-id → no menu; no-pubkey → nevent from id only), `/event` for both param forms, mobile 375px no overflow, zero console errors. `live-feed-feed-page` 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)