### PR TITLE
feat(note-surfaces): profile Content section + per-user /notes page + by-author read path

### DIFF
--- a/engineering-team/decisions/note-surfaces/0001-by-author-notes-read-path.md
+++ b/engineering-team/decisions/note-surfaces/0001-by-author-notes-read-path.md
@@ -1,0 +1,126 @@
+# ADR 0001: By-author notes read path — a public `GET /api/user/:pubkey/notes` that assembles one user's recent kind-1 notes
+
+**Status:** Accepted
+**Date:** 2026-06-18
+**Story:** `engineering-team/stories/note-surfaces/1-by-author-notes-read-path.md`
+**Epic:** `engineering-team/epics/note-surfaces.md`
+
+## Context
+
+The `note-surfaces` epic adds two surfaces — a profile "Content" section (`note-surfaces` #2) and a `/user/:pubkey/notes` page (#3) — that both need the same thing: the **N most-recent kind-1 notes authored by a given pubkey**, newest-first, profile-enriched into the shared note item shape. This ADR designs **only that backend read path**, exposed as data; the two surfaces (ADR 0002) consume it.
+
+It is a deliberately simpler sibling of the live-feed read path (`feedReadPath.js`, ADR `live-feed/0001`). The feed resolves a *source identity*, reads its kind-3 follow list, and fetches notes for the **set of followed authors**. This read path has **no source identity, no follow list, and no point-of-view** — the author is the pubkey in the URL. Only the *selection* of raw kind-1 differs; the enrichment (author display name + avatar + `nostr:` mention resolution, all from local kind-0) is the **already-shared `enrichNotes`** (`src/api/_shared/noteEnrichment.js:79`, `enrichNotes(notes, scanStrfry)` → items `{ id, pubkey, createdAt, content, author:{displayName,avatar}, mentions }`).
+
+### Acceptance criteria, quoted to design against
+
+> - **Selection & content.** kind-1 by that pubkey, newest-first, capped at N; each item carries id, author pubkey, timestamp, text + author display name/avatar from local kind-0; kind-6/kind-7 and other authors excluded; **item shape identical to the feed's** so `NoteCard` renders it unchanged.
+> - **Count parameterization & cap.** count=1 → single latest; count=50 → up to 50; absent/non-numeric/over-maximum → a defined default and a hard maximum (no unbounded result).
+> - **Empty outcome** (valid pubkey, zero notes) — distinct from the **invalid-input outcome** (malformed pubkey).
+> - **Mentions resolved like the feed** (same `enrichNotes`).
+
+### The sourcing question, settled empirically
+
+The story deferred "relays vs local strfry" to Architecture. **Settled: relays.** Read-only `strfry scan` against the running local stack (2026-06-18):
+
+| Query | Local strfry result |
+|---|---|
+| `{"kinds":[1],"limit":50}` (any author) | **0 events** |
+| `{"kinds":[1],"authors":["3129…f506"]}` (reference user) | **0 events** |
+| `{"kinds":[1],"limit":3000}` | **0 events** |
+| `{"authors":["3129…f506"]}` (any kind) | 1 event (their kind-0) |
+
+Local strfry on these instances is **not a kind-1 archive** — it holds graph-relevant events (kind-3 follows, kind-0 profiles, tag events), not arbitrary users' posts. Local-only sourcing would render "no notes" for essentially every user. The kind-1 **notes** must come from relays (exactly as `feedReadPath.fetchNotes` does); the **enrichment** (kind-0 author/mention names) stays **local**, exactly as `enrichNotes` already does.
+
+### Existing mechanisms to reuse / mirror (verified in source)
+
+| Need | Pattern | Source |
+|---|---|---|
+| Resolve general-purpose relay set (slug-from-TA + fallback) | `resolveGeneralPurposeRelays(runCypher)` | `feedReadPath.js:138-159` |
+| Fetch kind-1 from relays (SimplePool + timeout + id-dedup) | `realQuerySync` / `fetchNotes` | `feedReadPath.js:77-91,165-180` |
+| Local kind-0 scan for enrichment | `realScanStrfry` | `feedReadPath.js:57-69` |
+| Enrich raw kind-1 → item shape (author + mentions, local-only) | **`enrichNotes(notes, scanStrfry)`** (already shared) | `src/api/_shared/noteEnrichment.js:79` |
+| Public route registration | `app.get('/api/...', handler)` | `src/api/index.js:302` (`/api/feed`) |
+| `:pubkey` path-param precedent | `/api/search/profiles/meili/document/:pubkey` | `src/api/index.js:345` |
+| Anonymous reachability | auth middleware allows read-only API by default (only a write/backup blocklist is gated) | `src/middleware/auth.js:484-489` |
+
+### Constraints
+
+- **Additive, read-only.** No writes; no change to search, ranking, firmware, **or the shipped `feedReadPath.js`**. With the new module + one route line removed, the app behaves as before.
+- **JS-without-build, no new dependency.** `nostr-tools` (`SimplePool`), `ws`, the Neo4j driver, and the strfry CLI are all already used by `feedReadPath.js`. This ADR adds none.
+- **`enrichNotes` caller contract** (`noteEnrichment.js:30-37`): it caps the kind-0 *scan argument* at `PROFILE_LOOKUP_CAP=1000` but not the work; a caller serving >1000 distinct authors must pre-cap. This path serves **one** author with **≤50** notes → ≤1 distinct author + its mentions, far under the cap. Safe by construction.
+
+## Options considered
+
+### Option A — New self-contained read-path module sourcing from relays, reusing `enrichNotes` *(chosen)*
+
+Add `src/api/notes/userNotesReadPath.js` exporting `buildUserNotes({ pubkey, limit, deps })` and an Express handler `handleGetUserNotes`, wired at `GET /api/user/:pubkey/notes`. It **mirrors `feedReadPath.js`'s structure** — self-contained, with its own small copies of the sourcing helpers (relay-set resolution, `querySync`, local `scanStrfry`) and the same injectable-deps seam — but its selection step is "kind-1 authored by the single given pubkey, sorted desc, sliced to N." It reuses the one already-shared piece, `enrichNotes`.
+
+- **Pros:**
+  - **Matches house style exactly.** `feedReadPath.js` is itself self-contained (defines its own `realQuerySync`/`realScanStrfry`/`resolveGeneralPurposeRelays`); only `enrichNotes` is in `_shared`. This new path is the same shape — least surprising, consistent with the precedent the live-feed epic set.
+  - **Strictly additive & reversible.** Touches no shipped code except one route line in `src/api/index.js`. `feedReadPath.js` stays byte-identical — the working, staging-shipped feed carries **zero regression risk**.
+  - Reuses `enrichNotes` so the item shape is guaranteed identical to the feed's → `NoteCard` renders it unchanged (criterion 1).
+  - The injectable-deps seam (mirroring ADR `live-feed/0001`'s amendment) makes all outcomes unit-testable with in-memory fakes — no live relays/Neo4j/strfry.
+- **Cons:**
+  - Duplicates ~3 small sourcing helpers (relay resolution, `querySync`, `scanStrfry`) already present in `feedReadPath.js`. Acknowledged and flagged as a **deferred consolidation** (see Consequences) — the same trade-off ADR `live-feed/0001` made when it chose duplication over touching the shared `fetchProfiles.js`.
+
+### Option B — Extract the shared sourcing into `_shared/` and re-point `feedReadPath.js` to reuse it
+
+Move `resolveGeneralPurposeRelays`, `realQuerySync`, `realScanStrfry` into a new `src/api/_shared/relaySource.js`; have **both** `feedReadPath.js` and the new module import them.
+
+- **Pros:** DRY; a single home for relay-set sourcing; the clean long-term end-state.
+- **Cons (decisive *for now*):** it **modifies the shipped, staging-live feed read path**, turning a purely additive feature into a change with regression surface across `/feed` — which the epic frames as out of scope and the live-feed batch hasn't even reached prod yet. ADR `live-feed/0001` set the precedent explicitly: prefer a little duplication over touching shipped shared code until a consolidation is justified. We **defer** this to a separate, behavior-preserving refactor (a tracked follow-up) rather than fold it into this feature.
+
+### Option C — Source kind-1 from local strfry only (no relays)
+
+Select the user's kind-1 from local strfry via `scanStrfry({kinds:[1],authors:[pubkey]})`.
+
+- **Cons (decisive):** **empirically returns nothing.** Local strfry holds 0 kind-1 events (evidence above). This surface would be permanently empty for every user. Rejected.
+
+## Decision
+
+**Option A.** A new self-contained `src/api/notes/userNotesReadPath.js` exposing one public `GET /api/user/:pubkey/notes?limit=`, mirroring `feedReadPath.js`'s structure and injectable-deps seam, selecting kind-1 **by the single URL pubkey** from the general-purpose relays (with the same fallback), and reusing the shared `enrichNotes` for the (local-only) author/mention enrichment. It returns a discriminated `status` union (`OK` / `EMPTY` / `INVALID`) plus a `relaySource` (`set` | `fallback`) on `OK`/`EMPTY`, with each item the **exact feed item shape**. It is additive and reversible and leaves the shipped feed untouched. The DRY consolidation of the duplicated sourcing helpers is deferred to a tracked follow-up (Option B, done safely on its own).
+
+## Consequences
+
+- **Enables:** ADR 0002's two surfaces consume one endpoint, parameterized by `limit` (1 for the Content section, 50 for the notes page); they render, they do not re-derive.
+- **Constrains:** the response shape (`status`, item fields, `relaySource`) becomes a contract ADR 0002 depends on.
+- **New debt / follow-up (tracked):** the sourcing helpers (`resolveGeneralPurposeRelays`, `querySync`, `scanStrfry`) now exist in both `feedReadPath.js` and `userNotesReadPath.js`. Consolidate into `src/api/_shared/relaySource.js` and re-point both — a separate, behavior-preserving refactor (Option B) — when a third consumer appears or a dedicated cleanup is scheduled. Logged in `engineering-team/follow-ups.md` (or the epic) so it isn't silently dropped.
+- **Best-effort "N most recent" under relay timeout** — the cap is enforced post-fetch, so a slow/incomplete relay may return fewer than N (same property as the feed). Acceptable for a recent-window surface; noted in Out of scope.
+- **Firmware reinstall required?** **No.** Defines no concepts, changes no schema — it only *reads* the existing relay set and existing kind-1/kind-0 events.
+
+## Implementation notes
+
+Concrete targets for the Implementer.
+
+- **New file: `src/api/notes/userNotesReadPath.js`.**
+  - `const { enrichNotes } = require('../_shared/noteEnrichment');` (the one shared dependency).
+  - Constants: `NOTES_CAP = 50` (hard maximum + default), `HEX64 = /^[0-9a-f]{64}$/i`, `FETCH_TIMEOUT_MS = 8000`, the `FALLBACK_RELAYS` trio, `RELAY_SET_SLUG = 'the-set-of-general-purpose-relays'`, and the absolute `NOSTR_TOOLS_PATH`/`WS_PATH` module-path constants — **copied verbatim** from `feedReadPath.js:35-45` (house convention; lazy-required inside the real helper so the module loads in test/CI).
+  - **`clampLimit(raw)`** → integer in `[1, NOTES_CAP]`; non-numeric/absent/over-max → `NOTES_CAP` default (≤0 → 1). Pure; unit-tested directly.
+  - Real-helper defaults, **copied from `feedReadPath.js`** (kept private to this module): `realScanStrfry(filter)` (`feedReadPath.js:57-69`), `realRunCypher` (`:72-74`), `realQuerySync(relays, filter)` (`:77-91`), `resolveGeneralPurposeRelays(runCypher)` (`:138-159`).
+  - **`fetchAuthorNotes(pubkey, limit, relays, querySync)`** — `querySync(relays, { kinds:[1], authors:[pubkey], limit })`; app-side keep only `kind===1 && ev.pubkey===pubkey`, dedup by `id`, sort `created_at` desc, `slice(0, limit)`. (kind-1-only filter **excludes kind-6/kind-7 by construction**; the author filter excludes everyone else.)
+  - **`async function buildUserNotes({ pubkey, limit, deps } = {})`** reading injectable deps `deps?.X ?? options.X ?? <realHelper>` for `scanStrfry`, `runCypher`, `querySync` (mirror `feedReadPath.js:189-194`; **no `getSettings`** — there is no PoV resolution):
+    1. `if (!pubkey || !HEX64.test(pubkey)) return { status:'INVALID' };`
+    2. `const n = clampLimit(limit);`
+    3. `const { relays, source: relaySource } = await resolveGeneralPurposeRelays(runCypher);`
+    4. `const notes = await fetchAuthorNotes(pubkey, n, relays, querySync);`
+    5. `const items = await enrichNotes(notes, scanStrfry);`
+    6. `return items.length === 0 ? { status:'EMPTY', relaySource, items:[] } : { status:'OK', relaySource, items };`
+  - **`async function handleGetUserNotes(req, res)`** — `const r = await buildUserNotes({ pubkey: req.params.pubkey, limit: req.query.limit });` then: `r.status==='INVALID'` → `res.status(400).json({ success:false, ...r, error:'invalid pubkey' })`; else `res.json({ success:true, ...r })`. Wrap in try/catch → 500 `{ success:false, error }` (a relay timeout is **not** an error — it yields `EMPTY`/`OK` with whatever arrived, per `realQuerySync`).
+  - `module.exports = { buildUserNotes, handleGetUserNotes, clampLimit, NOTES_CAP };`
+- **Edit: `src/api/index.js`** — `const { handleGetUserNotes } = require('./notes/userNotesReadPath.js');` and register `app.get('/api/user/:pubkey/notes', handleGetUserNotes);` beside `/api/feed` (line 302). (Confirm it is registered **before** any `app.get('*')` SPA fallback, like the other `/api/*` routes.)
+- **No auth change** — anonymous read-only API is allowed by default (`src/middleware/auth.js:488-489`); `/api/user/:pubkey/notes` is not in any write/protected blocklist.
+- **No new dependency, no lint/build tooling, no concept/firmware change.**
+
+### Testability
+
+Mirror `test/live-feed-read-path.test.js` (the `test/test.js` Node runner; execution tests with in-memory fakes):
+- `buildUserNotes` drives every outcome via injected deps — `INVALID` (bad pubkey, **no deps called**), `EMPTY` (querySync returns `[]`), `OK` (returns kind-1 → assert newest-first order, the N-cap, kind-6/7 + foreign-author exclusion, the item shape, and `relaySource` set-vs-fallback via the `runCypher` fake). No live relays/Neo4j/strfry.
+- `clampLimit` is a pure unit: `1→1`, `50→50`, `0/-5→1`, `999→50`, `undefined/'x'→50`.
+- Mention resolution is owned/tested by `enrichNotes` (reused unchanged) — this path asserts it passes notes through and returns the enriched shape.
+
+## Out of scope
+
+- The two **surfaces** (Content section, notes page) and their rendering — ADR 0002.
+- **Consolidating the duplicated sourcing helpers** into `_shared/relaySource.js` and re-pointing `feedReadPath.js` (Option B) — a tracked follow-up, done separately to keep this additive.
+- **Exact-N guarantee under relay timeout** (best-effort, like the feed); caching; pagination beyond N; content kinds other than kind-1; replies/threading/reposts/reactions.
+- Any write/publish; any change to the feed read path, search, ranking, or firmware.

--- a/engineering-team/decisions/note-surfaces/0002-note-surfaces-ui.md
+++ b/engineering-team/decisions/note-surfaces/0002-note-surfaces-ui.md
@@ -1,0 +1,120 @@
+# ADR 0002: The two note surfaces — a shared `useUserNotes` hook, a profile "Content" section, and the `/user/:pubkey/notes` page
+
+**Status:** Accepted
+**Date:** 2026-06-18
+**Stories:** `engineering-team/stories/note-surfaces/2-profile-content-section.md`, `engineering-team/stories/note-surfaces/3-per-user-notes-page.md`
+**Epic:** `engineering-team/epics/note-surfaces.md`
+**Depends on:** ADR `note-surfaces/0001` (the `GET /api/user/:pubkey/notes?limit=` contract)
+
+## Context
+
+Two **front-end-only** surfaces render ADR 0001's output. Neither adds read logic — they fetch the contracted endpoint and render the **existing shared `NoteCard`** (`ui/src/components/NoteCard.jsx`, takes one already-enriched `{ item }`).
+
+- **Story #2 — profile "Content" section:** the last section of `/user/:pubkey` (`ui/src/pages/BrainstormProfile.jsx`), showing the single most-recent note (limit 1) or an empty state, plus a link to the notes page.
+- **Story #3 — per-user notes page:** a new client route `/user/:pubkey/notes` (sibling of `/user/:pubkey/follows`), rendering up to 50 notes as a `NoteCard` list, with a "whose notes" header and an empty state, no horizontal overflow at 1280px.
+
+### The contract these surfaces consume (ADR 0001)
+
+`GET /api/user/:pubkey/notes?limit=N` → `{ success, status, relaySource?, items? }`:
+
+| `status` | HTTP | Other fields | Surface meaning |
+|---|---|---|---|
+| `OK` | 200 | `relaySource`, `items:[…]` (newest-first, ≤N) | render the card(s) |
+| `EMPTY` | 200 | `relaySource`, `items:[]` | "no kind-1 events could be located" |
+| `INVALID` | 400 | `error` | defensive (malformed pubkey in URL) |
+| (transport error / 500 / non-`success`) | — | — | defensive |
+
+Each `OK` item is the feed item shape `{ id, pubkey, createdAt, content, author:{displayName,avatar}, mentions }` — exactly what `NoteCard` already renders.
+
+### House patterns to mirror (verified in source)
+
+- **Data hook** → `ui/src/hooks/useFeed.js`: `useState`/`useEffect`/`AbortController`, `fetch().then(r=>r.json())`, pass the whole `success` body through as `data`, else set `error`; abort on unmount. (Ours adds `pubkey`/`limit` args and re-runs on change.)
+- **Pubkey-scoped sub-page** → `ui/src/pages/BrainstormFollows.jsx`: `bsp-page` → `bsp-top-bar` (logo + `BrainstormUserMenu`) → `bsp-content` with a `← Back to profile` `<Link to={\`/user/${pubkey}\`}>` + `<h1>` title + loading/error/empty/list states; driven by a `use…(pubkey)` hook (`BrainstormFollows.jsx:76-81,150-229`).
+- **Pure state→view + copy constants** → `ui/src/pages/BrainstormFeed.jsx`: a named-exported `renderFeedState({data,loading,error})` (pure: no fetch/auth/router/browser globals) + module-level `FEED_COPY`, so states are unit-/sentinel-testable (`BrainstormFeed.jsx:20-28,62-96`).
+- **Card reuse** → `NoteCard` renders the avatar/name (links to `/user/<pubkey>`), the relative timestamp, and `NoteContent` (with mentions). It is surface-neutral (`bsp-note-card-*`) and already used by the feed list.
+- **Subject display name** → `BrainstormProfile.jsx:132` fetches `/api/profiles?pubkeys=${pubkey}` → `data.profiles[pubkey]` (`display_name`/`name`); the notes page reuses this to name the user in its header (so it identifies whose notes even when empty).
+
+### Constraints
+
+- **Additive & read-only.** New: one hook, one component, one page, one route line, one section-insertion line, a small CSS block. Edits to shared files are **two single-line insertions** (`App.jsx` route, `BrainstormProfile.jsx` section) + their imports; nothing existing changes behavior. Remove them and the app is as before.
+- **Vite-built UI; no new dependency / tooling.** React 19, `react-router-dom` 7, the `bsp-*` styles, and `NoteCard` are all present. `npm run build` in `ui/` → `/dist` is the existing (only) build step.
+- **No re-derivation.** Surfaces map `{status, items}` to DOM; they do not re-fetch/re-sort/re-enrich (ADR 0001 owns that). `relaySource` is ignored (not asked for).
+
+## Options considered
+
+### Option A — One shared `useUserNotes(pubkey, limit)` hook; a `ProfileContentSection` component; a `BrainstormUserNotes` page; `NoteCard` reused as-is *(chosen)*
+
+- **Hook** `ui/src/hooks/useUserNotes.js` — `useFeed`-shaped but parameterized by `(pubkey, limit)`, re-running on change; returns `{ data, loading, error }` (whole result object on `success`). One hook, both surfaces (the intake's "one read-path helper parameterized by limit", realized at the hook).
+- **Story #2** `ui/src/components/ProfileContentSection.jsx` — `ProfileContentSection({ pubkey })` using `useUserNotes(pubkey, 1)`; a `bsp-section` with `<h3>Content</h3>`, a pure body (loading / one `<NoteCard>` / empty), and an always-present `<Link to={\`/user/${pubkey}/notes\`}>`. Inserted as the **last child** of `BrainstormProfile.jsx`'s content fragment (after the Reputation section, `:406`). A self-contained component keeps the edit to the big shared file a one-line insert + import.
+- **Story #3** `ui/src/pages/BrainstormUserNotes.jsx` — modeled on `BrainstormFollows.jsx`'s shell; `useUserNotes(pubkey, 50)`; a back link, a header naming the user (small `/api/profiles?pubkeys=` fetch), a pure `renderUserNotesState` mapping OK→`items.map(<NoteCard>)` / EMPTY→empty copy / defensive→neutral copy. Route added to `ui/src/App.jsx` beside the other `/user/:pubkey/*` routes.
+- **`NoteCard`: reused unchanged — no variant prop** (see the dedicated decision below).
+
+- **Pros:** mirrors three established patterns (hook / sub-page / pure-render); one hook serves both surfaces; strictly additive (two one-line edits to shared files); `NoteCard` untouched → the feed carries zero risk; pure render helpers + copy constants make both surfaces sentinel-testable without a browser.
+- **Cons:** a `useFeed`/`useUserNotes` near-duplication (the hooks differ only by args) — acceptable and parallel to having two read paths; a future `useNotes` generalization is a trivial later step, not worth coupling now.
+
+### Option B — Fold the Content section's fetch+render inline into `BrainstormProfile.jsx`; no shared hook/component
+
+- **Cons (decisive):** puts feature logic + a fetch effect into the already-large profile page; no reuse with the notes page; the state→view mapping is no longer an importable unit (defeats the sentinel-test pattern). Rejected — same reasoning ADR `live-feed/0002` used to reject inlining into `App.jsx`.
+
+### Option C — Add a compact/`actionsless` **variant** to `NoteCard` for the profile latest-note
+
+`NoteCard`'s header invites this ("layout variants … should arrive as explicit props … the first consumer that needs one should add it here"). The profile Content section is the first non-feed consumer.
+
+- **Cons (decisive *now*):** the operator's intent is simply "show the latest kind-1 note" — **no compact/stripped requirement was stated**. Adding a variant prop **modifies the shared `NoteCard`** (touching the feed's component) for no required behavior, trading the epic's zero-risk additivity for speculative flexibility. The full card (including its actions menu — copy link/id, tag) is coherent on a profile. **Decision: reuse `NoteCard` as-is; add no variant.** When a surface genuinely needs a compact card, the prop is added to `NoteCard` per its own guidance — a deferred, separate change. (Recorded in `engineering-team/follow-ups.md` / the epic.)
+
+## Decision
+
+**Option A**, with **`NoteCard` reused unchanged (no variant — Option C deferred)**. A shared `useUserNotes(pubkey, limit)` hook feeds a self-contained `ProfileContentSection` (limit 1, appended as the last profile section) and a new `BrainstormUserNotes` page at `/user/:pubkey/notes` (limit 50, modeled on `BrainstormFollows`). Both delegate their body to a pure, named-exported render helper with module-level copy constants. The only edits to existing shared files are two single-line insertions (+ imports) in `App.jsx` and `BrainstormProfile.jsx`; `NoteCard.jsx` and the feed are untouched.
+
+## Consequences
+
+- **Enables:** the two user-visible surfaces the epic exists to stand up; the Content section's "View all" links the profile to the page.
+- **Constrains:** both surfaces are coupled to ADR 0001's response shape (`status`/items); a change there changes them. `NoteCard` stays the single home for per-note presentation — future per-note improvements land once for the feed and both new surfaces.
+- **Build/deploy:** the Vite `/dist` must be rebuilt (`npm run build` in `ui/`) for the route/section to resolve client-side — the existing build step, no new tooling.
+- **New debt / follow-up (tracked):** a `NoteCard` layout-variant prop (Option C) when a compact card is first genuinely needed; a `useFeed`/`useUserNotes` generalization if a third notes consumer appears. Both deferred, neither blocking.
+- **Defensive vs empty copy:** transport/`INVALID` failures collapse to the same operator-delegated "no kind-1 events could be located" message (the operator's wording is deliberately agnostic between "none exist" and "couldn't load"). A future "couldn't load — retry" distinction is a possible enhancement, out of scope.
+- **Firmware reinstall required?** **No.** Renders existing endpoint output; defines no concepts, changes no schema.
+
+## Implementation notes
+
+All UI under `ui/src` (Vite — `npm run build` in `ui/` to reflect changes in `/dist`).
+
+- **New hook: `ui/src/hooks/useUserNotes.js`** — mirror `useFeed.js`; signature `useUserNotes(pubkey, limit)`:
+  - `useEffect` deps `[pubkey, limit]`; guard `if (!pubkey) { setLoading(false); return; }`.
+  - `fetch(\`/api/user/${pubkey}/notes?limit=${limit}\`, { signal })` → `.then(r=>r.json())`; on `json.success` set `data = json` (whole `{status, relaySource, items}`), else set `error`; `catch` (ignore `AbortError`) sets `error`; abort on unmount.
+  - Return `{ data, loading, error }`.
+- **New component: `ui/src/components/ProfileContentSection.jsx`** — `export default function ProfileContentSection({ pubkey })`:
+  - `const { data, loading, error } = useUserNotes(pubkey, 1);`
+  - Module-level `export const CONTENT_COPY = { HEADING:'Content', EMPTY:'No kind-1 events could be located for this user.', VIEW_ALL:'View all notes →', LOADING:'Loading…' };` (punctuation non-binding per the stories).
+  - Render `<section className="bsp-section bsp-content-section">` → `<h3>{CONTENT_COPY.HEADING}</h3>` → `renderContentBody({ data, loading, error })` → `<Link className="bsp-content-viewall" to={\`/user/${pubkey}/notes\`}>{CONTENT_COPY.VIEW_ALL}</Link>` (link present in **all** states, per #2 AC).
+  - `export function renderContentBody({ data, loading, error })` — **pure** (no fetch/auth/router/browser globals): `loading && !data` → `LOADING` line; `data?.status==='OK' && data.items?.[0]` → `<NoteCard item={data.items[0]} />` (the single latest; never more); else (`EMPTY`/`error`/`INVALID`/unknown) → `<div className="bsp-empty">{CONTENT_COPY.EMPTY}</div>`.
+- **Edit: `ui/src/pages/BrainstormProfile.jsx`** — `import ProfileContentSection from '../components/ProfileContentSection';` and insert `<ProfileContentSection pubkey={pubkey} />` as the **last child inside the content fragment** — immediately after the Reputation `</div>` (`:406`), before the fragment closes (`:408`). One line + import; the Reputation/grid data path and every existing section are untouched (#2 "additive/no-regression" AC).
+- **New page: `ui/src/pages/BrainstormUserNotes.jsx`** — model the shell on `BrainstormFollows.jsx`:
+  - `const { pubkey } = useParams(); const { user, login, logout } = useAuth();`
+  - `const { data, loading, error } = useUserNotes(pubkey, 50);`
+  - Subject name for the header: small effect fetching `/api/profiles?pubkeys=${pubkey}` → `profiles[pubkey]?.display_name || name`, default `nip19.npubEncode(pubkey).slice(0,12)+'…'` (mirror `BrainstormProfile.jsx:132` + `safeNpub` in `BrainstormFollows.jsx:11`).
+  - Module-level `export const NOTES_COPY = { HEADING:'Notes', INDICATOR:'Showing the most recent 50 notes.', EMPTY:'No kind-1 events could be located for this user.', LOADING:'Loading notes…' };`
+  - Shell: `bsp-page` → `bsp-top-bar` (logo + `<BrainstormUserMenu user login logout/>`) → `bsp-content` → header `<Link className="bsp-back-link" to={\`/user/${pubkey}\`}>← Back to profile</Link>`, `<h1 className="bsp-follows-title">{NOTES_COPY.HEADING}</h1>`, and the subject name (e.g. a `bsp-notes-subtitle` line) so the page names whose notes (#3 "whose notes" AC).
+  - `export function renderUserNotesState({ data, loading, error })` — **pure**, mirroring `renderFeedState`: `loading && !data` → `LOADING`; `error || data==null || !['OK','EMPTY'].includes(data.status)` → `<div className="bsp-empty">{NOTES_COPY.EMPTY}</div>` (defensive collapses to the same message); `data.status==='EMPTY'` → same empty block; `data.status==='OK'` → `<div className="bsp-notes-indicator">{NOTES_COPY.INDICATOR}</div>` + `<div className="bsp-notes-list">{data.items.map(it => <NoteCard key={it.id} item={it} />)}</div>` **in array order** (already newest-first; do not re-sort).
+- **Edit: `ui/src/App.jsx`** — `import BrainstormUserNotes from './pages/BrainstormUserNotes';` and add `{ path: '/user/:pubkey/notes', element: <BrainstormUserNotes /> }` to the router array, beside the other `/user/:pubkey/*` routes (after `:128`). Server needs no change — the SPA fallback already 200s any non-`/api/` path (per ADR `live-feed/0002` §"How this app serves front-end pages").
+- **Styles: `ui/src/styles.css`** — reuse `bsp-page`/`bsp-top-bar`/`bsp-content`/`bsp-section`/`bsp-empty`/`bsp-back-link`/`bsp-follows-title`/`bsp-note-card*`/`bsp-feed-list`. Add only minimal token-based classes if needed (`bsp-content-section`, `bsp-content-viewall`, `bsp-notes-list`, `bsp-notes-indicator`, `bsp-notes-subtitle`) using existing CSS variables; cap the column width + wrap note text (`overflow-wrap:anywhere`) so the page never exceeds 1280px (#3 no-overflow AC). `NoteCard`'s own `bsp-note-card-*` styling already exists from the feed.
+- **No new dependency, no lint/typecheck/build tooling, no concept/firmware change. `NoteCard.jsx` is not edited.**
+
+### Testability
+
+UI is tested by **source-regex sentinels** under the `test/test.js` Node runner (JSX can't transpile in that harness — see `test/live-feed-feed-page.test.js` and the profile sentinel tests). The pure render helpers + module-level copy constants make sentinels precise:
+- `ProfileContentSection` / `renderContentBody`: sentinel the `Content` heading, the `CONTENT_COPY.EMPTY` string, the single-`NoteCard` OK branch, and the always-present `to={\`/user/${'${'}pubkey}/notes\`}` link.
+- `BrainstormUserNotes` / `renderUserNotesState`: sentinel the back link, the heading + subject-name fetch, the `OK` → `items.map(NoteCard)` branch, the indicator, and the `EMPTY`/defensive copy.
+- `BrainstormProfile.jsx`: sentinel that `<ProfileContentSection` is rendered after the Reputation section and that the existing sections/`TRUST_METRICS` path are unchanged.
+- `useUserNotes`: sentinel the `\`/api/user/${'${'}pubkey}/notes?limit=${'${'}limit}\`` URL, the `success`→`data` pass-through, and the abort-on-unmount.
+- `App.jsx`: sentinel the `/user/:pubkey/notes` route → `<BrainstormUserNotes>`.
+- **Rendered-UI confirmation** (the one piece wanting a browser) is gathered on **staging** after deploy (this epic targets staging): an anonymous `/user/<pubkey>/notes` 200 with ≥1 card, and the profile's Content section — a deploy-stage capstone, not a per-story blocker. (Local full-stack verification is intentionally avoided — the shared local Docker stack is in use by the parallel session.)
+
+## Out of scope
+
+- The read/selection logic (ADR 0001).
+- A `NoteCard` compact/actionsless **variant** (Option C — deferred until a surface needs it).
+- More than one note in the Content section; pagination beyond 50; content kinds other than kind-1; replies/threading/reposts/reactions; tagging notes.
+- A PoV/source selector (these are the viewed user's own posts).
+- A "couldn't load — retry" state distinct from the empty message (deferred enhancement).
+- Any write/publish; any change to the feed, search, ranking, or firmware.

--- a/engineering-team/epics/note-surfaces.md
+++ b/engineering-team/epics/note-surfaces.md
@@ -1,0 +1,36 @@
+# Epic: Note Surfaces
+
+**Status:** Active
+**Provenance:** `_intake.md` entries 2026-06-18 ("profile latest note on `/user/:pubkey`" + "per-user notes page, 50 recent kind-1"); operator-confirmed scope 2026-06-18 (this session). Built atop the `live-feed` epic's shared note seam (`NoteCard` + `enrichNotes`), shipped to staging 2026-06-18.
+
+## What this is
+Two new read-only surfaces that show a **single viewed user's own** kind-1 notes — distinct from the `live-feed` epic, which shows notes from the accounts a *source identity follows*. Here there is **no follow list and no point-of-view resolution**: the selection is simply "the most-recent kind-1 notes **authored by** the pubkey being viewed."
+
+- A **"Content" section** at the bottom of the user profile page (`/user/:pubkey`) showing that user's single most-recent note.
+- A **`/user/:pubkey/notes` page** showing that user's 50 most-recent notes.
+
+Both consume **one shared by-author read path** and render the **existing shared note card**. The section is labelled **"Content"** (not "Notes") deliberately: it may host other content kinds later, but is **kind-1 only** for now.
+
+Additive and read-only: it adds one read path, one client route/page, and one profile section; it performs no writes and does not change search, ranking/scoring, the existing `/feed`, or firmware. Remove the three additions and the rest of the app behaves as before.
+
+## Stories
+`stories/note-surfaces/`:
+1. **by-author-notes-read-path** — backend read path: given a pubkey and a count, produce the N most-recent kind-1 notes authored by that pubkey, newest-first, profile-enriched into the shared note item shape, plus the empty and invalid-input outcomes. One subsystem; testable without any page. **Both surfaces depend on it.**
+2. **profile-content-section** — the "Content" section at the bottom of the profile page: the single most-recent note as a card, the empty state, and a link to the notes page. Front-end; consumes #1 at count 1.
+3. **per-user-notes-page** — the public `/user/:pubkey/notes` page rendering #1's output at count 50 as a list of note cards, with the empty state and no horizontal overflow at 1280px. Front-end; consumes #1 at count 50.
+
+**Dependency order:** #1 first; #2 and #3 are independent of each other.
+
+## Out of scope (whole epic)
+- Content kinds other than kind-1 (reposts kind-6, reactions kind-7, long-form kind-30023, etc.) — the "Content" label is future-proofed, but only kind-1 is in scope now.
+- Pagination beyond the per-surface cap (1 / 50), infinite scroll, full history.
+- Replies/threading, reactions/repost display, tagging notes.
+- Any point-of-view selector — these are the viewed user's *own* posts; no source-identity / PoV resolution applies.
+- Any write/publish; any change to search, the existing `/feed`, ranking/scoring, or firmware.
+
+## Concepts (referenced, not re-defined)
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-kind` — kind-1 (the notes / "Content"), kind-0 (author + mention display data).
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-user` — the viewed user (the note author, identified by pubkey).
+- `39999:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:the-set-of-general-purpose-relays` — general-purpose relays (the likely note source; Architecture confirms relays-vs-local sourcing).
+
+> Handles above mirror those the `live-feed` epic recorded. The Architect should re-resolve them against the **target instance's own** Tapestry Assistant (never a hardcoded deployment identifier).

--- a/engineering-team/reviews/note-surfaces/1-note-surfaces-implementation.md
+++ b/engineering-team/reviews/note-surfaces/1-note-surfaces-implementation.md
@@ -56,7 +56,15 @@
 - **1280px no-overflow tested only at the CSS-mechanism level (not a rendered scrollbar assertion)** — *not a defect:* this is exactly ADR 0002 §Testability's plan (rendered proof = staging capstone); the node harness can't render.
 - **500 path returns raw `err.message` to the client** — *not a defect this change introduces:* byte-identical to the shipped `feedReadPath.js:227`; a pre-existing cross-cutting consideration, not a regression here.
 
-## Verdict
-**CHANGES_REQUESTED** — a single small required fix (finding #1: a real wrong-data bug against Story #3's "whose notes" AC; one-line fix, zero risk). Recommend folding in #2 (same root cause). Everything else is optional. All quality gates otherwise pass; the change is clean, additive, ADR-conformant, and invariant-safe.
+## Verdict (initial)
+**CHANGES_REQUESTED** — a single small required fix (finding #1: a real wrong-data bug against Story #3's "whose notes" AC). Recommend folding in #2 (same root cause). Everything else optional; all other gates pass.
 
-> Operator override available: given #1's narrow reachability and that it mirrors an existing shipped latent pattern, PASS-and-log-#1-as-a-follow-up is defensible. Reviewer's recommendation is to fix it now (cheap + correct) before staging.
+## Re-review (post-fix) — 2026-06-18, commit `80443ba5`
+Operator chose "fix now." The Implementer applied the minimal, same-root-cause fix:
+- **Finding #1 (required) — resolved.** `BrainstormUserNotes.jsx` now `setSubjectName(null)` on `pubkey` change and sets it **unconditionally** from the response (`p ? (display_name||name||null) : null`) — so a param-only A→B navigation clears the prior name and the npub fallback engages for users with no local kind-0. "Whose notes" now holds in every case.
+- **Finding #2 (recommended) — resolved.** `useUserNotes.js` now `setData(null)` on `[pubkey, limit]` change — the loading line shows during re-fetch instead of the previous user's notes.
+
+Re-verification: `note-surfaces-ui` **19/19** and `note-surfaces-read-path` **28/28** still green; both edited files compile (`node --check` + esbuild JSX transform). The fix touches only these two files, which only the `note-surfaces-ui` suite reads — so the full-suite delta is unchanged (12 pre-existing environmental + my 2 green). Remaining nits (#3 redundant-but-ADR-prescribed EMPTY branch, #4 `<div>` vs ADR's `<section>`, #5 untested 500 path mirroring the feed) accepted as-is — optional, non-blocking.
+
+## Verdict
+**PASS** — all acceptance criteria covered by passing tests; ADR-conformant; architecture invariants (POV-first, no TA hardcode) honored; strictly additive (`feedReadPath.js`/`NoteCard.jsx` unchanged); the one real finding fixed and re-verified. Ready for the deploy chain (`cycle-staging`).

--- a/engineering-team/reviews/note-surfaces/1-note-surfaces-implementation.md
+++ b/engineering-team/reviews/note-surfaces/1-note-surfaces-implementation.md
@@ -1,0 +1,62 @@
+# Review: Epic note-surfaces — by-author read path + Content section + /notes page (stories #1–#3)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-18
+**Diff:** `git diff staging..feat/note-surfaces` (impl commit `98686ddf`) — 8 files, **+472 / −0** (fully additive)
+**Stories:** `note-surfaces/{1-by-author-notes-read-path, 2-profile-content-section, 3-per-user-notes-page}.md`
+**ADRs:** `note-surfaces/{0001-by-author-notes-read-path, 0002-note-surfaces-ui}.md`
+**Method:** Reviewer audit + a 3-lens adversarial sub-review (correctness / ADR-conformance / invariants-security), 10 agents, **each finding independently verified** (7 raw → 5 confirmed real, 2 refuted).
+
+## Quality gates (run by the reviewer, not trusted)
+
+- [x] **`npm test` (new suites)** — `note-surfaces-read-path` **28/28 PASS**, `note-surfaces-ui` **19/19 PASS**.
+- [x] **`npm test` (full, regression delta)** — FAIL suites = **exactly the same 12** pre-existing tag/pin *publish-flow* suites as the pre-change baseline (byte-identical list); **zero new regressions**. Those 12 fail on `fetch failed` — they need the live local stack and read none of the edited files (environmental, out of scope).
+- [x] **Targeted regression** — all 13 hermetic suites that read the edited files (`profile-*` ×9, both `live-feed`, `reputation-info-popup`) → **0 failures**.
+- [x] **Build** — isolated `vite build` of the worktree → **✓ built, exit 0**; all new JSX compiles (no syntax/import errors).
+- [ ] **Playwright / rendered-UI** — not run locally (the local Docker stack is in use by a parallel session; per ADR 0002 §Testability the rendered proof — anonymous `/user/<pubkey>/notes` 200 + a visible card, the profile Content section, no 1280px scrollbar — is the **staging** capstone).
+- [n/a] Lint / typecheck — not configured (intentional, JS-without-build).
+
+## Spec adherence
+- [x] Every acceptance criterion maps to ≥1 passing test (read path: OK/EMPTY/INVALID, newest-first, limit=1/limit=N/over-max cap, kind-6/7 + foreign-author exclusion, item shape, set-vs-fallback, mentions; UI: "Content" label + single card + empty + link, route + 50-list + whose-notes + empty + no-overflow mechanism + pure helpers).
+- [x] No criterion silently dropped. No behavior added beyond the stories (the section is kind-1 only; "Content" label future-proofed; no PoV picker; no writes).
+
+## ADR adherence
+- [x] Files changed match ADR 0001/0002 implementation notes (read-path module + endpoint; shared hook; Content component + last-section insertion; page + route; minimal CSS).
+- [x] **Relays sourcing** with set/fallback discriminator — mirrors the feed (correct per the empirical 0-local-kind-1 finding).
+- [x] **`enrichNotes` reused unchanged** (`require('../_shared/noteEnrichment')`), not re-implemented; item shape identical to the feed → `NoteCard` renders it unmodified.
+- [x] **`INVALID`→400, OK/EMPTY→200**, validation before any I/O; `NOTES_CAP=50` default+cap; `clampLimit` handles string/absent/non-numeric/≤0/over-max.
+- [x] **Additive:** `src/api/feed/feedReadPath.js` and `ui/src/components/NoteCard.jsx` are **byte-unchanged** (regression sentinels `R1`/`R2` green); `NoteCard` reused with **no variant prop** (Option C deferred, as decided).
+- [~] **Deviation (nit #4):** ADR 0002 §Impl line 89 wrote `<section className="bsp-section bsp-content-section">`; the impl uses `<div className="bsp-section bsp-content-section">` (`ProfileContentSection.jsx:27`). The `<div>` form is **more consistent with the existing profile sections** (`BrainstormProfile.jsx` uses `<div className="bsp-section">` throughout) — the ADR note was slightly off vs the codebase convention. Cosmetic; no test or behavior depends on it.
+
+## Architecture invariants (CLAUDE.md)
+- [x] **POV-first:** correct — these surfaces show the **viewed user's own** kind-1 posts (selection by author). There is no per-POV "truth" being computed; the only POV-namespaced data (reputation grid) is untouched. No global denormalization introduced.
+- [x] **No hardcoded TA pubkey:** the relay-set handle resolves the TA at runtime via `getOwnerAssistantPubkey()` (`userNotesReadPath.js:120`) — honored. No `82b75e47…`/literal anywhere.
+- [x] **Decentralized / filter-at-read:** read-only scan of relay events + local enrichment; no write-time gating, no "approved author" list.
+- [x] **No firmware change** (defines no concepts); concept handles in the docs are `kind:pubkey:slug`.
+
+## Things tests can't catch
+- [x] No secrets; no `console.log`/debug; no commented-out or dead code.
+- [x] Input validation at the boundary — `HEX64` checked **before** any relay/Neo4j query (`buildUserNotes` step 1); the `strfry scan` shell construction is the copied-verbatim feed helper and is only reached with a validated author + local pubkeys (same exposure as the shipped feed).
+- [~] **Error/edge handling:** one real edge bug (finding #1 below) + two state-reset nits (#3) + an untested 500 path (#5). See Findings.
+
+## Findings
+
+### Required before merge (1)
+1. **`ui/src/pages/BrainstormUserNotes.jsx:40–55` — stale subject name across param-only navigation (real, narrow).** The route element has no `key`, so `/user/A/notes` → `/user/B/notes` re-runs the effect without remounting. The subject-name effect sets state only inside `if (p) setSubjectName(...)` and never resets it, so navigating from a user **with** a local kind-0 (`subjectName='Alice'`) to one **without** leaves `subjectName` stale-truthy → `displayName = subjectName || shortNpub` keeps showing **'Alice' on B's page**, defeating Story #3's "whose notes" AC. Reachability is narrow (every in-app link out of the page unmounts it; only back/forward or manual URL hits notes→notes) and it faithfully mirrors the **identical latent pattern in `BrainstormProfile.jsx:130–142`** — hence the adversarial grade of *non-blocking*. **But the fix is one line and the new code should be correct against its own AC.** Asked change: reset on pubkey change — set `subjectName` unconditionally from the response (`setSubjectName(p ? (p.display_name||p.name||null) : null)`), or `setSubjectName(null)` at the top of the effect.
+
+### Non-blocking (fix recommended alongside #1, same root cause)
+2. **`ui/src/hooks/useUserNotes.js:24–49` — stale `data` not cleared on `[pubkey, limit]` change** → a brief flash of the *previous* user's note(s) during the in-flight re-fetch (the helpers gate the loading line on `loading && !data`, so truthy stale data skips it). Self-corrects on resolve; mirrors the `useFeed.js` precedent (which has no params, so the case never arises there). Optional: `setData(null)` at the top of the effect — clears the flash and is the same hygiene as #1.
+
+### Nits (optional)
+3. **`ui/src/pages/BrainstormUserNotes.jsx:97–99`** — the explicit `status === 'EMPTY'` branch is redundant (the defensive guard above already renders the identical empty block). Correct and **ADR-prescribed** (0002:98 keeps it explicit to mirror the OK/EMPTY/defensive contract); no behavior change. Leave or collapse.
+4. **`ui/src/components/ProfileContentSection.jsx:27`** — `<div>` vs the ADR note's `<section>` (see ADR adherence above). Recommend leaving `<div>` (matches the profile-section convention) or aligning the ADR note.
+5. **`src/api/notes/userNotesReadPath.js:197–203`** — the handler's `catch → 500` branch has no test (mirrors the feed, whose 500 path is likewise untested). Optional: add a `handleGetUserNotes` test that injects a throwing dep and asserts 500.
+
+### Refuted (raised by the sub-review, verified NOT defects)
+- **1280px no-overflow tested only at the CSS-mechanism level (not a rendered scrollbar assertion)** — *not a defect:* this is exactly ADR 0002 §Testability's plan (rendered proof = staging capstone); the node harness can't render.
+- **500 path returns raw `err.message` to the client** — *not a defect this change introduces:* byte-identical to the shipped `feedReadPath.js:227`; a pre-existing cross-cutting consideration, not a regression here.
+
+## Verdict
+**CHANGES_REQUESTED** — a single small required fix (finding #1: a real wrong-data bug against Story #3's "whose notes" AC; one-line fix, zero risk). Recommend folding in #2 (same root cause). Everything else is optional. All quality gates otherwise pass; the change is clean, additive, ADR-conformant, and invariant-safe.
+
+> Operator override available: given #1's narrow reachability and that it mirrors an existing shipped latent pattern, PASS-and-log-#1-as-a-follow-up is defensible. Reviewer's recommendation is to fix it now (cheap + correct) before staging.

--- a/engineering-team/stories/note-surfaces/1-by-author-notes-read-path.md
+++ b/engineering-team/stories/note-surfaces/1-by-author-notes-read-path.md
@@ -1,0 +1,47 @@
+# Story 1: By-author notes read path — a user's own recent kind-1 notes
+
+**Status:** Approved
+**Created:** 2026-06-18
+**Type:** Feature
+
+## Background
+Both new surfaces in the `note-surfaces` epic — the profile "Content" section (`note-surfaces` #2) and the `/user/:pubkey/notes` page (`note-surfaces` #3) — need the same thing: the **N most-recent kind-1 notes authored by a given pubkey**, newest-first, profile-enriched into the shared note item shape. This story builds **only that read path**, independent of any page.
+
+It is deliberately simpler than the `live-feed` read path (`live-feed` #1). There is **no source-identity resolution, no kind-3 follow list, and no point-of-view**: the selection is "kind-1 authored by *this* pubkey." The author display name + avatar (and any in-text mention names) come from the instance's **existing local profile data** (kind-0), exactly as the feed does — only the *selection* of the raw notes differs.
+
+Affected: anyone viewing a user (logged in or anonymous). The work is **additive and read-only** — no writes/publishes, and no change to the existing feed, search, ranking/scoring, or firmware.
+
+## User-facing description
+As a visitor viewing a specific user, I want the system to assemble that user's own most-recent notes (newest-first, bounded by a requested count) with each note's author display info — so the profile surfaces can show "what this user has posted," and so they can distinguish "this user has no notes" from a malformed request.
+
+## Acceptance criteria
+Testable from the outside (input → observable behavior).
+
+- [ ] **Selection & content.** Given a valid pubkey that has posted kind-1 notes and a requested count N, when that user's notes are requested, then the result is the kind-1 notes **authored by that pubkey**, ordered **newest-first**, capped at **N**; each item carries the note's **id, author pubkey, timestamp, and text**, plus the author's **display name and avatar from local profile data** (kind-0). Kind-6 (reposts) and kind-7 (reactions) are **excluded**; notes authored by anyone else are excluded. The item shape is **identical to the existing feed item shape**, so the same shared note card can render it unchanged.
+
+- [ ] **Count parameterization & cap.** Given count = 1, exactly the **single** most-recent qualifying note is returned (when one exists). Given count = 50, **up to 50** are returned. Given an **absent, non-numeric, or above-maximum** count, the read path applies a **defined default and a hard maximum** rather than returning an unbounded result.
+
+- [ ] **Empty outcome.** Given a valid pubkey with **no locatable kind-1 notes**, when that user's notes are requested, then the result is an explicit **empty outcome** (an empty set for a valid request) — distinct from the invalid-input outcome below — so a surface can show "no kind-1 events could be located."
+
+- [ ] **Invalid-input outcome.** Given a **malformed pubkey**, when notes are requested, then the result is an explicit **invalid-input outcome** — not a crash, and not silently an empty list.
+
+- [ ] **Mentions resolved like the feed.** Given a returned note whose text references other users via `nostr:` mentions resolvable from local profile data, then those mentions are resolved to display names in the item (the **same enrichment the feed already performs**); unresolved references are left for the surface to fall back on.
+
+## Concepts touched
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-kind` — kind-1 (the selected notes), kind-0 (author + mention display data).
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-user` — the viewed user (note author, by pubkey).
+- `39999:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:the-set-of-general-purpose-relays` — general-purpose relays, the likely note source (Architecture confirms relays-vs-local — see Open questions).
+
+## Out of scope
+- The two surfaces that consume this — the Content section (`note-surfaces` #2) and the notes page (`note-surfaces` #3). This story produces the assembled data + outcomes, not their presentation.
+- Source-identity / follow-list / PoV logic — there is none here; this is one named author's own posts.
+- Content kinds other than kind-1; replies/threading; reactions/reposts; pagination beyond the requested count; full history.
+- Any write/publish; any change to the existing `/feed` read path, search, ranking, or firmware. The existing `enrichNotes` enrichment is **reused, not modified**.
+
+## Open questions
+- **Note source: relays vs local strfry — deferred to Architecture (a *how*, not a *what*).** The product intent is the user's *actual* recent notes as published to the network. The existing feed fetches kind-1 from the instance's general-purpose relays (local strfry on these instances is not a full kind-1 archive), so relays is the expected source — but whether local strfry holds enough kind-1 to serve locally is an **Architecture** determination (the feed precedent plus a quick local-coverage check settle it). If relays are used, the resolved-set-with-fallback behavior should mirror the feed's. This is a sourcing mechanism, not a blocking product question, so it does not gate story approval.
+
+## Linked artifacts
+- ADR: (filled in after Architecture)
+- Test plan: (filled in after Test Design)
+- Review: (filled in after Review)

--- a/engineering-team/stories/note-surfaces/1-by-author-notes-read-path.md
+++ b/engineering-team/stories/note-surfaces/1-by-author-notes-read-path.md
@@ -44,4 +44,4 @@ Testable from the outside (input → observable behavior).
 ## Linked artifacts
 - ADR: `engineering-team/decisions/note-surfaces/0001-by-author-notes-read-path.md`
 - Test plan: `engineering-team/stories/note-surfaces/1-by-author-notes-read-path.test-plan.md`
-- Review: (filled in after Review)
+- Review: `engineering-team/reviews/note-surfaces/1-note-surfaces-implementation.md` (CHANGES_REQUESTED — 2026-06-18)

--- a/engineering-team/stories/note-surfaces/1-by-author-notes-read-path.md
+++ b/engineering-team/stories/note-surfaces/1-by-author-notes-read-path.md
@@ -42,6 +42,6 @@ Testable from the outside (input → observable behavior).
 - **Note source: relays vs local strfry — deferred to Architecture (a *how*, not a *what*).** The product intent is the user's *actual* recent notes as published to the network. The existing feed fetches kind-1 from the instance's general-purpose relays (local strfry on these instances is not a full kind-1 archive), so relays is the expected source — but whether local strfry holds enough kind-1 to serve locally is an **Architecture** determination (the feed precedent plus a quick local-coverage check settle it). If relays are used, the resolved-set-with-fallback behavior should mirror the feed's. This is a sourcing mechanism, not a blocking product question, so it does not gate story approval.
 
 ## Linked artifacts
-- ADR: (filled in after Architecture)
+- ADR: `engineering-team/decisions/note-surfaces/0001-by-author-notes-read-path.md`
 - Test plan: (filled in after Test Design)
 - Review: (filled in after Review)

--- a/engineering-team/stories/note-surfaces/1-by-author-notes-read-path.md
+++ b/engineering-team/stories/note-surfaces/1-by-author-notes-read-path.md
@@ -43,5 +43,5 @@ Testable from the outside (input → observable behavior).
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/note-surfaces/0001-by-author-notes-read-path.md`
-- Test plan: (filled in after Test Design)
+- Test plan: `engineering-team/stories/note-surfaces/1-by-author-notes-read-path.test-plan.md`
 - Review: (filled in after Review)

--- a/engineering-team/stories/note-surfaces/1-by-author-notes-read-path.md
+++ b/engineering-team/stories/note-surfaces/1-by-author-notes-read-path.md
@@ -1,6 +1,6 @@
 # Story 1: By-author notes read path — a user's own recent kind-1 notes
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-18
 **Type:** Feature
 
@@ -44,4 +44,4 @@ Testable from the outside (input → observable behavior).
 ## Linked artifacts
 - ADR: `engineering-team/decisions/note-surfaces/0001-by-author-notes-read-path.md`
 - Test plan: `engineering-team/stories/note-surfaces/1-by-author-notes-read-path.test-plan.md`
-- Review: `engineering-team/reviews/note-surfaces/1-note-surfaces-implementation.md` (CHANGES_REQUESTED — 2026-06-18)
+- Review: `engineering-team/reviews/note-surfaces/1-note-surfaces-implementation.md` (PASS — 2026-06-18)

--- a/engineering-team/stories/note-surfaces/1-by-author-notes-read-path.test-plan.md
+++ b/engineering-team/stories/note-surfaces/1-by-author-notes-read-path.test-plan.md
@@ -1,0 +1,100 @@
+# Test Plan: Story note-surfaces #1 — By-author notes read path
+
+**Story:** `engineering-team/stories/note-surfaces/1-by-author-notes-read-path.md`
+**ADR:** `engineering-team/decisions/note-surfaces/0001-by-author-notes-read-path.md`
+**Date:** 2026-06-18
+**Test file:** `test/note-surfaces-read-path.test.js` (wired into `test/test.js`)
+
+## Scope
+
+Covers **Story #1 only — the backend read path** (`buildUserNotes` / `handleGetUserNotes` / `clampLimit` at `src/api/notes/userNotesReadPath.js`). The two UI surfaces (the Content section, the `/user/:pubkey/notes` page) are Stories #2/#3, tested by `test/note-surfaces-ui.test.js`. The OK/EMPTY/INVALID outcomes, newest-first ordering, the count cap, kind-6/7 + foreign-author exclusion, the item shape, and the set-vs-fallback discriminator are exercised as **data**.
+
+## Test level & seam (read this first)
+
+The ACs are driven as **observable behavior** against `buildUserNotes`, not as source-regex. `buildUserNotes` crosses three I/O boundaries the suite must not touch live (mirroring the live-feed read-path seam, minus the House-PoV boundary — there is no PoV here):
+
+| Boundary | Real mechanism (ADR) | Fake injected by the tests |
+|---|---|---|
+| general-purpose relay set (Concept Graph) | `runCypher(cypher, params)` | `runCypher() → rows[]` (each `{ json }`) |
+| kind-1 notes (external relays) | `SimplePool.querySync(relays, filter)` | `querySync(relays, filter) → events[]` |
+| kind-0 profiles (local strfry, via `enrichNotes`) | `exec`/`execSync` `strfry scan` | `scanStrfry(filter) → events[]` |
+
+The tests pass these fakes via `buildUserNotes`'s **options object** (`{ pubkey, limit, deps, ...deps }` — both the `deps:` and spread shapes, matching the ADR's injectable-deps seam). Production callers pass no deps and get the real helpers. If the Implementer hard-wires the boundaries and ignores injected deps, the behavioral tests fail loudly (real I/O / throw) — correct pressure toward the seam, not a false pass.
+
+The relays-vs-local sourcing decision (relays) is **already settled in the ADR** by the empirical 0-local-kind-1 evidence; these tests assert the *contract* over mocked boundaries, not the live wiring.
+
+## Coverage map
+
+| Criterion | Test name | Level |
+|---|---|---|
+| (module exists / exports) | `S1: module … exports buildUserNotes + handleGetUserNotes + clampLimit` | structural |
+| (endpoint registered) | `S2: GET /api/user/:pubkey/notes is registered to handleGetUserNotes` | structural |
+| (reuse, not re-implement) | `S3: the read path REUSES the shared enrichNotes` | structural |
+| **AC-2** count pass-through | `C1: clampLimit passes 1 → 1, 50 → 50 (number and string forms)` | unit |
+| **AC-2** default + hard cap | `C2: clampLimit applies max 50 + floor 1; absent/non-numeric → default 50` | unit |
+| **AC-1** selection | `B1: a valid author with kind-1 notes yields OK carrying that author's notes` | behavioral |
+| **AC-1** item shape | `B2: each item is the feed item shape { id, pubkey, createdAt, content, author:{…}, mentions }` | behavioral |
+| **AC-1** local profiles | `B3: author displayName + avatar come from LOCAL kind-0, never external relays` | behavioral |
+| **AC-1** missing profile | `B4: an author with no local kind-0 yields null displayName + null avatar` | behavioral |
+| **AC-1** ordering | `B5: items are ordered newest-first by the note timestamp` | behavioral |
+| **AC-1** kind-1-only | `B6: kind-6 (reposts) and kind-7 (reactions) are excluded` | behavioral |
+| **AC-1** author-only | `B7: notes authored by anyone else are excluded even if a relay leaks them` | behavioral |
+| **AC-2** limit=1 | `B8: limit=1 returns exactly the single most-recent note` | behavioral |
+| **AC-2** cap to N | `B9: the result is capped at the requested count (limit=3 → 3 most recent)` | behavioral |
+| **AC-2** hard max | `B10: an over-maximum limit is clamped to the hard cap of 50 (60 → 50 newest)` | behavioral |
+| **AC-2** relaySource set | `B11: a resolvable relay set yields relaySource "set"` | behavioral |
+| **AC-2** fallback (empty) | `B12: an empty/unresolvable set falls back, still returning notes` | behavioral |
+| **AC-2** fallback (error) | `B13: a runCypher error degrades to the fallback relays, not a crash` | behavioral |
+| **AC-3** EMPTY | `B14: a valid author with no notes yields EMPTY with items: []` | behavioral |
+| **AC-4** INVALID | `B15: a malformed pubkey yields the explicit INVALID outcome — not EMPTY, not a crash` | behavioral |
+| **AC-4** no I/O on invalid | `B16: INVALID short-circuits before any relay/Neo4j is queried` | behavioral |
+| **AC-3/4** distinctness | `B17: OK, EMPTY, INVALID are three mutually distinct status values` | behavioral |
+| **AC-5** mentions | `M1: a nostr:npub mention resolves to the mentioned profile's LOCAL name` | behavioral |
+| **AC-5** mention-free | `M2: a note with no mentions carries an empty mentions map` | behavioral |
+| **AC-4** handler → 400 | `H1: handleGetUserNotes responds 400 {success:false,status:"INVALID"} for a bad :pubkey` | behavioral |
+| **AC-4** handler mapping | `H2: the handler source maps INVALID → 400 and valid outcomes → 200` | source |
+| (additive — feed untouched) | `R1: the shipped feed read path is untouched (FEED_CAP=50, exports intact)` | regression |
+| (additive — seam unchanged) | `R2: the shared enrichNotes seam still exports enrichNotes + PROFILE_LOOKUP_CAP` | regression |
+
+## Edge cases (explicitly covered)
+
+- [x] **Invalid pubkey** → INVALID, distinct from EMPTY (B15), short-circuits before I/O (B16).
+- [x] **Valid pubkey, zero notes** → EMPTY with `items: []` (B14).
+- [x] **limit string forms** (query params are strings) — `'1'`/`'50'` parse (C1).
+- [x] **Over-max / non-numeric / absent / ≤0 limit** → clamped/defaulted (C2), 60-note hard cap (B10).
+- [x] **Newest-first** with out-of-order relay arrival (B5).
+- [x] **kind-6 / kind-7** excluded even when a relay ignores the kind filter (B6).
+- [x] **Foreign author** leaked by a relay is excluded (B7).
+- [x] **Relay set empty / runCypher throws** → fallback, no crash (B12, B13).
+- [x] **No local kind-0** → null name/avatar, never an external profile fetch (B3, B4).
+- [x] **Mentions** resolved via the reused `enrichNotes`, local-only (M1); empty-map stable shape (M2).
+
+### Deliberately NOT covered here
+
+- The two **surfaces** (Content section, `/notes` page) → `test/note-surfaces-ui.test.js` (Stories #2/#3).
+- **Live round-trip** against real strfry / Neo4j / external relays, and the rendered-UI proof — the **staging** smoke (anonymous `/user/<pubkey>/notes` 200 with a card), per the ADR. These unit tests prove the *logic* over mocked boundaries.
+- The exact internal Cypher / `strfry scan` argv — implementation details the spec does not pin.
+- `nsec`/junk mention rejection + the kind-0 lookup cap — owned and tested by the reused `enrichNotes` (its own suite, `test/live-feed-read-path.test.js` M4/M5/E2).
+
+## Test infrastructure
+
+- **Framework:** Node built-in runner via `npm test` (= `node test/test.js`). New suite exports `run()`, aggregated in `test/test.js` (require, `await …run()`, a result line, inclusion in `overallOk`). No new framework.
+- **No live services.** The three I/O boundaries are injected as in-memory fakes; `nostr-tools` (`nip19`) is used only to mint mention fixtures (resolved via the worktree's `node_modules` symlink to the shared checkout). No Concept Graph API, strfry, Neo4j, or network relay required.
+- **No firmware precondition** (the feature defines no concepts).
+- **Fixtures (in-file):** `HEX(c)` 64-hex pubkeys (`AUTHOR`, `OTHER`, `MENTIONED`), `kind1`/`kind0` event builders, `makeDeps(overrides)` assembling the three fakes.
+
+## How to run
+
+```
+npm test
+```
+
+Run just this suite:
+
+```
+node -e "require('./test/note-surfaces-read-path.test.js').run().then(r => console.log(JSON.stringify(r)))"
+```
+
+## Verification
+
+The new suite fails with the current code — every S/C/B/M/H test fails because `src/api/notes/userNotesReadPath.js` does not exist (legible "feature absent", not a require crash); the R* regression sentinels PASS (the shipped feed + shared seam are present and unmodified). Confirmed on 2026-06-18 — see the captured output pasted into the gate summary (commit recorded at the phase boundary).

--- a/engineering-team/stories/note-surfaces/2-profile-content-section.md
+++ b/engineering-team/stories/note-surfaces/2-profile-content-section.md
@@ -1,6 +1,6 @@
 # Story 2: Profile "Content" section — the user's latest note
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-18
 **Type:** Feature
 
@@ -45,4 +45,4 @@ None — placement (bottom / last section), label ("Content"), single-note count
 ## Linked artifacts
 - ADR: `engineering-team/decisions/note-surfaces/0002-note-surfaces-ui.md`
 - Test plan: `engineering-team/stories/note-surfaces/2-profile-content-section.test-plan.md`
-- Review: `engineering-team/reviews/note-surfaces/1-note-surfaces-implementation.md` (CHANGES_REQUESTED — 2026-06-18)
+- Review: `engineering-team/reviews/note-surfaces/1-note-surfaces-implementation.md` (PASS — 2026-06-18)

--- a/engineering-team/stories/note-surfaces/2-profile-content-section.md
+++ b/engineering-team/stories/note-surfaces/2-profile-content-section.md
@@ -45,4 +45,4 @@ None — placement (bottom / last section), label ("Content"), single-note count
 ## Linked artifacts
 - ADR: `engineering-team/decisions/note-surfaces/0002-note-surfaces-ui.md`
 - Test plan: `engineering-team/stories/note-surfaces/2-profile-content-section.test-plan.md`
-- Review: (filled in after Review)
+- Review: `engineering-team/reviews/note-surfaces/1-note-surfaces-implementation.md` (CHANGES_REQUESTED — 2026-06-18)

--- a/engineering-team/stories/note-surfaces/2-profile-content-section.md
+++ b/engineering-team/stories/note-surfaces/2-profile-content-section.md
@@ -44,5 +44,5 @@ None — placement (bottom / last section), label ("Content"), single-note count
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/note-surfaces/0002-note-surfaces-ui.md`
-- Test plan: (filled in after Test Design)
+- Test plan: `engineering-team/stories/note-surfaces/2-profile-content-section.test-plan.md`
 - Review: (filled in after Review)

--- a/engineering-team/stories/note-surfaces/2-profile-content-section.md
+++ b/engineering-team/stories/note-surfaces/2-profile-content-section.md
@@ -43,6 +43,6 @@ Testable from the outside.
 None — placement (bottom / last section), label ("Content"), single-note count, empty-state intent, and the link target (`/user/:pubkey/notes`) were operator-resolved at Planning.
 
 ## Linked artifacts
-- ADR: (filled in after Architecture)
+- ADR: `engineering-team/decisions/note-surfaces/0002-note-surfaces-ui.md`
 - Test plan: (filled in after Test Design)
 - Review: (filled in after Review)

--- a/engineering-team/stories/note-surfaces/2-profile-content-section.md
+++ b/engineering-team/stories/note-surfaces/2-profile-content-section.md
@@ -1,0 +1,48 @@
+# Story 2: Profile "Content" section — the user's latest note
+
+**Status:** Approved
+**Created:** 2026-06-18
+**Type:** Feature
+
+## Background
+The user profile page (`/user/:pubkey`) shows identity, reputation, and follows/followers — but nothing the user has actually **posted**. This story adds a **"Content"** section at the very bottom of the profile that shows the viewed user's **single most-recent kind-1 note**, an explicit empty state, and a link to the full notes page (`note-surfaces` #3).
+
+It consumes the by-author read path (`note-surfaces` #1) at count 1 and renders the **existing shared note card** — it adds no read logic of its own. The label is **"Content"** — not "Notes" — deliberately: the section may later host other content kinds, but only kind-1 is shown for now.
+
+Affected: anyone viewing any user profile.
+
+## User-facing description
+As someone viewing a user's profile, I want a "Content" section at the bottom showing that user's most-recent note, so I can see what they've posted at a glance; when they have none, I want to be told clearly; and I want a link to see more of their notes.
+
+## Acceptance criteria
+Testable from the outside.
+
+- [ ] **Section presence & label.** Given any user profile at `/user/:pubkey`, when the profile renders, then a section labelled **"Content"** appears as the **last** section of the page.
+
+- [ ] **Latest note rendered.** Given the viewed user has at least one locatable kind-1 note, when the Content section renders, then it shows that user's **single most-recent** note as a note card (author display name + avatar + timestamp + text) — and **no more than that one** note.
+
+- [ ] **Empty state.** Given the viewed user has **no locatable kind-1 note**, when the Content section renders, then it shows an explicit message that **no kind-1 events could be located** — and renders **no** note card.
+
+- [ ] **Link to the full notes page.** Given the Content section renders (populated **or** empty), then it includes a link to **`/user/:pubkey/notes`** for that user.
+
+- [ ] **Additive / no regression.** Everything else on the profile page renders exactly as before; with the Content section removed, the profile page behaves as it did prior to this story.
+
+> Canonical empty-state wording ("no kind-1 events could be located") is operator-delegated; exact punctuation is non-binding so long as it conveys that meaning.
+
+## Concepts touched
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-kind` — kind-1 (the note shown), kind-0 (author display).
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-user` — the viewed user (profile subject + note author).
+
+## Out of scope
+- The read/selection logic (that is `note-surfaces` #1) and the full notes page (`note-surfaces` #3).
+- Showing more than one note, pagination, or any content kind other than kind-1.
+- Any change to the rest of the profile page's existing sections, data, or layout beyond appending the new section.
+- Any write/publish.
+
+## Open questions
+None — placement (bottom / last section), label ("Content"), single-note count, empty-state intent, and the link target (`/user/:pubkey/notes`) were operator-resolved at Planning.
+
+## Linked artifacts
+- ADR: (filled in after Architecture)
+- Test plan: (filled in after Test Design)
+- Review: (filled in after Review)

--- a/engineering-team/stories/note-surfaces/2-profile-content-section.test-plan.md
+++ b/engineering-team/stories/note-surfaces/2-profile-content-section.test-plan.md
@@ -1,0 +1,65 @@
+# Test Plan: Story note-surfaces #2 — Profile "Content" section
+
+**Story:** `engineering-team/stories/note-surfaces/2-profile-content-section.md`
+**ADR:** `engineering-team/decisions/note-surfaces/0002-note-surfaces-ui.md`
+**Date:** 2026-06-18
+**Test file:** `test/note-surfaces-ui.test.js` (shared with Story #3; wired into `test/test.js`)
+
+## Scope
+
+Covers **Story #2 — the profile "Content" section** (`ui/src/components/ProfileContentSection.jsx` + its insertion into `ui/src/pages/BrainstormProfile.jsx`, consuming the shared `ui/src/hooks/useUserNotes.js` at limit 1). The shared hook tests (U1–U2) and the `/user/:pubkey/notes` page (U9–U16) belong to Story #3's plan but live in the same file.
+
+## Test level (read this first)
+
+UI is asserted at the **source-text level**, the house convention for `ui/src/*.jsx` (the Node runner has no JSX transpile; `react-dom` lives only in the `ui/` Vite workspace; adding a transpile is forbidden tooling). This matches `test/live-feed-feed-page.test.js` and the `profile-*` suites. The ADR shapes the section so its body is a **pure, named-exported `renderContentBody`** with **module-level `CONTENT_COPY` constants**, making the source sentinels precise (copy is pinned; branches are sliced out of the pure helper). The *rendered* card / empty state in a browser is the **staging** capstone (anonymous profile page), not this suite.
+
+## Coverage map
+
+| Criterion | Test name | Level |
+|---|---|---|
+| (shared hook) | `U1: useUserNotes(pubkey, limit) fetches /api/user/<pubkey>/notes?limit=<limit>, returns {data,loading,error}` | source |
+| (shared hook) | `U2: useUserNotes gates on success, sets error, aborts on unmount, re-runs on [pubkey,limit]` | source |
+| **#2** label "Content" | `U3: ProfileContentSection exists, uses useUserNotes(pubkey, 1), labelled "Content"` | source |
+| **#2** latest note (one) | `U4: the OK branch renders exactly ONE NoteCard for items[0], not a list` | source |
+| **#2** empty state | `U5: the empty/defensive branch shows "no kind-1 events could be located", no card` | source |
+| **#2** link to page | `U6: the section links to /user/<pubkey>/notes in all states` | source |
+| **#2** testability | `U7: renderContentBody is a named-exported PURE function (no fetch/hook/router/globals)` | source |
+| **#2** placement (last) | `U8: BrainstormProfile renders <ProfileContentSection> as the LAST section, AFTER Reputation` | source |
+| **#2** additive/no-regression | `R3: the Reputation section + TRUST_METRICS grid path are untouched` | regression |
+| (card reused, no fork) | `R2: NoteCard is reused as-is — single { item } prop, no variant fork` | regression |
+
+## Edge cases (explicitly covered)
+
+- [x] **No locatable note** → the empty message (operator's "no kind-1 events could be located"), no card (U5).
+- [x] **Transport/INVALID failure** → collapses to the same empty message (the operator's phrasing is agnostic between "none exist" and "couldn't load"), asserted via the pure helper's defensive branch (U5 + U7 banning hook/fetch inside the helper).
+- [x] **Single-note discipline** — the section renders `items[0]` only, never a `.map` list (U4).
+- [x] **Link present even when empty** (U6).
+- [x] **Additive** — Reputation/grid untouched (R3); the section is appended after it (U8); NoteCard not forked (R2).
+
+### Deliberately NOT covered here
+
+- The read path (Story #1, `test/note-surfaces-read-path.test.js`).
+- The `/user/:pubkey/notes` page body (Story #3, U9–U16 in the same file).
+- **Rendered DOM / the card actually appearing on a profile** → the **staging** capstone (the local Docker stack is in use by a parallel session; local full-stack verification is intentionally skipped per the ADR).
+
+## Test infrastructure
+
+- **Framework:** Node runner via `npm test`; the shared `test/note-surfaces-ui.test.js` exports `run()` and is aggregated in `test/test.js`. **No new framework, no JSX transpile, no `react-dom`.**
+- **No live services / no `node_modules` beyond `fs`/`path`** — the UI suite is pure source assertion (the worktree's `node_modules` symlink is irrelevant to it).
+- **Fixtures:** none (source-text sentinels with `safeRead` + a `helperBody` slicer).
+
+## How to run
+
+```
+npm test
+```
+
+Run just this suite:
+
+```
+node -e "require('./test/note-surfaces-ui.test.js').run().then(r => console.log(JSON.stringify(r)))"
+```
+
+## Verification
+
+The `U3–U8` Story-#2 tests (and `U1–U2` for the shared hook) fail with the current code — `ProfileContentSection.jsx`, `useUserNotes.js` don't exist, and `BrainstormProfile.jsx` has no `<ProfileContentSection>` insertion (legible "does not exist yet" messages). `R2`/`R3` PASS now (NoteCard and the Reputation section are present and unmodified). Captured output is in the gate summary (commit recorded at the phase boundary).

--- a/engineering-team/stories/note-surfaces/3-per-user-notes-page.md
+++ b/engineering-team/stories/note-surfaces/3-per-user-notes-page.md
@@ -43,6 +43,6 @@ Testable from the outside.
 None — route (`/user/:pubkey/notes`), the 50 cap, and the empty-state intent were operator-resolved at Planning.
 
 ## Linked artifacts
-- ADR: (filled in after Architecture)
+- ADR: `engineering-team/decisions/note-surfaces/0002-note-surfaces-ui.md`
 - Test plan: (filled in after Test Design)
 - Review: (filled in after Review)

--- a/engineering-team/stories/note-surfaces/3-per-user-notes-page.md
+++ b/engineering-team/stories/note-surfaces/3-per-user-notes-page.md
@@ -1,6 +1,6 @@
 # Story 3: Per-user notes page (`/user/:pubkey/notes`)
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-18
 **Type:** Feature
 
@@ -45,4 +45,4 @@ None — route (`/user/:pubkey/notes`), the 50 cap, and the empty-state intent w
 ## Linked artifacts
 - ADR: `engineering-team/decisions/note-surfaces/0002-note-surfaces-ui.md`
 - Test plan: `engineering-team/stories/note-surfaces/3-per-user-notes-page.test-plan.md`
-- Review: `engineering-team/reviews/note-surfaces/1-note-surfaces-implementation.md` (CHANGES_REQUESTED — 2026-06-18)
+- Review: `engineering-team/reviews/note-surfaces/1-note-surfaces-implementation.md` (PASS — 2026-06-18)

--- a/engineering-team/stories/note-surfaces/3-per-user-notes-page.md
+++ b/engineering-team/stories/note-surfaces/3-per-user-notes-page.md
@@ -45,4 +45,4 @@ None — route (`/user/:pubkey/notes`), the 50 cap, and the empty-state intent w
 ## Linked artifacts
 - ADR: `engineering-team/decisions/note-surfaces/0002-note-surfaces-ui.md`
 - Test plan: `engineering-team/stories/note-surfaces/3-per-user-notes-page.test-plan.md`
-- Review: (filled in after Review)
+- Review: `engineering-team/reviews/note-surfaces/1-note-surfaces-implementation.md` (CHANGES_REQUESTED — 2026-06-18)

--- a/engineering-team/stories/note-surfaces/3-per-user-notes-page.md
+++ b/engineering-team/stories/note-surfaces/3-per-user-notes-page.md
@@ -44,5 +44,5 @@ None — route (`/user/:pubkey/notes`), the 50 cap, and the empty-state intent w
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/note-surfaces/0002-note-surfaces-ui.md`
-- Test plan: (filled in after Test Design)
+- Test plan: `engineering-team/stories/note-surfaces/3-per-user-notes-page.test-plan.md`
 - Review: (filled in after Review)

--- a/engineering-team/stories/note-surfaces/3-per-user-notes-page.md
+++ b/engineering-team/stories/note-surfaces/3-per-user-notes-page.md
@@ -1,0 +1,48 @@
+# Story 3: Per-user notes page (`/user/:pubkey/notes`)
+
+**Status:** Approved
+**Created:** 2026-06-18
+**Type:** Feature
+
+## Background
+The `note-surfaces` epic's read path (`note-surfaces` #1) can produce a given user's most-recent kind-1 notes; the profile "Content" section (`note-surfaces` #2) shows only the latest one and links here. This story adds the **public `/user/:pubkey/notes` page** that renders that user's **50 most-recent notes** as a list — a sibling of the existing `/user/:pubkey/follows`, `/followers`, and `/follows-hops` sub-pages.
+
+It is **front-end only**: it consumes `note-surfaces` #1 at count 50 and renders the **existing shared note card**, reusing the established feed-page rendering and empty-state patterns. It adds no read logic of its own.
+
+Affected: anyone (logged in or anonymous) who wants to read a specific user's recent notes.
+
+## User-facing description
+As someone viewing a user, I want a `/user/:pubkey/notes` page that shows that user's 50 most-recent notes, newest-first, each with the author's name, avatar, timestamp, and text — so I can read their recent posts; and when there are none, I want to be told clearly rather than seeing a blank page or an error.
+
+## Acceptance criteria
+Testable from the outside.
+
+- [ ] **Public reachability + no overflow.** Given any pubkey, when a client requests `/user/:pubkey/notes`, then the response is HTTP 200 and renders the notes surface (the populated list **or** the empty state) — never a login wall or error page — and at a **1280px-wide viewport** the rendered page produces **no horizontal overflow** (no content extends beyond 1280px / no horizontal scrollbar).
+
+- [ ] **Populated list: content, order, cap.** Given the viewed user has one or more locatable notes, when the page renders, then it shows **one entry per note** — each with the author's **display name, avatar, timestamp, and text** — ordered **newest-first**, capped at the **50 most recent**.
+
+- [ ] **Whose notes.** Given the page renders, then it identifies **whose** notes are shown (the viewed user's display name / identity).
+
+- [ ] **Empty state.** Given the viewed user has **no locatable kind-1 note**, when the page renders, then it shows an explicit message that **no kind-1 events could be located** and shows **no** entries.
+
+- [ ] **Additive / no regression.** The page is purely additive: with the `/user/:pubkey/notes` route removed, the rest of the app behaves exactly as before.
+
+> Canonical empty-state wording ("no kind-1 events could be located") is operator-delegated; exact punctuation is non-binding so long as it conveys that meaning.
+
+## Concepts touched
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-kind` — kind-1 (the notes), kind-0 (author display).
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-user` — the viewed user (note author).
+
+## Out of scope
+- The read/selection logic (that is `note-surfaces` #1).
+- Pagination beyond 50, infinite scroll, full history, content kinds other than kind-1.
+- Replies/threading, reactions/repost display, tagging notes, any write/publish.
+- A PoV / source selector — these are the viewed user's own posts.
+
+## Open questions
+None — route (`/user/:pubkey/notes`), the 50 cap, and the empty-state intent were operator-resolved at Planning.
+
+## Linked artifacts
+- ADR: (filled in after Architecture)
+- Test plan: (filled in after Test Design)
+- Review: (filled in after Review)

--- a/engineering-team/stories/note-surfaces/3-per-user-notes-page.test-plan.md
+++ b/engineering-team/stories/note-surfaces/3-per-user-notes-page.test-plan.md
@@ -1,0 +1,66 @@
+# Test Plan: Story note-surfaces #3 — Per-user notes page (`/user/:pubkey/notes`)
+
+**Story:** `engineering-team/stories/note-surfaces/3-per-user-notes-page.md`
+**ADR:** `engineering-team/decisions/note-surfaces/0002-note-surfaces-ui.md`
+**Date:** 2026-06-18
+**Test file:** `test/note-surfaces-ui.test.js` (shared with Story #2; wired into `test/test.js`)
+
+## Scope
+
+Covers **Story #3 — the public `/user/:pubkey/notes` page** (`ui/src/pages/BrainstormUserNotes.jsx` + its route in `ui/src/App.jsx`, consuming the shared `ui/src/hooks/useUserNotes.js` at limit 50). The shared hook (U1–U2) and the Content section (U3–U8) belong to Story #2's plan but live in the same file.
+
+## Test level (read this first)
+
+Source-text assertion, as for Story #2 — the house `ui/src/*.jsx` convention (no JSX transpile in the Node runner). The page delegates its body to a **pure, named-exported `renderUserNotesState`** with module-level `NOTES_COPY` constants. The runtime properties source can't prove — an anonymous `GET /user/<pubkey>/notes` returning 200 with a rendered card, and **no horizontal overflow at 1280px** — are the **staging** capstone (a `curl` 200 check + a DOM/visual extract), gathered after deploy per the ADR. This suite proves the page is *built-to-render* the populated/empty states and *wired-to-be* a public, width-bounded route.
+
+## Coverage map
+
+| Criterion | Test name | Level |
+|---|---|---|
+| **#3** route reachability | `U9: App.jsx registers /user/:pubkey/notes → BrainstormUserNotes, public top-level (before /tapestry)` | source |
+| **#3** list + card reuse | `U10: the page uses useUserNotes(pubkey, 50), reuses the public shell, renders notes via NoteCard` | source |
+| **#3** order (no re-sort) | `U11: the OK branch maps items in ARRAY ORDER and does NOT re-sort` | source |
+| **#3** whose notes | `U12: the page fetches the subject profile name (/api/profiles?pubkeys=) and shows it` | source |
+| **#3** empty state | `U13: the empty/defensive branch shows "no kind-1 events could be located", no entries` | source |
+| **#3** heading + back link | `U14: the page shows a "Notes" heading and a back link to the profile` | source |
+| **#3** testability | `U15: renderUserNotesState is a named-exported PURE function (no fetch/hook/router/globals)` | source |
+| **#3** no overflow @1280px | `U16: the note-card text wraps + the notes column is width-bounded` | source |
+| **#3** additive route | `R1: App.jsx still registers the existing /user/:pubkey/* sub-routes — /notes added beside them` | regression |
+| (card reused, no fork) | `R2: NoteCard is reused as-is — single { item } prop, no variant fork` | regression |
+| (shared hook) | `U1–U2` (see Story #2 plan) | source |
+
+## Edge cases (explicitly covered)
+
+- [x] **Public reachability** — the route sits in the top-level group (before `/tapestry` admin), so the SPA fallback serves it to anonymous clients; runtime 200 is the staging `curl` capstone (U9).
+- [x] **Newest-first, no re-derivation** — renders the read path's array order; `.sort` on items is banned (U11).
+- [x] **Whose notes even when empty** — the subject name comes from a profile fetch, not from `items[0]` (which is absent when empty) (U12).
+- [x] **No locatable note** → the empty message, no entries (U13).
+- [x] **Transport/INVALID failure** → collapses to the same empty message via the pure helper's defensive branch (U13 + U15).
+- [x] **No 1280px overflow** — shared `bsp-note-card-*` text wraps + a width-bounded column (U16).
+- [x] **Additive** — existing `/user/:pubkey/*` routes preserved (R1); NoteCard not forked (R2).
+
+### Deliberately NOT covered here
+
+- The read path (Story #1).
+- The Content section body (Story #2, U3–U8).
+- **Rendered 200 + the ≥1-card screenshot + the 1280px no-scrollbar proof** → the **staging** capstone (`curl` for the 200/content-type, a DOM/visual extract for the card and overflow). Local full-stack verification is intentionally skipped — the shared local Docker stack belongs to a parallel session.
+
+## Test infrastructure
+
+Identical to Story #2's plan — Node runner via `npm test`, pure source assertion, no new framework / JSX transpile / `react-dom`, no live services, no fixtures.
+
+## How to run
+
+```
+npm test
+```
+
+Run just this suite:
+
+```
+node -e "require('./test/note-surfaces-ui.test.js').run().then(r => console.log(JSON.stringify(r)))"
+```
+
+## Verification
+
+The `U9–U16` Story-#3 tests fail with the current code — `BrainstormUserNotes.jsx`, `useUserNotes.js` don't exist and `App.jsx` has no `/user/:pubkey/notes` route (legible "does not exist yet" messages). `R1`/`R2` PASS now (the existing routes and NoteCard are present and unmodified). Captured output is in the gate summary (commit recorded at the phase boundary).

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -82,6 +82,7 @@ const { handleFetchProfiles } = require('./profiles/fetchProfiles.js');
 const { handleFetchExternalReactions } = require('./reactions/fetchReactions.js');
 const { handleFetchExternalEvents } = require('./relay/fetchEvents.js');
 const { handleGetFeed } = require('./feed/feedReadPath.js');
+const { handleGetUserNotes } = require('./notes/userNotesReadPath.js');
 const { requireOwner, handleGetSettings, handleGetDefaults, handleGetOverrides, handleUpdateSettings, handleResetSetting } = require('./settings/settingsApi.js');
 const { handleGetGrapevinePreferences, handleUpdateGrapevinePreferences } = require('./settings/grapevinePrefApi.js');
 const { handleGetUserPrefs, handleUpdateUserPrefs } = require('./settings/userPrefsApi.js');
@@ -300,6 +301,9 @@ async function register(app) {
 
     // Live-feed read path (public, read-only) — Story live-feed #1, ADR live-feed/0001
     app.get('/api/feed', handleGetFeed);
+
+    // By-author notes read path (public, read-only) — Story note-surfaces #1, ADR note-surfaces/0001
+    app.get('/api/user/:pubkey/notes', handleGetUserNotes);
 
     // Settings endpoints (owner-only except GET merged)
     // /api/grapevine/preferences writes to the HOUSE config (settings.grapevine.searchPreferences)

--- a/src/api/notes/userNotesReadPath.js
+++ b/src/api/notes/userNotesReadPath.js
@@ -1,0 +1,205 @@
+/**
+ * By-author notes read path (Story note-surfaces #1, ADR note-surfaces/0001 — Option A).
+ *
+ * A single self-contained, additive, read-only module that assembles ONE user's own recent
+ * kind-1 notes: the N most-recent kind-1 events authored by a given pubkey, newest-first,
+ * capped at the requested limit (hard max NOTES_CAP), with author display name + avatar (and
+ * in-text mention names) drawn from LOCAL kind-0 profile data — never the external relays.
+ *
+ * It is the simpler sibling of feedReadPath.js: there is NO source identity, NO kind-3 follow
+ * list, and NO point-of-view — the author is the pubkey in the URL. Only the SELECTION of raw
+ * kind-1 differs (by-author here vs by-follow-set in the feed). The notes are fetched from the
+ * general-purpose relays (settled empirically — local strfry holds 0 kind-1); the enrichment
+ * reuses the shared enrichNotes seam unchanged.
+ *
+ * Exports:
+ *   - buildUserNotes(options) — the orchestrator, returns a discriminated `status` union
+ *     { OK, EMPTY, INVALID } plus, on OK/EMPTY, a `relaySource` discriminator { set, fallback }
+ *     and an `items` array of the SAME shape the feed serves:
+ *       { id, pubkey, createdAt, content, author: { displayName, avatar }, mentions }.
+ *   - handleGetUserNotes(req, res) — the public GET /api/user/:pubkey/notes Express handler
+ *     (INVALID → 400; OK/EMPTY → 200 { success:true, ... }).
+ *   - clampLimit(raw) — the limit default + hard cap (req.query.limit is a string).
+ *   - NOTES_CAP — the hard maximum (and default) note count.
+ *
+ * Injectable dependency seam (mirrors feedReadPath.js). buildUserNotes reads its three I/O
+ * boundaries from `options`, each defaulting to the real helper when absent. Fakes may be
+ * spread onto the options object OR live under `options.deps` (read
+ * `options.deps?.X ?? options.X ?? <realHelper>`):
+ *   - scanStrfry(filter)     — local strfry scan for kind-0 (via enrichNotes)
+ *   - runCypher(cypher,prms) — general-purpose relay-set resolution
+ *   - querySync(relays,flt)  — external kind-1 fetch (by author)
+ * Production callers invoke buildUserNotes({ pubkey, limit }) with no deps and get the real
+ * helpers. The seam is parameter wiring only — no behavior change.
+ *
+ * NOTE (ADR note-surfaces/0001 §Consequences): the sourcing helpers below
+ * (resolveGeneralPurposeRelays / realQuerySync / realScanStrfry / the module-path constants)
+ * are intentionally DUPLICATED from feedReadPath.js rather than extracted, to keep this change
+ * additive and leave the staging-shipped feed read path byte-identical. Consolidation into
+ * src/api/_shared/relaySource.js (re-pointing both) is a deferred follow-up.
+ */
+
+// nostr-tools / ws required via the container's absolute module path (the convention
+// fetchEvents.js / feedReadPath.js use). Done lazily inside the real querySync helper so the
+// module loads in test/CI where the path is absent.
+const NOSTR_TOOLS_PATH = '/usr/local/lib/node_modules/brainstorm/node_modules/nostr-tools';
+const WS_PATH = '/usr/local/lib/node_modules/brainstorm/node_modules/ws';
+
+// Shared note enrichment (author + mention display names from local kind-0). Reused unchanged
+// from the feed — the one shared seam; only the SELECTION of raw notes differs per read path.
+const { enrichNotes } = require('../_shared/noteEnrichment');
+
+const FETCH_TIMEOUT_MS = 8000;
+const NOTES_CAP = 50;                 // hard maximum + default note count
+const FALLBACK_RELAYS = ['wss://relay.damus.io', 'wss://relay.primal.net', 'wss://nos.lol'];
+const RELAY_SET_SLUG = 'the-set-of-general-purpose-relays';
+
+const HEX64 = /^[0-9a-f]{64}$/i;
+
+// ─── Real helper defaults (used when no deps are injected) ──────────────────────
+
+/** Default local strfry scan (kind-0 profiles, via enrichNotes). */
+function realScanStrfry(filter) {
+  const { execSync } = require('child_process');
+  const filterStr = typeof filter === 'string' ? filter : JSON.stringify(filter);
+  const raw = execSync(`strfry scan '${filterStr.replace(/'/g, "\\'")}'`, {
+    timeout: 5000, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const events = [];
+  for (const line of raw.trim().split('\n')) {
+    if (!line) continue;
+    try { events.push(JSON.parse(line)); } catch { /* skip non-event log lines */ }
+  }
+  return events;
+}
+
+/** Default relay-set resolution via Neo4j. */
+function realRunCypher(cypher, params) {
+  return require('../../lib/neo4j-driver').runCypher(cypher, params);
+}
+
+/** Default external kind-1 fetch via SimplePool. */
+async function realQuerySync(relays, filter) {
+  if (typeof globalThis.WebSocket === 'undefined') {
+    globalThis.WebSocket = require(WS_PATH);
+  }
+  const { SimplePool } = require(NOSTR_TOOLS_PATH);
+  const pool = new SimplePool();
+  try {
+    return await Promise.race([
+      pool.querySync(relays, filter),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), FETCH_TIMEOUT_MS)),
+    ]);
+  } finally {
+    try { pool.close(relays); } catch { /* ignore */ }
+  }
+}
+
+// ─── Internal orchestration helpers ─────────────────────────────────────────────
+
+/**
+ * The note count: default to NOTES_CAP, floor at 1, cap at NOTES_CAP. `req.query.limit` arrives
+ * as a string; absent/non-numeric ⇒ the default. (No unbounded result.)
+ */
+function clampLimit(raw) {
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n)) return NOTES_CAP;   // absent / non-numeric → default
+  if (n < 1) return 1;                          // floor
+  if (n > NOTES_CAP) return NOTES_CAP;          // hard cap
+  return n;
+}
+
+/**
+ * Resolve the general-purpose relay set by slug-from-TA. Empty / error ⇒ the hardcoded fallback
+ * relays. → { relays: string[], source: 'set' | 'fallback' }. (Mirrors feedReadPath.js.)
+ */
+async function resolveGeneralPurposeRelays(runCypher) {
+  try {
+    const ta = require('../../utils/assistantKeys').getOwnerAssistantPubkey();
+    const handle = `39999:${ta}:${RELAY_SET_SLUG}`;
+    const rows = await runCypher(
+      'MATCH (s:Set {uuid:$h})-[:HAS_ELEMENT]->(m:ListItem) WHERE NOT m:Superset ' +
+      'MATCH (m)-[:HAS_TAG]->(jt:NostrEventTag {type:\'json\'}) RETURN jt.value AS json',
+      { h: handle }
+    );
+    const relays = [];
+    for (const row of rows || []) {
+      try {
+        const url = JSON.parse(row.json)?.nostrRelay?.websocketUrl;
+        if (typeof url === 'string' && (url.startsWith('wss://') || url.startsWith('ws://'))) {
+          relays.push(url);
+        }
+      } catch { /* skip unparseable member */ }
+    }
+    if (relays.length > 0) return { relays, source: 'set' };
+  } catch { /* fall through to fallback */ }
+  return { relays: FALLBACK_RELAYS.slice(), source: 'fallback' };
+}
+
+/**
+ * Fetch kind-1 notes for a single author from the relays, then app-side: keep only kind-1
+ * authored by that pubkey, dedup by id, sort newest-first, cap at `limit`.
+ */
+async function fetchAuthorNotes(pubkey, limit, relays, querySync) {
+  const events = (await querySync(relays, { kinds: [1], authors: [pubkey], limit })) || [];
+  const seen = new Set();
+  const notes = [];
+  for (const ev of events) {
+    if (!ev || ev.kind !== 1) continue;        // kind-1 only ⇒ excludes kind-6 / kind-7
+    if (ev.pubkey !== pubkey) continue;        // author-only ⇒ drop relay-leaked strangers
+    if (seen.has(ev.id)) continue;             // dedup by id
+    seen.add(ev.id);
+    notes.push(ev);
+  }
+  notes.sort((a, b) => b.created_at - a.created_at);
+  return notes.slice(0, limit);
+}
+
+// ─── Orchestrator ───────────────────────────────────────────────────────────────
+
+/**
+ * Assemble one user's recent notes. See the three-outcome contract in the module header / ADR.
+ * @param {Object} options - { pubkey, limit } plus optional injected deps (spread or under
+ *   `options.deps`): scanStrfry, runCypher, querySync.
+ */
+async function buildUserNotes(options = {}) {
+  const { pubkey, limit, deps } = options;
+  const scanStrfry = deps?.scanStrfry ?? options.scanStrfry ?? realScanStrfry;
+  const runCypher = deps?.runCypher ?? options.runCypher ?? realRunCypher;
+  const querySync = deps?.querySync ?? options.querySync ?? realQuerySync;
+
+  // 1. Validate the author pubkey FIRST — malformed ⇒ INVALID, no relays/Neo4j queried.
+  if (!pubkey || !HEX64.test(pubkey)) return { status: 'INVALID' };
+
+  // 2. Count (default + hard cap).
+  const n = clampLimit(limit);
+
+  // 3. Relay set (slug-from-TA) with fallback.
+  const { relays, source: relaySource } = await resolveGeneralPurposeRelays(runCypher);
+
+  // 4. Fetch + filter + order + cap, then enrich from local profiles.
+  const notes = await fetchAuthorNotes(pubkey, n, relays, querySync);
+  const items = await enrichNotes(notes, scanStrfry);
+
+  if (items.length === 0) {
+    return { status: 'EMPTY', relaySource, items: [] };
+  }
+  return { status: 'OK', relaySource, items };
+}
+
+// ─── Public Express handler ─────────────────────────────────────────────────────
+
+/** GET /api/user/:pubkey/notes — public, read-only. INVALID → 400; OK/EMPTY → 200. */
+async function handleGetUserNotes(req, res) {
+  try {
+    const r = await buildUserNotes({ pubkey: req.params.pubkey, limit: req.query.limit });
+    if (r.status === 'INVALID') {
+      return res.status(400).json({ success: false, ...r, error: 'invalid pubkey' });
+    }
+    return res.json({ success: true, ...r });
+  } catch (err) {
+    return res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+module.exports = { buildUserNotes, handleGetUserNotes, clampLimit, NOTES_CAP };

--- a/test/note-surfaces-read-path.test.js
+++ b/test/note-surfaces-read-path.test.js
@@ -1,0 +1,479 @@
+/**
+ * Story note-surfaces #1: By-author notes read path — a user's own recent kind-1 notes.
+ * ADR note-surfaces/0001. See engineering-team/stories/note-surfaces/1-by-author-notes-read-path.test-plan.md
+ *
+ * ADR chose Option A: a self-contained module `src/api/notes/userNotesReadPath.js`
+ * exporting `buildUserNotes({ pubkey, limit, deps })`, an Express handler
+ * `handleGetUserNotes`, and a pure `clampLimit` — exposed at GET /api/user/:pubkey/notes.
+ * It mirrors feedReadPath.js's structure but SELECTS kind-1 by the single given author
+ * (no source identity / follow list / PoV), sourcing notes from the general-purpose
+ * relays (settled empirically — local strfry holds 0 kind-1) and REUSING the shared
+ * `enrichNotes` (src/api/_shared/noteEnrichment.js) for author/mention enrichment.
+ * Result is a discriminated `status` union { OK, EMPTY, INVALID } plus a `relaySource`
+ * { set, fallback } on OK/EMPTY, each item shaped
+ *   { id, pubkey, createdAt, content, author: { displayName, avatar }, mentions } —
+ * the SAME item shape as the feed, so NoteCard renders it unchanged.
+ *
+ * WHY behavioral, not source-regex: the ACs require the OK/EMPTY/INVALID outcomes +
+ * newest-first ordering + the limit cap + kind-6/7 + foreign-author exclusion + the
+ * set-vs-fallback discriminator to be OBSERVABLE BEHAVIOR, without touching live strfry,
+ * Neo4j, or external relays. buildUserNotes crosses three I/O boundaries —
+ *   - relay set : runCypher(...) on the-set-of-general-purpose-relays node
+ *   - kind-1    : SimplePool.querySync(relays, filter) (external relays)
+ *   - kind-0    : exec/execSync `strfry scan ...` (local strfry, via enrichNotes)
+ * so the tests inject FAKES via buildUserNotes's options object (the same { pubkey, limit }
+ * object the ADR passes). Production callers pass no deps and get the real helpers; tests
+ * pass deps to stay hermetic. If the Implementer hard-wires the boundaries and ignores
+ * injected deps, the behavioral assertions fail loudly (real I/O / throw) — correct pressure
+ * toward the seam, not a false pass.
+ *
+ * ALL S/C/B/M/H tests FAIL pre-implementation (module absent) and must PASS post.
+ * R* are regression sentinels — PASS before AND after (the shipped feed read path is untouched).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MODULE_PATH = path.resolve(__dirname, '../src/api/notes/userNotesReadPath.js');
+const API_INDEX = path.resolve(__dirname, '../src/api/index.js');
+const FEED_READ_PATH = path.resolve(__dirname, '../src/api/feed/feedReadPath.js');
+const SHARED_ENRICH = path.resolve(__dirname, '../src/api/_shared/noteEnrichment.js');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+
+// Load the not-yet-written module without letting a missing-file require crash the suite.
+function loadModule() {
+  try { delete require.cache[require.resolve(MODULE_PATH)]; } catch { /* not resolvable yet */ }
+  try { return require(MODULE_PATH); } catch { return null; }
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures: pubkeys, kind-1/kind-0 events, the three injectable fakes.
+// ---------------------------------------------------------------------------
+
+const HEX = (c) => c.repeat(64);
+const AUTHOR = HEX('a');     // the viewed user (the note author)
+const OTHER = HEX('9');      // a DIFFERENT author a relay might leak into the response
+const NOT_HEX = 'not-a-valid-pubkey';
+
+function kind1(id, author, createdAt, content) {
+  return { id, kind: 1, pubkey: author, created_at: createdAt, content: content || '', tags: [] };
+}
+function kind0(pubkey, profile, createdAt) {
+  return { id: 'k0-' + pubkey.slice(0, 6), kind: 0, pubkey, created_at: createdAt || 50, tags: [], content: JSON.stringify(profile) };
+}
+
+/**
+ * Build the three injectable fakes (no getSettings — this read path has no PoV/source
+ * resolution). Any can be overridden per-test.
+ *  - scanStrfry : (filter) => events[]   (fake LOCAL strfry: kind-0 profiles only)
+ *  - runCypher  : (cypher, params) => rows[]  (fake relay-set resolution)
+ *  - querySync  : (relays, filter) => events[]  (fake external kind-1 fetch by author)
+ */
+function makeDeps(overrides = {}) {
+  return {
+    // Default local strfry: no kind-0 profiles (author renders with null name/avatar).
+    scanStrfry: () => [],
+    // Default relay set: two non-fallback members.
+    runCypher: async () => ([
+      { json: JSON.stringify({ nostrRelay: { websocketUrl: 'wss://set-relay-a.example' } }) },
+      { json: JSON.stringify({ nostrRelay: { websocketUrl: 'wss://set-relay-b.example' } }) },
+    ]),
+    // Default external fetch: two notes by the viewed author, out of order.
+    querySync: async () => ([
+      kind1('n1', AUTHOR, 200, 'first'),
+      kind1('n2', AUTHOR, 100, 'second'),
+    ]),
+    ...overrides,
+  };
+}
+
+/**
+ * Invoke buildUserNotes with injected deps, tolerating the ADR's naming latitude (deps may
+ * live under `deps:` or be spread onto the options object — we pass BOTH; the impl reads
+ * whichever it exposes, mirroring the live-feed read-path test seam).
+ */
+async function callBuildUserNotes(mod, { pubkey = AUTHOR, limit, deps } = {}) {
+  assert(mod && typeof mod.buildUserNotes === 'function',
+    'src/api/notes/userNotesReadPath.js must export an async `buildUserNotes` function — the feature is not implemented yet ' +
+    '(ADR note-surfaces/0001 §Implementation notes).');
+  return mod.buildUserNotes({ pubkey, limit, deps, ...deps });
+}
+
+// ===========================================================================
+// STRUCTURAL SENTINELS — make "feature absent" legible, pin the contract + reuse.
+// ===========================================================================
+
+test('S1: module src/api/notes/userNotesReadPath.js exists and exports buildUserNotes + handleGetUserNotes + clampLimit (ADR §Decision / §Impl)', () => {
+  const mod = loadModule();
+  assert(mod !== null,
+    'src/api/notes/userNotesReadPath.js does not exist / does not load yet — the Implementer must create the by-author read-path module (ADR note-surfaces/0001 Option A).');
+  assert(typeof mod.buildUserNotes === 'function',
+    'userNotesReadPath.js must export `buildUserNotes` (the orchestrator the outcomes are asserted against).');
+  assert(typeof mod.handleGetUserNotes === 'function',
+    'userNotesReadPath.js must export `handleGetUserNotes` (the public GET /api/user/:pubkey/notes Express handler).');
+  assert(typeof mod.clampLimit === 'function',
+    'userNotesReadPath.js must export `clampLimit` (the limit default/cap, unit-tested directly).');
+});
+
+test('S2: GET /api/user/:pubkey/notes is registered to handleGetUserNotes in src/api/index.js (ADR §Impl)', () => {
+  const src = safeRead(API_INDEX);
+  assert(src.length > 0, 'src/api/index.js missing — unexpected.');
+  assert(/['"]\/api\/user\/:pubkey\/notes['"]/.test(src),
+    "src/api/index.js must register the public route '/api/user/:pubkey/notes' (alongside /api/feed).");
+  assert(/handleGetUserNotes/.test(src),
+    'src/api/index.js must wire /api/user/:pubkey/notes to handleGetUserNotes.');
+});
+
+test('S3 (reuse): the read path REUSES the shared enrichNotes (it does not re-implement enrichment)', () => {
+  const src = safeRead(MODULE_PATH);
+  assert(src.length > 0, 'userNotesReadPath.js does not exist yet.');
+  assert(/require\(\s*['"]\.\.\/_shared\/noteEnrichment['"]\s*\)/.test(src) && /enrichNotes/.test(src),
+    "userNotesReadPath.js must require enrichNotes from '../_shared/noteEnrichment' and use it (ADR: reuse the shared seam, do not re-implement author/mention enrichment).");
+});
+
+// ===========================================================================
+// clampLimit — the count default + hard cap (AC-2). req.query.limit is a STRING.
+// ===========================================================================
+
+test('C1 (AC-2): clampLimit passes the known caller values through — 1 → 1, 50 → 50 (number and string forms)', () => {
+  const mod = loadModule();
+  assert(mod && typeof mod.clampLimit === 'function', 'clampLimit must be exported (feature absent).');
+  assert(mod.clampLimit(1) === 1, `clampLimit(1) must be 1; got ${mod.clampLimit(1)}.`);
+  assert(mod.clampLimit(50) === 50, `clampLimit(50) must be 50; got ${mod.clampLimit(50)}.`);
+  assert(mod.clampLimit('1') === 1, `clampLimit('1') must be 1 — query params arrive as strings; got ${mod.clampLimit('1')}.`);
+  assert(mod.clampLimit('50') === 50, `clampLimit('50') must be 50 — query params arrive as strings; got ${mod.clampLimit('50')}.`);
+});
+
+test('C2 (AC-2): clampLimit applies a hard maximum (NOTES_CAP=50) and a floor of 1; absent/non-numeric → the default', () => {
+  const mod = loadModule();
+  assert(mod && typeof mod.clampLimit === 'function', 'clampLimit must be exported (feature absent).');
+  assert(mod.NOTES_CAP === 50, `NOTES_CAP must be exported and === 50 (the page cap / feed cap); got ${mod.NOTES_CAP}.`);
+  assert(mod.clampLimit(51) === 50, `clampLimit(51) must clamp to the 50 maximum; got ${mod.clampLimit(51)}.`);
+  assert(mod.clampLimit(1000) === 50, `clampLimit(1000) must clamp to 50 (no unbounded result); got ${mod.clampLimit(1000)}.`);
+  assert(mod.clampLimit(0) === 1, `clampLimit(0) must floor to 1; got ${mod.clampLimit(0)}.`);
+  assert(mod.clampLimit(-5) === 1, `clampLimit(-5) must floor to 1; got ${mod.clampLimit(-5)}.`);
+  assert(mod.clampLimit(undefined) === 50, `an ABSENT limit must default to 50; got ${mod.clampLimit(undefined)}.`);
+  assert(mod.clampLimit('banana') === 50, `a NON-NUMERIC limit must default to 50 (not NaN/unbounded); got ${mod.clampLimit('banana')}.`);
+});
+
+// ===========================================================================
+// AC-1 — Selection & content (kind-1 by the given author, shape, local profiles)
+// ===========================================================================
+
+test('B1 (AC-1): a valid author with kind-1 notes yields status OK carrying that author\'s notes', async () => {
+  const mod = loadModule();
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 50, deps: makeDeps() });
+  assert(r && r.status === 'OK', `expected status 'OK' for an author with notes; got ${JSON.stringify(r && r.status)}.`);
+  assert(Array.isArray(r.items) && r.items.length === 2, `expected 2 items; got ${JSON.stringify(r && r.items && r.items.length)}.`);
+  assert(r.items.every((it) => it.pubkey === AUTHOR), `every item must be authored by the viewed pubkey; got ${JSON.stringify(r.items.map((it) => it.pubkey.slice(0, 6)))}.`);
+});
+
+test('B2 (AC-1): each item is the feed item shape — { id, pubkey, createdAt, content, author:{displayName,avatar}, mentions }', async () => {
+  const mod = loadModule();
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 50, deps: makeDeps() });
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  const item = r.items.find((it) => it.id === 'n1');
+  assert(item, 'expected an item for note id "n1".');
+  assert(item.pubkey === AUTHOR, `item.pubkey must be the author; got ${item.pubkey}.`);
+  assert(item.createdAt === 200, `item.createdAt must be the note timestamp (created_at=200); got ${item.createdAt}.`);
+  assert(item.content === 'first', `item.content must be the note text; got ${JSON.stringify(item.content)}.`);
+  assert(item.author && typeof item.author === 'object' && 'displayName' in item.author && 'avatar' in item.author,
+    'each item must carry a nested author { displayName, avatar } (the feed item shape NoteCard renders).');
+  assert(item.mentions && typeof item.mentions === 'object',
+    'each item must carry a `mentions` map (empty when the note has no nostr: refs) — the feed item shape.');
+});
+
+test('B3 (AC-1): author displayName + avatar come from LOCAL kind-0 (scanStrfry), never the external relays', async () => {
+  const mod = loadModule();
+  const deps = makeDeps({
+    scanStrfry: (filter) => {
+      const f = typeof filter === 'string' ? JSON.parse(filter) : filter;
+      if (Array.isArray(f.kinds) && f.kinds.includes(0)) return [kind0(AUTHOR, { display_name: 'Alice Local', name: 'alice', picture: 'https://local/alice.png' })];
+      return [];
+    },
+    querySync: async (relays, filter) => {
+      const f = filter || {};
+      assert(!(Array.isArray(f.kinds) && f.kinds.includes(0)),
+        'profile (kind-0) data must come from LOCAL strfry, never the external relays (AC-1; ADR §Constraints).');
+      return [kind1('n1', AUTHOR, 200, 'hi')];
+    },
+  });
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 50, deps });
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  const item = r.items.find((it) => it.id === 'n1');
+  assert(item.author.displayName === 'Alice Local', `author.displayName must come from local kind-0 ("Alice Local"); got ${JSON.stringify(item.author.displayName)}.`);
+  assert(item.author.avatar === 'https://local/alice.png', `author.avatar must come from local kind-0 picture; got ${JSON.stringify(item.author.avatar)}.`);
+});
+
+test('B4 (AC-1): an author with no local kind-0 profile yields null displayName + null avatar (never an external fetch)', async () => {
+  const mod = loadModule();
+  const deps = makeDeps({ querySync: async () => [kind1('n1', AUTHOR, 200, 'hi')] }); // default scanStrfry → no kind-0
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 50, deps });
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  const item = r.items.find((it) => it.id === 'n1');
+  assert(item.author.displayName === null, `missing local profile must give author.displayName === null; got ${JSON.stringify(item.author.displayName)}.`);
+  assert(item.author.avatar === null, `missing local profile must give author.avatar === null; got ${JSON.stringify(item.author.avatar)}.`);
+});
+
+test('B5 (AC-1): items are ordered newest-first by the note timestamp', async () => {
+  const mod = loadModule();
+  const deps = makeDeps({
+    querySync: async () => ([
+      kind1('old', AUTHOR, 100, 'oldest'),
+      kind1('new', AUTHOR, 300, 'newest'),
+      kind1('mid', AUTHOR, 200, 'middle'),
+    ]),
+  });
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 50, deps });
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  const ids = r.items.map((it) => it.id);
+  assert(JSON.stringify(ids) === JSON.stringify(['new', 'mid', 'old']),
+    `items must be newest-first by timestamp (expected ['new','mid','old']); got ${JSON.stringify(ids)}.`);
+});
+
+test('B6 (AC-1): kind-6 (reposts) and kind-7 (reactions) are excluded even if a relay returns them', async () => {
+  const mod = loadModule();
+  const deps = makeDeps({
+    querySync: async () => ([
+      kind1('note', AUTHOR, 300, 'a real note'),
+      { id: 'repost', kind: 6, pubkey: AUTHOR, created_at: 400, content: '', tags: [] },
+      { id: 'reaction', kind: 7, pubkey: AUTHOR, created_at: 500, content: '+', tags: [] },
+    ]),
+  });
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 50, deps });
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  const ids = r.items.map((it) => it.id);
+  assert(ids.includes('note'), 'the kind-1 note must be present.');
+  assert(!ids.includes('repost'), 'kind-6 reposts must be excluded (AC-1).');
+  assert(!ids.includes('reaction'), 'kind-7 reactions must be excluded (AC-1).');
+  assert(r.items.length === 1, `only the single kind-1 note should remain; got ${r.items.length} items.`);
+});
+
+test('B7 (AC-1): notes authored by ANYONE ELSE are excluded even if a relay leaks them', async () => {
+  const mod = loadModule();
+  const deps = makeDeps({
+    querySync: async () => ([
+      kind1('mine', AUTHOR, 300, 'by the viewed user'),
+      kind1('intruder', OTHER, 400, 'by a different author'),
+    ]),
+  });
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 50, deps });
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  const ids = r.items.map((it) => it.id);
+  assert(ids.includes('mine'), "the viewed author's note must be present.");
+  assert(!ids.includes('intruder'), 'a note from a DIFFERENT author must be excluded (AC-1: notes authored by anyone else are excluded).');
+  assert(r.items.length === 1, `only the viewed author's note should remain; got ${r.items.length}.`);
+});
+
+// ===========================================================================
+// AC-2 — Count parameterization & cap
+// ===========================================================================
+
+test('B8 (AC-2): limit=1 returns exactly the single most-recent qualifying note', async () => {
+  const mod = loadModule();
+  const deps = makeDeps({
+    querySync: async () => ([
+      kind1('a', AUTHOR, 100, 'old'),
+      kind1('b', AUTHOR, 300, 'newest'),
+      kind1('c', AUTHOR, 200, 'mid'),
+    ]),
+  });
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 1, deps });
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  assert(r.items.length === 1, `limit=1 must return exactly one item; got ${r.items.length}.`);
+  assert(r.items[0].id === 'b', `limit=1 must return the single MOST-RECENT note (id 'b', createdAt 300); got ${r.items[0].id}.`);
+});
+
+test('B9 (AC-2): the result is capped at the requested count — limit=3 keeps the 3 most recent of many', async () => {
+  const mod = loadModule();
+  const many = [];
+  for (let i = 1; i <= 10; i++) many.push(kind1('e' + i, AUTHOR, i, 'note ' + i));
+  const deps = makeDeps({ querySync: async () => many });
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 3, deps });
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  assert(r.items.length === 3, `limit=3 must return 3 items; got ${r.items.length}.`);
+  assert(JSON.stringify(r.items.map((it) => it.createdAt)) === JSON.stringify([10, 9, 8]),
+    `limit=3 must keep the 3 MOST RECENT (createdAt 10,9,8 newest-first); got ${JSON.stringify(r.items.map((it) => it.createdAt))}.`);
+});
+
+test('B10 (AC-2): an over-maximum limit is clamped to the hard cap of 50 (60 notes → 50 newest)', async () => {
+  const mod = loadModule();
+  const many = [];
+  for (let i = 1; i <= 60; i++) many.push(kind1('e' + i, AUTHOR, i, 'note ' + i));
+  const deps = makeDeps({ querySync: async () => many });
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 999, deps });
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  assert(r.items.length === 50, `an over-max limit must clamp to 50 items; got ${r.items.length}.`);
+  assert(r.items[0].createdAt === 60, `the cap must keep the MOST RECENT (newest createdAt=60 first); got ${r.items[0].createdAt}.`);
+  assert(r.items[r.items.length - 1].createdAt === 11, `the 50-cap drops the oldest (kept window createdAt 11..60); tail should be 11, got ${r.items[r.items.length - 1].createdAt}.`);
+});
+
+// ===========================================================================
+// AC-2 — relaySource set-vs-fallback discriminator
+// ===========================================================================
+
+test('B11 (AC-2): when the general-purpose relay set resolves to members, relaySource is "set"', async () => {
+  const mod = loadModule();
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 50, deps: makeDeps() });
+  assert(r && (r.status === 'OK' || r.status === 'EMPTY'), `expected OK/EMPTY; got ${JSON.stringify(r && r.status)}.`);
+  assert(r.relaySource === 'set', `with a resolvable, non-empty relay set, relaySource must be 'set'; got ${JSON.stringify(r.relaySource)}.`);
+});
+
+test('B12 (AC-2): an empty/unresolvable relay set falls back to the fixed relays (relaySource "fallback"), still returning notes', async () => {
+  const mod = loadModule();
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 50, deps: makeDeps({ runCypher: async () => [] }) });
+  assert(r && r.status === 'OK', `with an empty set, the fallback relays must still yield notes (OK); got ${JSON.stringify(r && r.status)}.`);
+  assert(r.relaySource === 'fallback', `an empty/unresolvable relay set must set relaySource to 'fallback'; got ${JSON.stringify(r.relaySource)}.`);
+  assert(Array.isArray(r.items) && r.items.length >= 1, 'the fallback path must still return notes (the default querySync fake yields 2).');
+});
+
+test('B13 (AC-2): a runCypher error during set resolution degrades to the fallback relays, not a crash', async () => {
+  const mod = loadModule();
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 50, deps: makeDeps({ runCypher: async () => { throw new Error('neo4j down'); } }) });
+  assert(r && r.status === 'OK', `a relay-set resolution ERROR must degrade to the fallback relays, not throw; got ${JSON.stringify(r && r.status)}.`);
+  assert(r.relaySource === 'fallback', `on relay-set resolution error, relaySource must be 'fallback'; got ${JSON.stringify(r.relaySource)}.`);
+});
+
+// ===========================================================================
+// AC-3 — Empty outcome vs AC-4 — Invalid-input outcome (the two must be distinct)
+// ===========================================================================
+
+test('B14 (AC-3): a valid author with no locatable kind-1 notes yields status EMPTY with items: []', async () => {
+  const mod = loadModule();
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 50, deps: makeDeps({ querySync: async () => [] }) });
+  assert(r && r.status === 'EMPTY', `a valid author with no notes must yield status 'EMPTY'; got ${JSON.stringify(r && r.status)}.`);
+  assert(Array.isArray(r.items) && r.items.length === 0, `EMPTY must carry an empty items array; got ${JSON.stringify(r && r.items)}.`);
+});
+
+test('B15 (AC-4): a malformed pubkey yields the explicit INVALID outcome — not EMPTY, not a crash', async () => {
+  const mod = loadModule();
+  const r = await callBuildUserNotes(mod, { pubkey: NOT_HEX, limit: 50, deps: makeDeps() });
+  assert(r && r.status === 'INVALID', `a malformed pubkey must yield the distinct 'INVALID' outcome; got ${JSON.stringify(r && r.status)}.`);
+  assert(r.status !== 'EMPTY', 'INVALID must NOT collapse into EMPTY — a bad request is distinct from "no notes" (AC-3/AC-4).');
+});
+
+test('B16 (AC-4): the INVALID outcome short-circuits before any relay/Neo4j is queried', async () => {
+  const mod = loadModule();
+  let queried = false, cyphered = false;
+  const deps = makeDeps({
+    querySync: async () => { queried = true; return []; },
+    runCypher: async () => { cyphered = true; return []; },
+  });
+  const r = await callBuildUserNotes(mod, { pubkey: NOT_HEX, limit: 50, deps });
+  assert(r && r.status === 'INVALID', `expected INVALID; got ${JSON.stringify(r && r.status)}.`);
+  assert(queried === false && cyphered === false,
+    'a malformed pubkey must be rejected up-front, querying no relays and no Neo4j (validation is step 1).');
+});
+
+test('B17: OK, EMPTY, and INVALID are three mutually distinct status values', async () => {
+  const mod = loadModule();
+  const ok = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 50, deps: makeDeps() });
+  const empty = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 50, deps: makeDeps({ querySync: async () => [] }) });
+  const invalid = await callBuildUserNotes(mod, { pubkey: NOT_HEX, limit: 50, deps: makeDeps() });
+  const statuses = [ok.status, empty.status, invalid.status];
+  assert(JSON.stringify(statuses) === JSON.stringify(['OK', 'EMPTY', 'INVALID']),
+    `the three outcomes must be the distinct statuses [OK, EMPTY, INVALID]; got ${JSON.stringify(statuses)}.`);
+  assert(new Set(statuses).size === 3, 'all three status values must be mutually distinct.');
+});
+
+// ===========================================================================
+// AC-5 — Mentions resolved like the feed (via the reused enrichNotes)
+// ===========================================================================
+
+test('M1 (AC-5): a nostr:npub mention resolves to the mentioned profile\'s LOCAL display name (same local kind-0 scan, not an external fetch)', async () => {
+  const mod = loadModule();
+  const { nip19 } = require('nostr-tools');
+  const MENTIONED = HEX('5');
+  const npub = nip19.npubEncode(MENTIONED);
+  const deps = makeDeps({
+    scanStrfry: (filter) => {
+      const f = typeof filter === 'string' ? JSON.parse(filter) : filter;
+      if (Array.isArray(f.kinds) && f.kinds.includes(0)) {
+        assert(Array.isArray(f.authors) && f.authors.includes(MENTIONED),
+          'the local kind-0 scan must include the mentioned pubkey so its name resolves in the same pass (no separate/external fetch).');
+        return [kind0(MENTIONED, { display_name: 'Bob Mentioned', name: 'bob' }, 60)];
+      }
+      return [];
+    },
+    querySync: async (relays, filter) => {
+      const f = filter || {};
+      assert(!(Array.isArray(f.kinds) && f.kinds.includes(0)), 'mentioned-profile kind-0 must come from LOCAL strfry, never external relays.');
+      return [kind1('n1', AUTHOR, 200, `hey nostr:${npub} welcome`)];
+    },
+  });
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 50, deps });
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  const item = r.items.find((it) => it.id === 'n1');
+  assert(item && item.mentions && typeof item.mentions === 'object', 'each item must carry a `mentions` map (pubkey → displayName).');
+  assert(item.mentions[MENTIONED] === 'Bob Mentioned', `the npub mention must resolve to the local display name; got ${JSON.stringify(item.mentions[MENTIONED])}.`);
+});
+
+test('M2 (AC-5): a note with no nostr: mentions carries an empty mentions map (stable shape, no crash)', async () => {
+  const mod = loadModule();
+  const deps = makeDeps({ querySync: async () => [kind1('n1', AUTHOR, 200, 'just plain text here')] });
+  const r = await callBuildUserNotes(mod, { pubkey: AUTHOR, limit: 50, deps });
+  const item = r.items.find((it) => it.id === 'n1');
+  assert(item.mentions && typeof item.mentions === 'object' && Object.keys(item.mentions).length === 0,
+    `a mention-free note must carry an empty mentions object; got ${JSON.stringify(item.mentions)}.`);
+});
+
+// ===========================================================================
+// HANDLER — the public Express handler maps the outcomes to HTTP (INVALID → 400).
+// The INVALID path short-circuits before any I/O, so this runs hermetically with
+// the REAL handler (no injected deps, no live relays/Neo4j).
+// ===========================================================================
+
+test('H1 (AC-4): handleGetUserNotes responds 400 { success:false, status:"INVALID" } for a malformed :pubkey (no live I/O)', async () => {
+  const mod = loadModule();
+  assert(mod && typeof mod.handleGetUserNotes === 'function', 'handleGetUserNotes must be exported (feature absent).');
+  let statusCode = 200; let body = null;
+  const req = { params: { pubkey: NOT_HEX }, query: { limit: '50' } };
+  const res = { status(c) { statusCode = c; return this; }, json(b) { body = b; return this; } };
+  await mod.handleGetUserNotes(req, res);
+  assert(statusCode === 400, `a malformed :pubkey must respond HTTP 400; got ${statusCode}.`);
+  assert(body && body.success === false && body.status === 'INVALID',
+    `the 400 body must be { success:false, status:'INVALID', ... }; got ${JSON.stringify(body)}.`);
+});
+
+test('H2 (AC-4): the handler source maps INVALID → 400 and the valid outcomes → 200 (success body)', () => {
+  const src = safeRead(MODULE_PATH);
+  assert(src.length > 0, 'userNotesReadPath.js does not exist yet.');
+  assert(/status\(?\s*400|400\b/.test(src) && /INVALID/.test(src),
+    'the handler must respond 400 on the INVALID outcome (a malformed pubkey is a client error).');
+  assert(/success:\s*true/.test(src),
+    'the handler must respond { success: true, ...result } for the valid OK/EMPTY outcomes (the shape the UI hook gates on).');
+});
+
+// ===========================================================================
+// REGRESSION — the shipped feed read path is NOT modified (additive; ADR Option A).
+// ===========================================================================
+
+test('R1: the shipped feed read path src/api/feed/feedReadPath.js is untouched (FEED_CAP=50, still exports buildFeed/handleGetFeed)', () => {
+  const src = safeRead(FEED_READ_PATH);
+  assert(src.length > 0, 'src/api/feed/feedReadPath.js missing — unexpected (ADR note-surfaces/0001 must NOT touch the shipped feed).');
+  assert(/FEED_CAP\s*=\s*50/.test(src), 'feedReadPath.js must keep FEED_CAP = 50 — this story duplicates sourcing helpers rather than refactoring the shipped feed (ADR Option A).');
+  assert(/module\.exports\s*=\s*\{\s*buildFeed\s*,\s*handleGetFeed\s*\}/.test(src),
+    'feedReadPath.js must still export { buildFeed, handleGetFeed } unchanged — the by-author read path is additive, it does not re-point the feed (ADR Option A; consolidation is a deferred follow-up).');
+});
+
+test('R2: the shared enrichNotes seam still exports enrichNotes + PROFILE_LOOKUP_CAP (reused, not modified)', () => {
+  const src = safeRead(SHARED_ENRICH);
+  assert(src.length > 0, 'src/api/_shared/noteEnrichment.js missing — unexpected.');
+  assert(/enrichNotes/.test(src) && /PROFILE_LOOKUP_CAP/.test(src),
+    'noteEnrichment.js must still export enrichNotes + PROFILE_LOOKUP_CAP — this story reuses the seam unchanged (ADR §Out of scope: enrichNotes is reused, not modified).');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try { await t.fn(); console.log(`  ✓ ${t.name}`); pass++; }
+    catch (err) { console.log(`  ✗ ${t.name}`); console.log(`      ${err.message}`); fail++; }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/note-surfaces-ui.test.js
+++ b/test/note-surfaces-ui.test.js
@@ -1,0 +1,289 @@
+/**
+ * Stories note-surfaces #2 (profile "Content" section) + #3 (per-user /notes page).
+ * ADR note-surfaces/0002. See the two .test-plan.md files alongside the stories.
+ *
+ * ADR 0002 chose Option A: one shared hook ui/src/hooks/useUserNotes.js (mirroring
+ * useFeed.js, parameterized by pubkey+limit); a ui/src/components/ProfileContentSection.jsx
+ * appended as the LAST section of ui/src/pages/BrainstormProfile.jsx (limit 1); and a new
+ * ui/src/pages/BrainstormUserNotes.jsx page at the client route /user/:pubkey/notes (limit 50),
+ * modeled on BrainstormFollows.jsx. Both delegate their body to a PURE, named-exported render
+ * helper with module-level copy constants. NoteCard is REUSED AS-IS — no variant prop.
+ *
+ * TEST LEVEL — source assertion, not runtime render (matching live-feed-feed-page.test.js and
+ * the profile-* suites): the Node harness has no JSX transpile and react-dom is only in the ui/
+ * Vite workspace, so we assert on the ui/src/*.jsx SOURCE TEXT. The page/section/hook/route do
+ * not exist pre-implementation, so the U tests FAIL now and PASS once built. R tests are
+ * regression sentinels (additive change) — PASS before AND after.
+ *
+ * The runtime properties source can't prove — an anonymous /user/<pubkey>/notes 200 with a
+ * rendered card, the profile's Content section in a browser, no 1280px horizontal scrollbar —
+ * are gathered on STAGING after deploy (ADR §Testability), not here.
+ *
+ * COPY NOTE: the empty-state copy is operator-delegated and punctuation is non-binding; the copy
+ * sentinels assert the load-bearing MEANING tokens ("kind-1", "could be located"), anchored on
+ * the exported copy constants, not a byte-for-byte sentence.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const HOOK = path.resolve(__dirname, '../ui/src/hooks/useUserNotes.js');
+const CONTENT = path.resolve(__dirname, '../ui/src/components/ProfileContentSection.jsx');
+const NOTES_PAGE = path.resolve(__dirname, '../ui/src/pages/BrainstormUserNotes.jsx');
+const APP = path.resolve(__dirname, '../ui/src/App.jsx');
+const PROFILE = path.resolve(__dirname, '../ui/src/pages/BrainstormProfile.jsx');
+const STYLES = path.resolve(__dirname, '../ui/src/styles.css');
+const NOTE_CARD = path.resolve(__dirname, '../ui/src/components/NoteCard.jsx');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+
+// Slice a named body-helper function out of a page/component so branch sentinels match logic
+// INSIDE the pure helper, not anywhere on the page. Returns the whole source if not found (so a
+// missing helper fails the export sentinel + the branch sentinels rather than passing silently).
+function helperBody(src, names) {
+  const m = src.match(new RegExp('function\\s+(' + names.join('|') + ')\\s*\\('));
+  return m ? src.slice(m.index) : src;
+}
+
+// ===========================================================================
+// Shared hook — useUserNotes(pubkey, limit): fetches the read path, passes the
+// result through, gates on success, aborts on unmount (supports #2 + #3).
+// ===========================================================================
+
+test('U1: useUserNotes(pubkey, limit) fetches /api/user/<pubkey>/notes?limit=<limit> and returns { data, loading, error }', () => {
+  const src = safeRead(HOOK);
+  assert(src.length > 0, 'ui/src/hooks/useUserNotes.js does not exist yet — the Implementer must create the shared notes hook (ADR 0002 §Impl, mirroring useFeed.js).');
+  assert(/useUserNotes\s*\(\s*pubkey\s*,\s*limit\s*\)/.test(src) || /function\s+useUserNotes\s*\(/.test(src),
+    'useUserNotes must take (pubkey, limit) so both surfaces share it (the Content section passes 1, the page passes 50).');
+  assert(/fetch\(\s*[`'"]\/api\/user\/\$\{?pubkey\}?\/notes\?limit=\$\{?limit\}?[`'"]/.test(src) || (/fetch\(/.test(src) && /\/api\/user\//.test(src) && /\/notes/.test(src) && /limit=/.test(src)),
+    "useUserNotes must call fetch(`/api/user/${pubkey}/notes?limit=${limit}`) — the ADR 0001 endpoint.");
+  assert(/return\s*\{[\s\S]{0,120}data[\s\S]{0,120}loading[\s\S]{0,120}error[\s\S]{0,40}\}/.test(src),
+    'useUserNotes must return { data, loading, error } (the established hook shape, mirroring useFeed.js).');
+});
+
+test('U2: useUserNotes gates on the response `success` flag, sets `error` on failure, and aborts on unmount', () => {
+  const src = safeRead(HOOK);
+  assert(src.length > 0, 'useUserNotes.js does not exist yet.');
+  assert(/success/.test(src), 'useUserNotes must gate on the body\'s `success` flag (ADR 0001 returns { success:true, ...result }).');
+  assert(/setError|error/.test(src), 'useUserNotes must set `error` on a non-success / transport failure (drives the surfaces\' empty/defensive branch).');
+  assert(/AbortController/.test(src) && /\.abort\(\)/.test(src), 'useUserNotes must abort the fetch on unmount via AbortController (the useFeed.js / useGrapevineFollows.js convention).');
+  assert(/\[\s*pubkey\s*,\s*limit\s*\]/.test(src) || /\[pubkey, ?limit\]/.test(src),
+    'useUserNotes must re-run when pubkey or limit changes (effect deps [pubkey, limit]).');
+});
+
+// ===========================================================================
+// Story #2 — the profile "Content" section
+// ===========================================================================
+
+test('U3 (#2 AC label): ProfileContentSection exists, uses useUserNotes(pubkey, 1), and is labelled "Content"', () => {
+  const src = safeRead(CONTENT);
+  assert(src.length > 0, 'ui/src/components/ProfileContentSection.jsx does not exist yet — the Implementer must create the Content section (ADR 0002 §Impl).');
+  assert(/export\s+default\s+function\s+ProfileContentSection\s*\(\s*\{\s*pubkey/.test(src) || (/ProfileContentSection/.test(src) && /pubkey/.test(src)),
+    'ProfileContentSection({ pubkey }) must be the default export.');
+  assert(/useUserNotes\s*\(\s*pubkey\s*,\s*1\s*\)/.test(src),
+    'the Content section must consume the read path at limit 1: useUserNotes(pubkey, 1).');
+  assert(/CONTENT_COPY/.test(src) && /HEADING\s*:\s*['"]Content['"]/.test(src),
+    'the section must be labelled exactly "Content" via an exported CONTENT_COPY.HEADING (the operator-chosen label; kind-1 only for now, future-proofed name).');
+});
+
+test('U4 (#2 AC latest note): the OK branch renders exactly ONE NoteCard for the single latest note (items[0]), not a list', () => {
+  const src = safeRead(CONTENT);
+  assert(src.length > 0, 'ProfileContentSection.jsx does not exist yet.');
+  assert(/import\s+NoteCard/.test(src) && /<NoteCard\b[^>]*\bitem=\{/.test(src),
+    'the Content section must render the shared <NoteCard item={...} /> (reuse the card, no inline markup, no fork).');
+  const body = helperBody(src, ['renderContentBody']);
+  assert(/items\s*\[\s*0\s*\]/.test(body) || /items\?\.\[0\]/.test(body),
+    'the OK branch must render the SINGLE most-recent note (items[0]) — the latest note, not a .map list (#2 AC: no more than one note).');
+  assert(!/\bitems\b[\s\S]{0,16}\.map\s*\(/.test(body),
+    'the Content section must NOT map a list of notes — it shows only the single latest one (#2 AC).');
+});
+
+test('U5 (#2 AC empty state): the empty/defensive branch shows a "no kind-1 events could be located" message, no card', () => {
+  const src = safeRead(CONTENT);
+  assert(src.length > 0, 'ProfileContentSection.jsx does not exist yet.');
+  assert(/CONTENT_COPY[\s\S]{0,120}EMPTY\s*:\s*['"][^'"]*['"]/.test(src),
+    'CONTENT_COPY must define an EMPTY message constant.');
+  assert(/EMPTY\s*:\s*['"][^'"]*kind[\s-]?1[^'"]*['"]/i.test(src),
+    'the empty-state copy must name kind-1 (the operator\'s "no kind 1 events could be located" framing).');
+  assert(/EMPTY\s*:\s*['"][^'"]*(could (?:not |n't )?be located|locate|no .*(?:events|notes))[^'"]*['"]/i.test(src),
+    'the empty-state copy must convey that no kind-1 events could be located (operator-delegated meaning; punctuation non-binding).');
+});
+
+test('U6 (#2 AC link): the section links to /user/<pubkey>/notes in all states (populated or empty)', () => {
+  const src = safeRead(CONTENT);
+  assert(src.length > 0, 'ProfileContentSection.jsx does not exist yet.');
+  assert(/to=\{\s*[`'"]\/user\/\$\{pubkey\}\/notes[`'"]\s*\}/.test(src) || (/<Link\b/.test(src) && /\/user\/\$\{pubkey\}\/notes/.test(src)),
+    'the Content section must include a <Link to={`/user/${pubkey}/notes`}> to the full notes page (#2 AC: link present populated OR empty).');
+});
+
+test('U7 (#2 testability): renderContentBody is a named-exported PURE function (no fetch/hook/router/browser globals)', () => {
+  const src = safeRead(CONTENT);
+  assert(src.length > 0, 'ProfileContentSection.jsx does not exist yet.');
+  assert(/export\s+(function\s+renderContentBody|const\s+renderContentBody\s*=)/.test(src),
+    'ProfileContentSection.jsx must NAMED-export a pure body helper renderContentBody({ data, loading, error }) so its states are an isolated, sentinel-testable unit.');
+  const body = helperBody(src, ['renderContentBody']);
+  for (const banned of ['fetch(', 'useUserNotes(', 'useAuth(', 'useParams(', 'window.', 'document.']) {
+    assert(!body.includes(banned), `the pure renderContentBody must not call ${banned} — it is a pure function of { data, loading, error } (data fetching lives in the component wrapper).`);
+  }
+});
+
+test('U8 (#2 AC placement): BrainstormProfile renders <ProfileContentSection> as the LAST section, AFTER the Reputation section', () => {
+  const src = safeRead(PROFILE);
+  assert(src.length > 0, 'ui/src/pages/BrainstormProfile.jsx missing — unexpected.');
+  assert(/import\s+ProfileContentSection\s+from\s+['"]\.\.\/components\/ProfileContentSection['"]/.test(src),
+    'BrainstormProfile.jsx must import ProfileContentSection.');
+  assert(/<ProfileContentSection\b[^>]*\bpubkey=\{pubkey\}/.test(src),
+    'BrainstormProfile.jsx must render <ProfileContentSection pubkey={pubkey} />.');
+  const repIdx = src.search(/<h3>\s*Reputation/);
+  const contentIdx = src.search(/<ProfileContentSection\b/);
+  assert(repIdx !== -1 && contentIdx !== -1 && contentIdx > repIdx,
+    'the Content section must appear AFTER the Reputation section (it is the last section of the profile — #2 AC).');
+});
+
+// ===========================================================================
+// Story #3 — the per-user /notes page
+// ===========================================================================
+
+test('U9 (#3 AC route): App.jsx registers /user/:pubkey/notes → BrainstormUserNotes, among the pubkey-scoped routes', () => {
+  const src = safeRead(APP);
+  assert(src.length > 0, 'ui/src/App.jsx missing — unexpected.');
+  assert(/path:\s*['"]\/user\/:pubkey\/notes['"]/.test(src),
+    "App.jsx must declare the route path '/user/:pubkey/notes'. Absent pre-implementation.");
+  assert(/BrainstormUserNotes/.test(src) && /import\s+BrainstormUserNotes/.test(src),
+    'App.jsx must import and map /user/:pubkey/notes to the BrainstormUserNotes page.');
+  // It belongs in the top-level group (with the other /user/:pubkey/* routes), before the /tapestry admin block — so it is public.
+  const notesIdx = src.search(/path:\s*['"]\/user\/:pubkey\/notes['"]/);
+  const tapestryIdx = src.search(/path:\s*['"]\/tapestry['"]/);
+  assert(notesIdx !== -1 && tapestryIdx !== -1 && notesIdx < tapestryIdx,
+    'the /user/:pubkey/notes route must be a public top-level route (before the /tapestry admin group), like /user/:pubkey/follows — so anonymous clients reach it (#3 AC reachability).');
+});
+
+test('U10 (#3 AC list + reuse): BrainstormUserNotes uses useUserNotes(pubkey, 50), reuses the public shell, and renders notes via NoteCard', () => {
+  const src = safeRead(NOTES_PAGE);
+  assert(src.length > 0, 'ui/src/pages/BrainstormUserNotes.jsx does not exist yet — the Implementer must create the notes page (ADR 0002 §Impl, modeled on BrainstormFollows.jsx).');
+  assert(/useUserNotes\s*\(\s*pubkey\s*,\s*50\s*\)/.test(src),
+    'the page must consume the read path at limit 50: useUserNotes(pubkey, 50).');
+  assert(/bsp-page/.test(src) && /bsp-top-bar/.test(src) && /bsp-content/.test(src) && /BrainstormUserMenu/.test(src),
+    'the page must reuse the public shell (bsp-page → bsp-top-bar → bsp-content + <BrainstormUserMenu>), modeled on BrainstormFollows.jsx.');
+  assert(/import\s+NoteCard/.test(src) && /<NoteCard\b[^>]*\bitem=\{/.test(src),
+    'the page must render each note via the shared <NoteCard item={...} /> (reuse the card).');
+});
+
+test('U11 (#3 AC order): the OK branch maps items in ARRAY ORDER (newest-first from the read path) and does NOT re-sort', () => {
+  const src = safeRead(NOTES_PAGE);
+  assert(src.length > 0, 'BrainstormUserNotes.jsx does not exist yet.');
+  const body = helperBody(src, ['renderUserNotesState']);
+  assert(/status\s*===?\s*['"]OK['"]/.test(body), "the body helper must branch on status === 'OK' (the populated list).");
+  assert(/\bitems\b[\s\S]{0,40}\.map\s*\(/.test(body) || /\.map\s*\(\s*\(?\s*(it|item|n)\b/.test(body),
+    'the OK branch must render one entry per note via items.map(...) (#3 AC: one entry per note).');
+  assert(!/\bitems\b[\s\S]{0,8}\.sort\s*\(/.test(body) && !/\.sort\s*\([\s\S]{0,40}createdAt/.test(src),
+    'the page must render items in the array order the read path delivered (already newest-first); it must NOT re-sort (re-derivation; ADR §No re-derivation).');
+});
+
+test('U12 (#3 AC whose-notes): the page identifies WHOSE notes — it fetches the subject profile name and shows it', () => {
+  const src = safeRead(NOTES_PAGE);
+  assert(src.length > 0, 'BrainstormUserNotes.jsx does not exist yet.');
+  assert(/\/api\/profiles\?pubkeys=/.test(src),
+    'the page must fetch the subject\'s display name (/api/profiles?pubkeys=<pubkey>, the BrainstormProfile convention) so it identifies whose notes are shown — even when empty (#3 AC: whose notes).');
+  assert(/display_name|displayName/.test(src),
+    'the page must show the subject display name in its header (#3 AC: identifies the viewed user).');
+});
+
+test('U13 (#3 AC empty state): the empty/defensive branch shows a "no kind-1 events could be located" message and no entries', () => {
+  const src = safeRead(NOTES_PAGE);
+  assert(src.length > 0, 'BrainstormUserNotes.jsx does not exist yet.');
+  assert(/NOTES_COPY/.test(src), 'BrainstormUserNotes.jsx must define the exported NOTES_COPY copy constants.');
+  assert(/EMPTY\s*:\s*['"][^'"]*kind[\s-]?1[^'"]*['"]/i.test(src),
+    'NOTES_COPY.EMPTY must name kind-1 (the operator\'s "no kind 1 events could be located" framing).');
+  assert(/EMPTY\s*:\s*['"][^'"]*(could (?:not |n't )?be located|locate|no .*(?:events|notes))[^'"]*['"]/i.test(src),
+    'NOTES_COPY.EMPTY must convey that no kind-1 events could be located (operator-delegated meaning).');
+  const body = helperBody(src, ['renderUserNotesState']);
+  assert(/status\s*===?\s*['"]EMPTY['"]/.test(body) || /EMPTY/.test(body),
+    'the body helper must branch on the EMPTY outcome and render the empty copy with no entries.');
+});
+
+test('U14 (#3 heading): the page shows a "Notes" heading and a back link to the profile', () => {
+  const src = safeRead(NOTES_PAGE);
+  assert(src.length > 0, 'BrainstormUserNotes.jsx does not exist yet.');
+  assert(/NOTES_COPY[\s\S]{0,80}HEADING\s*:\s*['"]Notes['"]/.test(src) || /HEADING\s*:\s*['"]Notes['"]/.test(src),
+    'NOTES_COPY.HEADING must be "Notes" (the page heading).');
+  assert(/to=\{\s*[`'"]\/user\/\$\{pubkey\}[`'"]\s*\}/.test(src) || (/<Link\b/.test(src) && /Back to profile/i.test(src)),
+    'the page must include a back link to /user/${pubkey} (the BrainstormFollows convention).');
+});
+
+test('U15 (#3 testability): renderUserNotesState is a named-exported PURE function (no fetch/hook/router/browser globals)', () => {
+  const src = safeRead(NOTES_PAGE);
+  assert(src.length > 0, 'BrainstormUserNotes.jsx does not exist yet.');
+  assert(/export\s+(function\s+renderUserNotesState|const\s+renderUserNotesState\s*=)/.test(src),
+    'BrainstormUserNotes.jsx must NAMED-export a pure body helper renderUserNotesState({ data, loading, error }) (ADR §Testability — the property the per-story level rests on).');
+  const body = helperBody(src, ['renderUserNotesState']);
+  for (const banned of ['fetch(', 'useUserNotes(', 'useAuth(', 'useParams(', 'useNavigate(', 'window.', 'document.']) {
+    assert(!body.includes(banned), `the pure renderUserNotesState must not call ${banned} — it is a pure function of { data, loading, error }.`);
+  }
+});
+
+// ===========================================================================
+// AC (no overflow @1280px) — the wrap + capped-column mechanism (the rendered
+// no-scrollbar proof is the staging capstone; here we prove the mechanism exists)
+// ===========================================================================
+
+test('U16 (#3 AC no overflow): the shared note-card text wraps and the notes column is width-bounded (no 1280px overflow)', () => {
+  const css = safeRead(STYLES);
+  const page = safeRead(NOTES_PAGE);
+  assert(css.length > 0, 'ui/src/styles.css missing — unexpected.');
+  assert(page.length > 0, 'BrainstormUserNotes.jsx does not exist yet.');
+  // The shared bsp-note-card-* text rule must wrap long content/URLs (this travels with the card to
+  // every surface that reuses it — it already exists from the feed; here it protects this page too).
+  const cardRules = (css.match(/\.bsp-note-card[\w-]*\s*\{[^}]*\}/g) || []).join('\n');
+  assert(cardRules.length > 0, 'styles.css must define the shared bsp-note-card-* rules.');
+  assert(/overflow-wrap\s*:\s*(anywhere|break-word)|word-break\s*:\s*(break-word|break-all)/.test(cardRules),
+    'a bsp-note-card-* rule must wrap note text (overflow-wrap:anywhere / word-break) so a long URL/token cannot extend past 1280px (#3 AC no overflow).');
+  // The page renders inside the capped shared bsp-content column (the BrainstormFollows pattern) OR
+  // caps its own list — accept either, mirroring live-feed's column-cap sentinel.
+  assert(/bsp-content/.test(page) || /maxWidth\s*:\s*\d/.test(page) || /max-width\s*:\s*\d/.test((css.match(/\.bsp-notes[\w-]*\s*\{[^}]*\}/g) || []).join('\n')),
+    'the notes list must live in a width-bounded column (the shared bsp-content column, an inline maxWidth, or a capped bsp-notes-* rule) so the page does not overflow 1280px (#3 AC).');
+});
+
+// ===========================================================================
+// REGRESSION SENTINELS (PASS before AND after — additive change)
+// ===========================================================================
+
+test('R1: App.jsx still registers the existing /user/:pubkey sub-routes — /notes is ADDED beside them, nothing removed', () => {
+  const src = safeRead(APP);
+  assert(src.length > 0, 'ui/src/App.jsx missing — unexpected.');
+  for (const route of ['/user/:pubkey/follows', '/user/:pubkey/followers', '/user/:pubkey/follows-hops']) {
+    assert(new RegExp("path:\\s*['\"]" + route.replace(/\//g, '\\/') + "['\"]").test(src),
+      `the existing sub-route '${route}' must remain (the /notes route is added beside it, not in place of it).`);
+  }
+  assert(/path:\s*['"]\/user\/:pubkey['"]/.test(src) && /BrainstormProfile/.test(src),
+    'the /user/:pubkey profile route must remain registered (additive change).');
+});
+
+test('R2: NoteCard is REUSED AS-IS — it still takes a single { item } prop and renders a bsp-note-card (no variant fork)', () => {
+  const src = safeRead(NOTE_CARD);
+  assert(src.length > 0, 'ui/src/components/NoteCard.jsx missing — unexpected.');
+  assert(/export\s+default\s+function\s+NoteCard\s*\(\s*\{\s*item\s*\}/.test(src),
+    'NoteCard must keep its single-{ item } presentational contract — ADR 0002 chose to reuse it as-is (no variant prop added this story).');
+  assert(/bsp-note-card/.test(src), 'NoteCard must still render the shared bsp-note-card markup (unchanged).');
+});
+
+test('R3: the profile Reputation section + TRUST_METRICS grid path are untouched (additive — the Content section only appends)', () => {
+  const src = safeRead(PROFILE);
+  assert(src.length > 0, 'BrainstormProfile.jsx missing — unexpected.');
+  assert(/<h3>\s*Reputation/.test(src) && /TRUST_METRICS/.test(src),
+    'BrainstormProfile.jsx must keep its Reputation section + TRUST_METRICS grid — the Content section is appended after it, changing nothing existing (#2 AC additive/no-regression).');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try { await t.fn(); console.log(`  ✓ ${t.name}`); pass++; }
+    catch (err) { console.log(`  ✗ ${t.name}`); console.log(`      ${err.message}`); fail++; }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -93,6 +93,8 @@ const nostrUserTagHybridEaWriter = require('./nostr-user-tag-hybrid-ea-writer.te
 const reputationInfoPopup = require('./reputation-info-popup.test.js');
 const liveFeedReadPath = require('./live-feed-read-path.test.js');
 const liveFeedFeedPage = require('./live-feed-feed-page.test.js');
+const noteSurfacesReadPath = require('./note-surfaces-read-path.test.js');
+const noteSurfacesUi = require('./note-surfaces-ui.test.js');
 const verifiedReportersReportColumns = require('./verified-reporters-report-columns.test.js');
 const profileIdentityDetailsPopover = require('./profile-identity-details-popover.test.js');
 const profileFollowsHops = require('./profile-follows-hops.test.js');
@@ -252,6 +254,12 @@ async function main() {
 
   console.log('\nlive-feed-feed-page suite:');
   const liveFeedFeedPageResult = await liveFeedFeedPage.run();
+
+  console.log('\nnote-surfaces-read-path suite:');
+  const noteSurfacesReadPathResult = await noteSurfacesReadPath.run();
+
+  console.log('\nnote-surfaces-ui suite:');
+  const noteSurfacesUiResult = await noteSurfacesUi.run();
 
   console.log('\nverified-reporters-report-columns suite:');
   const verifiedReportersReportColumnsResult = await verifiedReportersReportColumns.run();
@@ -448,6 +456,12 @@ async function main() {
     `live-feed-feed-page suite:                       ${liveFeedFeedPageResult.fail === 0 ? 'PASS' : 'FAIL'} (${liveFeedFeedPageResult.pass} passed, ${liveFeedFeedPageResult.fail} failed)`
   );
   console.log(
+    `note-surfaces-read-path suite:                   ${noteSurfacesReadPathResult.fail === 0 ? 'PASS' : 'FAIL'} (${noteSurfacesReadPathResult.pass} passed, ${noteSurfacesReadPathResult.fail} failed)`
+  );
+  console.log(
+    `note-surfaces-ui suite:                          ${noteSurfacesUiResult.fail === 0 ? 'PASS' : 'FAIL'} (${noteSurfacesUiResult.pass} passed, ${noteSurfacesUiResult.fail} failed)`
+  );
+  console.log(
     `verified-reporters-report-columns suite:         ${verifiedReportersReportColumnsResult.fail === 0 ? 'PASS' : 'FAIL'} (${verifiedReportersReportColumnsResult.pass} passed, ${verifiedReportersReportColumnsResult.fail} failed)`
   );
   console.log(
@@ -542,6 +556,8 @@ async function main() {
     reputationInfoPopupResult.fail === 0 &&
     liveFeedReadPathResult.fail === 0 &&
     liveFeedFeedPageResult.fail === 0 &&
+    noteSurfacesReadPathResult.fail === 0 &&
+    noteSurfacesUiResult.fail === 0 &&
     verifiedReportersReportColumnsResult.fail === 0 &&
     profileIdentityDetailsPopoverResult.fail === 0 &&
     profileFollowsHopsResult.fail === 0 &&

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -69,6 +69,7 @@ import BrainstormFollows from './pages/BrainstormFollows';
 import BrainstormFollowers from './pages/BrainstormFollowers';
 import BrainstormReporters from './pages/BrainstormReporters';
 import BrainstormFollowsHops from './pages/BrainstormFollowsHops';
+import BrainstormUserNotes from './pages/BrainstormUserNotes';
 import BrainstormSettings from './pages/BrainstormSettings';
 import BrainstormPersonalization from './pages/BrainstormPersonalization';
 import BrainstormHowSearchWorks from './pages/BrainstormHowSearchWorks';
@@ -125,6 +126,10 @@ const router = createBrowserRouter([
   {
     path: '/user/:pubkey/follows-hops',
     element: <BrainstormFollowsHops />,
+  },
+  {
+    path: '/user/:pubkey/notes',
+    element: <BrainstormUserNotes />,
   },
   {
     path: '/settings',

--- a/ui/src/components/ProfileContentSection.jsx
+++ b/ui/src/components/ProfileContentSection.jsx
@@ -1,0 +1,53 @@
+import { Link } from 'react-router-dom';
+import NoteCard from './NoteCard';
+import useUserNotes from '../hooks/useUserNotes';
+
+/**
+ * Story note-surfaces #2 / ADR note-surfaces/0002: the profile "Content" section.
+ *
+ * Front-end only. Appended as the LAST section of BrainstormProfile.jsx, it shows the viewed
+ * user's single most-recent kind-1 note (the read path at limit 1) as one shared <NoteCard>,
+ * an explicit empty state when none can be located, and a link to the full /user/:pubkey/notes
+ * page. It adds no read logic — useUserNotes owns the fetch.
+ *
+ * Labelled "Content" (not "Notes") deliberately: the section may host other content kinds later
+ * but is kind-1 only for now. The body is delegated to a PURE, named-exported renderContentBody
+ * of { data, loading, error } — no fetch/hook/router/browser globals — so its states are an
+ * isolated, sentinel-testable unit.
+ */
+
+// Operator-delegated copy (story #2). Punctuation is non-binding; meaning is exact.
+export const CONTENT_COPY = {
+  HEADING: 'Content',
+  EMPTY: 'No kind-1 events could be located for this user.',
+  VIEW_ALL: 'View all notes →',
+  LOADING: 'Loading…',
+};
+
+export default function ProfileContentSection({ pubkey }) {
+  const { data, loading, error } = useUserNotes(pubkey, 1);
+
+  return (
+    <div className="bsp-section bsp-content-section">
+      <h3>{CONTENT_COPY.HEADING}</h3>
+      {renderContentBody({ data, loading, error })}
+      <Link to={`/user/${pubkey}/notes`} className="bsp-content-viewall">{CONTENT_COPY.VIEW_ALL}</Link>
+    </div>
+  );
+}
+
+/**
+ * Pure state→view mapping for the Content section. A function only of its args. Renders the
+ * single latest note (items[0]) on OK; the operator-delegated "no kind-1 events could be
+ * located" message on EMPTY / a transport failure / an unknown status — never a card on an
+ * error and never a raw error. Defined last so it stays a pure function of its args.
+ */
+export function renderContentBody({ data, loading, error }) {
+  if (loading && !data) {
+    return <div className="bsp-content-loading">{CONTENT_COPY.LOADING}</div>;
+  }
+  if (!error && data && data.status === 'OK' && data.items && data.items[0]) {
+    return <NoteCard item={data.items[0]} />;
+  }
+  return <div className="bsp-empty">{CONTENT_COPY.EMPTY}</div>;
+}

--- a/ui/src/hooks/useUserNotes.js
+++ b/ui/src/hooks/useUserNotes.js
@@ -1,0 +1,53 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook: fetch a single user's recent kind-1 notes from the by-author read path
+ * (`/api/user/:pubkey/notes?limit=`, ADR note-surfaces/0001), consumed by the profile
+ * "Content" section (limit 1) and the per-user /notes page (limit 50). Returns
+ * { data, loading, error }.
+ *
+ * The read path returns `{ success: true, ...result }` where `result` is the discriminated
+ * three-outcome object `{ status, relaySource?, items? }` (status ∈ {OK, EMPTY, INVALID}).
+ * On a `success` body we pass the WHOLE result object through as `data` — the surfaces read
+ * `status` + `items`; we do NOT reshape it (no re-derivation; #1 owns the read path).
+ *
+ * A non-success body / non-2xx / thrown / malformed response sets `error`, which drives the
+ * surfaces' empty/defensive branch. Re-runs when `pubkey` or `limit` changes; aborts the fetch
+ * on unmount, mirroring useFeed.js / useGrapevineFollows.js.
+ */
+export default function useUserNotes(pubkey, limit) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!pubkey) { setLoading(false); return; }
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    fetch(`/api/user/${pubkey}/notes?limit=${limit}`, { signal: controller.signal })
+      .then(r => r.json())
+      .then(json => {
+        if (json?.success) {
+          setData(json);
+          setError(null);
+        } else {
+          setData(null);
+          setError(json?.error || json?.message || 'Failed to load notes');
+        }
+      })
+      .catch(err => {
+        if (err.name === 'AbortError') return;
+        setError(err.message || 'Fetch failed');
+        setData(null);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [pubkey, limit]);
+
+  return { data, loading, error };
+}

--- a/ui/src/hooks/useUserNotes.js
+++ b/ui/src/hooks/useUserNotes.js
@@ -25,6 +25,7 @@ export default function useUserNotes(pubkey, limit) {
     const controller = new AbortController();
     setLoading(true);
     setError(null);
+    setData(null); // clear the prior result on pubkey/limit change so the loading line shows, not stale notes
 
     fetch(`/api/user/${pubkey}/notes?limit=${limit}`, { signal: controller.signal })
       .then(r => r.json())

--- a/ui/src/pages/BrainstormProfile.jsx
+++ b/ui/src/pages/BrainstormProfile.jsx
@@ -17,6 +17,7 @@ import { toExternalUrl } from '../utils/url';
 import VerificationInfo from '../components/VerificationInfo';
 import ReputationInfo from '../components/ReputationInfo';
 import IdentityDetails from '../components/IdentityDetails';
+import ProfileContentSection from '../components/ProfileContentSection';
 
 /* ── Verified Reporters alarm thresholds (ADR 0032) ──────
    Alarm (red + icon) only when verifiedReporterCount >= BASE + one "freebie" per
@@ -404,6 +405,9 @@ export default function BrainstormProfile() {
                 </div>
               )}
             </div>
+
+            {/* Content — the user's latest kind-1 note + link to all (note-surfaces #2) */}
+            <ProfileContentSection pubkey={pubkey} />
 
           </>
         )}

--- a/ui/src/pages/BrainstormUserNotes.jsx
+++ b/ui/src/pages/BrainstormUserNotes.jsx
@@ -1,0 +1,111 @@
+import { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { nip19 } from 'nostr-tools';
+import { useAuth } from '../context/AuthContext';
+import BrainstormUserMenu from '../components/BrainstormUserMenu';
+import NoteCard from '../components/NoteCard';
+import useUserNotes from '../hooks/useUserNotes';
+
+/**
+ * Story note-surfaces #3 / ADR note-surfaces/0002: the public per-user notes page
+ * (/user/:pubkey/notes), a sibling of /user/:pubkey/follows.
+ *
+ * Front-end only. It renders the by-author read path's output (ADR 0001) at limit 50 as a list
+ * of shared <NoteCard>s, newest-first (array order — it does NOT re-sort), with a back link, a
+ * heading naming whose notes these are, and an empty state. It adds no read logic — useUserNotes
+ * owns the fetch. Modeled on BrainstormFollows.jsx's public shell. The body is delegated to a
+ * PURE, named-exported renderUserNotesState of { data, loading, error }.
+ */
+
+// Operator-delegated copy (story #3). Punctuation is non-binding; meaning is exact.
+export const NOTES_COPY = {
+  HEADING: 'Notes',
+  INDICATOR: 'Showing the most recent 50 notes.',
+  EMPTY: 'No kind-1 events could be located for this user.',
+  LOADING: 'Loading notes…',
+};
+
+function shortNpub(pubkey) {
+  try { return nip19.npubEncode(pubkey).slice(0, 12) + '…'; }
+  catch { return pubkey ? `${pubkey.slice(0, 10)}…` : '—'; }
+}
+
+export default function BrainstormUserNotes() {
+  const { pubkey } = useParams();
+  const { user, login, logout } = useAuth();
+  const { data, loading, error } = useUserNotes(pubkey, 50);
+
+  // Subject display name for the header — so the page identifies WHOSE notes even when empty
+  // (the /api/profiles?pubkeys= convention from BrainstormProfile.jsx). Falls back to a short npub.
+  const [subjectName, setSubjectName] = useState(null);
+  useEffect(() => {
+    if (!pubkey) return;
+    let cancelled = false;
+    fetch(`/api/profiles?pubkeys=${pubkey}`)
+      .then(r => r.json())
+      .then(d => {
+        if (cancelled) return;
+        const p = d?.profiles?.[pubkey];
+        if (p) setSubjectName(p.display_name || p.name || null);
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [pubkey]);
+
+  const displayName = subjectName || shortNpub(pubkey);
+
+  return (
+    <div className="bsp-page">
+      {/* Top bar */}
+      <div className="bsp-top-bar">
+        <a href="/" className="bsp-logo">
+          <img src="/brainstorm.svg" alt="" className="bsp-logo-img" />
+        </a>
+        <div className="bsp-auth">
+          <BrainstormUserMenu user={user} login={login} logout={logout} />
+        </div>
+      </div>
+
+      <div className="bsp-content">
+        {/* Header + back link */}
+        <div className="bsp-follows-header">
+          <Link to={`/user/${pubkey}`} className="bsp-back-link">← Back to profile</Link>
+          <h1 className="bsp-follows-title">{NOTES_COPY.HEADING}</h1>
+        </div>
+        <div className="bsp-notes-subtitle">{displayName}</div>
+
+        {renderUserNotesState({ data, loading, error })}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Pure state→view mapping. A function only of its args — the populated list (status OK) in array
+ * order (already newest-first; the page does NOT re-sort), the operator-delegated empty message
+ * (status EMPTY / a transport failure / an unknown status), and a transient loading line. Never a
+ * raw error or a blank surface. Defined last so it stays a pure function of its args.
+ */
+export function renderUserNotesState({ data, loading, error }) {
+  if (loading && !data) {
+    return <div className="bsp-feed-loading">{NOTES_COPY.LOADING}</div>;
+  }
+  const status = data && data.status;
+  if (error || data == null || !['OK', 'EMPTY'].includes(status)) {
+    return <div className="bsp-empty">{NOTES_COPY.EMPTY}</div>;
+  }
+  if (status === 'EMPTY') {
+    return <div className="bsp-empty">{NOTES_COPY.EMPTY}</div>;
+  }
+  // status === 'OK' — the indicator, then one entry per note IN ARRAY ORDER (already newest-first
+  // from the read path; the page does NOT re-sort).
+  const items = data.items || [];
+  return (
+    <>
+      <div className="bsp-notes-indicator">{NOTES_COPY.INDICATOR}</div>
+      <div className="bsp-notes-list">
+        {items.map(item => <NoteCard key={item.id} item={item} />)}
+      </div>
+    </>
+  );
+}

--- a/ui/src/pages/BrainstormUserNotes.jsx
+++ b/ui/src/pages/BrainstormUserNotes.jsx
@@ -41,12 +41,14 @@ export default function BrainstormUserNotes() {
   useEffect(() => {
     if (!pubkey) return;
     let cancelled = false;
+    setSubjectName(null); // clear the prior user's name on a param-only navigation (A/notes → B/notes)
     fetch(`/api/profiles?pubkeys=${pubkey}`)
       .then(r => r.json())
       .then(d => {
         if (cancelled) return;
         const p = d?.profiles?.[pubkey];
-        if (p) setSubjectName(p.display_name || p.name || null);
+        // Set unconditionally so a user with no local kind-0 resolves to null → npub fallback engages.
+        setSubjectName(p ? (p.display_name || p.name || null) : null);
       })
       .catch(() => {});
     return () => { cancelled = true; };

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -7201,6 +7201,43 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   flex-direction: column;
   gap: 1rem;
 }
+/* Per-user notes page (BrainstormUserNotes.jsx) + profile "Content" section
+   (ProfileContentSection.jsx) — note-surfaces epic. Reuse the shared note-card unit; only
+   layout tokens here. The note-card text already wraps and bsp-content is width-capped, so
+   neither surface overflows 1280px. */
+.bsp-notes-subtitle {
+  font-size: 0.95rem;
+  opacity: 0.7;
+  margin-bottom: 1rem;
+  overflow-wrap: anywhere;
+}
+.bsp-notes-indicator {
+  font-size: 0.85rem;
+  opacity: 0.6;
+  margin-bottom: 1rem;
+}
+.bsp-notes-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.bsp-content-section {
+  margin-top: 1rem;
+}
+.bsp-content-loading {
+  opacity: 0.6;
+  padding: 0.5rem 0;
+}
+.bsp-content-viewall {
+  display: inline-block;
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  color: #a5b4fc;
+  text-decoration: none;
+}
+.bsp-content-viewall:hover {
+  text-decoration: underline;
+}
 /* Shared note-card unit (NoteCard.jsx) — surface-neutral so the feed, profile
    "latest note", and per-user notes page all reuse it without feed-specific styling. */
 .bsp-note-card {


### PR DESCRIPTION
## Summary

Surfaces a user's own kind-1 notes in two new places, reusing the shared note seam (`NoteCard` + `enrichNotes`) the live-feed epic extracted. Distinct from the feed: these show the **viewed user's own** posts (selection by author), with no follow-list and no point-of-view. Built through the full engineering harness (Planning → Architecture → Test → Implement → Review **PASS**); strictly additive.

## Changes

- **New** `src/api/notes/userNotesReadPath.js` — `GET /api/user/:pubkey/notes?limit=` (`buildUserNotes`/`handleGetUserNotes`/`clampLimit`, `NOTES_CAP=50`). Selects the N most-recent kind-1 by a given author from the general-purpose relays (settled empirically — local strfry holds 0 kind-1), reuses `enrichNotes` unchanged; statuses `OK`/`EMPTY`/`INVALID` (handler `INVALID`→400).
- **New** `ui/src/hooks/useUserNotes.js`, `ui/src/components/ProfileContentSection.jsx`, `ui/src/pages/BrainstormUserNotes.jsx`.
- **Additive edits** — `src/api/index.js` (route), `ui/src/App.jsx` (`/user/:pubkey/notes` route), `ui/src/pages/BrainstormProfile.jsx` ("Content" section appended after Reputation), `ui/src/styles.css` (layout classes).
- `feedReadPath.js` and `NoteCard.jsx` are byte-unchanged.
- Tests: `test/note-surfaces-read-path.test.js` (28), `test/note-surfaces-ui.test.js` (19); 3 stories + 2 ADRs + 3 test plans + review under `engineering-team/`.

## Test plan

- [ ] After merge: deploy-staging.yml runs.
- [ ] `GET https://staging.brainstorm.world/api/user/3129509e23d3a6125e1451a5912dbe01099e151726c4766b44e1ecb8c846f506/notes?limit=1` returns `{ success: true, status: OK|EMPTY, ... }`.
- [ ] Profile page shows a bottom **"Content"** section with the latest note (or the empty state) + a link to the notes page.
- [ ] `/user/<pubkey>/notes` renders up to 50 notes (or the empty state), no horizontal overflow at 1280px.
- [ ] Regression sweep: feed `/feed` and profile pages unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)