### PR TITLE
feat(feed): relative timestamps + pins copyText dedupe

### DIFF
--- a/test/live-feed-feed-page.test.js
+++ b/test/live-feed-feed-page.test.js
@@ -35,17 +35,27 @@
 
 const fs = require('fs');
 const path = require('path');
+const { pathToFileURL } = require('url');
 
 const PAGE   = path.resolve(__dirname, '../ui/src/pages/BrainstormFeed.jsx');
 const HOOK   = path.resolve(__dirname, '../ui/src/hooks/useFeed.js');
 const APP    = path.resolve(__dirname, '../ui/src/App.jsx');
 const STYLES = path.resolve(__dirname, '../ui/src/styles.css');
 const READ_PATH = path.resolve(__dirname, '../src/api/feed/feedReadPath.js');
+const TIMEAGO = path.resolve(__dirname, '../ui/src/utils/timeAgo.js');
 
 const tests = [];
 function test(name, fn) { tests.push({ name, fn }); }
 function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
 function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+async function loadEsm(absPath) {
+  try { return await import(pathToFileURL(absPath).href); }
+  catch { return null; }
+}
+
+// Fixed "now" so the relative-time assertions are deterministic.
+const TA_NOW = 1_700_000_000;
+const TA_MIN = 60, TA_HOUR = 3600, TA_DAY = 86400, TA_YEAR = 365 * TA_DAY;
 
 // Slice the body-helper function (renderFeedState OR FeedBody) out of the page source so the
 // branch sentinels match logic *inside* the pure helper, not anywhere on the page. Returns the
@@ -313,6 +323,47 @@ test('R2: this story re-derives nothing — the read-path module src/api/feed/fe
     assert(new RegExp("status:\\s*['\"]" + status + "['\"]").test(src),
       `the read path must still return the '${status}' status (the four-outcome contract this page maps over — owned by #1, untouched by this story).`);
   }
+});
+
+// ===========================================================================
+// RELATIVE TIMESTAMP — the feed shows a compact "time ago" label (max two
+// y/d/h/m units, space-separated), delegating the unit math to the shared
+// formatTimeAgo helper. These EXECUTE the real ui ESM (dynamic import).
+// ===========================================================================
+
+test('T17: formatTimeAgo({maxUnits:2, separator:" "}) renders the feed two-unit space format', async () => {
+  const mod = await loadEsm(TIMEAGO);
+  assert(mod && typeof mod.formatTimeAgo === 'function',
+    'ui/src/utils/timeAgo.js must export formatTimeAgo — the feed reuses it for its relative label.');
+  const fmt = (sec) => mod.formatTimeAgo(TA_NOW - sec, TA_NOW, { maxUnits: 2, separator: ' ' });
+  assert(fmt(2 * TA_MIN) === '2m ago', `2m → "2m ago", got "${fmt(2 * TA_MIN)}"`);
+  assert(fmt(4 * TA_HOUR + 53 * TA_MIN) === '4h 53m ago', `4h53m → "4h 53m ago", got "${fmt(4 * TA_HOUR + 53 * TA_MIN)}"`);
+  assert(fmt(1 * TA_YEAR + 213 * TA_DAY) === '1y 213d ago', `1y213d → "1y 213d ago", got "${fmt(1 * TA_YEAR + 213 * TA_DAY)}"`);
+  // The third unit is dropped — at most two units (the story's "1y, 23d, 4h" → "1y 23d").
+  assert(fmt(1 * TA_YEAR + 23 * TA_DAY + 4 * TA_HOUR) === '1y 23d ago',
+    `1y23d4h → "1y 23d ago" (3rd unit dropped), got "${fmt(1 * TA_YEAR + 23 * TA_DAY + 4 * TA_HOUR)}"`);
+});
+
+test('T18: formatTimeAgo DEFAULTS are unchanged (3 units, comma separator) — verified-reporters untouched (regression)', async () => {
+  const mod = await loadEsm(TIMEAGO);
+  assert(mod && typeof mod.formatTimeAgo === 'function', 'ui/src/utils/timeAgo.js must export formatTimeAgo.');
+  // No opts → must still be the 3-unit comma format the verified-reporters suite pins.
+  const got = mod.formatTimeAgo(TA_NOW - (3 * TA_DAY + 4 * TA_HOUR + 12 * TA_MIN), TA_NOW);
+  assert(got === '3d, 4h, 12m ago', `default 3-unit comma format must be preserved; got "${got}"`);
+  assert(mod.formatTimeAgo(TA_NOW - 30, TA_NOW) === '0m ago', 'default sub-minute must still be "0m ago".');
+});
+
+test('T19: the page reuses formatTimeAgo, renders "just now" for sub-minute, and keeps the exact time on hover (title)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormFeed.jsx does not exist yet.');
+  assert(/from\s+['"]\.\.\/utils\/timeAgo['"]/.test(src) && /formatTimeAgo/.test(src),
+    'BrainstormFeed.jsx must import + use formatTimeAgo from ../utils/timeAgo (reuse, not a third time-format copy).');
+  assert(/just now/.test(src),
+    'formatTimestamp must render "just now" for the sub-minute case (the smallest unit is the minute).');
+  assert(/maxUnits\s*:\s*2/.test(src),
+    'the feed must request the two-unit form via formatTimeAgo(..., { maxUnits: 2, ... }).');
+  assert(/bsp-feed-time[^>]*title=/.test(src) || /title=\{[^}]*absoluteTimestamp/.test(src),
+    'the timestamp element must carry a title (hover) with the exact local time so no precision is lost.');
 });
 
 async function run() {

--- a/ui/src/components/PinnedListPanel.jsx
+++ b/ui/src/components/PinnedListPanel.jsx
@@ -9,6 +9,7 @@ import {
   pinTag, unpinTag, computeTLDTag,
   syncPinnedExportsForTag, WELL_KNOWN_FALLBACK_RELAYS,
 } from '../utils/publishTagPin';
+import { copyText } from '../utils/clipboard';
 
 /**
  * Story 20 / ADR 0018 — the "Pinned" tab body on the tag-detail page.
@@ -46,29 +47,6 @@ function timeAgoShort(unixSeconds) {
   if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
   if (diff < 2592000) return `${Math.floor(diff / 86400)}d ago`;
   return `${Math.floor(diff / 2592000)}mo ago`;
-}
-
-/** Copy text to the clipboard, with a fallback for non-secure contexts
- *  (http:// on a LAN IP) and older browsers where navigator.clipboard is
- *  unavailable. Resolves on success, rejects if every path fails. */
-function copyText(text) {
-  if (navigator.clipboard && window.isSecureContext) {
-    return navigator.clipboard.writeText(text);
-  }
-  return new Promise((resolve, reject) => {
-    try {
-      const ta = document.createElement('textarea');
-      ta.value = text;
-      ta.setAttribute('readonly', '');
-      ta.style.position = 'fixed';
-      ta.style.top = '-9999px';
-      document.body.appendChild(ta);
-      ta.select();
-      const ok = document.execCommand('copy');
-      document.body.removeChild(ta);
-      if (ok) resolve(); else reject(new Error('copy command rejected'));
-    } catch (e) { reject(e); }
-  });
 }
 
 /** A naddr metadata row: a truncated id (first-5…last-4) that expands on

--- a/ui/src/pages/BrainstormFeed.jsx
+++ b/ui/src/pages/BrainstormFeed.jsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu from '../components/BrainstormUserMenu';
 import NoteActionsMenu from '../components/NoteActionsMenu';
+import { formatTimeAgo } from '../utils/timeAgo';
 import useFeed from '../hooks/useFeed';
 
 /**
@@ -28,8 +29,20 @@ export const FEED_COPY = {
   COULDNT_LOAD: "Couldn't load the feed right now.",
 };
 
-// Unix seconds → a human-readable local timestamp. Tiny local helper, no date library.
+// Unix seconds → a compact relative "time ago" label: the two most-significant
+// non-zero units among years/days/hours/minutes, space-separated (e.g. "2m ago",
+// "4h 53m ago", "1y 213d ago"). Sub-minute renders "just now". Delegates the unit
+// math to the shared formatTimeAgo helper (no date library).
 export function formatTimestamp(createdAt) {
+  if (typeof createdAt !== 'number' || !Number.isFinite(createdAt)) return '';
+  const now = Math.floor(Date.now() / 1000);
+  if (now - createdAt < 60) return 'just now';
+  return formatTimeAgo(createdAt, now, { maxUnits: 2, separator: ' ' });
+}
+
+// The exact local date/time, shown on hover (title) so the relative label keeps
+// its precision a click away. Built-in Date only — no date library.
+export function absoluteTimestamp(createdAt) {
   if (typeof createdAt !== 'number' || !Number.isFinite(createdAt)) return '';
   return new Date(createdAt * 1000).toLocaleString();
 }
@@ -91,7 +104,7 @@ function FeedItem({ item }) {
           ) : (
             <div className="bsp-name bsp-feed-name">{displayName}</div>
           )}
-          <div className="bsp-feed-time">{formatTimestamp(item.createdAt)}</div>
+          <div className="bsp-feed-time" title={absoluteTimestamp(item.createdAt)}>{formatTimestamp(item.createdAt)}</div>
         </div>
         {/* Per-note actions (copy link / id, tag) — floats to the top-right of the entry. */}
         <NoteActionsMenu item={item} />

--- a/ui/src/utils/timeAgo.js
+++ b/ui/src/utils/timeAgo.js
@@ -29,15 +29,18 @@ export function timeAgo(unixSeconds) {
 
 /**
  * Format a unix timestamp (SECONDS) as a compact, multi-unit relative string,
- * e.g. "3d, 4h, 12m ago". Shows the 3 most-significant non-zero units among
+ * e.g. "3d, 4h, 12m ago". Shows the most-significant non-zero units among
  * years / days / hours / minutes (minute is the smallest unit); zero-valued units
  * are dropped. Sub-minute and future timestamps render "0m ago".
  *
  * @param {number} unixSeconds - report time as unix SECONDS (nostr created_at)
  * @param {number} [now] - current time in unix seconds (injectable for tests)
+ * @param {Object} [opts]
+ * @param {number} [opts.maxUnits=3] - how many of the most-significant non-zero units to show
+ * @param {string} [opts.separator=', '] - string joining the units (e.g. ' ' → "4h 53m ago")
  * @returns {string} e.g. "2y, 14d, 3h ago" / "45m ago" / "0m ago"; "" for missing/invalid input
  */
-export function formatTimeAgo(unixSeconds, now = Math.floor(Date.now() / 1000)) {
+export function formatTimeAgo(unixSeconds, now = Math.floor(Date.now() / 1000), { maxUnits = 3, separator = ', ' } = {}) {
   if (unixSeconds == null || !Number.isFinite(Number(unixSeconds))) return '';
 
   let rem = Math.max(0, Math.floor(now - Number(unixSeconds)));
@@ -49,8 +52,8 @@ export function formatTimeAgo(unixSeconds, now = Math.floor(Date.now() / 1000)) 
 
   const parts = units
     .filter(([, v]) => v > 0)   // drop zero-valued units
-    .slice(0, 3)                // 3 most-significant remaining
+    .slice(0, maxUnits)         // the most-significant remaining
     .map(([u, v]) => `${v}${u}`);
 
-  return `${parts.length ? parts.join(', ') : '0m'} ago`;
+  return `${parts.length ? parts.join(separator) : '0m'} ago`;
 }


### PR DESCRIPTION
## Summary

Two small, independent changes bundled (disjoint files, zero coupling):

1. **Relative feed timestamps** — kind-1 notes on `/feed` now show a compact "time ago" label (the two most-significant non-zero units of years/days/hours/minutes, space-separated) instead of an absolute date: `2m ago`, `4h 53m ago`, `1y 213d ago`; a third unit is dropped (`1y 23d 4h` → `1y 23d ago`). Sub-minute → `just now`. The exact local date/time stays available on hover (`title`).
2. **Pins `copyText` dedupe** — `PinnedListPanel` now imports the shared `copyText` from `ui/src/utils/clipboard.js` (extracted during the note-actions-menu work) and drops its byte-identical local copy. Pure refactor, no behavior change. (Completes the dedup flagged in the note-actions-menu review.)

The relative format reuses the existing `formatTimeAgo` helper via a backward-compatible `{ maxUnits, separator }` option (defaults unchanged → the verified-reporters feature and its tests are untouched).

## Changes

- `ui/src/pages/BrainstormFeed.jsx` — `formatTimestamp` delegates to `formatTimeAgo({ maxUnits: 2, separator: ' ' })`, `just now` for sub-minute, `absoluteTimestamp` for the hover title
- `ui/src/utils/timeAgo.js` — `formatTimeAgo` gains `{ maxUnits = 3, separator = ', ' }` (defaults preserve current behavior)
- `ui/src/components/PinnedListPanel.jsx` — import shared `copyText`, delete local copy
- `test/live-feed-feed-page.test.js` — T17 (feed format), T18 (defaults-unchanged regression), T19 (page wiring)

## Test plan

- [ ] After merge: deploy-staging.yml runs (Vite build green — confirmed locally).
- [ ] Smoke test on staging.brainstorm.world.
- [ ] `/feed` shows relative timestamps (`Nm ago` / `Nh Nm ago` / `Ny Nd ago` / `just now`) with the exact time on hover.
- [ ] Pins panel copy controls still work (copyText refactor).

Verified locally: live-feed-feed-page 21/21, verified-reporters 26/26, full `vite build` green, browser-confirmed all five timestamp cases + hover tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)