### PR TITLE
refactor(feed): shared NoteCard + enrichNotes seams (no behavior change)

### DIFF
--- a/BIBLE.md
+++ b/BIBLE.md
@@ -658,6 +658,8 @@ Legacy Brainstorm HTML pages are served at `/legacy/` (not part of the React SPA
 ├── about                         Brainstorm + NosFabrica overview, links to nostr
 ├── how-search-works              Mechanics: Meilisearch + Verification (GrapeRank)
 ├── personalization               POV explainer (House vs My Point of View)
+├── feed                          Live Feed — public kind-1 notes from the source identity's follows
+├── event                         Single-event view (placeholder; reads ?id= / ?nevent= / ?naddr=)
 └── developers                    NIP-50 developer integration docs
 
 /tapestry/                        Dashboard (Getting Started + stats)
@@ -720,6 +722,9 @@ Legacy Brainstorm HTML pages are served at `/legacy/` (not part of the React SPA
 |-----------|----------|---------|
 | `DataTable` | `components/DataTable.jsx` | Reusable sortable table with row click |
 | `AuthorCell` | `components/AuthorCell.jsx` | Author display with avatar + name |
+| `NoteCard` | `components/NoteCard.jsx` | **Shared kind-1 note unit** — avatar + author link + relative time + actions menu + content. Reused by every note surface (see "Shared note rendering"). |
+| `NoteContent` | `components/NoteContent.jsx` | Renders note text, linkifying NIP-21 `nostr:` entities (mentions → `/user/<pk>`, events → `/event?…`) |
+| `NoteActionsMenu` | `components/NoteActionsMenu.jsx` | Per-note `⋯` menu (copy link / nevent / event id; tag stub) |
 | `Breadcrumbs` | `components/Breadcrumbs.jsx` | Auto-generated from route handles |
 | `Layout` | `components/Layout.jsx` | Sidebar navigation + main content |
 | `Header` | `components/Header.jsx` | Auth UI + user dropdown |
@@ -737,6 +742,44 @@ Legacy Brainstorm HTML pages are served at `/legacy/` (not part of the React SPA
 - **Dark theme** — CSS variables in `styles.css` (`--bg-primary`, `--text`, `--accent`)
 - **No markdown tables in Discord/WhatsApp** — bullet lists instead
 - **API clients** in `ui/src/api/` (relay.js, cypher.js, normalize.js, audit.js)
+
+### Shared note rendering (kind-1)
+
+Every surface that shows kind-1 notes composes **one** rendering unit and **one** server
+enrichment, so a per-note improvement is made once instead of per-surface. This split is
+the load-bearing decision — honor it when adding new note surfaces.
+
+- **Client — `NoteCard` (`components/NoteCard.jsx`).** Pure presentational: it takes an
+  already-enriched note `item` and renders the whole card (avatar + author-profile link +
+  relative timestamp w/ exact time on hover + `NoteActionsMenu` + `NoteContent`). No data
+  fetching, no read logic. Markup uses surface-neutral `bsp-note-card-*` classes (not
+  `bsp-feed-*`) so non-feed surfaces reuse it without inheriting feed styling. Layout
+  variants arrive as explicit props, never forks.
+- **Server — `enrichNotes(notes, scanStrfry)` (`src/api/_shared/noteEnrichment.js`).**
+  Turns raw kind-1 events into the item shape every read path serves, resolving author +
+  mention display names from **local kind-0 only** (one scan covers both; bounded by
+  `PROFILE_LOOKUP_CAP`). Read paths differ only in how they **select** raw events; they
+  all call `enrichNotes`.
+
+**The enriched note item shape (the contract):**
+
+```
+{ id, pubkey, createdAt, content,
+  author:   { displayName, avatar },          // local kind-0; null when not held locally
+  mentions: { <pubkey>: <displayName> } }       // resolved nostr:npub/nprofile refs (others omit → UI shows truncated npub)
+```
+
+**POV boundary.** Display names are self-asserted kind-0 metadata — **not** POV-dependent —
+so `enrichNotes` resolves them globally (mirrors author enrichment, consistent with the
+WoT-score namespacing rule above where only `wot_*_<suffix>` columns are POV-scoped). A
+*POV-dependent* decoration (e.g. "is this mentioned/replied-to author in **my** WoT?") must
+take the POV/source as a parameter and compute per-view — never bake a global answer into
+the shape. See the architecture invariants in `CLAUDE.md` (POV-first; filter at view time).
+
+**Today:** the Live Feed (`/feed`) is the only consumer. The profile "latest note" and a
+per-user notes page are planned to reuse both seams (a new read path that selects by author
++ `<NoteCard>`); future per-note features (reposts, reply indicators, event tags) extend
+`NoteCard` + `enrichNotes` once.
 
 ### Brainstorm Search Features
 
@@ -1312,6 +1355,7 @@ docker compose exec tapestry strfry sync wss://dcosl.brainstorm.world \
 - ✅ Profile verified counts moved to **Owner PoV** + verification explainer + dynamic reporter alarm (2026-06-08, staging) — the profile **Verified Followers / Verified Reporters** counts now read from Neo4j (Owner PoV) so the badge agrees with its list table, dropping the broken raw-follower Meili fallback (#35, ADR `profile/0031`); a shared **"What does verification mean?"** popover (profile + `/reporters`) shows the configured cutoff ×100 + owner name/avatar, and the Verified Reporters badge shows a red 🚩 alarm only past a popularity-adjusted threshold (`vr ≥ 3 + floor(vf/750)`) (#36, ADR `profile/0032`). The point-of-view model these counts use is the three-PoV standard ratified in **§27** (ADR `pov-resolution/0033`). On staging; later promoted to prod.
 - ✅ Report Type + Reported columns on `/user/:pubkey/reporters` (2026-06-15, prod) — the reporters table now surfaces each NIP-56 report's `report_type` (humanized label) and `timestamp`, read from the `REPORTS` edge (`GET /api/get-grapevine-reporters` extended to return `rel.report_type` + `rel.timestamp` per edge). Default columns → **Picture / Report Type / Rank**; the **Reported** column shows relative "Xd, Yh ago" text but sorts by the **raw unix integer** (new opt-in `sortValue(row)` accessor on the shared `DataTable`, missing values sorted last in both directions — the existing string/`localeCompare` path is unchanged for all other consumers); a **"N reporters, M reports"** summary distinguishes distinct reporters from reports. Report-centric — one row per `REPORTS` edge, no client-side de-duplication (so duplicate-edge bugs stay visible). verified-reporters #4, ADR `verified-reporters/0004`.
 - ✅ Live Feed at `/feed` (2026-06-15, prod) — a public, login-free, read-only feed of the most recent (≤50) kind-1 notes from the accounts the **source identity** follows (the logged-in user, else the House PoV identity), newest first. Follow list (kind-3) read from local strfry; followed authors' notes from the configured general-purpose relays; author name/avatar from local kind-0/Meilisearch. Additive and read-only — adds `GET /api/feed` (the read path) + the `/feed` page; no writes/publishes, no firmware/ranking/search changes. Intended as the host surface for a later tagging book. Direction-mode book; ADRs `live-feed/0001` (read path) + `0002` (page).
+- ✅ Live Feed enhancements + shared note module (2026-06-18, staging) — a batch of additive `/feed` improvements, all behind the read path's existing contract: (1) author name/avatar link to `/user/<pubkey>`; (2) a per-note `⋯` actions menu (copy note link / nevent / event id; tag-event stub) + a placeholder `/event` page (`?id=`/`?nevent=`/`?naddr=`); (3) relative "time ago" timestamps (two y/d/h/m units, "just now" sub-minute, exact time on hover) reusing a parameterized `formatTimeAgo`; (4) NIP-21 `nostr:` entity linkification in note text (`npub/nprofile`→`/user`, `note/nevent/naddr`→`/event`; `nsec` never linkified); (5) mention **display-name** resolution (`@alice`, not `@npub1…`) resolved server-side in the read path from local kind-0. Then a **behavior-preserving refactor** extracted the shared seams so the two planned new note surfaces and future per-note features land once: client `NoteCard` + server `enrichNotes` (`src/api/_shared/noteEnrichment.js`) — see §13 "Shared note rendering". Staging only; prod promotion not yet done.
 - ✅ Follows-hops **HOPS** stat on `/user/:pubkey` (2026-06-17, staging) — the profile counter row shows a **HOPS** value between Verified Followers and Verified Reporters: the **live, directed** FOLLOWS shortest-path distance from the source (logged-in viewer, else the **Owner** — not the House PoV) to the viewed profile. Computed on demand via `shortestPath((src)-[:FOLLOWS*..20]->(tgt))` through the pooled Bolt driver (~2.5s timeout, pubkeys bound) — **no** precomputed value, deliberately not reconciled with the owner-rooted `hops` property (§ Graph Algorithms). Loads async (own hook); renders **∞** for no-path-within-cap, **0** for self-view, and a non-misleading "—" on lookup error/timeout (never a false ∞). New public `GET /api/get-follows-hops`. profile #38, ADR `profile/0034`. On staging; **prod promotion held** (co-promotes with the tags bundle). Note: a second "Hops" figure also exists in the Reputation grid (precomputed, owner-rooted) — PoV reconciliation deferred (`OPEN.md` #7).
 - ✅ Follows-hops **path page** + HOPS link activation (2026-06-17, staging) — the HOPS stat becomes a link to a new **`/user/:pubkey/follows-hops`** page showing one shortest follow-path as a vertical chain of profile cards (picture, name, Owner-PoV rank = `round(influence×100)`), ordered source→target, with a **re-roll** button that swaps in a random one of the equally-short paths (shown only when >1 exists). Backed by new public `GET /api/get-follows-hops-paths` (`allShortestPaths`, cap 20, `LIMIT 25`, returning up to 25 ordered `[{pubkey,influence}]` paths + a `truncated` flag); the client re-rolls client-side over the returned set. profile #39, ADR `profile/0035`. On staging; held with #38.
 

--- a/engineering-team/reviews/live-feed/6-notecard-refactor.md
+++ b/engineering-team/reviews/live-feed/6-notecard-refactor.md
@@ -1,0 +1,46 @@
+# Review: NoteCard + enrichNotes extraction refactor — PASS (with SHOULD_FIX addressed)
+
+**Scope:** behavior-preserving refactor extracting (a) the shared client component
+`ui/src/components/NoteCard.jsx` from the feed's inline `FeedItem`, and (b) the shared
+server module `src/api/_shared/noteEnrichment.js` (`enrichNotes`) from `feedReadPath`'s
+`enrichAuthors`. Conversational (non-harness) change; no story/ADR/test-plan.
+
+**Method:** 4-lens adversarial review run as a multi-agent workflow (each lens an
+independent agent returning structured findings): behavior-preservation, seam quality /
+future-readiness, test adequacy, architecture-fit. Reviewed commit `7f5279b8`; the
+SHOULD_FIX + cheap nice-to-haves were then applied in `6164b9a6`.
+
+## Verdicts
+
+| Lens | Verdict |
+|---|---|
+| Behavior preservation | **clean** — moved code is byte-identical (FeedItem→NoteCard differs only in the signature line; enrichAuthors→enrichNotes only in one comment). Every className/conditional/prop preserved; removed imports genuinely dead; both suites pass. |
+| Seam quality / future-readiness | **concerns** → resolved. The only real issue: `bsp-feed-*` class names on the shared card (SHOULD_FIX, below). |
+| Test adequacy | **clean** — no coverage lost (verified by mutation that re-pointed T5/T6/T19/T24/T25 still fail when the moved code breaks); page→NoteCard delegation asserted; enrichNotes still fully covered via M1–M5 + E1. |
+| Architecture fit | **clean** — display-name resolution correctly global (self-asserted kind-0, non-POV), POV extension point honored, decentralized-first held, no TA-pubkey hardcode, `_shared` is the right home (alongside `pov.js`), no new deps/tooling. |
+
+## Findings & resolution
+
+- **BLOCKER / SHOULD_FIX before merge:** none outstanding.
+- **SHOULD_FIX (addressed in `6164b9a6`):** shared `NoteCard` wore feed-namespaced classes
+  → renamed to surface-neutral `bsp-note-card-*` (+ CSS), so the two upcoming non-feed
+  pages reuse it without inheriting feed styling or forking. Cheapest moment (1 edit now
+  vs 3 after they ship). Behavior-preserving (computed styles verified identical).
+- **NICE_TO_HAVE (addressed):** E2 locks the direct-import contract
+  (`extractMentionPubkeys`, `PROFILE_LOOKUP_CAP`, direct `enrichNotes` resolution) the two
+  new read paths will depend on; `noteEnrichment` header now states the cap CALLER CONTRACT.
+- **NICE_TO_HAVE / NIT (deferred to the two new-location sessions — see OPEN.md / intake):**
+  add a `NoteCard` layout-variant prop when the first variant is needed (don't fork);
+  consider a trailing-options arg on `enrichNotes` for the first POV-aware decoration
+  (additive, non-breaking — can wait); a NoteCard execution/render test (the node harness
+  can't transpile JSX, so card edges stay source-text + browser-verified — pre-existing).
+- **Explicitly NOT changed:** the per-module `NOSTR_TOOLS_PATH` constant is duplicated by
+  codebase convention (6+ modules); consolidation would be a separate cross-cutting refactor.
+
+## Gates (run, not trusted)
+- live-feed-read-path **30/30**, live-feed-feed-page **27/27**; full `vite build` green.
+- Feed browser-verified rendering identically before and after both commits (author link,
+  relative time + hover title, actions menu, nostr: entity links, resolved @mention),
+  zero console errors. Overall `npm test` FAILs are pre-existing unrelated backend suites.
+
+**Verdict: PASS** — mergeable.

--- a/engineering-team/stories/_intake.md
+++ b/engineering-team/stories/_intake.md
@@ -1040,3 +1040,51 @@ Full verified review (the dominant finding, the per-move verdicts, the open deci
 **Phase path:** `/discuss` (settle the open decisions + PoV-safe headline placement) → Planning → Architecture (ADR) → Test Design → Implementation → Review.
 **Priority:** Medium — real UX win, but **deferred pending operator discussion**; not a fast-track change.
 **Depends on:** Story A (pubkey/npub details drawer) for the Identity→Links relabel; otherwise independent. **Related:** 2026-06-06 item 4 (absorbed); ADRs `profile/0029–0032`, `verified-reporters/0001`.
+
+---
+
+## 2026-06-18 — Feature: profile "latest note" on `/user/:pubkey` (reuses the shared note module)
+
+**Raw request (verbatim, from the feed session):**
+
+> I want to show kind 1 events in two new locations: first, on the user profile page, where I want to show the user's most recent kind 1 event …
+
+**Context / why now:** the 2026-06-18 feed session extracted the shared note seams precisely so this lands once (see BIBLE §13 "Shared note rendering (kind-1)" + review `reviews/live-feed/6-notecard-refactor.md`). The building blocks already exist on staging:
+- **Client:** `<NoteCard item={...} />` (`ui/src/components/NoteCard.jsx`) — drop-in, surface-neutral `bsp-note-card-*` styling, no data logic.
+- **Server:** `enrichNotes(notes, scanStrfry)` (`src/api/_shared/noteEnrichment.js`) — produces the item shape `{ id, pubkey, createdAt, content, author:{displayName,avatar}, mentions }`.
+
+**Scope sketch (settle in Planning):** a small read path that **selects** the single most-recent kind-1 by the viewed pubkey (by-author, limit 1) and runs it through `enrichNotes`; a hook + placement on `ui/src/pages/BrainstormProfile.jsx` rendering one `<NoteCard>`. Mirror the feed read path's local-vs-relay sourcing decision (Planning to confirm: local strfry only, or relays like `/api/feed`?). **Likely the first `NoteCard` variant** (compact / maybe hide the actions menu) — per the review, add an explicit variant prop to `NoteCard`, do **not** fork it.
+
+**Classification:** Feature (read path + UI). **Strictness:** Standard.
+**Phase path:** `/discuss` or Planning (source + variant decisions) → Architecture → Test Design → Implementation → Review.
+**Priority:** Medium — operator-requested; cheap given the seams exist.
+**Depends on:** the shared note module (shipped to staging 2026-06-18; promote that batch to prod first or build atop staging).
+
+---
+
+## 2026-06-18 — Feature: per-user notes page (50 most recent kind-1 from a given user)
+
+**Raw request (verbatim, from the feed session):**
+
+> … secondly, on a page that shows the 50 most recent events from just a given user.
+
+**Context / why now:** second consumer of the shared note module (same building blocks as the profile-latest-note entry above). A new public page + read path; renders a list of `<NoteCard>`.
+
+**Scope sketch (settle in Planning):** a read path that **selects** the 50 most-recent kind-1 by a given pubkey (by-author, limit 50) and runs `enrichNotes`; a new route + page (likely `/user/:pubkey/notes`, beside the existing `/user/:pubkey/{follows,followers,reporters,follows-hops}` sub-pages) mapping items to `<NoteCard>`. **Caller-contract reminder (from the review):** `enrichNotes` caps the kind-0 **scan argument** at `PROFILE_LOOKUP_CAP` (1000) but does not cap the work — this page selects ≤50 notes by one author so it's safely under, but any future many-author variant must pre-cap (see `noteEnrichment.js` header).
+
+**Classification:** Feature (read path + new page + route). **Strictness:** Standard.
+**Phase path:** Planning (source + route shape) → Architecture → Test Design → Implementation → Review.
+**Priority:** Medium — operator-requested; cheap given the seams exist.
+**Depends on:** the shared note module (shipped to staging 2026-06-18). **Related:** profile "latest note" entry above (sibling; shares the by-author selection logic — consider one read-path helper parameterized by limit).
+
+---
+
+## 2026-06-18 — Deferred (note-module follow-ups, from the refactor review)
+
+Small future-readiness items the 2026-06-18 multi-lens review (`reviews/live-feed/6-notecard-refactor.md`) flagged as NICE_TO_HAVE/NIT and deliberately deferred — best handled **inside** the two surface stories above when the need is concrete, not as standalone work:
+
+- **`NoteCard` layout-variant prop** — the first surface that needs a compact card / hidden actions menu adds an explicit prop to `NoteCard` rather than branching at the call site or forking.
+- **`enrichNotes` options arg for POV-dependent decorations** — the first POV-aware per-note feature (e.g. "reply author in my WoT", repost attribution) should add a trailing options arg (`enrichNotes(notes, scanStrfry, opts)`); additive/non-breaking, so it can wait.
+- **`NoteCard` execution/render test** — the no-pubkey/unlinked + placeholder-avatar branches are source-text + browser-verified only (the node harness can't transpile JSX). If a render-test path is ever added, cover these edges.
+
+**Classification:** Cleanup/hardening. **Priority:** Low — fold into the surface stories.

--- a/src/api/_shared/noteEnrichment.js
+++ b/src/api/_shared/noteEnrichment.js
@@ -27,10 +27,13 @@
 // mention resolution simply no-ops — it never breaks a read path.
 const NOSTR_TOOLS_PATH = '/usr/local/lib/node_modules/brainstorm/node_modules/nostr-tools';
 
-// Upper bound on pubkeys passed to a single local kind-0 scan (authors + mentions).
-// Authors are bounded by the read path's own cap; this bounds the mention set so a note
-// stuffed with thousands of refs can't push the `strfry scan` argument past the OS
-// arg-length limit. Excess mentions simply keep their npub fallback in the UI.
+// Upper bound on pubkeys passed to a single local kind-0 scan (authors + mentions,
+// authors first). This bounds the scan *argument* so a note stuffed with thousands of
+// refs can't push the `strfry scan` command past the OS arg-length limit; excess
+// mentions simply keep their npub fallback in the UI. CALLER CONTRACT: enrichNotes
+// bounds only the scan argument, not the work — a read path serving more than ~1000
+// distinct authors must itself cap/page its note set before calling, or author profiles
+// past the cap fall back to null name/avatar. (The feed caps at 50 via FEED_CAP.)
 const PROFILE_LOOKUP_CAP = 1000;
 
 let _nip19;

--- a/src/api/_shared/noteEnrichment.js
+++ b/src/api/_shared/noteEnrichment.js
@@ -1,0 +1,123 @@
+/**
+ * Shared note enrichment — turns raw kind-1 events into the enriched feed/note item
+ * shape every read path serves, so the logic (and future improvements) live in ONE
+ * place. The live feed uses it today; the profile "latest note" and per-user notes
+ * read paths are expected to use it next. Read paths differ only in how they SELECT
+ * the raw events; they all run this same enrichment to produce the same item shape:
+ *
+ *     { id, pubkey, createdAt, content,
+ *       author:   { displayName, avatar },              // from local kind-0
+ *       mentions: { <pubkey>: <displayName> } }          // resolved nostr:npub/nprofile refs
+ *
+ * Constraints (mirror the feed read path's contract):
+ *  - LOCAL only: author + mention profiles come from the injected local kind-0 scan,
+ *    never an external relay fetch.
+ *  - One scan covers authors + mentioned pubkeys (the lookup set, bounded — see cap).
+ *  - Display names are self-asserted kind-0 metadata, NOT point-of-view-dependent, so
+ *    this enrichment is global. POV-DEPENDENT decorations (e.g. "is this mentioned/
+ *    replied-to author in *my* WoT?") must take the POV/source as a parameter and
+ *    compute per-view — do not bake a global answer into this shape.
+ *
+ * Pure but for the injected `scanStrfry` seam: `enrichNotes(notes, scanStrfry)`.
+ */
+
+// nip19 (for decoding NIP-21 mention references) loaded the lazy, path-tolerant way the
+// rest of the codebase uses: the container's absolute path first, then a bare require
+// (which resolves in test/CI and from brainstorm's node_modules). If neither loads,
+// mention resolution simply no-ops — it never breaks a read path.
+const NOSTR_TOOLS_PATH = '/usr/local/lib/node_modules/brainstorm/node_modules/nostr-tools';
+
+// Upper bound on pubkeys passed to a single local kind-0 scan (authors + mentions).
+// Authors are bounded by the read path's own cap; this bounds the mention set so a note
+// stuffed with thousands of refs can't push the `strfry scan` argument past the OS
+// arg-length limit. Excess mentions simply keep their npub fallback in the UI.
+const PROFILE_LOOKUP_CAP = 1000;
+
+let _nip19;
+function loadNip19() {
+  if (_nip19 !== undefined) return _nip19;
+  try { _nip19 = require(NOSTR_TOOLS_PATH).nip19; }
+  catch {
+    try { _nip19 = require('nostr-tools').nip19; }
+    catch { _nip19 = null; }
+  }
+  return _nip19;
+}
+
+// The pubkeys referenced by `nostr:npub…` / `nostr:nprofile…` mentions in a note's
+// text (NIP-21). Undecodable refs are skipped; nsec/event refs are never matched.
+function extractMentionPubkeys(content) {
+  if (typeof content !== 'string' || content.length === 0) return [];
+  const nip19 = loadNip19();
+  if (!nip19) return [];
+  const re = /nostr:((?:npub|nprofile)1[02-9ac-hj-np-z]+)/g;
+  const out = [];
+  let m;
+  while ((m = re.exec(content)) !== null) {
+    try {
+      const dec = nip19.decode(m[1]);
+      if (dec.type === 'npub' && dec.data) out.push(dec.data);
+      else if (dec.type === 'nprofile' && dec.data && dec.data.pubkey) out.push(dec.data.pubkey);
+    } catch { /* undecodable ref → skip */ }
+  }
+  return out;
+}
+
+/**
+ * Enrich raw kind-1 events with author display name + avatar and resolved mention
+ * display names, all from LOCAL kind-0 profile data only (via the injected scanStrfry).
+ * Missing author profile ⇒ { displayName: null, avatar: null }. `mentions` includes
+ * only refs we can resolve locally (the UI falls back to a truncated npub otherwise).
+ *
+ * @param {Array} notes - raw kind-1 events ({ id, pubkey, created_at, content })
+ * @param {Function} scanStrfry - local strfry scan: (filter) => events[]
+ * @returns {Promise<Array>} enriched items (see module header for the shape)
+ */
+async function enrichNotes(notes, scanStrfry) {
+  const mentionsByNote = notes.map(n => extractMentionPubkeys(n.content));
+  // Authors are always looked up; mentioned pubkeys fill the rest up to
+  // PROFILE_LOOKUP_CAP so a ref-stuffed note can't overflow the local scan argument.
+  const authorPubkeys = [...new Set(notes.map(n => n.pubkey))];
+  const mentionedPubkeys = [...new Set(mentionsByNote.flat())].filter(pk => !authorPubkeys.includes(pk));
+  const lookup = [...authorPubkeys, ...mentionedPubkeys].slice(0, PROFILE_LOOKUP_CAP);
+  const profiles = new Map();
+  if (lookup.length > 0) {
+    let events = [];
+    try {
+      events = (await scanStrfry({ kinds: [0], authors: lookup })) || [];
+    } catch { events = []; }
+    for (const ev of events) {
+      if (!ev || ev.kind !== 0) continue;
+      const prev = profiles.get(ev.pubkey);
+      if (prev && prev.created_at >= ev.created_at) continue;
+      let parsed = {};
+      try { parsed = JSON.parse(ev.content) || {}; } catch { parsed = {}; }
+      profiles.set(ev.pubkey, {
+        created_at: ev.created_at,
+        displayName: parsed.display_name || parsed.name || null,
+        avatar: parsed.picture || null,
+      });
+    }
+  }
+  return notes.map((n, i) => {
+    const p = profiles.get(n.pubkey);
+    const mentions = {};
+    for (const pk of mentionsByNote[i]) {
+      const mp = profiles.get(pk);
+      if (mp && mp.displayName) mentions[pk] = mp.displayName;
+    }
+    return {
+      id: n.id,
+      pubkey: n.pubkey,
+      createdAt: n.created_at,
+      content: n.content,
+      author: {
+        displayName: p ? p.displayName : null,
+        avatar: p ? p.avatar : null,
+      },
+      mentions,
+    };
+  });
+}
+
+module.exports = { enrichNotes, extractMentionPubkeys, PROFILE_LOOKUP_CAP };

--- a/src/api/feed/feedReadPath.js
+++ b/src/api/feed/feedReadPath.js
@@ -35,13 +35,12 @@
 const NOSTR_TOOLS_PATH = '/usr/local/lib/node_modules/brainstorm/node_modules/nostr-tools';
 const WS_PATH = '/usr/local/lib/node_modules/brainstorm/node_modules/ws';
 
+// Shared note enrichment (author + mention display names from local kind-0). Extracted
+// so the profile "latest note" and per-user notes read paths reuse the same logic/shape.
+const { enrichNotes } = require('../_shared/noteEnrichment');
+
 const FETCH_TIMEOUT_MS = 8000;
 const FEED_CAP = 50;
-// Upper bound on pubkeys passed to a single local kind-0 scan (authors + mentions).
-// Authors are ≤ FEED_CAP; this bounds the mention set so a note stuffed with thousands
-// of refs can't push the `strfry scan` argument past the OS arg-length limit. Excess
-// mentions simply keep their npub fallback.
-const PROFILE_LOOKUP_CAP = 1000;
 const FALLBACK_RELAYS = ['wss://relay.damus.io', 'wss://relay.primal.net', 'wss://nos.lol'];
 const RELAY_SET_SLUG = 'the-set-of-general-purpose-relays';
 
@@ -180,97 +179,6 @@ async function fetchNotes(followPubkeys, relays, querySync) {
   return notes.slice(0, FEED_CAP);
 }
 
-// nip19 (for decoding NIP-21 mention references) loaded the same lazy, path-tolerant
-// way as the other nostr-tools usage: the container's absolute path first, then a bare
-// require (which resolves in test/CI and from brainstorm's node_modules). If neither
-// loads, mention resolution simply no-ops — it never breaks the feed.
-let _nip19;
-function loadNip19() {
-  if (_nip19 !== undefined) return _nip19;
-  try { _nip19 = require(NOSTR_TOOLS_PATH).nip19; }
-  catch {
-    try { _nip19 = require('nostr-tools').nip19; }
-    catch { _nip19 = null; }
-  }
-  return _nip19;
-}
-
-// The pubkeys referenced by `nostr:npub…` / `nostr:nprofile…` mentions in a note's
-// text (NIP-21). Used to resolve mentioned-profile display names from LOCAL kind-0,
-// so the UI can show "@name" rather than a raw npub. Undecodable refs are skipped;
-// nsec/event refs are never matched.
-function extractMentionPubkeys(content) {
-  if (typeof content !== 'string' || content.length === 0) return [];
-  const nip19 = loadNip19();
-  if (!nip19) return [];
-  const re = /nostr:((?:npub|nprofile)1[02-9ac-hj-np-z]+)/g;
-  const out = [];
-  let m;
-  while ((m = re.exec(content)) !== null) {
-    try {
-      const dec = nip19.decode(m[1]);
-      if (dec.type === 'npub' && dec.data) out.push(dec.data);
-      else if (dec.type === 'nprofile' && dec.data && dec.data.pubkey) out.push(dec.data.pubkey);
-    } catch { /* undecodable ref → skip */ }
-  }
-  return out;
-}
-
-/**
- * Attach author display name + avatar, and resolved mention display names, from LOCAL
- * kind-0 profile data only. Missing author profile ⇒ { displayName: null, avatar: null }.
- * `mentions` maps each `nostr:npub…/nprofile…` pubkey in the note to its local display
- * name (only those we can resolve; the UI falls back to a truncated npub otherwise).
- * Never an external fetch — the mentioned profiles are resolved from the SAME local
- * kind-0 scan as the authors (one scan covers both sets of pubkeys).
- */
-async function enrichAuthors(notes, scanStrfry) {
-  const mentionsByNote = notes.map(n => extractMentionPubkeys(n.content));
-  // Authors (≤ FEED_CAP) are always looked up; mentioned pubkeys fill the rest up to
-  // PROFILE_LOOKUP_CAP so a ref-stuffed note can't overflow the local scan argument.
-  const authorPubkeys = [...new Set(notes.map(n => n.pubkey))];
-  const mentionedPubkeys = [...new Set(mentionsByNote.flat())].filter(pk => !authorPubkeys.includes(pk));
-  const lookup = [...authorPubkeys, ...mentionedPubkeys].slice(0, PROFILE_LOOKUP_CAP);
-  const profiles = new Map();
-  if (lookup.length > 0) {
-    let events = [];
-    try {
-      events = (await scanStrfry({ kinds: [0], authors: lookup })) || [];
-    } catch { events = []; }
-    for (const ev of events) {
-      if (!ev || ev.kind !== 0) continue;
-      const prev = profiles.get(ev.pubkey);
-      if (prev && prev.created_at >= ev.created_at) continue;
-      let parsed = {};
-      try { parsed = JSON.parse(ev.content) || {}; } catch { parsed = {}; }
-      profiles.set(ev.pubkey, {
-        created_at: ev.created_at,
-        displayName: parsed.display_name || parsed.name || null,
-        avatar: parsed.picture || null,
-      });
-    }
-  }
-  return notes.map((n, i) => {
-    const p = profiles.get(n.pubkey);
-    const mentions = {};
-    for (const pk of mentionsByNote[i]) {
-      const mp = profiles.get(pk);
-      if (mp && mp.displayName) mentions[pk] = mp.displayName;
-    }
-    return {
-      id: n.id,
-      pubkey: n.pubkey,
-      createdAt: n.created_at,
-      content: n.content,
-      author: {
-        displayName: p ? p.displayName : null,
-        avatar: p ? p.avatar : null,
-      },
-      mentions,
-    };
-  });
-}
-
 // ─── Orchestrator ───────────────────────────────────────────────────────────────
 
 /**
@@ -300,7 +208,7 @@ async function buildFeed(options = {}) {
 
   // 4. Fetch + filter + order + cap, then enrich from local profiles.
   const notes = await fetchNotes(followResult.follows, relays, querySync);
-  const items = await enrichAuthors(notes, scanStrfry);
+  const items = await enrichNotes(notes, scanStrfry);
 
   if (items.length === 0) {
     return { status: 'EMPTY', source, relaySource, items: [] };

--- a/test/live-feed-feed-page.test.js
+++ b/test/live-feed-feed-page.test.js
@@ -45,6 +45,7 @@ const READ_PATH = path.resolve(__dirname, '../src/api/feed/feedReadPath.js');
 const TIMEAGO = path.resolve(__dirname, '../ui/src/utils/timeAgo.js');
 const NOSTR_ENTITIES = path.resolve(__dirname, '../ui/src/utils/nostrEntities.js');
 const COMPONENT_NOTE_CONTENT = path.resolve(__dirname, '../ui/src/components/NoteContent.jsx');
+const NOTE_CARD = path.resolve(__dirname, '../ui/src/components/NoteCard.jsx');
 
 const tests = [];
 function test(name, fn) { tests.push({ name, fn }); }
@@ -127,8 +128,9 @@ test('T4: the OK branch renders the indicator then maps items in ARRAY ORDER wit
 });
 
 test('T5: each note entry shows author display name + avatar (with placeholder fallback) + timestamp + text (AC-2 content)', () => {
-  const src = safeRead(PAGE);
-  assert(src.length > 0, 'BrainstormFeed.jsx does not exist yet.');
+  // The per-note card is now the shared NoteCard component (extracted from the page).
+  const src = safeRead(NOTE_CARD);
+  assert(src.length > 0, 'ui/src/components/NoteCard.jsx must exist — the shared per-note card unit.');
   // Per-note content fields off the contract item { author:{ displayName, avatar }, createdAt, content }.
   assert(/author[\s\S]{0,12}displayName|displayName/.test(src),
     "each entry must show the author display name (item.author.displayName) (AC-2).");
@@ -143,10 +145,10 @@ test('T5: each note entry shows author display name + avatar (with placeholder f
 });
 
 test('T6: derives the per-note timestamp from createdAt via a local formatTimestamp helper, with no date library (AC-2 timestamp)', () => {
-  const src = safeRead(PAGE);
-  assert(src.length > 0, 'BrainstormFeed.jsx does not exist yet.');
+  const src = safeRead(NOTE_CARD);
+  assert(src.length > 0, 'ui/src/components/NoteCard.jsx must exist.');
   assert(/formatTimestamp/.test(src),
-    'the page must define a local formatTimestamp helper that turns the Unix-seconds createdAt into a human timestamp (ADR §Impl: a tiny local helper, no date library).');
+    'NoteCard must define a local formatTimestamp helper that turns the Unix-seconds createdAt into a human timestamp (a tiny local helper, no date library).');
   // ADR/house rule: no new dependency — must not import a date library (moment/dayjs/date-fns/luxon).
   assert(!/from\s+['"](moment|dayjs|date-fns|luxon)['"]/.test(src) && !/require\(\s*['"](moment|dayjs|date-fns|luxon)['"]/.test(src),
     'formatTimestamp must NOT pull in a date library (moment/dayjs/date-fns/luxon) — no new dependency (ADR §Constraints / house rules). Use the built-in Date.');
@@ -355,15 +357,15 @@ test('T18: formatTimeAgo DEFAULTS are unchanged (3 units, comma separator) — v
   assert(mod.formatTimeAgo(TA_NOW - 30, TA_NOW) === '0m ago', 'default sub-minute must still be "0m ago".');
 });
 
-test('T19: the page reuses formatTimeAgo, renders "just now" for sub-minute, and keeps the exact time on hover (title)', () => {
-  const src = safeRead(PAGE);
-  assert(src.length > 0, 'BrainstormFeed.jsx does not exist yet.');
+test('T19: NoteCard reuses formatTimeAgo, renders "just now" for sub-minute, and keeps the exact time on hover (title)', () => {
+  const src = safeRead(NOTE_CARD);
+  assert(src.length > 0, 'ui/src/components/NoteCard.jsx must exist.');
   assert(/from\s+['"]\.\.\/utils\/timeAgo['"]/.test(src) && /formatTimeAgo/.test(src),
-    'BrainstormFeed.jsx must import + use formatTimeAgo from ../utils/timeAgo (reuse, not a third time-format copy).');
+    'NoteCard must import + use formatTimeAgo from ../utils/timeAgo (reuse, not a third time-format copy).');
   assert(/just now/.test(src),
     'formatTimestamp must render "just now" for the sub-minute case (the smallest unit is the minute).');
   assert(/maxUnits\s*:\s*2/.test(src),
-    'the feed must request the two-unit form via formatTimeAgo(..., { maxUnits: 2, ... }).');
+    'the card must request the two-unit form via formatTimeAgo(..., { maxUnits: 2, ... }).');
   assert(/bsp-feed-time[^>]*title=/.test(src) || /title=\{[^}]*absoluteTimestamp/.test(src),
     'the timestamp element must carry a title (hover) with the exact local time so no precision is lost.');
 });
@@ -433,21 +435,26 @@ test('T23: the user-provided real example strings decode to a profile and an eve
   assert(eseg && eseg.href.startsWith('/event?nevent=nevent1'), `the nevent example must resolve to /event?nevent=…, got ${eseg && eseg.href}`);
 });
 
-test('T24: the feed renders note content through NoteContent (NIP-21 entity links), not as a raw string', () => {
+test('T24: the feed renders each note via the shared NoteCard, which renders content through NoteContent (NIP-21 entity links)', () => {
   const page = safeRead(PAGE);
+  const card = safeRead(NOTE_CARD);
   const comp = safeRead(COMPONENT_NOTE_CONTENT);
-  assert(page.length > 0 && comp.length > 0, 'BrainstormFeed.jsx and NoteContent.jsx must exist.');
-  assert(/<NoteContent\s+content=\{item\.content\}/.test(page),
-    'the feed item must render its text via <NoteContent content={item.content} /> (the entity-linkifying renderer), not {item.content} verbatim.');
+  assert(page.length > 0 && card.length > 0 && comp.length > 0, 'BrainstormFeed.jsx, NoteCard.jsx and NoteContent.jsx must exist.');
+  // The page delegates each item to the shared card unit (so the two new locations + future
+  // per-note improvements reuse one component) — it does not inline the card markup.
+  assert(/<NoteCard\b[^>]*\bitem=\{item\}/.test(page) && /import NoteCard/.test(page),
+    'the feed must render each note via <NoteCard item={item} /> (the shared per-note card), not inline card markup.');
+  assert(/<NoteContent\s+content=\{item\.content\}/.test(card),
+    'NoteCard must render the note text via <NoteContent content={item.content} /> (the entity-linkifying renderer), not {item.content} verbatim.');
   assert(/parseNostrContent/.test(comp) && /react-router-dom/.test(comp),
     'NoteContent must map parseNostrContent segments to react-router <Link>s.');
 });
 
-test('T25: the feed passes the resolved mentions map and NoteContent renders "@name" over the raw npub', () => {
-  const page = safeRead(PAGE);
+test('T25: NoteCard passes the resolved mentions map and NoteContent renders "@name" over the raw npub', () => {
+  const card = safeRead(NOTE_CARD);
   const comp = safeRead(COMPONENT_NOTE_CONTENT);
-  assert(/<NoteContent\b[^>]*\bmentions=\{item\.mentions\}/.test(page),
-    'BrainstormFeed must pass the read path\'s resolved mentions map: <NoteContent content={item.content} mentions={item.mentions} />.');
+  assert(/<NoteContent\b[^>]*\bmentions=\{item\.mentions\}/.test(card),
+    'NoteCard must pass the read path\'s resolved mentions map: <NoteContent content={item.content} mentions={item.mentions} />.');
   assert(/mentions\[seg\.pubkey\]/.test(comp) && /@\$\{name\}/.test(comp),
     'NoteContent must look up mentions[seg.pubkey] and render "@${name}" when the display name is resolved (falling back to the npub otherwise).');
 });

--- a/test/live-feed-feed-page.test.js
+++ b/test/live-feed-feed-page.test.js
@@ -222,14 +222,15 @@ test('T10: useFeed fetches /api/feed and surfaces a transport failure as `error`
 test('T11: note text wraps so a long token cannot overflow 1280px (overflow-wrap / word-break) (AC-1 no overflow)', () => {
   const css = safeRead(STYLES);
   assert(css.length > 0, 'ui/src/styles.css missing — unexpected.');
-  // A new feed-item / feed-text class must wrap long content/URLs. Anchor on a bsp-feed-* rule
-  // (none exist pre-implementation) carrying overflow-wrap/word-break.
-  const block = css.match(/\.bsp-feed[\w-]*\s*\{[^}]*\}/g);
+  // The shared note-card text class must wrap long content/URLs. Anchor on a bsp-note-card-*
+  // rule carrying overflow-wrap/word-break (the protection now travels with the card to every
+  // surface that reuses it, not just the feed).
+  const block = css.match(/\.bsp-note-card[\w-]*\s*\{[^}]*\}/g);
   assert(block && block.length > 0,
-    'styles.css must define at least one new bsp-feed-* rule for the feed items (none exist pre-implementation).');
+    'styles.css must define the shared bsp-note-card-* rules for the note card.');
   const joined = block.join('\n');
   assert(/overflow-wrap\s*:\s*(anywhere|break-word)|word-break\s*:\s*(break-word|break-all)/.test(joined),
-    'a bsp-feed-* rule must wrap note text (overflow-wrap:anywhere / word-break) so a long URL or unbroken token cannot extend past the column / 1280px (AC-1 no horizontal overflow).');
+    'a bsp-note-card-* rule must wrap note text (overflow-wrap:anywhere / word-break) so a long URL or unbroken token cannot extend past the column / 1280px (AC-1 no horizontal overflow).');
 });
 
 test('T12: the feed column is width-capped with box-sizing:border-box so content cannot exceed 1280px (AC-1 no overflow)', () => {
@@ -239,14 +240,14 @@ test('T12: the feed column is width-capped with box-sizing:border-box so content
   assert(css.length > 0, 'ui/src/styles.css missing — unexpected.');
   // The column must be capped (a max-width token / inline maxWidth, as BrainstormAbout does) and
   // box-sizing:border-box so padding doesn't push the box past its cap. Accept the cap on the page
-  // (inline maxWidth, the BrainstormAbout pattern) OR in a bsp-feed-* CSS rule.
+  // (inline maxWidth, the BrainstormAbout pattern) OR in a shared bsp-note-card-* CSS rule.
   const cappedOnPage = /maxWidth\s*:\s*\d/.test(src);
-  const feedRules = (css.match(/\.bsp-feed[\w-]*\s*\{[^}]*\}/g) || []).join('\n');
-  const cappedInCss = /max-width\s*:\s*\d/.test(feedRules);
+  const cardRules = (css.match(/\.bsp-note-card[\w-]*\s*\{[^}]*\}/g) || []).join('\n');
+  const cappedInCss = /max-width\s*:\s*\d/.test(cardRules);
   assert(cappedOnPage || cappedInCss,
-    'the feed column must be width-capped — an inline maxWidth on the bsp-content column (the BrainstormAbout pattern) or a max-width on a bsp-feed-* rule — so the page does not stretch unbounded (AC-1 no overflow @1280px).');
-  assert(/box-sizing\s*:\s*border-box/.test(feedRules) || /box-sizing\s*:\s*border-box/.test(css),
-    'the feed item/column must use box-sizing:border-box so its padding is inside the capped width and cannot push content past 1280px (AC-1).');
+    'the column must be width-capped — an inline maxWidth on the bsp-content column (the BrainstormAbout pattern) or a max-width on a bsp-note-card-* rule — so the page does not stretch unbounded (AC-1 no overflow @1280px).');
+  assert(/box-sizing\s*:\s*border-box/.test(cardRules) || /box-sizing\s*:\s*border-box/.test(css),
+    'the note card/column must use box-sizing:border-box so its padding is inside the capped width and cannot push content past 1280px (AC-1).');
 });
 
 // ===========================================================================
@@ -366,7 +367,7 @@ test('T19: NoteCard reuses formatTimeAgo, renders "just now" for sub-minute, and
     'formatTimestamp must render "just now" for the sub-minute case (the smallest unit is the minute).');
   assert(/maxUnits\s*:\s*2/.test(src),
     'the card must request the two-unit form via formatTimeAgo(..., { maxUnits: 2, ... }).');
-  assert(/bsp-feed-time[^>]*title=/.test(src) || /title=\{[^}]*absoluteTimestamp/.test(src),
+  assert(/bsp-note-card-time[^>]*title=/.test(src) || /title=\{[^}]*absoluteTimestamp/.test(src),
     'the timestamp element must carry a title (hover) with the exact local time so no precision is lost.');
 });
 

--- a/test/live-feed-read-path.test.js
+++ b/test/live-feed-read-path.test.js
@@ -674,6 +674,33 @@ test('E1 (shared seam): enrichNotes is reusable — exported from _shared, turns
     'each enriched item must carry a mentions map (empty when the note has no nostr: refs).');
 });
 
+test('E2 (shared seam): the direct-import contract the two new read paths depend on — extractMentionPubkeys, PROFILE_LOOKUP_CAP, and direct mention resolution', async () => {
+  const mod = require('../src/api/_shared/noteEnrichment');
+  const { nip19 } = require('nostr-tools');
+  // The cap the future per-user notes page must respect (it calls enrichNotes directly).
+  assert(mod.PROFILE_LOOKUP_CAP === 1000, `PROFILE_LOOKUP_CAP must be exported and === 1000; got ${mod.PROFILE_LOOKUP_CAP}.`);
+  // extractMentionPubkeys: npub/nprofile → pubkey; nsec/junk → [] (never a private key).
+  assert(typeof mod.extractMentionPubkeys === 'function', 'noteEnrichment must export extractMentionPubkeys.');
+  const M = HEX('5');
+  assert(JSON.stringify(mod.extractMentionPubkeys(`hi nostr:${nip19.npubEncode(M)} x`)) === JSON.stringify([M]),
+    'extractMentionPubkeys must decode a nostr:npub mention to its pubkey.');
+  assert(mod.extractMentionPubkeys(`k nostr:${nip19.nsecEncode(new Uint8Array(32).fill(9))} z`).length === 0,
+    'extractMentionPubkeys must NEVER return anything for an nsec (a private key is not a mention).');
+  // enrichNotes called DIRECTLY (not via buildFeed): a resolvable mention → name; unknown → omitted.
+  const KNOWN = HEX('5'), UNKNOWN = HEX('6');
+  const content = `cc nostr:${nip19.npubEncode(KNOWN)} & nostr:${nip19.npubEncode(UNKNOWN)}`;
+  const scanStrfry = (filter) => {
+    const f = typeof filter === 'string' ? JSON.parse(filter) : filter;
+    if (Array.isArray(f.kinds) && f.kinds.includes(0)) {
+      return [{ id: 'k0', kind: 0, pubkey: KNOWN, created_at: 10, tags: [], content: JSON.stringify({ name: 'Cara' }) }];
+    }
+    return [];
+  };
+  const [it] = await mod.enrichNotes([kind1('n', HEX('1'), 100, content)], scanStrfry);
+  assert(it.mentions[KNOWN] === 'Cara', `direct enrichNotes must resolve a known mention to its name; got ${JSON.stringify(it.mentions[KNOWN])}.`);
+  assert(!(UNKNOWN in it.mentions), 'an unresolved mention must be omitted (UI falls back to the npub).');
+});
+
 async function run() {
   let pass = 0, fail = 0;
   for (const t of tests) {

--- a/test/live-feed-read-path.test.js
+++ b/test/live-feed-read-path.test.js
@@ -650,6 +650,30 @@ test('M5 (mentions/robustness): the local kind-0 lookup is capped so a ref-stuff
     `the kind-0 lookup must be capped (≤1000 — authors + bounded mentions) so a ref-stuffed note can't overflow the scan argument; got ${scanAuthors.length}.`);
 });
 
+test('E1 (shared seam): enrichNotes is reusable — exported from _shared, turns raw notes into the enriched item shape via the injected local scan', async () => {
+  let mod;
+  try { mod = require('../src/api/_shared/noteEnrichment'); } catch { mod = null; }
+  assert(mod && typeof mod.enrichNotes === 'function',
+    'src/api/_shared/noteEnrichment.js must export enrichNotes(notes, scanStrfry) — the shared seam the feed and the future profile/user-notes read paths all use.');
+  const A = HEX('1');
+  const scanStrfry = (filter) => {
+    const f = typeof filter === 'string' ? JSON.parse(filter) : filter;
+    if (Array.isArray(f.kinds) && f.kinds.includes(0)) {
+      return [{ id: 'k0', kind: 0, pubkey: A, created_at: 10, tags: [], content: JSON.stringify({ name: 'Ann', picture: 'p.png' }) }];
+    }
+    return [];
+  };
+  const items = await mod.enrichNotes([kind1('x', A, 100, 'hi')], scanStrfry);
+  assert(items.length === 1, 'one raw note in → one enriched item out.');
+  const it = items[0];
+  assert(it.id === 'x' && it.pubkey === A && it.createdAt === 100 && it.content === 'hi',
+    'enrichNotes must preserve id/pubkey/createdAt/content (createdAt mapped from created_at).');
+  assert(it.author && it.author.displayName === 'Ann' && it.author.avatar === 'p.png',
+    'enrichNotes must resolve the author name/avatar from the injected LOCAL kind-0 scan.');
+  assert(it.mentions && typeof it.mentions === 'object',
+    'each enriched item must carry a mentions map (empty when the note has no nostr: refs).');
+});
+
 async function run() {
   let pass = 0, fail = 0;
   for (const t of tests) {

--- a/ui/src/components/NoteCard.jsx
+++ b/ui/src/components/NoteCard.jsx
@@ -1,0 +1,77 @@
+import { Link } from 'react-router-dom';
+import NoteActionsMenu from './NoteActionsMenu';
+import NoteContent from './NoteContent';
+import { formatTimeAgo } from '../utils/timeAgo';
+
+/**
+ * NoteCard — the shared visual unit for a single kind-1 note. Pure presentational:
+ * it takes an already-enriched note `item`
+ *   { id, pubkey, createdAt, content, author: { displayName, avatar }, mentions }
+ * (the shape every read path serves, see src/api/_shared/noteEnrichment.js) and renders
+ * the card. No data fetching, no read logic — the page/parent supplies the item.
+ *
+ * Used by the live feed today; the profile "latest note" and per-user notes page are
+ * expected to reuse it next. Future per-note improvements (reposts, reply indicator,
+ * event tags) belong HERE so every location gets them at once. Layout variants should
+ * arrive as explicit props (kept few and intentional), not forks of this component.
+ *
+ * The avatar + display name link to the author's profile (/user/<pubkey>); when the note
+ * has no pubkey (defensive; enriched OK items always carry one) they render unlinked so
+ * we never emit a /user/ link to nowhere.
+ */
+
+// Unix seconds → a compact relative "time ago" label: the two most-significant non-zero
+// units among years/days/hours/minutes, space-separated (e.g. "2m ago", "4h 53m ago",
+// "1y 213d ago"). Sub-minute renders "just now". Delegates the unit math to the shared
+// formatTimeAgo helper (no date library).
+export function formatTimestamp(createdAt) {
+  if (typeof createdAt !== 'number' || !Number.isFinite(createdAt)) return '';
+  const now = Math.floor(Date.now() / 1000);
+  if (now - createdAt < 60) return 'just now';
+  return formatTimeAgo(createdAt, now, { maxUnits: 2, separator: ' ' });
+}
+
+// The exact local date/time, shown on hover (title) so the relative label keeps its
+// precision a click away. Built-in Date only — no date library.
+export function absoluteTimestamp(createdAt) {
+  if (typeof createdAt !== 'number' || !Number.isFinite(createdAt)) return '';
+  return new Date(createdAt * 1000).toLocaleString();
+}
+
+export default function NoteCard({ item }) {
+  const author = item.author || {};
+  const displayName = author.displayName || (item.pubkey ? `${item.pubkey.slice(0, 8)}…` : 'Unknown');
+  const avatar = author.avatar;
+  const profileHref = item.pubkey ? `/user/${item.pubkey}` : null;
+
+  const avatarEl = avatar ? (
+    <img className="bsp-avatar bsp-feed-avatar" src={avatar} alt="" />
+  ) : (
+    <div className="bsp-avatar bsp-avatar-placeholder bsp-feed-avatar">
+      {displayName.charAt(0).toUpperCase()}
+    </div>
+  );
+
+  return (
+    <div className="bsp-feed-item">
+      <div className="bsp-feed-item-head">
+        {profileHref ? (
+          <Link to={profileHref} className="bsp-feed-author-link" aria-label={`View ${displayName}'s profile`}>
+            {avatarEl}
+          </Link>
+        ) : avatarEl}
+        <div className="bsp-feed-item-meta">
+          {profileHref ? (
+            <Link to={profileHref} className="bsp-name bsp-feed-name bsp-feed-name-link">{displayName}</Link>
+          ) : (
+            <div className="bsp-name bsp-feed-name">{displayName}</div>
+          )}
+          <div className="bsp-feed-time" title={absoluteTimestamp(item.createdAt)}>{formatTimestamp(item.createdAt)}</div>
+        </div>
+        {/* Per-note actions (copy link / id, tag) — floats to the top-right of the entry. */}
+        <NoteActionsMenu item={item} />
+      </div>
+      <div className="bsp-feed-text"><NoteContent content={item.content} mentions={item.mentions} /></div>
+    </div>
+  );
+}

--- a/ui/src/components/NoteCard.jsx
+++ b/ui/src/components/NoteCard.jsx
@@ -11,9 +11,14 @@ import { formatTimeAgo } from '../utils/timeAgo';
  * the card. No data fetching, no read logic — the page/parent supplies the item.
  *
  * Used by the live feed today; the profile "latest note" and per-user notes page are
- * expected to reuse it next. Future per-note improvements (reposts, reply indicator,
- * event tags) belong HERE so every location gets them at once. Layout variants should
- * arrive as explicit props (kept few and intentional), not forks of this component.
+ * expected to reuse it next. Its markup uses surface-neutral `bsp-note-card-*` classes
+ * (not feed-specific ones) precisely so those non-feed surfaces can reuse it without
+ * inheriting feed styling or forking. Future per-note improvements (reposts, reply
+ * indicator, event tags) belong HERE so every location gets them at once.
+ *
+ * Layout variants (e.g. a compact profile latest-note, or hiding the actions menu)
+ * should arrive as explicit props — there is no variant prop yet; the first consumer
+ * that needs one should add it here rather than branching at the call site or forking.
  *
  * The avatar + display name link to the author's profile (/user/<pubkey>); when the note
  * has no pubkey (defensive; enriched OK items always carry one) they render unlinked so
@@ -45,33 +50,33 @@ export default function NoteCard({ item }) {
   const profileHref = item.pubkey ? `/user/${item.pubkey}` : null;
 
   const avatarEl = avatar ? (
-    <img className="bsp-avatar bsp-feed-avatar" src={avatar} alt="" />
+    <img className="bsp-avatar bsp-note-card-avatar" src={avatar} alt="" />
   ) : (
-    <div className="bsp-avatar bsp-avatar-placeholder bsp-feed-avatar">
+    <div className="bsp-avatar bsp-avatar-placeholder bsp-note-card-avatar">
       {displayName.charAt(0).toUpperCase()}
     </div>
   );
 
   return (
-    <div className="bsp-feed-item">
-      <div className="bsp-feed-item-head">
+    <div className="bsp-note-card">
+      <div className="bsp-note-card-head">
         {profileHref ? (
-          <Link to={profileHref} className="bsp-feed-author-link" aria-label={`View ${displayName}'s profile`}>
+          <Link to={profileHref} className="bsp-note-card-author-link" aria-label={`View ${displayName}'s profile`}>
             {avatarEl}
           </Link>
         ) : avatarEl}
-        <div className="bsp-feed-item-meta">
+        <div className="bsp-note-card-meta">
           {profileHref ? (
-            <Link to={profileHref} className="bsp-name bsp-feed-name bsp-feed-name-link">{displayName}</Link>
+            <Link to={profileHref} className="bsp-name bsp-note-card-name bsp-note-card-name-link">{displayName}</Link>
           ) : (
-            <div className="bsp-name bsp-feed-name">{displayName}</div>
+            <div className="bsp-name bsp-note-card-name">{displayName}</div>
           )}
-          <div className="bsp-feed-time" title={absoluteTimestamp(item.createdAt)}>{formatTimestamp(item.createdAt)}</div>
+          <div className="bsp-note-card-time" title={absoluteTimestamp(item.createdAt)}>{formatTimestamp(item.createdAt)}</div>
         </div>
         {/* Per-note actions (copy link / id, tag) — floats to the top-right of the entry. */}
         <NoteActionsMenu item={item} />
       </div>
-      <div className="bsp-feed-text"><NoteContent content={item.content} mentions={item.mentions} /></div>
+      <div className="bsp-note-card-text"><NoteContent content={item.content} mentions={item.mentions} /></div>
     </div>
   );
 }

--- a/ui/src/pages/BrainstormFeed.jsx
+++ b/ui/src/pages/BrainstormFeed.jsx
@@ -1,9 +1,6 @@
-import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu from '../components/BrainstormUserMenu';
-import NoteActionsMenu from '../components/NoteActionsMenu';
-import NoteContent from '../components/NoteContent';
-import { formatTimeAgo } from '../utils/timeAgo';
+import NoteCard from '../components/NoteCard';
 import useFeed from '../hooks/useFeed';
 
 /**
@@ -30,24 +27,6 @@ export const FEED_COPY = {
   COULDNT_LOAD: "Couldn't load the feed right now.",
 };
 
-// Unix seconds → a compact relative "time ago" label: the two most-significant
-// non-zero units among years/days/hours/minutes, space-separated (e.g. "2m ago",
-// "4h 53m ago", "1y 213d ago"). Sub-minute renders "just now". Delegates the unit
-// math to the shared formatTimeAgo helper (no date library).
-export function formatTimestamp(createdAt) {
-  if (typeof createdAt !== 'number' || !Number.isFinite(createdAt)) return '';
-  const now = Math.floor(Date.now() / 1000);
-  if (now - createdAt < 60) return 'just now';
-  return formatTimeAgo(createdAt, now, { maxUnits: 2, separator: ' ' });
-}
-
-// The exact local date/time, shown on hover (title) so the relative label keeps
-// its precision a click away. Built-in Date only — no date library.
-export function absoluteTimestamp(createdAt) {
-  if (typeof createdAt !== 'number' || !Number.isFinite(createdAt)) return '';
-  return new Date(createdAt * 1000).toLocaleString();
-}
-
 export default function BrainstormFeed() {
   const { user, login, logout } = useAuth();
   const { data, loading, error } = useFeed();
@@ -68,49 +47,6 @@ export default function BrainstormFeed() {
         <h1 className="bsp-feed-heading">{FEED_COPY.HEADING}</h1>
         {renderFeedState({ data, loading, error })}
       </div>
-    </div>
-  );
-}
-
-// One note entry: avatar (placeholder fallback) + author display name + timestamp + text.
-// The avatar and the display name link to the author's profile (/user/<pubkey>) — an
-// in-app SPA <Link>, the same target the search/follows lists use. When the note has no
-// pubkey (defensive; OK items always carry one) the avatar/name render unlinked so we
-// never emit a /user/ link to nowhere.
-function FeedItem({ item }) {
-  const author = item.author || {};
-  const displayName = author.displayName || (item.pubkey ? `${item.pubkey.slice(0, 8)}…` : 'Unknown');
-  const avatar = author.avatar;
-  const profileHref = item.pubkey ? `/user/${item.pubkey}` : null;
-
-  const avatarEl = avatar ? (
-    <img className="bsp-avatar bsp-feed-avatar" src={avatar} alt="" />
-  ) : (
-    <div className="bsp-avatar bsp-avatar-placeholder bsp-feed-avatar">
-      {displayName.charAt(0).toUpperCase()}
-    </div>
-  );
-
-  return (
-    <div className="bsp-feed-item">
-      <div className="bsp-feed-item-head">
-        {profileHref ? (
-          <Link to={profileHref} className="bsp-feed-author-link" aria-label={`View ${displayName}'s profile`}>
-            {avatarEl}
-          </Link>
-        ) : avatarEl}
-        <div className="bsp-feed-item-meta">
-          {profileHref ? (
-            <Link to={profileHref} className="bsp-name bsp-feed-name bsp-feed-name-link">{displayName}</Link>
-          ) : (
-            <div className="bsp-name bsp-feed-name">{displayName}</div>
-          )}
-          <div className="bsp-feed-time" title={absoluteTimestamp(item.createdAt)}>{formatTimestamp(item.createdAt)}</div>
-        </div>
-        {/* Per-note actions (copy link / id, tag) — floats to the top-right of the entry. */}
-        <NoteActionsMenu item={item} />
-      </div>
-      <div className="bsp-feed-text"><NoteContent content={item.content} mentions={item.mentions} /></div>
     </div>
   );
 }
@@ -153,7 +89,7 @@ export function renderFeedState({ data, loading, error }) {
     <>
       <div className="bsp-feed-indicator">{FEED_COPY.INDICATOR}</div>
       <div className="bsp-feed-list">
-        {items.map(item => <FeedItem key={item.id} item={item} />)}
+        {items.map(item => <NoteCard key={item.id} item={item} />)}
       </div>
     </>
   );

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -7201,35 +7201,37 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   flex-direction: column;
   gap: 1rem;
 }
-.bsp-feed-item {
+/* Shared note-card unit (NoteCard.jsx) — surface-neutral so the feed, profile
+   "latest note", and per-user notes page all reuse it without feed-specific styling. */
+.bsp-note-card {
   max-width: 100%;
   box-sizing: border-box;
   padding: 1rem;
   border: 1px solid rgba(255,255,255,0.06);
   border-radius: 10px;
 }
-.bsp-feed-item-head {
+.bsp-note-card-head {
   display: flex;
   align-items: center;
   gap: 0.75rem;
   margin-bottom: 0.6rem;
 }
-.bsp-feed-avatar {
+.bsp-note-card-avatar {
   width: 40px;
   height: 40px;
 }
-.bsp-feed-item-meta {
+.bsp-note-card-meta {
   min-width: 0;
 }
-.bsp-feed-name {
+.bsp-note-card-name {
   font-size: 0.95rem;
   overflow-wrap: anywhere;
 }
-.bsp-feed-time {
+.bsp-note-card-time {
   font-size: 0.75rem;
   opacity: 0.5;
 }
-.bsp-feed-text {
+.bsp-note-card-text {
   font-size: 0.9rem;
   line-height: 1.5;
   white-space: pre-wrap;
@@ -7251,19 +7253,19 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   text-underline-offset: 2px;
 }
 /* Author avatar/name link to the author's profile (/user/<pubkey>). */
-.bsp-feed-author-link {
+.bsp-note-card-author-link {
   display: inline-flex;
   flex: none;
   border-radius: 50%;
 }
-.bsp-feed-author-link:hover {
+.bsp-note-card-author-link:hover {
   opacity: 0.85;
 }
-.bsp-feed-name-link {
+.bsp-note-card-name-link {
   color: inherit;
   text-decoration: none;
 }
-.bsp-feed-name-link:hover {
+.bsp-note-card-name-link:hover {
   text-decoration: underline;
   text-decoration-color: rgba(165, 180, 252, 0.5);
   text-underline-offset: 2px;


### PR DESCRIPTION
## Summary

Behavior-preserving refactor that extracts the per-note rendering and note-enrichment into shared seams, so the planned profile "latest note" + per-user notes page (and future per-note features: reposts, reply indicators, event tags) are implemented **once** instead of three times. `/feed` is unchanged for users.

- **Client** `ui/src/components/NoteCard.jsx` — the per-note card (avatar + author link + relative time + actions menu + content), moved out of the feed's inline `FeedItem`. Pure presentational; surface-neutral `bsp-note-card-*` classes.
- **Server** `src/api/_shared/noteEnrichment.js` — `enrichNotes(notes, scanStrfry)` (the former `enrichAuthors`), reusable by any read path. The enriched item shape `{ id, pubkey, createdAt, content, author, mentions }` is the documented contract.

Independent multi-lens review: **PASS** (the one SHOULD_FIX — surface-neutral class names — applied). BIBLE §13 documents the seam; intake entries queue the two new surfaces.

## Changes

- `ui/src/components/NoteCard.jsx` (new) + `src/api/_shared/noteEnrichment.js` (new)
- `ui/src/pages/BrainstormFeed.jsx` (renders `<NoteCard>`) + `src/api/feed/feedReadPath.js` (imports `enrichNotes`)
- `ui/src/styles.css` (`bsp-feed-*` card classes → `bsp-note-card-*`)
- `test/live-feed-read-path.test.js` (E1/E2) + `test/live-feed-feed-page.test.js` (re-pointed to NoteCard)
- `BIBLE.md`, `engineering-team/reviews/live-feed/6-notecard-refactor.md`, `engineering-team/stories/_intake.md`

## Test plan

- [ ] After merge: deploy-staging.yml runs (vite build green — confirmed locally).
- [ ] Smoke on staging.brainstorm.world: `/feed` renders identically (author link, relative time + hover, actions menu, nostr: entity links, resolved @mention).
- [ ] `/api/feed` items still carry the `{author, mentions}` shape.

Verified locally: live-feed-read-path 30/30, live-feed-feed-page 27/27, full `vite build` green, feed browser-verified rendering identically (incl. computed-style check after the class rename), zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)