### PR TITLE
feat(feed): resolve mention names (@name) in note content

### DIFF
--- a/engineering-team/reviews/live-feed/5-feed-mention-names.md
+++ b/engineering-team/reviews/live-feed/5-feed-mention-names.md
@@ -1,0 +1,161 @@
+# Review: live-feed — resolve mention names (show `@name` instead of `@npub` in note content)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-18
+**Diff:** `git diff origin/staging...HEAD` (commit `54c5e4ae`, branch `feat/feed-mention-names`)
+**Mode:** Conversational (non-harness) change — no formal story / ADR / test-plan. Gates skipped per
+instruction; diff audited directly for correctness, security, architecture-fit, and edge cases. This is the
+natural follow-on to review #4 (feed-nostr-entities), which deferred display-name resolution to the read path.
+
+## What it does
+Feed profile mentions (`nostr:npub…` / `nostr:nprofile…`) now render the mentioned person's display name
+(`@alice`) instead of a raw `@npub1…`. Resolution is server-side in the read path: `enrichAuthors` extracts each
+note's mentioned pubkeys (new `extractMentionPubkeys` + lazy `loadNip19`), resolves their display names from the
+SAME local kind-0 strfry scan it already does for authors (one scan covers authors + mentions), and attaches a
+per-item `mentions` map `{ pubkey: displayName }` containing only locally-resolvable names. Client `NoteContent`
+renders `@<name>` when present, else falls back to the truncated npub the parser already produced; the exact npub
+stays on hover (`title`). `BrainstormFeed` passes `item.mentions`.
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **live-feed-read-path: PASS (27/27)**, **live-feed-feed-page: PASS (27/27)** (the two
+      suites this diff touches). Full suite reports `Overall: FAIL`, but I confirmed every failing suite is a
+      **pre-existing backend-integration failure unrelated to this diff.** Method: ran the full suite on a clean
+      `origin/staging` worktree (with this repo's `node_modules` symlinked in) — it produced the *identical* set
+      of failing suites (concept-graph, profile-tags, tag-detail-publish, profile-tag-polish, pin-a-tag,
+      tl-publication-from-pins, customize-pin-curation-publish, most-pinned-tag-index-publish — all "fetch
+      failed" / "preconditions not met" against an unseeded local Meili/strfry/firmware stack). **None of those
+      test files references any of the five changed files** (grep-verified: `feedReadPath` / `NoteContent` /
+      `BrainstormFeed` appear in none of them). Not a blocker for this change.
+- [x] `npm run test:playwright` — not run. The change is browser-rendering, but the renderer is a thin
+      `<Link>`-label swap with no logic worth a Playwright run; it's covered by the unit suite (T25 asserts the
+      page wiring + the `@${name}` lookup) plus the Implementer's reported browser verification (resolved →
+      `@Alice Resolved`, unresolved → `@npub1…`, npub on hover, no console errors).
+- [x] _Build_ — I ran `npx vite build` in `ui/` myself: **green** (`✓ built in 1m 51s`, no errors). The
+      pre-existing chunk-size warnings are unrelated.
+- [x] _Lint not configured — skipped._
+- [x] _Typecheck not configured — skipped._
+
+## Architecture invariants (the scrutiny target)
+
+1. **POV-first — RESPECTED.** Display names come from each profile's own self-asserted kind-0 (`display_name ||
+   name`). A kind-0 display name is not a POV-dependent judgement (trust, rank, "does this count") — it's the
+   subject's own claim about itself, identical under every POV. So there is no per-POV truth being collapsed:
+   resolving it globally is correct, and it mirrors the *existing* author enrichment (lines 240–244) byte for
+   byte — same scan, same `display_name || name || null` derivation, same Map. No `wot_*` column, no per-POV
+   namespacing is warranted or smuggled in.
+2. **Decentralized-first — RESPECTED.** No write-time gating; the read path accepts any signed kind-0/kind-1.
+   A mention whose kind-0 we don't hold locally is simply *omitted* from the map (M2 pins this), and the UI
+   falls back to the npub — exactly the decentralized-first degradation. Nothing requires a "known" or
+   "approved" author.
+3. **Filter-at-view-time — RESPECTED.** Names are resolved on read from raw kind-0 events, not precomputed or
+   denormalized into a stored column. Nothing is cached per (POV × target).
+4. **No hardcoded TA pubkey** — grep-clean on the changed file (no 64-hex literal, no `82b75e47…`). The TA-pubkey
+   ADR-0015 / runtime-helper rules are not engaged by this diff.
+
+## Security & robustness audit
+
+1. **`loadNip19` fallback (container + host/CI) — SOUND.** Tries the container absolute path first, then bare
+   `require('nostr-tools')`, then `null`. Both `require`s are individually try/caught, so a missing path can't
+   throw out of the function. The null-cache is correct: `_nip19` starts `undefined`; the guard is
+   `if (_nip19 !== undefined) return _nip19;`, so once it's set to `null` (both requires failed) it returns the
+   cached `null` and never retries — and `extractMentionPubkeys` no-ops (`if (!nip19) return []`). In test/CI the
+   bare require resolves (the suite itself does `require('nostr-tools')`), so resolution is live there. Degrades,
+   never throws.
+2. **`extractMentionPubkeys` regex — SOUND & linear.** `/nostr:((?:npub|nprofile)1[02-9ac-hj-np-z]+)/g` matches
+   only npub/nprofile — `nsec`/`note`/`nevent`/`naddr` are excluded by construction (M4 pins nsec). Single
+   linear char-class, one `+`, no nested quantifier / overlapping alternation → no ReDoS. I stress-tested it:
+   a 2M-char adversarial token matched in ~3ms; 50k separate tokens in ~6ms.
+3. **Decode safety — guarded.** `nip19.decode` is wrapped in try/catch (undecodable → skip). `npub` →
+   `dec.data` (hex string, guarded `dec.data`); `nprofile` → `dec.data.pubkey` (guarded `dec.data &&
+   dec.data.pubkey`). No path pushes `undefined` into the lookup set.
+4. **Server/client pubkey agreement — VERIFIED at runtime.** The server derives the pubkey for npub from
+   `dec.data` and for nprofile from `dec.data.pubkey`; the client parser (`nostrEntities.js:42–45`) derives
+   `seg.pubkey` the same way. I confirmed both yield the identical 64-char hex for the same token, so the
+   client's `mentions[seg.pubkey]` lookup matches the server's map key. They also share the *same* greedy-match
+   behavior, so when a glued/over-matched token fails decode, **both** sides drop it and fall back to the npub in
+   lockstep — no divergence where one side shows a name and the other a broken key.
+5. **Scan-filter growth (the one real edge to weigh) — ACCEPTABLE, degrades gracefully.** `enrichAuthors` now
+   feeds `[...authors, ...mentions]` (deduped) into the single `strfry scan '<json>'` arg. The feed is capped at
+   50 notes, but a kind-1 note's content is large (relays commonly allow 16–128 KB), and a hostile followed
+   author could stuff a note with thousands of *unique* npubs (~69 B each) that won't dedup. At ~67 B/author in
+   the JSON filter, a pathological 50-note feed could push the single shell argument past Linux's per-arg
+   `MAX_ARG_STRLEN` (128 KB) and `execSync` would throw `E2BIG`. **But the scan is wrapped in `try { … } catch {
+   events = []; }` (lines 231–233), so the worst case is "no names resolve" (authors fall back to null, mentions
+   fall back to npub) — the feed never crashes.** This is acceptable: the failure is bounded, graceful, and only
+   reachable via deliberately abusive content. See NICE-TO-HAVE #1 for an optional cap.
+6. **Client XSS — SAFE.** `label = name ? `@${name}` : seg.label` is rendered as React text children
+   (auto-escaped), never `dangerouslySetInnerHTML`. `to`/`title` are unchanged from the prior (already-audited)
+   safe values.
+
+## Correctness — map construction & contract
+
+- **Per-note isolation — correct.** `mentionsByNote` is built `notes.map(...)` and consumed in the final
+   `notes.map((n, i) => …)` at the same index `i`; the arrays are co-indexed, so note *i*'s mentions come only
+   from note *i*'s content.
+- **No author/mention cross-contamination.** The `profiles` Map is keyed purely by `ev.pubkey`; a pubkey that is
+   both an author (of one note) and a mention (in another) resolves to one shared profile — correct, not a bug.
+- **Newest-kind-0-wins still holds.** The dedupe `if (prev && prev.created_at >= ev.created_at) continue;` is
+   unchanged and keyed by pubkey, so merging authors + mentions into one scan doesn't perturb it.
+- **Only resolved names included.** `if (mp && mp.displayName) mentions[pk] = …` omits unknown profiles *and*
+   profiles with falsy display names (empty `display_name` falls through `display_name || name || null` to
+   `null`), so the UI npub fallback fires consistently with author handling. M2 pins omission; M3 pins the
+   empty-`{}` shape.
+- **Read-path contract — additive, intact.** `mentions` is added only to items in the OK/EMPTY `items` array;
+   `NO_SOURCE` / `FOLLOW_LIST_UNAVAILABLE` carry no items, so the four-status union is unchanged. The module
+   header doc (lines 13–16) is updated to the new item shape and is accurate.
+- **Client undefined-safety.** `NoteContent` guards `mentions && seg.pubkey`, so an absent `item.mentions`
+   (e.g., a stale response) falls back to `seg.label` without throwing — belt-and-suspenders over the read
+   path's always-`{}` guarantee.
+
+## Concept-graph / house rules
+- [x] No concept definitions touched → no firmware reinstall needed.
+- [x] No handles constructed; no `kind:pubkey:slug` strings introduced.
+- [x] No new lint/typecheck/build tooling; no new runtime dependency (reuses `nostr-tools`, already present).
+- [x] Concept Graph API authority not engaged (display-name resolution is plain kind-0, not a concept).
+
+## Things tests can't catch
+- [x] No secrets / no hardcoded TA pubkey in the diff (grep-clean).
+- [x] No `console.log` / `debugger` / `TODO` / `FIXME` introduced (grep-clean).
+- [x] No commented-out code.
+- [x] Error/edge paths handled (nip19 unavailable, undecodable ref, missing kind-0, empty content, scan throw).
+- [x] No concurrency concern: `enrichAuthors` is sequential; the module-level `_nip19` cache is set
+      idempotently and is safe under Node's single-threaded model. The regex is a fresh `/g` literal created
+      per call inside `extractMentionPubkeys`, so there is no shared-`lastIndex` reuse bug.
+
+## Findings
+
+### BLOCKER
+_None._
+
+### SHOULD-FIX
+_None._
+
+### NICE-TO-HAVE
+1. **`src/api/feed/feedReadPath.js:224` — no cap on the mention pubkey set fed to the strfry scan.** A
+   deliberately abusive note (thousands of unique npubs) could push the single `execSync` filter argument past
+   Linux's 128 KB `MAX_ARG_STRLEN`, throwing `E2BIG`. It degrades safely (the `try/catch` zeroes the scan, so
+   names just don't resolve), so this is not blocking — but a small belt: cap total looked-up pubkeys (e.g.,
+   slice the deduped `lookup` to a few hundred, or cap mentions-per-note before flattening). Optional hardening.
+2. **`src/api/feed/feedReadPath.js:201` — the mention regex inherits the same greedy over-match as the client
+   parser** (review #4 NICE-TO-HAVE #1): an entity glued to following bech32-charset letters over-matches and
+   fails decode, dropping the mention. This is *consistent* with the client (both drop in lockstep → npub
+   fallback on both sides), so it's not a defect introduced here — noting only so the two parsers are fixed
+   together if the client one ever is.
+
+### NIT
+_None new._ (The inaccurate `1/b/i/o` doc-comment justification flagged in review #4 was **not** carried into
+this change's comments — the new `extractMentionPubkeys` comment is accurate.)
+
+## Verdict
+**PASS**
+
+Architecture invariants are respected — display-name resolution from self-asserted kind-0 is genuinely not
+POV-scoped and mirrors the existing author enrichment exactly (same scan, same derivation); decentralized-first
+degradation (omit unknown → npub fallback) and filter-at-view-time are both honored; no hardcoded TA pubkey, no
+write-time gating. Security is sound: nip19 load degrades-not-throws with a correct null-cache, the regex is
+linear and npub/nprofile-only, decode is guarded, server/client pubkeys agree at runtime, and the client label
+is React-escaped. The two relevant suites pass 27/27; the `Overall: FAIL` is pre-existing backend-integration
+failure (reproduced identically on `origin/staging`) in suites this diff does not touch. The one real edge —
+unbounded scan-filter growth from abusive content — fails closed via the existing `try/catch`, so it's a
+non-blocking hardening suggestion, not a gate.

--- a/src/api/feed/feedReadPath.js
+++ b/src/api/feed/feedReadPath.js
@@ -10,7 +10,10 @@
  *   - buildFeed(options)   — the orchestrator, returns a discriminated `status`
  *     union { OK, EMPTY, NO_SOURCE, FOLLOW_LIST_UNAVAILABLE } plus, on OK/EMPTY,
  *     a `relaySource` discriminator { set, fallback } and an `items` array shaped
- *       { id, pubkey, createdAt, content, author: { displayName, avatar } }.
+ *       { id, pubkey, createdAt, content, author: { displayName, avatar },
+ *         mentions: { <pubkey>: <displayName> } }.
+ *     `mentions` resolves the note's `nostr:npub…/nprofile…` references to local
+ *     display names (so the UI shows "@name" not a raw npub); empty when none resolve.
  *   - handleGetFeed(req, res) — the public GET /api/feed Express handler.
  *
  * Injectable dependency seam (ADR amendment 2026-06-15). buildFeed reads its four
@@ -34,6 +37,11 @@ const WS_PATH = '/usr/local/lib/node_modules/brainstorm/node_modules/ws';
 
 const FETCH_TIMEOUT_MS = 8000;
 const FEED_CAP = 50;
+// Upper bound on pubkeys passed to a single local kind-0 scan (authors + mentions).
+// Authors are ≤ FEED_CAP; this bounds the mention set so a note stuffed with thousands
+// of refs can't push the `strfry scan` argument past the OS arg-length limit. Excess
+// mentions simply keep their npub fallback.
+const PROFILE_LOOKUP_CAP = 1000;
 const FALLBACK_RELAYS = ['wss://relay.damus.io', 'wss://relay.primal.net', 'wss://nos.lol'];
 const RELAY_SET_SLUG = 'the-set-of-general-purpose-relays';
 
@@ -172,17 +180,62 @@ async function fetchNotes(followPubkeys, relays, querySync) {
   return notes.slice(0, FEED_CAP);
 }
 
+// nip19 (for decoding NIP-21 mention references) loaded the same lazy, path-tolerant
+// way as the other nostr-tools usage: the container's absolute path first, then a bare
+// require (which resolves in test/CI and from brainstorm's node_modules). If neither
+// loads, mention resolution simply no-ops — it never breaks the feed.
+let _nip19;
+function loadNip19() {
+  if (_nip19 !== undefined) return _nip19;
+  try { _nip19 = require(NOSTR_TOOLS_PATH).nip19; }
+  catch {
+    try { _nip19 = require('nostr-tools').nip19; }
+    catch { _nip19 = null; }
+  }
+  return _nip19;
+}
+
+// The pubkeys referenced by `nostr:npub…` / `nostr:nprofile…` mentions in a note's
+// text (NIP-21). Used to resolve mentioned-profile display names from LOCAL kind-0,
+// so the UI can show "@name" rather than a raw npub. Undecodable refs are skipped;
+// nsec/event refs are never matched.
+function extractMentionPubkeys(content) {
+  if (typeof content !== 'string' || content.length === 0) return [];
+  const nip19 = loadNip19();
+  if (!nip19) return [];
+  const re = /nostr:((?:npub|nprofile)1[02-9ac-hj-np-z]+)/g;
+  const out = [];
+  let m;
+  while ((m = re.exec(content)) !== null) {
+    try {
+      const dec = nip19.decode(m[1]);
+      if (dec.type === 'npub' && dec.data) out.push(dec.data);
+      else if (dec.type === 'nprofile' && dec.data && dec.data.pubkey) out.push(dec.data.pubkey);
+    } catch { /* undecodable ref → skip */ }
+  }
+  return out;
+}
+
 /**
- * Attach author display name + avatar from LOCAL kind-0 profile data only.
- * Missing profile ⇒ { displayName: null, avatar: null }. Never an external fetch.
+ * Attach author display name + avatar, and resolved mention display names, from LOCAL
+ * kind-0 profile data only. Missing author profile ⇒ { displayName: null, avatar: null }.
+ * `mentions` maps each `nostr:npub…/nprofile…` pubkey in the note to its local display
+ * name (only those we can resolve; the UI falls back to a truncated npub otherwise).
+ * Never an external fetch — the mentioned profiles are resolved from the SAME local
+ * kind-0 scan as the authors (one scan covers both sets of pubkeys).
  */
 async function enrichAuthors(notes, scanStrfry) {
-  const authors = [...new Set(notes.map(n => n.pubkey))];
+  const mentionsByNote = notes.map(n => extractMentionPubkeys(n.content));
+  // Authors (≤ FEED_CAP) are always looked up; mentioned pubkeys fill the rest up to
+  // PROFILE_LOOKUP_CAP so a ref-stuffed note can't overflow the local scan argument.
+  const authorPubkeys = [...new Set(notes.map(n => n.pubkey))];
+  const mentionedPubkeys = [...new Set(mentionsByNote.flat())].filter(pk => !authorPubkeys.includes(pk));
+  const lookup = [...authorPubkeys, ...mentionedPubkeys].slice(0, PROFILE_LOOKUP_CAP);
   const profiles = new Map();
-  if (authors.length > 0) {
+  if (lookup.length > 0) {
     let events = [];
     try {
-      events = (await scanStrfry({ kinds: [0], authors })) || [];
+      events = (await scanStrfry({ kinds: [0], authors: lookup })) || [];
     } catch { events = []; }
     for (const ev of events) {
       if (!ev || ev.kind !== 0) continue;
@@ -197,8 +250,13 @@ async function enrichAuthors(notes, scanStrfry) {
       });
     }
   }
-  return notes.map(n => {
+  return notes.map((n, i) => {
     const p = profiles.get(n.pubkey);
+    const mentions = {};
+    for (const pk of mentionsByNote[i]) {
+      const mp = profiles.get(pk);
+      if (mp && mp.displayName) mentions[pk] = mp.displayName;
+    }
     return {
       id: n.id,
       pubkey: n.pubkey,
@@ -208,6 +266,7 @@ async function enrichAuthors(notes, scanStrfry) {
         displayName: p ? p.displayName : null,
         avatar: p ? p.avatar : null,
       },
+      mentions,
     };
   });
 }

--- a/test/live-feed-feed-page.test.js
+++ b/test/live-feed-feed-page.test.js
@@ -443,6 +443,15 @@ test('T24: the feed renders note content through NoteContent (NIP-21 entity link
     'NoteContent must map parseNostrContent segments to react-router <Link>s.');
 });
 
+test('T25: the feed passes the resolved mentions map and NoteContent renders "@name" over the raw npub', () => {
+  const page = safeRead(PAGE);
+  const comp = safeRead(COMPONENT_NOTE_CONTENT);
+  assert(/<NoteContent\b[^>]*\bmentions=\{item\.mentions\}/.test(page),
+    'BrainstormFeed must pass the read path\'s resolved mentions map: <NoteContent content={item.content} mentions={item.mentions} />.');
+  assert(/mentions\[seg\.pubkey\]/.test(comp) && /@\$\{name\}/.test(comp),
+    'NoteContent must look up mentions[seg.pubkey] and render "@${name}" when the display name is resolved (falling back to the npub otherwise).');
+});
+
 async function run() {
   let pass = 0, fail = 0;
   for (const t of tests) {

--- a/test/live-feed-read-path.test.js
+++ b/test/live-feed-read-path.test.js
@@ -544,6 +544,112 @@ test('B21 (resolution): with no login but a House PoV configured, the House iden
   }
 });
 
+// ===========================================================================
+// MENTIONS — a note's nostr:npub/nprofile references are resolved to LOCAL
+// display names (so the UI can show "@name", not a raw npub), drawn from the
+// SAME local kind-0 scan as the authors. Never an external fetch.
+// ===========================================================================
+
+test('M1 (mentions): a nostr:npub mention resolves to the mentioned profile\'s LOCAL display name (same local kind-0 scan)', async () => {
+  const mod = loadModule();
+  const { nip19 } = require('nostr-tools');
+  const MENTIONED = HEX('5');
+  const npub = nip19.npubEncode(MENTIONED);
+  const deps = makeDeps({
+    scanStrfry: (filter) => {
+      const f = typeof filter === 'string' ? JSON.parse(filter) : filter;
+      if (Array.isArray(f.kinds) && f.kinds.includes(3)) return [kind3(SOURCE, [FOLLOW_1])];
+      if (Array.isArray(f.kinds) && f.kinds.includes(0)) {
+        assert(Array.isArray(f.authors) && f.authors.includes(MENTIONED),
+          'the local kind-0 scan must include the mentioned pubkey so its name resolves in the same pass (no separate/external fetch).');
+        return [{ id: 'k0-m', kind: 0, pubkey: MENTIONED, created_at: 60, tags: [],
+          content: JSON.stringify({ display_name: 'Bob Mentioned', name: 'bob' }) }];
+      }
+      return [];
+    },
+    querySync: async (relays, filter) => {
+      const f = filter || {};
+      assert(!(Array.isArray(f.kinds) && f.kinds.includes(0)),
+        'mentioned-profile (kind-0) data must come from LOCAL strfry, never the external relays.');
+      return [kind1('n1', FOLLOW_1, 200, `hey nostr:${npub} welcome`)];
+    },
+  });
+  const r = await callBuildFeed(mod, { sessionPubkey: SOURCE, deps });
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  const item = r.items.find((it) => it.id === 'n1');
+  assert(item && item.mentions && typeof item.mentions === 'object', 'each item must carry a `mentions` map (pubkey → displayName).');
+  assert(item.mentions[MENTIONED] === 'Bob Mentioned',
+    `the npub mention must resolve to the local display name; got ${JSON.stringify(item.mentions[MENTIONED])}.`);
+});
+
+test('M2 (mentions): an nprofile mention resolves via its pubkey; a mention with no local kind-0 is omitted (UI falls back to npub)', async () => {
+  const mod = loadModule();
+  const { nip19 } = require('nostr-tools');
+  const KNOWN = HEX('5');     // has a local kind-0
+  const UNKNOWN = HEX('6');   // no local kind-0
+  const nprofile = nip19.nprofileEncode({ pubkey: KNOWN });
+  const npubUnknown = nip19.npubEncode(UNKNOWN);
+  const deps = makeDeps({
+    scanStrfry: (filter) => {
+      const f = typeof filter === 'string' ? JSON.parse(filter) : filter;
+      if (Array.isArray(f.kinds) && f.kinds.includes(3)) return [kind3(SOURCE, [FOLLOW_1])];
+      if (Array.isArray(f.kinds) && f.kinds.includes(0)) {
+        return [{ id: 'k0-k', kind: 0, pubkey: KNOWN, created_at: 60, tags: [], content: JSON.stringify({ name: 'Carol' }) }];
+      }
+      return [];
+    },
+    querySync: async () => [kind1('n1', FOLLOW_1, 200, `cc nostr:${nprofile} and nostr:${npubUnknown}`)],
+  });
+  const r = await callBuildFeed(mod, { sessionPubkey: SOURCE, deps });
+  const item = r.items.find((it) => it.id === 'n1');
+  assert(item.mentions[KNOWN] === 'Carol', `nprofile mention must resolve via its pubkey to "Carol"; got ${JSON.stringify(item.mentions[KNOWN])}.`);
+  assert(!(UNKNOWN in item.mentions),
+    'a mention with no local kind-0 must be OMITTED from mentions (the UI then falls back to the truncated npub).');
+});
+
+test('M3 (mentions): a note with no nostr: mentions carries an empty mentions map (stable shape, no crash)', async () => {
+  const mod = loadModule();
+  const deps = makeDeps({ querySync: async () => [kind1('n1', FOLLOW_1, 200, 'just plain text, no mentions here')] });
+  const r = await callBuildFeed(mod, { sessionPubkey: SOURCE, deps });
+  const item = r.items.find((it) => it.id === 'n1');
+  assert(item.mentions && typeof item.mentions === 'object' && Object.keys(item.mentions).length === 0,
+    `a mention-free note must carry an empty mentions object; got ${JSON.stringify(item.mentions)}.`);
+});
+
+test('M4 (mentions/security): an nsec reference is NEVER treated as a mention (no resolution, no crash)', async () => {
+  const mod = loadModule();
+  const { nip19 } = require('nostr-tools');
+  const nsec = nip19.nsecEncode(new Uint8Array(32).fill(3));
+  const deps = makeDeps({ querySync: async () => [kind1('n1', FOLLOW_1, 200, `oops nostr:${nsec} end`)] });
+  const r = await callBuildFeed(mod, { sessionPubkey: SOURCE, deps });
+  const item = r.items.find((it) => it.id === 'n1');
+  assert(item.mentions && Object.keys(item.mentions).length === 0,
+    'an nsec is a private key, never a profile reference — it must never be resolved as a mention.');
+});
+
+test('M5 (mentions/robustness): the local kind-0 lookup is capped so a ref-stuffed note cannot overflow the scan arg', async () => {
+  const mod = loadModule();
+  const { nip19 } = require('nostr-tools');
+  const many = [];
+  for (let i = 1; i <= 1010; i++) many.push('nostr:' + nip19.npubEncode(i.toString(16).padStart(64, '0')));
+  const content = 'spam ' + many.join(' ');
+  let scanAuthors = null;
+  const deps = makeDeps({
+    scanStrfry: (filter) => {
+      const f = typeof filter === 'string' ? JSON.parse(filter) : filter;
+      if (Array.isArray(f.kinds) && f.kinds.includes(3)) return [kind3(SOURCE, [FOLLOW_1])];
+      if (Array.isArray(f.kinds) && f.kinds.includes(0)) { scanAuthors = f.authors || []; return []; }
+      return [];
+    },
+    querySync: async () => [kind1('n1', FOLLOW_1, 200, content)],
+  });
+  const r = await callBuildFeed(mod, { sessionPubkey: SOURCE, deps });
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  assert(Array.isArray(scanAuthors), 'the local kind-0 scan must have been called.');
+  assert(scanAuthors.length <= 1000,
+    `the kind-0 lookup must be capped (≤1000 — authors + bounded mentions) so a ref-stuffed note can't overflow the scan argument; got ${scanAuthors.length}.`);
+});
+
 async function run() {
   let pass = 0, fail = 0;
   for (const t of tests) {

--- a/ui/src/components/NoteContent.jsx
+++ b/ui/src/components/NoteContent.jsx
@@ -8,19 +8,26 @@ import { parseNostrContent } from '../utils/nostrEntities';
  * `nostr:naddr…` become event links (→ /event?…). Everything else renders as plain
  * text; the parent's white-space:pre-wrap preserves newlines/spacing.
  *
+ * A profile mention shows the person's display name ("@name") when the read path
+ * resolved it (the optional `mentions` map: pubkey → displayName, from local kind-0);
+ * otherwise it falls back to the truncated npub the parser produced. The exact npub
+ * is always available on hover (title).
+ *
  * All parsing/decoding lives in the pure parseNostrContent helper; this component is
  * just the React mapping over its segments. Links are react-router <Link>s (SPA nav),
  * matching the feed's author links.
  */
-export default function NoteContent({ content }) {
+export default function NoteContent({ content, mentions }) {
   const segments = parseNostrContent(content);
   return (
     <>
       {segments.map((seg, i) => {
         if (seg.type === 'profile') {
+          const name = mentions && seg.pubkey ? mentions[seg.pubkey] : null;
+          const label = name ? `@${name}` : seg.label;
           return (
             <Link key={i} to={seg.href} className="bsp-note-mention" title={seg.bech32}>
-              {seg.label}
+              {label}
             </Link>
           );
         }

--- a/ui/src/pages/BrainstormFeed.jsx
+++ b/ui/src/pages/BrainstormFeed.jsx
@@ -110,7 +110,7 @@ function FeedItem({ item }) {
         {/* Per-note actions (copy link / id, tag) — floats to the top-right of the entry. */}
         <NoteActionsMenu item={item} />
       </div>
-      <div className="bsp-feed-text"><NoteContent content={item.content} /></div>
+      <div className="bsp-feed-text"><NoteContent content={item.content} mentions={item.mentions} /></div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

NIP-21 profile mentions (`nostr:npub…` / `nostr:nprofile…`) in feed notes now display the mentioned person's **display name** (`@alice`) instead of a raw `@npub1…` — the conventional, recognizable nostr-client treatment.

Resolution happens in the **read path** (the same step that already resolves each note's author name/avatar), not the React page: `enrichAuthors` extracts each note's mentioned pubkeys and resolves their display names from the **same local kind-0 scan** (one scan covers authors + mentions; never an external fetch), attaching a per-item `mentions: { pubkey → displayName }` map. The lookup set is capped (`PROFILE_LOOKUP_CAP`, authors first) so a ref-stuffed note can't overflow the strfry scan argument.

Client `NoteContent` renders `@<name>` when resolved and **falls back to the truncated `@npub1…`** otherwise; the exact npub stays on hover. Display names are self-asserted (kind-0), not POV-dependent — so this mirrors author enrichment exactly.

## Changes

- `src/api/feed/feedReadPath.js` — `extractMentionPubkeys` + lazy `loadNip19`; `enrichAuthors` resolves mentions from the local kind-0 scan and attaches `item.mentions`; `PROFILE_LOOKUP_CAP`
- `ui/src/components/NoteContent.jsx` — render `@name` from the `mentions` prop, npub fallback
- `ui/src/pages/BrainstormFeed.jsx` — pass `item.mentions`
- `test/live-feed-read-path.test.js` — M1–M5; `test/live-feed-feed-page.test.js` — T25
- `engineering-team/reviews/live-feed/5-feed-mention-names.md` — review (PASS)

## Test plan

- [ ] After merge: deploy-staging.yml runs (vite build green — confirmed locally).
- [ ] Smoke on staging.brainstorm.world.
- [ ] On `/feed`, profile mentions that previously showed `@npub1…` now show `@<name>` where the profile is held locally; unknown ones keep the `@npub1…` fallback.

Verified locally: live-feed-read-path 28/28 (incl. nsec-never-resolved + lookup-cap), live-feed-feed-page 27/27, full `vite build` green, browser-confirmed `@name` + fallback. Independent review: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)