### PR TITLE
feat(feed): linkify NIP-21 nostr: entities in note content

### DIFF
--- a/engineering-team/reviews/live-feed/4-feed-nostr-entities.md
+++ b/engineering-team/reviews/live-feed/4-feed-nostr-entities.md
@@ -1,0 +1,110 @@
+# Review: live-feed — linkify NIP-21 `nostr:` entities in note content
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-18
+**Diff:** `git diff origin/staging...HEAD` (commit `582d3770`, branch `feat/feed-nostr-entities`)
+**Mode:** Conversational (non-harness) UI change — no formal story / ADR / test-plan. Story/ADR/test-plan
+gates skipped per instruction; diff audited directly for correctness, security, consistency, edge cases.
+
+## What it does
+Parses NIP-21 `nostr:` URIs out of kind-1 note content on the public `/feed` and renders them as in-app
+links. New pure parser `ui/src/utils/nostrEntities.js` (`parseNostrContent`), new renderer
+`ui/src/components/NoteContent.jsx`, wired into `BrainstormFeed.jsx` (replacing `{item.content}`), `/event`
+page extended to accept `?naddr=`, CSS for the link classes, tests T20–T24.
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **live-feed-feed-page suite: PASS (26/26)**, live-feed-read-path: PASS (23/23).
+      Full suite reports `Overall: FAIL`, but **every failing suite is a pre-existing backend-integration
+      failure unrelated to this diff** (`fetch failed` against an unseeded local concept-graph / Meili /
+      strfry stack): concept-graph, profile-tags, tag-detail, tag-index, profile-tag-polish, pin-a-tag,
+      tl-publication-from-pins, customize-pin-curation, most-pinned-tag-index. **None of those test files
+      is touched by this diff** — the only test file changed is `test/live-feed-feed-page.test.js`, which
+      passes. The failures would reproduce identically on `origin/staging`. Not a blocker for this change.
+- [x] `npm run test:playwright` — not run; change is browser-rendering but covered by the unit suite which
+      executes the real ESM parser, plus the Implementer's browser verification. The renderer is a thin
+      `<Link>` map with no logic worth a Playwright run.
+- [x] _Build_ — Implementer reported `vite build` green; diff is additive ESM + CSS with no config changes.
+- [x] _Lint not configured — skipped._
+- [x] _Typecheck not configured — skipped._
+
+## Security audit (user-controlled content)
+
+1. **XSS / href injection — SAFE.** hrefs are always internal paths. Profile → `/user/<hex>` where `<hex>`
+   is the decoded 32-byte pubkey (`[0-9a-f]` only). Event → `/event?id=<hex>` (decoded hex) or
+   `/event?nevent=<bech32>` / `/event?naddr=<bech32>` where `<bech32>` is constrained to the data char-class
+   `[02-9ac-hj-np-z]`. I verified that char-class contains **none** of `: / ? # < > & " ' space % @ . \`, so
+   the dynamic portion cannot introduce a scheme (`javascript:` impossible — `:` is excluded and the prefix
+   is the literal `nostr:`), break out of the path/query, or inject markup. Links are react-router `<Link to=>`
+   (client-side nav only, never an external scheme), labels render as React-escaped text children. No vector.
+2. **nsec / private-key exposure — SAFE, two-layer defense.** `ENTITY_RE` only matches the
+   `npub|nprofile|note|nevent|naddr` prefixes, so `nsec` never matches in the first place; and even if it
+   reached `entityToSegment`, the `switch` `default` returns `null` → plain text. Verified at runtime:
+   `nostr:nsec1…` renders as `text`, preserved verbatim, never a link. T22 pins this.
+3. **ReDoS — SAFE, linear.** `ENTITY_RE` is a single linear char-class with one `+` quantifier, no nesting,
+   no alternation overlap that backtracks. A 200k-char pathological input matched in ~1ms.
+4. **Decode safety — guarded on every branch.** `nip19.decode` is wrapped in try/catch (returns `null` on
+   throw). Decode-shape branches confirmed against nostr-tools: `npub`/`note` → hex string in `data` (used
+   directly); `nprofile` → `data.pubkey` (guarded `data?.pubkey`); `nevent` → `data.id` (guarded `data?.id`);
+   `naddr` → object (href built from the original `bech32`, not the object). No path produces
+   `/user/undefined` — every nullable field is guarded and falls back to plain text.
+5. **Parser correctness — verified.** Probed null / undefined / number / object / `''` → all return `[]`
+   (the `typeof !== 'string'` guard). Entity at start, at end, many (50) entities, repeated calls (shared
+   `/g` regex is reset via `ENTITY_RE.lastIndex = 0` before the loop — the classic stale-lastIndex bug is
+   guarded), `nostr:` with no valid entity, bad prefix, undecodable/bad-checksum → all fall back to plain
+   text correctly. Common punctuation/whitespace terminators (`' ) . ! ? : , \n` and apostrophe-s) all
+   correctly bound the match. No off-by-one in the slice/lastIndex loop.
+6. **Architecture invariants — all respected.** Pure client-side parse/render. The feed read-path module
+   (`src/api/feed/feedReadPath.js`) is **not** touched — the ADR's "no enrichment" stance holds and
+   display-name resolution stays deferred (correctly noted as a read-path follow-up). No POV logic, no
+   write-time gating, no hardcoded TA pubkey (grep clean). POV-first / decentralized-first /
+   filter-at-view-time are not engaged by a display-only renderer.
+7. **Consistency — matches existing patterns.** `nip19.decode` in try/catch mirrors `BrainstormSearch.jsx`.
+   `<Link>` SPA nav matches the feed's author links. New CSS classes don't collide. `BrainstormEvent` is a
+   placeholder that only echoes the identifier, so the `?id=`/`?nevent=`/`?naddr=` triplet is handled.
+
+## Things tests can't catch
+- [x] No secrets / no hardcoded TA pubkey in the diff (grep clean).
+- [x] No `console.log` / debug / `TODO` / `debugger` / `alert(` in the diff.
+- [x] No commented-out code.
+- [x] Error/edge paths handled (decode throw, null shapes, empty input — all fall back to plain text).
+- [x] No concurrency concern (synchronous pure function; shared regex `lastIndex` reset guarded).
+
+## Findings
+
+### BLOCKER
+_None._
+
+### SHOULD-FIX
+_None._
+
+### NICE-TO-HAVE
+1. **`ui/src/utils/nostrEntities.js:26` — greedy match swallows a trailing word char / adjacent entity.**
+   The data class `[02-9ac-hj-np-z]+` *is* the bech32 alphabet, which overlaps ordinary letters, so when an
+   entity is immediately followed by alphanumerics with no boundary, the trailing chars get absorbed into the
+   match, break the checksum, and the **whole** thing falls back to plain text (mention lost). Verified:
+   `nostr:npub1…hello` → not linkified; two directly-concatenated `nostr:npub1…nostr:note1…` (no separator)
+   → **both** lost. Real-world impact is low — notes almost always separate `nostr:` URIs with whitespace or
+   punctuation (all common terminators `' ) . ! ? : , \n` and `'s` work correctly). Optional hardening if
+   you want to be bulletproof: anchor the end with a lookahead such that the match stops at a non-bech32
+   boundary, or special-case a following `nostr:`. Not blocking.
+
+### NIT
+1. **`ui/src/utils/nostrEntities.js:25` — the doc comment's justification is inaccurate.** It says excluding
+   `1/b/i/o` from the class prevents "a trailing word character getting swallowed into the match." That's not
+   what excluding those four chars does (it's the bech32 charset, required for *correct decoding*); it does
+   **not** prevent trailing-word absorption — see NICE-TO-HAVE #1, where a trailing word *is* swallowed.
+   Reword to "restricted to the bech32 charset so the decode is correct" and drop the swallowing claim.
+2. **`ui/src/components/NoteContent.jsx:19` — `key={i}` (array index as React key).** Acceptable here: the
+   segment list is rebuilt wholesale on each render and never reordered/spliced, so the index is stable. No
+   action needed; noting for completeness.
+
+## Verdict
+**PASS**
+
+All security-sensitive concerns (XSS/href injection, nsec exposure, ReDoS, decode safety) are sound and
+verified at runtime. The relevant test suite passes 26/26; the `Overall: FAIL` is pre-existing
+backend-integration failure in suites this diff does not touch. Architecture invariants are respected
+(pure client-side, no read-path enrichment, no POV/TA coupling). The two greedy-match edge cases are rare
+in practice and non-blocking; the inaccurate doc comment (NIT #1) is worth a one-line fix on the next pass
+but does not gate merge.

--- a/test/live-feed-feed-page.test.js
+++ b/test/live-feed-feed-page.test.js
@@ -43,6 +43,8 @@ const APP    = path.resolve(__dirname, '../ui/src/App.jsx');
 const STYLES = path.resolve(__dirname, '../ui/src/styles.css');
 const READ_PATH = path.resolve(__dirname, '../src/api/feed/feedReadPath.js');
 const TIMEAGO = path.resolve(__dirname, '../ui/src/utils/timeAgo.js');
+const NOSTR_ENTITIES = path.resolve(__dirname, '../ui/src/utils/nostrEntities.js');
+const COMPONENT_NOTE_CONTENT = path.resolve(__dirname, '../ui/src/components/NoteContent.jsx');
 
 const tests = [];
 function test(name, fn) { tests.push({ name, fn }); }
@@ -364,6 +366,81 @@ test('T19: the page reuses formatTimeAgo, renders "just now" for sub-minute, and
     'the feed must request the two-unit form via formatTimeAgo(..., { maxUnits: 2, ... }).');
   assert(/bsp-feed-time[^>]*title=/.test(src) || /title=\{[^}]*absoluteTimestamp/.test(src),
     'the timestamp element must carry a title (hover) with the exact local time so no precision is lost.');
+});
+
+// ===========================================================================
+// NIP-21 nostr: ENTITY PARSING — note content turns `nostr:<entity>` references
+// into in-app links (the standard nostr-client treatment). EXECUTES the real pure
+// parser (ui ESM via dynamic import); fixtures are minted with nostr-tools so the
+// asserted pubkey/id is self-validating, not hardcoded.
+// ===========================================================================
+
+const { nip19 } = require('nostr-tools');
+const TA_PK = 'a'.repeat(64);  // a deterministic 32-byte hex pubkey for fixtures
+const TA_ID = 'b'.repeat(64);  // a deterministic 32-byte hex event id
+
+function segsOfType(segs, t) { return segs.filter(s => s.type === t); }
+
+test('T20: parseNostrContent links npub/nprofile → /user/<pubkey> and note/nevent/naddr → /event?…', async () => {
+  const mod = await loadEsm(NOSTR_ENTITIES);
+  assert(mod && typeof mod.parseNostrContent === 'function',
+    'ui/src/utils/nostrEntities.js must export parseNostrContent — the feed reuses it to render note content.');
+  const p = mod.parseNostrContent;
+
+  const npub = nip19.npubEncode(TA_PK);
+  const nprofile = nip19.nprofileEncode({ pubkey: TA_PK });
+  const note = nip19.noteEncode(TA_ID);
+  const nevent = nip19.neventEncode({ id: TA_ID, author: TA_PK });
+  const naddr = nip19.naddrEncode({ identifier: 'x', pubkey: TA_PK, kind: 39998 });
+
+  const [pn] = segsOfType(p(`hi nostr:${npub} there`), 'profile');
+  assert(pn && pn.href === `/user/${TA_PK}` && pn.label.startsWith('@'), `npub → profile mention /user/<pubkey>, got ${JSON.stringify(pn)}`);
+  assert(segsOfType(p(`nostr:${nprofile}`), 'profile')[0]?.href === `/user/${TA_PK}`, 'nprofile → /user/<pubkey>');
+  assert(segsOfType(p(`nostr:${note}`), 'event')[0]?.href === `/event?id=${TA_ID}`, 'note → /event?id=<hex>');
+  assert(segsOfType(p(`nostr:${nevent}`), 'event')[0]?.href === `/event?nevent=${nevent}`, 'nevent → /event?nevent=<nevent>');
+  assert(segsOfType(p(`nostr:${naddr}`), 'event')[0]?.href === `/event?naddr=${naddr}`, 'naddr → /event?naddr=<naddr>');
+});
+
+test('T21: parseNostrContent preserves surrounding text in order (text / entity / text)', async () => {
+  const mod = await loadEsm(NOSTR_ENTITIES);
+  const nevent = nip19.neventEncode({ id: TA_ID });
+  const segs = mod.parseNostrContent(`before nostr:${nevent} after`);
+  assert(segs.length === 3, `expected 3 segments (text,event,text), got ${segs.length}`);
+  assert(segs[0].type === 'text' && segs[0].text === 'before ', 'leading text preserved');
+  assert(segs[1].type === 'event', 'middle segment is the event link');
+  assert(segs[2].type === 'text' && segs[2].text === ' after', 'trailing text preserved');
+});
+
+test('T22: parseNostrContent NEVER linkifies nsec, and keeps an undecodable entity as plain text (security + robustness)', async () => {
+  const mod = await loadEsm(NOSTR_ENTITIES);
+  const nsec = nip19.nsecEncode(new Uint8Array(32).fill(7));
+  const nsecSegs = mod.parseNostrContent(`leak? nostr:${nsec} end`);
+  assert(segsOfType(nsecSegs, 'profile').length === 0 && segsOfType(nsecSegs, 'event').length === 0,
+    'an nsec must NEVER be turned into a link — a private key stays as plain text.');
+  assert(nsecSegs.map(s => s.text || '').join('').includes(nsec), 'the nsec text itself is preserved verbatim (not dropped).');
+  // Undecodable (bad checksum) → kept as the original "nostr:…" text, never a broken link.
+  const bad = mod.parseNostrContent('nostr:nevent1qqsbadchecksumzzzz');
+  assert(segsOfType(bad, 'event').length === 0, 'an undecodable entity must not become an event link.');
+});
+
+test('T23: the user-provided real example strings decode to a profile and an event reference', async () => {
+  const mod = await loadEsm(NOSTR_ENTITIES);
+  const profileEx = 'nostr:nprofile1qqszv6q4uryjzr06xfxxew34wwc5hmjfmfpqn229d72gfegsdn2q3fgpz3mhxue69uhhyetvv9ujuerpd46hxtnfduq32amnwvaz7tmjv4kxz7fwv3sk6atn9e5k7tc6khtzt';
+  const eventEx = 'nostr:nevent1qqsz56926mefn8mj05mutplk4em3e8qypp9gmmkx6hq8yv5s3w0yqtsupa5xa';
+  const pseg = segsOfType(mod.parseNostrContent(profileEx), 'profile')[0];
+  assert(pseg && /^\/user\/[0-9a-f]{64}$/.test(pseg.href), `the nprofile example must resolve to /user/<64-hex>, got ${pseg && pseg.href}`);
+  const eseg = segsOfType(mod.parseNostrContent(eventEx), 'event')[0];
+  assert(eseg && eseg.href.startsWith('/event?nevent=nevent1'), `the nevent example must resolve to /event?nevent=…, got ${eseg && eseg.href}`);
+});
+
+test('T24: the feed renders note content through NoteContent (NIP-21 entity links), not as a raw string', () => {
+  const page = safeRead(PAGE);
+  const comp = safeRead(COMPONENT_NOTE_CONTENT);
+  assert(page.length > 0 && comp.length > 0, 'BrainstormFeed.jsx and NoteContent.jsx must exist.');
+  assert(/<NoteContent\s+content=\{item\.content\}/.test(page),
+    'the feed item must render its text via <NoteContent content={item.content} /> (the entity-linkifying renderer), not {item.content} verbatim.');
+  assert(/parseNostrContent/.test(comp) && /react-router-dom/.test(comp),
+    'NoteContent must map parseNostrContent segments to react-router <Link>s.');
 });
 
 async function run() {

--- a/ui/src/components/NoteContent.jsx
+++ b/ui/src/components/NoteContent.jsx
@@ -1,0 +1,38 @@
+import { Link } from 'react-router-dom';
+import { parseNostrContent } from '../utils/nostrEntities';
+
+/**
+ * Render a note's text content with NIP-21 `nostr:` entity references turned into
+ * in-app links — the standard nostr-client treatment: `nostr:npub…`/`nostr:nprofile…`
+ * become profile mentions (→ /user/<pubkey>), and `nostr:note…`/`nostr:nevent…`/
+ * `nostr:naddr…` become event links (→ /event?…). Everything else renders as plain
+ * text; the parent's white-space:pre-wrap preserves newlines/spacing.
+ *
+ * All parsing/decoding lives in the pure parseNostrContent helper; this component is
+ * just the React mapping over its segments. Links are react-router <Link>s (SPA nav),
+ * matching the feed's author links.
+ */
+export default function NoteContent({ content }) {
+  const segments = parseNostrContent(content);
+  return (
+    <>
+      {segments.map((seg, i) => {
+        if (seg.type === 'profile') {
+          return (
+            <Link key={i} to={seg.href} className="bsp-note-mention" title={seg.bech32}>
+              {seg.label}
+            </Link>
+          );
+        }
+        if (seg.type === 'event') {
+          return (
+            <Link key={i} to={seg.href} className="bsp-note-entity" title={seg.bech32}>
+              {seg.label}
+            </Link>
+          );
+        }
+        return <span key={i}>{seg.text}</span>;
+      })}
+    </>
+  );
+}

--- a/ui/src/pages/BrainstormEvent.jsx
+++ b/ui/src/pages/BrainstormEvent.jsx
@@ -14,8 +14,10 @@ export default function BrainstormEvent() {
   const { user, login, logout } = useAuth();
   const [params] = useSearchParams();
   const nevent = params.get('nevent');
+  const naddr = params.get('naddr');
   const id = params.get('id');
-  const identifier = nevent || id || null;
+  const identifier = nevent || naddr || id || null;
+  const identifierLabel = nevent ? 'nevent' : naddr ? 'naddr' : 'event id';
 
   return (
     <div className="bsp-page">
@@ -36,7 +38,7 @@ export default function BrainstormEvent() {
         </p>
         {identifier && (
           <p className="bsp-event-identifier">
-            <span className="bsp-event-identifier-label">{nevent ? 'nevent' : 'event id'}:</span>{' '}
+            <span className="bsp-event-identifier-label">{identifierLabel}:</span>{' '}
             <code className="bsp-event-identifier-value">{identifier}</code>
           </p>
         )}

--- a/ui/src/pages/BrainstormFeed.jsx
+++ b/ui/src/pages/BrainstormFeed.jsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu from '../components/BrainstormUserMenu';
 import NoteActionsMenu from '../components/NoteActionsMenu';
+import NoteContent from '../components/NoteContent';
 import { formatTimeAgo } from '../utils/timeAgo';
 import useFeed from '../hooks/useFeed';
 
@@ -109,7 +110,7 @@ function FeedItem({ item }) {
         {/* Per-note actions (copy link / id, tag) — floats to the top-right of the entry. */}
         <NoteActionsMenu item={item} />
       </div>
-      <div className="bsp-feed-text">{item.content}</div>
+      <div className="bsp-feed-text"><NoteContent content={item.content} /></div>
     </div>
   );
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -7236,6 +7236,20 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   overflow-wrap: anywhere;
   word-break: break-word;
 }
+/* NIP-21 nostr: entity references rendered inside note text (mentions + event links). */
+.bsp-note-mention,
+.bsp-note-entity {
+  color: #a5b4fc;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+  word-break: break-all;
+}
+.bsp-note-mention:hover,
+.bsp-note-entity:hover {
+  text-decoration: underline;
+  text-decoration-color: rgba(165, 180, 252, 0.5);
+  text-underline-offset: 2px;
+}
 /* Author avatar/name link to the author's profile (/user/<pubkey>). */
 .bsp-feed-author-link {
   display: inline-flex;

--- a/ui/src/utils/nostrEntities.js
+++ b/ui/src/utils/nostrEntities.js
@@ -1,0 +1,78 @@
+import { nip19 } from 'nostr-tools';
+
+/**
+ * Parse NIP-21 `nostr:` URIs out of free text (e.g. a kind-1 note's content) into an
+ * ordered list of render segments, so a UI can turn entity references into links the
+ * way nostr clients conventionally do. Pure — no React, no DOM, no network — so it is
+ * unit-testable and the rendering layer (NoteContent.jsx) stays a thin map over it.
+ *
+ * Recognized entities (NIP-19 / NIP-21), each prefixed with `nostr:`:
+ *   - npub / nprofile → a profile mention → /user/<pubkey>
+ *   - note / nevent / naddr → an event reference → /event?…
+ *
+ * `nsec` is deliberately NOT recognized: a private key must never be turned into a link
+ * (it stays as plain text, exactly as any other unmatched token). Undecodable entities
+ * (bad checksum, truncated) also fall back to plain text — never a broken link.
+ *
+ * @param {string} content - raw note text
+ * @returns {Array<{type:'text',text:string}
+ *                 | {type:'profile',pubkey:string,href:string,label:string,bech32:string}
+ *                 | {type:'event',href:string,label:string,bech32:string}>}
+ *          ordered segments; [] for empty/non-string input.
+ */
+
+// `nostr:` + a public NIP-19 entity (bech32). The data part uses the bech32 charset
+// (excludes 1/b/i/o) so decoding is correct; a token terminated by whitespace,
+// punctuation, or end-of-string — the normal case — matches cleanly. An entity glued
+// directly to following bech32-charset letters with no separator over-matches and then
+// fails decode → it falls back to verbatim text (a dropped link, never a broken one).
+const ENTITY_RE = /nostr:((?:npub|nprofile|note|nevent|naddr)1[02-9ac-hj-np-z]+)/g;
+
+// First-12…last-6 of a long bech32 string, so a mention/link is recognizable but compact.
+function shorten(s) {
+  return s.length > 20 ? `${s.slice(0, 12)}…${s.slice(-6)}` : s;
+}
+
+function entityToSegment(bech32) {
+  let decoded;
+  try { decoded = nip19.decode(bech32); } catch { return null; }
+  if (!decoded) return null;
+  const { type, data } = decoded;
+  switch (type) {
+    case 'npub':
+      return data ? { type: 'profile', pubkey: data, href: `/user/${data}`, label: `@${shorten(bech32)}`, bech32 } : null;
+    case 'nprofile':
+      return data?.pubkey ? { type: 'profile', pubkey: data.pubkey, href: `/user/${data.pubkey}`, label: `@${shorten(bech32)}`, bech32 } : null;
+    case 'note':
+      return data ? { type: 'event', href: `/event?id=${data}`, label: shorten(bech32), bech32 } : null;
+    case 'nevent':
+      return data?.id ? { type: 'event', href: `/event?nevent=${bech32}`, label: shorten(bech32), bech32 } : null;
+    case 'naddr':
+      return data ? { type: 'event', href: `/event?naddr=${bech32}`, label: shorten(bech32), bech32 } : null;
+    default:
+      return null; // nsec or anything else → not linkified
+  }
+}
+
+export function parseNostrContent(content) {
+  if (typeof content !== 'string' || content.length === 0) return [];
+
+  const segments = [];
+  let lastIndex = 0;
+  let m;
+  ENTITY_RE.lastIndex = 0;
+  while ((m = ENTITY_RE.exec(content)) !== null) {
+    const [full, bech32] = m;
+    if (m.index > lastIndex) {
+      segments.push({ type: 'text', text: content.slice(lastIndex, m.index) });
+    }
+    const seg = entityToSegment(bech32);
+    // Undecodable → keep the original "nostr:…" text verbatim (no broken link).
+    segments.push(seg || { type: 'text', text: full });
+    lastIndex = m.index + full.length;
+  }
+  if (lastIndex < content.length) {
+    segments.push({ type: 'text', text: content.slice(lastIndex) });
+  }
+  return segments;
+}


### PR DESCRIPTION
## Summary

Note content on `/feed` now parses NIP-21 `nostr:` URIs and renders them as in-app links — the standard nostr-client treatment:

- `nostr:npub…` / `nostr:nprofile…` → profile mention → `/user/<pubkey>`
- `nostr:note…` → `/event?id=<hex>`
- `nostr:nevent…` → `/event?nevent=…`
- `nostr:naddr…` → `/event?naddr=…`

Event links reuse the `/event` page (extended to also accept `?naddr=`). Parsing lives in a pure, unit-tested helper (`parseNostrContent`); `NoteContent.jsx` is a thin React map over it, wired into the feed item body (replacing raw `{item.content}`).

**Security/robustness:** `nsec` is never linkified (a private key stays plain text); undecodable entities fall back to verbatim text — never a broken link; hrefs are internal paths built from decoded hex / bech32 (safe charset); labels render as React-escaped text; the matcher is a single linear char-class (no ReDoS). Independent review: PASS.

## Changes

- `ui/src/utils/nostrEntities.js` (new) — pure `parseNostrContent`
- `ui/src/components/NoteContent.jsx` (new) — segment → `<Link>` renderer
- `ui/src/pages/BrainstormFeed.jsx` — render content via `<NoteContent>`
- `ui/src/pages/BrainstormEvent.jsx` — accept `?naddr=`
- `ui/src/styles.css` — mention/entity link styles
- `test/live-feed-feed-page.test.js` — T20–T24
- `engineering-team/reviews/live-feed/4-feed-nostr-entities.md` — review (PASS)

## Test plan

- [ ] After merge: deploy-staging.yml runs (vite build green — confirmed locally).
- [ ] Smoke test on staging.brainstorm.world.
- [ ] On `/feed`, `nostr:npub…`/`nostr:nprofile…` render as `@…` links to `/user/<pubkey>`; `nostr:note…`/`nostr:nevent…`/`nostr:naddr…` link to `/event?…`.
- [ ] An `nsec` in note content is NOT linkified (stays plain text).

Verified locally: live-feed-feed-page 26/26 (incl. the real example strings + nsec/undecodable safety), full `vite build` green, browser-confirmed rendering + SPA nav + no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)