### PR TITLE
feat(event-page): /event single-event view (kind-1) + by-id/by-author read path

### DIFF
--- a/engineering-team/decisions/event-page/0001-event-read-path.md
+++ b/engineering-team/decisions/event-page/0001-event-read-path.md
@@ -1,0 +1,110 @@
+# ADR 0001: Event read path — a public `GET /api/event` that resolves a kind-1 by id or by author across a relay union
+
+**Status:** Accepted
+**Date:** 2026-06-18
+**Story:** `engineering-team/stories/event-page/1-event-read-path.md`
+**Epic:** `engineering-team/epics/event-page.md`
+
+## Context
+
+The `/event` page needs to take a resolved target — an **event id** (from `nevent`/`id`, with optional relay hints + optional known author) or an **author pubkey** (from `pubkey`/`npub`/`nprofile`, with optional hints) — and return either a displayable kind-1 or a precise, distinct reason. This ADR designs **only that backend read path**; the page (ADR 0002) consumes it.
+
+It is the richer cousin of `userNotesReadPath.js` (`note-surfaces` #1): same local-enriched feed item shape (reuses `enrichNotes`), but with (a) an **event-id** mode, (b) **verification** + **kind-gating**, and (c) a **relay union** that adds embedded hints and the author's **outbox** to the well-known set.
+
+### Why a server read path (the client/server split)
+
+The page must decode the 6 bech32 formats client-side anyway (search-field format validation + `naddr`'s kind), but the **fetch** belongs server-side:
+- the **well-known set** is the firmware general-purpose relay set, resolvable only via `runCypher` (server) — `feedReadPath.js:138-159`;
+- the **outbox bootstrap** (fetch the author's kind-10002, use its write relays) is a server-appropriate multi-relay step;
+- keeping `verifyEvent` + enrichment server-side matches the feed/user-notes precedent and the local-only profile rule.
+
+So: **client decodes** → passes `{ id?, author?, relays? }` to `GET /api/event` → **server** resolves the union, fetches, verifies, kind-gates, enriches, returns a discriminated outcome. `naddr` never reaches the server (its kind is in the coordinate → the page reports "kind ‹N› not yet supported" with no fetch — ADR 0002).
+
+### Acceptance criteria, quoted to design against
+> - **By event reference** → one of: found (verified kind-1) / unsupported-kind (carries kind) / does-not-validate / not-found.
+> - **By author** → author's most-recent verified kind-1, else no-author-note.
+> - **Relay union** = hints + author outbox (NIP-65 kind-10002 write relays, when resolvable) + well-known (general-purpose set, slug-from-TA, else fallback `relay.primal.net`/`nos.lol`/`relay.damus.io`); set-vs-fallback observable.
+> - **Verification**: never return an unverified event as found.
+> - **Enriched, feed-shaped item** (local kind-0 names), so `NoteCard` renders it unchanged.
+
+### Existing mechanisms to reuse (verified in source)
+| Need | Pattern | Source |
+|---|---|---|
+| Relay-set resolution (slug-from-TA + fallback) | `resolveGeneralPurposeRelays(runCypher)` | `feedReadPath.js:138-159` |
+| External relay fetch (SimplePool + timeout + dedup) | `realQuerySync` / `handleFetchExternalEvents` | `feedReadPath.js:77-91`, `relay/fetchEvents.js` |
+| Local kind-0 scan for enrichment | `realScanStrfry` | `feedReadPath.js:57-69` |
+| Enrich raw kind-1 → feed item shape (local-only) | **`enrichNotes(notes, scanStrfry)`** | `_shared/noteEnrichment.js:79` |
+| NIP-65 kind-10002 → write relays (r-tag, write-marker filter) | `fetchWriteRelaysFromKind10002` | `ui/src/utils/publishTagPin.js:190-208` (logged-in user; mirror the **parsing** server-side for an arbitrary author) |
+| Signature/id verification | `verifyEvent` (confirmed exported) | `nostr-tools` |
+| Public route registration; anonymous read-only allowed | `app.get('/api/...')`; auth middleware default | `src/api/index.js:302`; `src/middleware/auth.js:488-489` |
+
+### Constraints
+- **Additive, read-only**; no new dependency (`nostr-tools`/`ws`/Neo4j driver/strfry already used). No firmware/concept change.
+- **`enrichNotes` reused unchanged** (`enrichNotes` caps the kind-0 *scan arg* at 1000; this path enriches ≤1 note → trivially safe).
+- Relay-set handle resolved by **slug-from-TA at runtime** — never a hardcoded pubkey (CLAUDE.md).
+
+## Options considered (the relay-sourcing-reuse decision)
+
+This is the **3rd consumer** of `resolveGeneralPurposeRelays` + the `querySync`/`scanStrfry` wrappers (feed, user-notes, now event). `note-surfaces` ADR 0001 explicitly deferred consolidation "until a third consumer appears." It has.
+
+### Option A — New `event/eventReadPath.js`; extract the sourcing into a NEW `_shared/relaySource.js` that the event path uses; **defer** re-pointing the two shipped modules *(chosen)*
+Create `src/api/_shared/relaySource.js` exporting the shared primitives (`resolveGeneralPurposeRelays`, `realQuerySync`, `realScanStrfry`, `realRunCypher`, `FALLBACK_RELAYS`, `RELAY_SET_SLUG`, the module-path constants). The new `eventReadPath.js` imports them; `feedReadPath.js` / `userNotesReadPath.js` keep their private copies **for now**.
+- **Pros:** the new code introduces **zero** new duplication (it consumes the shared home); finally establishes `_shared/relaySource.js`; **the event epic stays additive** — it touches no shipped read path, so it doesn't entangle the feed's prod-promotion sequencing or risk the staging-live feed/user-notes. The re-pointing of the two shipped modules becomes a concrete, standalone, behavior-preserving follow-up (guarded by `live-feed-read-path` + `note-surfaces-read-path` suites).
+- **Cons:** temporary triplication — `_shared/relaySource.js` duplicates the logic still inlined in the two shipped modules until the follow-up lands. A known, shrinking, tracked debt.
+
+### Option B — Full consolidation now: extract `_shared/relaySource.js` **and** re-point `feedReadPath.js` + `userNotesReadPath.js` in this epic
+- **Pros:** zero duplication immediately; closes the deferred follow-up outright.
+- **Cons (why not now):** edits two **shipped** modules (feed on staging→prod-pending; user-notes on staging) inside the event epic — entangling their promotions with the event page and adding regression surface to a feature that is otherwise purely additive. Better as a dedicated, separately-promotable refactor. **Surfaced to the operator at the gate** — if they prefer to close the debt now, this is a one-step upgrade from Option A.
+
+### Option C — Inline a 3rd private copy of the sourcing in `eventReadPath.js`
+- **Cons (decisive):** grows the duplication into new code with no shared home — exactly what the "3rd consumer" trigger says to stop. Rejected.
+
+## Decision
+
+**Option A.** A new self-contained `src/api/event/eventReadPath.js` exposing `buildEvent(options)` + `handleGetEvent` at public `GET /api/event`, composed from a **new `src/api/_shared/relaySource.js`** (the extracted sourcing primitives) + the reused `enrichNotes`, adding outbox resolution, by-id/by-author fetch, `verifyEvent`, and kind-gating. It returns a discriminated `status` union plus `relaySource`. The event epic touches **no** shipped read path; re-pointing `feedReadPath`/`userNotesReadPath` to `_shared/relaySource.js` is the now-concrete follow-up (Option B as a standalone refactor). Client/server split as in Context; `naddr` is page-only.
+
+## Consequences
+- **Enables:** ADR 0002's page calls one endpoint and renders the outcome; future event-centric features (threads, reactions) extend this path.
+- **Constrains:** the response shape (`status`, `item`, `kind`, `relaySource`) is a contract ADR 0002 depends on.
+- **New shared module:** `_shared/relaySource.js` becomes the canonical sourcing home. **Tracked follow-up (concrete):** re-point `feedReadPath.js` + `userNotesReadPath.js` to it and delete their private copies — behavior-preserving, guarded by their existing suites. Logged in `engineering-team/follow-ups.md`.
+- **Best-effort under relay timeout** (cap/timeout per the feed); a slow relay may miss an event that exists elsewhere — acceptable, noted.
+- **Firmware reinstall?** **No.**
+
+## Implementation notes
+
+- **New file: `src/api/_shared/relaySource.js`** — move (copy, since the shipped modules aren't re-pointed yet) the sourcing primitives from `feedReadPath.js`:
+  - `NOSTR_TOOLS_PATH`, `WS_PATH`, `FETCH_TIMEOUT_MS`, `FALLBACK_RELAYS = ['wss://relay.primal.net','wss://nos.lol','wss://relay.damus.io']`, `RELAY_SET_SLUG`.
+  - `realScanStrfry(filter)`, `realRunCypher(cypher,params)`, `realQuerySync(relays,filter)`, `resolveGeneralPurposeRelays(runCypher)` — verbatim from `feedReadPath.js:57-159`.
+  - `module.exports` all of them. (Note the fallback order matches the operator's stated list; the feed's existing array is the same set, order non-binding.)
+- **New file: `src/api/event/eventReadPath.js`**
+  - `const { resolveGeneralPurposeRelays, realQuerySync, realScanStrfry, realRunCypher, FALLBACK_RELAYS } = require('../_shared/relaySource');`
+  - `const { enrichNotes } = require('../_shared/noteEnrichment');`
+  - `const HEX64 = /^[0-9a-f]{64}$/i;` `const AUTHOR_FETCH_CAP = 10;` (newest-batch to verify through for by-author).
+  - **`verify(ev)`** → `require(NOSTR_TOOLS_PATH).verifyEvent(ev)` (lazy require, path-tolerant like enrichNotes; on throw → false).
+  - **`fetchOutboxRelays(author, bootstrapRelays, querySync)`** → `querySync(bootstrapRelays, { kinds:[10002], authors:[author], limit: 5 })`; newest kind-10002; collect `r`-tag URLs whose marker ≠ `'read'` (mirror `publishTagPin.js:200-206`); return `wss://`/`ws://` only. Empty/none → `[]`.
+  - **`unionRelays(hints, outbox, wellKnown)`** → dedup + keep `wss://`/`ws://`.
+  - **`async function buildEvent({ id, author, relays, deps } = {})`** reading injectable deps `deps?.X ?? options.X ?? real*` for `scanStrfry`, `runCypher`, `querySync` (mirrors the feed seam):
+    1. Validate: if `id` present and `HEX64.test(id)` → by-id mode; else if `author` present and `HEX64.test(author)` → by-author mode; else `return { status:'INVALID' }`.
+    2. `const hints = (relays||[]).filter(wss/ws);` `const { relays: wk, source: relaySource } = await resolveGeneralPurposeRelays(runCypher);`
+    3. Outbox: the author to look up = by-author's `author`, or (by-id) the `author` hint if supplied. If present → `outbox = await fetchOutboxRelays(authorPk, [...hints, ...wk], querySync)` else `[]`.
+    4. `const union = unionRelays(hints, outbox, wk);`
+    5. **by-id:** `events = await querySync(union, { ids:[id] })`; pick the event with matching `id`; none → `{ status:'NOT_FOUND', relaySource }`; found but `!verify(ev)` → `{ status:'INVALID_EVENT', relaySource }`; verified but `ev.kind !== 1` → `{ status:'UNSUPPORTED_KIND', kind: ev.kind, relaySource }`; verified kind-1 → enrich → `{ status:'OK', relaySource, item }`.
+    6. **by-author:** `events = await querySync(union, { kinds:[1], authors:[author], limit: AUTHOR_FETCH_CAP })`; keep kind-1 by `author`, sort `created_at` desc, take the first that `verify`s; none → `{ status:'NO_AUTHOR_NOTE', relaySource }`; else enrich `[chosen]` → `{ status:'OK', relaySource, item }`.
+  - **`item` = `(await enrichNotes([ev], scanStrfry))[0]`** — the feed item shape.
+  - **`async function handleGetEvent(req, res)`** — read `req.query.{id,author,relays}` (`relays` CSV → array); `const r = await buildEvent({ id, author, relays })`; `INVALID` → `res.status(400).json({ success:false, ...r, error:'no valid id or author' })`; else `res.json({ success:true, ...r })`; try/catch → 500. Public (no auth gate; not in any blocklist).
+  - `module.exports = { buildEvent, handleGetEvent }`.
+- **Edit: `src/api/index.js`** — `const { handleGetEvent } = require('./event/eventReadPath.js');` and `app.get('/api/event', handleGetEvent);` beside `/api/feed`/`/api/user/:pubkey/notes`. (`/api/event` confirmed unused.)
+- **No new dependency, no lint/build tooling, no concept/firmware change.**
+
+### Testability
+Mirror `note-surfaces-read-path.test.js` (Node runner, in-memory fakes for `scanStrfry`/`runCypher`/`querySync`):
+- by-id: OK (verified kind-1) / UNSUPPORTED_KIND (verified non-kind-1, carries kind) / INVALID_EVENT (id matches but verify fails) / NOT_FOUND (no match) / INVALID (bad/empty id+author).
+- by-author: OK (newest **verified** kind-1; skips an unverified newer one) / NO_AUTHOR_NOTE.
+- relay union: assert the `querySync` fake is called with a relay list that **includes** the hints, the outbox write-relays (from the kind-10002 fake), and the well-known set; `relaySource` set-vs-fallback via the `runCypher` fake.
+- outbox: `fetchOutboxRelays` parses write-marker r-tags, drops `read`-marked, newest kind-10002 wins.
+- `verifyEvent` is stubbed at the boundary (inject a `verify`/`querySync`-shaped fake or feed pre-built events) so tests stay hermetic — the seam detail is an implementation choice the Tester pins.
+
+## Out of scope
+- The page, param decoding, the search field, `naddr` handling, all rendering (ADR 0002).
+- **Re-pointing `feedReadPath`/`userNotesReadPath` to `_shared/relaySource.js`** — the tracked follow-up (Option B as a standalone refactor).
+- Threads/replies/reactions; multiple results; addressable/non-kind-1 rendering; any write/publish; firmware.

--- a/engineering-team/decisions/event-page/0002-event-page-ui.md
+++ b/engineering-team/decisions/event-page/0002-event-page-ui.md
@@ -1,0 +1,91 @@
+# ADR 0002: The `/event` page — client-side param decode + precedence, the search fallback, and outcome rendering
+
+**Status:** Accepted
+**Date:** 2026-06-18
+**Stories:** `engineering-team/stories/event-page/2-event-page-param-render.md`, `engineering-team/stories/event-page/3-event-page-search.md`
+**Epic:** `engineering-team/epics/event-page.md`
+**Depends on:** ADR `event-page/0001` (`GET /api/event` contract)
+
+## Context
+
+Rework the placeholder `ui/src/pages/BrainstormEvent.jsx` (today it just echoes the identifier) into a working single-event view. **Front-end only**: it decodes/validates the 6 params client-side, resolves a target, calls `GET /api/event` (ADR 0001) for `id`/`author` targets, and renders the outcome with the shared `NoteCard` (like `/feed`). The `/event` route already exists in `ui/src/App.jsx` (top-level public) — **no routing change needed.**
+
+### The contract this page consumes (ADR 0001)
+`GET /api/event?id=&author=&relays=` → `{ success, status, relaySource?, item?, kind? }`, status ∈ `OK` (item) / `UNSUPPORTED_KIND` (kind) / `INVALID_EVENT` / `NOT_FOUND` / `NO_AUTHOR_NOTE` / `INVALID`. `OK` item is the feed shape → `NoteCard` renders it unchanged.
+
+### Why client-side decode
+The 6 bech32/hex formats decode with `nip19` in the browser (the `nostrEntities.js:36-55` patterns already do exactly this). The page needs client decode anyway for: the search-field **format validation**, extracting **relay hints** (`nevent`/`nprofile` `.relays`) and **author** (`nevent.author`) to pass to the endpoint, and **`naddr`** (its `.kind` → "not yet supported" with no fetch). The server only ever sees resolved `{id?, author?, relays?}`.
+
+### The 6 params, precedence, and the hex ambiguity
+Precedence (operator-confirmed): **`nevent` › `id` › `naddr` › `pubkey` › `npub` › `nprofile`**. Decode map:
+| param | nip19 / form | target |
+|---|---|---|
+| `nevent` | decode → `{id, author?, relays?}` | `{mode:'id', id, author, relays}` |
+| `id` | 64-hex | `{mode:'id', id}` |
+| `naddr` | decode → `{kind, …}` | `{mode:'naddrUnsupported', kind}` (no fetch) |
+| `pubkey` | 64-hex | `{mode:'author', author}` |
+| `npub` | decode → pubkey | `{mode:'author', author}` |
+| `nprofile` | decode → `{pubkey, relays?}` | `{mode:'author', author, relays}` |
+
+**Hex ambiguity (search field only):** a bare 64-hex is valid as *both* `id` and `pubkey`. In a URL the param **name** disambiguates. In the search field there's no name, so by **precedence (`id` before `pubkey`)** a pasted bare 64-hex is treated as an **event id**. (To look up an author by raw key via search, paste an `npub`/`nprofile`; or use the `?pubkey=` URL param.) Documented gotcha, deterministic.
+
+### Constraints
+- **Additive & read-only.** Reworks one placeholder page; reuses `NoteCard`; the only other touch is the route already existing. No new dependency/tooling; `nip19` + `react-router-dom` + the `bsp-*`/`bsp-note-card-*` styles are present.
+- **No re-derivation of the read path** — the page maps `{status,item,kind}` to DOM; it does not fetch/verify/enrich (ADR 0001 owns that). `relaySource` is ignored (not asked for).
+- Public by construction (top-level route + SPA fallback; auth middleware lets non-`/api/` through).
+
+## Options considered
+
+### Option A — Client decode util + a `useEventResolve` hook + pure render helper + an `EventSearch` component; rework `BrainstormEvent.jsx` *(chosen)*
+- **`ui/src/utils/eventParam.js`** (new, pure, nip19-based, unit-testable): `resolveEventParams(searchParams)` → `{ target | null, invalidParams: string[] }` (precedence iteration; supported-but-undecodable → `invalidParams`; unknown names ignored); and `classifyEventInput(string)` → a `target` or `null` (the search-field classifier, hex→id per precedence).
+- **`ui/src/hooks/useEventResolve.js`** (new, mirrors `useUserNotes.js`): given `{id?, author?, relays?}`, fetch `/api/event?…`; `{data, loading, error}`; no fetch when neither id nor author.
+- **`BrainstormEvent.jsx`** reworked: `resolveEventParams` → if `target` is id/author use the hook, render via a pure exported `renderResolvedEvent({data,loading,error})`; if `naddrUnsupported` render "kind ‹N› not yet supported"; if no target render `<EventSearch />`; always show an invalid-params notice when `invalidParams` is non-empty.
+- **`EventSearch`** (story #3, in the page file or its own component): input + Enter; on submit `classifyEventInput` → if valid, **navigate to the canonical `/event?<type>=<value>`** (so the result is shareable and #2's path renders it); else show the "not recognized" notice.
+- **Pros:** mirrors the established hook + pure-render + copy-constant pattern (`BrainstormFeed.jsx`); the decode/classify logic is a pure, sentinel-testable unit; search reduces to "produce a URL param," unifying it with the param path; strictly additive (one route already exists; `NoteCard` reused).
+- **Cons:** a few new files — but each matches an existing convention and keeps the page testable.
+
+### Option B — Decode + fetch entirely client-side (no `/api/event`; the page queries relays in-browser)
+- **Cons (decisive):** the **well-known set** needs `runCypher` (server-only) and the **outbox bootstrap** is a server step — ADR 0001's whole rationale. Pushing relay/Neo4j logic into the browser contradicts it and can't resolve the firmware set. Rejected.
+
+### Option C — Server decodes the bech32 too (page passes raw `nevent`/`npub`/… to the server)
+- **Cons:** the search field still needs **client** format-validation, and `naddr`'s kind-gate is a no-fetch client decision — so the client decodes regardless. Decoding twice (or round-tripping `naddr` to the server just to be told its kind) is wasteful. Client-decode + server-fetch (Option A) is the clean split. Rejected.
+
+## Decision
+**Option A.** A pure `eventParam.js` decode/classify util, a `useEventResolve` hook, a reworked `BrainstormEvent.jsx` with a pure exported `renderResolvedEvent` + module-level `EVENT_COPY`, and an `EventSearch` field that resolves by navigating to the canonical URL param. `naddr` and invalid/unsupported-param handling are client-side; `id`/`author` fetch via ADR 0001. No routing change.
+
+## Consequences
+- **Enables:** the user-visible `/event` view; note `nostr:` links (`/event?id=`, `/event?nevent=`, `/event?naddr=`) now resolve to a real view or a precise message instead of the placeholder.
+- **Constrains:** coupled to ADR 0001's `status` shape. The hex-ambiguity rule (search bare-hex → id) is a documented behavior.
+- **Build/deploy:** Vite `/dist` rebuild (existing step). **Firmware reinstall?** No.
+- **No new debt** beyond ADR 0001's shared-sourcing follow-up.
+
+## Implementation notes
+All UI under `ui/src` (Vite — `npm run build` in `ui/`).
+
+- **New `ui/src/utils/eventParam.js`** — `import { nip19 } from 'nostr-tools'`:
+  - `const HEX64 = /^[0-9a-f]{64}$/i;` `const ORDER = ['nevent','id','naddr','pubkey','npub','nprofile'];`
+  - `decodeOne(type, value)` → a `target` or `null`: `nevent`→`nip19.decode` guard type==='nevent' → `{mode:'id', id:data.id, author:data.author||null, relays:data.relays||[]}`; `id`/`pubkey`→`HEX64` → `{mode:'id',id}` / `{mode:'author',author}`; `naddr`→decode → `{mode:'naddrUnsupported', kind:data.kind}`; `npub`→decode → `{mode:'author',author:data}`; `nprofile`→decode → `{mode:'author',author:data.pubkey,relays:data.relays||[]}`. Any throw / wrong type → `null`.
+  - `export function resolveEventParams(searchParams)` → iterate `ORDER`; for each name **present** in `searchParams`, `decodeOne`; first non-null → `target`; every present supported name that decoded `null` → push to `invalidParams`; return `{ target: firstValid||null, invalidParams }`. (Names outside `ORDER` untouched → ignored.)
+  - `export function classifyEventInput(str)` → trim; try in precedence order: bech32 prefix dispatch (`nevent1`/`naddr1`/`npub1`/`nprofile1` → `decodeOne`), else `HEX64` → `{mode:'id',id}` (**id before pubkey**); return `target` or `null`. Also return the canonical `{paramName, value}` for URL navigation (e.g. `nevent`→`('nevent', str)`, hex→`('id', str)`).
+- **New `ui/src/hooks/useEventResolve.js`** — mirror `useUserNotes.js`: args `{ id, author, relays }`; effect deps on those; `if (!id && !author) { setLoading(false); return; }`; `fetch('/api/event?' + qs)` where qs includes `id`/`author` and `relays` (CSV) when present; gate on `success`; `{data,loading,error}`; abort on unmount.
+- **Rework `ui/src/pages/BrainstormEvent.jsx`** — keep the `bsp-page`→`bsp-top-bar`(logo + `BrainstormUserMenu`)→`bsp-content` shell:
+  - `const [params, setParams] = useSearchParams();` `const { target, invalidParams } = resolveEventParams(params);`
+  - `const { data, loading, error } = useEventResolve(target && (target.mode==='id'||target.mode==='author') ? target : {});`
+  - Module-level `export const EVENT_COPY = { HEADING:'Event', LOADING:'Loading…', UNSUPPORTED:(k)=>\`Kind ${k} events are not yet supported.\`, INVALID_EVENT:'This event could not be verified — its signature or id does not validate.', NOT_FOUND:'Event not found on the relays we checked.', NO_AUTHOR_NOTE:'No kind-1 note found for this author.', INVALID_PARAMS:(n)=>\`Ignoring invalid parameter(s): ${n}.\`, SEARCH_PROMPT:'Paste an nevent, id, naddr, npub, pubkey, or nprofile.', SEARCH_INVALID:'That isn’t a recognized nevent, id, naddr, npub, pubkey, or nprofile.' };` (punctuation non-binding).
+  - Body: render the invalid-params notice when `invalidParams.length`; then: no `target` → `<EventSearch />`; `target.mode==='naddrUnsupported'` → `<div className="bsp-empty">{EVENT_COPY.UNSUPPORTED(target.kind)}</div>`; id/author → `renderResolvedEvent({ data, loading, error })`.
+  - **`export function renderResolvedEvent({ data, loading, error })`** — **pure** (no fetch/hook/router/globals): `loading && !data` → loading; `error || !data || !STATUSES.includes(data.status)` → a neutral "couldn’t load" (defensive); `OK` → `<NoteCard item={data.item} />`; `UNSUPPORTED_KIND` → `UNSUPPORTED(data.kind)`; `INVALID_EVENT` → `INVALID_EVENT`; `NOT_FOUND` → `NOT_FOUND`; `NO_AUTHOR_NOTE` → `NO_AUTHOR_NOTE` (each in a `bsp-empty` block).
+  - **`EventSearch`** (component, exported for sentinels): controlled input + Enter button; on submit `const c = classifyEventInput(input)` → if `c` → `setParams({ [c.paramName]: c.value })` (navigates in-page → `resolveEventParams` re-runs); else show `EVENT_COPY.SEARCH_INVALID`. Shows `EVENT_COPY.SEARCH_PROMPT` as the label/placeholder.
+- **Styles `ui/src/styles.css`** — reuse `bsp-page`/`bsp-content`/`bsp-empty`/`bsp-note-card-*`; add minimal `bsp-event-*` (search input, notice) using existing tokens; cap column + wrap (no 1280px overflow — `bsp-content` is already capped, `bsp-note-card-text` already wraps).
+- **No App.jsx change** (the `/event` route exists). **No new dependency, no tooling, no concept/firmware change. `NoteCard.jsx` not edited.**
+
+### Testability
+Source-sentinels (the `ui/src/*.jsx` house pattern) **plus** real unit tests for the pure `eventParam.js` (it's plain JS + `nip19`, executes in the Node runner — like `nostrEntities` is tested in `live-feed-feed-page.test.js` T20-T23):
+- `eventParam.js` (execute): `resolveEventParams` precedence (multiple valid → first by ORDER; malformed supported → `invalidParams`; unknown names ignored); each of the 6 decodes; `naddr`→`naddrUnsupported`+kind; `classifyEventInput` (bech32 dispatch; bare-hex→id; junk→null; canonical paramName). Fixtures minted with `nip19` (self-validating), as the feed suite does.
+- Sentinels: `BrainstormEvent.jsx` renders via `<NoteCard item=`, exports pure `renderResolvedEvent`, has the `EVENT_COPY` strings + each status branch, renders `<EventSearch>` when no target, and the naddr→unsupported branch; `useEventResolve.js` fetches `/api/event` + returns `{data,loading,error}` + aborts; `EventSearch` classifies + `setParams`/navigates on valid, shows the notice on invalid.
+- Rendered confirmation (the reference `nevent`, an author lookup, the search field, an `naddr`) is the **staging** capstone (local Docker avoided — parallel session).
+
+## Out of scope
+- The read/fetch/verify/relay logic (ADR 0001).
+- Rendering non-kind-1 events; threads/replies/reactions; multiple results.
+- NIP-05 / free-text search; autocomplete/history.
+- Any write/publish; changes to the feed, profiles, ranking, firmware, or existing note link targets.

--- a/engineering-team/epics/event-page.md
+++ b/engineering-team/epics/event-page.md
@@ -1,0 +1,37 @@
+# Epic: Event Page
+
+**Status:** Active
+**Provenance:** Operator request 2026-06-18 (this session), immediately after the `note-surfaces` epic shipped to staging. Builds on the shared note seam (`NoteCard` + `enrichNotes`) and the relay-set resolution pattern established by `live-feed` / `note-surfaces`.
+
+## What this is
+A working public **`/event`** single-event view (currently a placeholder). It resolves a **kind-1** note from one of two entry modes and renders it like the `/feed` page:
+
+- A **supported URL parameter** identifying an event or an author, or
+- A **search field** (shown only when no valid parameter is present) into which a person pastes one of the supported identifiers.
+
+Six identifier formats are supported, in this precedence: **`nevent` › `id` › `naddr` › `pubkey` › `npub` › `nprofile`**. `nevent`/`id` resolve a specific event; `pubkey`/`npub`/`nprofile` resolve that author's most-recent kind-1; `naddr` is recognized but — because addressable events are always kind 30000–39999, never kind-1 — reported as a not-yet-supported kind.
+
+Every fetch looks across a **relay union**: relay hints embedded in `nevent`/`nprofile`, **plus** the author's outbox (their published NIP-65 write relays) when resolvable, **plus** the instance's well-known relays (the general-purpose relay set, else a fixed fallback).
+
+**Scope: kind-1 only.** Additive and read-only — it adds the `/event` view and its supporting read path; it performs no writes and does not change search, the feed, profiles, ranking, or firmware.
+
+## Stories
+`stories/event-page/`:
+1. **event-read-path** — the backend read path: given an event id (with optional relay hints) **or** an author pubkey, fetch across the relay union (hints + author outbox + well-known/fallback), verify, kind-gate, and enrich into the shared note item shape — returning a discriminated set of outcomes (found-kind-1 / unsupported-kind / does-not-validate / not-found / no-author-note). Testable without the page.
+2. **event-page-param-render** — the `/event` page's URL-parameter path: parse the 6 params by precedence, distinguish malformed-supported (flag as invalid) from unsupported names (ignore), decode `naddr` to its kind locally, and render the resolved event (via `NoteCard`) or the precise outcome message. Consumes #1.
+3. **event-page-search** — the no-parameter fallback: a search field that validates a pasted string against the 6 formats and resolves it exactly as the equivalent URL parameter, or reports "not a recognized format." Shown only when no valid parameter is present.
+
+**Dependency order:** #1 first; #2 then #3 (same page; #3 adds the fallback surface). #2 and #3 both consume #1.
+
+## Out of scope (whole epic)
+- Rendering any non-kind-1 event — addressable/long-form (kind 30023), reposts (kind 6), reactions (kind 7), etc. (`naddr` and non-kind-1 `nevent`/`id` resolve to a "kind ‹N› not yet supported" message, not a rendered view).
+- Threads / replies / comments / reactions *on* the shown event; "load more"; navigating between events.
+- Any write/publish; relay-hint editing; auth/login gating.
+- Changing the existing note `nostr:` link targets, the feed, profiles, ranking, or firmware.
+
+## Concepts (referenced, not re-defined)
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-kind` — kind-1 (the event shown), kind-0 (author/mention display), kind-10002 (the author's NIP-65 outbox relay list).
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-user` — the event author / the looked-up author (by pubkey).
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-relay` + `39999:…:the-set-of-general-purpose-relays` — the well-known relay set (else the fixed fallback).
+
+> Handles mirror those recorded by `live-feed` / `note-surfaces`; the Architect should re-resolve against the target instance's own Tapestry Assistant (never a hardcoded identifier).

--- a/engineering-team/follow-ups.md
+++ b/engineering-team/follow-ups.md
@@ -127,3 +127,13 @@ Story 20 retired `ui/src/pages/PinDetail.jsx`; `/pin/:dTag` now redirects (via `
 3. Verify the export-section assertion against the **changed pin-row match key**: `PinnedListPanel` matches the export row by `p.pinEventId === viewerPin.pinEventId` (old `PinDetail` matched by tag identity). The `mockPinsRoute` row uses `pinEventId: PIN_EVENT_ID`, so it aligns iff the mocked `viewerPin.pinEventId` is also `PIN_EVENT_ID`.
 
 **To resume:** re-run `/review-changes` after the spec is fixed → expect PASS → then retire Story 20 (Status: Done, `git mv` story + test-plan to `stories/done/`, update path refs) and ship via the deploy chain. Full detail in `engineering-team/reviews/20-pin-detail-into-tag-pinned-tab.md` (Blocking #1) and its non-blocking notes (orphan `tabpanel` ARIA when unpinned; `PinnedListPanel` fetch-while-hidden; pre-existing "default 2" string in `PinsMemberCountHint`).
+
+## Consolidate relay-sourcing into `_shared/relaySource.js` (re-point the shipped read paths)
+
+**Surfaced during:** `note-surfaces` Architecture (ADR 0001, 2026-06-18, deferred) and again at `event-page` Architecture (ADR `event-page/0001`, 2026-06-18) — the **3rd consumer** of the relay-sourcing helpers (`resolveGeneralPurposeRelays` / `realQuerySync` / `realScanStrfry` / `resolveGeneralPurposeRelays` + fallback).
+
+**State now:** `src/api/_shared/relaySource.js` exists (created by the `event-page` epic; `eventReadPath.js` consumes it). But `src/api/feed/feedReadPath.js` and `src/api/notes/userNotesReadPath.js` **still carry their own private copies** of those helpers — Option A deliberately left them byte-unchanged so each epic stayed additive and didn't entangle the feed's prod-promotion sequencing.
+
+**The fix:** re-point `feedReadPath.js` + `userNotesReadPath.js` to import the sourcing primitives from `_shared/relaySource.js` and delete their private copies. Behavior-preserving; guarded by the existing `live-feed-read-path` + `note-surfaces-read-path` suites + a staging re-smoke of `/feed` and `/user/:pubkey/notes`.
+
+**Caveat for whoever does it:** `_shared/relaySource.realQuerySync` is the **verifying** SimplePool (the feed's only verification gate). The **event** path intentionally uses its *own* NO-VERIFY `querySync` (so `buildEvent`'s `verify()` can surface the distinct `INVALID_EVENT` outcome) — do **not** unify those two `querySync` variants, or the feed/user-notes would start returning unverified events.

--- a/engineering-team/reviews/event-page/1-event-page-implementation.md
+++ b/engineering-team/reviews/event-page/1-event-page-implementation.md
@@ -1,0 +1,45 @@
+# Review: Epic event-page — /event view + by-id/by-author read path (stories #1–#3)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-06-18
+**Diff:** `git diff origin/staging..feat/event-page` (base `da269ba8`, impl `efeca754`) — **7 files, +570 / −20** (additive). (NB: the local `staging` ref is stale at `d6e41193`; reviewed against `origin/staging`, the real fork point.)
+**Stories:** `event-page/{1-event-read-path, 2-event-page-param-render, 3-event-page-search}.md`
+**ADRs:** `event-page/{0001-event-read-path, 0002-event-page-ui}.md`
+**Method:** Reviewer audit + a 3-lens adversarial sub-review (correctness / ADR-conformance / invariants-security), 10 agents, every finding independently verified (**7 raw → 7 confirmed real**: 2 non-blocking-correctness, 1 non-blocking-hygiene, 4 nits).
+
+## Quality gates (run by the reviewer)
+- [x] **`npm test` (new suites)** — `event-page-read-path` **21/21**, `event-page-ui` **12/12**.
+- [x] **`npm test` (full)** — only the **same 12 pre-existing environmental** tag/pin publish-flow suites FAIL (`fetch failed`, need the live stack); `live-feed` (×2) + `note-surfaces` (×2) all PASS → **no regression**.
+- [x] **Isolated `vite build`** — ✓ exit 0 (the reworked page + new util/hook compile).
+- [ ] Playwright / rendered-UI — not run locally (parallel session owns the Docker stack); the rendered proof (reference `nevent`, author lookup, search submit, `naddr`, 1280px) is the **staging** capstone (ADR §Testability).
+- [n/a] lint/typecheck — not configured.
+
+## Spec & ADR adherence
+- [x] **Option A honored:** `src/api/_shared/relaySource.js` extracted; `feedReadPath.js`, `userNotesReadPath.js`, `NoteCard.jsx` are **byte-unchanged** (confirmed: not in the diff name-list). No `App.jsx` change (route pre-existed). `enrichNotes` reused, not re-implemented.
+- [x] Discriminated outcomes (`OK`/`UNSUPPORTED_KIND`/`INVALID_EVENT`/`NOT_FOUND`/`NO_AUTHOR_NOTE`/`INVALID`), handler `INVALID`→400; 6-param precedence; `naddr` client-side (no fetch); kind-gate; relay union assembled (hints + outbox + well-known/fallback).
+- [~] **Deviation (finding #1):** the page drops the `nevent`-carried author, so the by-id **outbox** leg of the relay union is unreachable from the UI (the server supports it). See Findings.
+- [~] **Spec-fidelity gap (finding #2):** with the real verifying `SimplePool`, `INVALID_EVENT` is unreachable in production (folds into `NOT_FOUND`). See Findings.
+
+## Architecture invariants (CLAUDE.md)
+- [x] **POV-first:** correct — `/event` resolves an event by id or an author's *own* latest note; nothing point-of-view-dependent, no per-POV truth computed.
+- [x] **No hardcoded TA pubkey:** the well-known set resolves the TA at runtime via `getOwnerAssistantPubkey()` in `_shared/relaySource.js:75`. No literal pubkey anywhere.
+- [x] **Security:** `HEX64` validated before any relay/Neo4j I/O (`buildEvent` `INVALID` short-circuit); the copied `strfry scan` is reached only with validated/local pubkeys; outbox r-tag parsing tolerates malformed tags; `verify()` only ever sees fresh relay JSON (no verified-Symbol caching trick). No secrets, no `console.log`/debug, no commented-out/dead code, no new dependency.
+
+## Findings
+
+### Required before merge (2)
+1. **`ui/src/pages/BrainstormEvent.jsx:42–48` — `nevent` author dropped → by-id outbox leg never engaged (real, non-blocking).** `fetchArg` sets `author: target.mode === 'author' ? target.author : undefined`, so for an `nevent` (mode `'id'`, which carries `author`) the author hint is forced to `undefined`. `buildEvent` *does* consult the author's outbox for a by-id request when an author rides along (`eventReadPath.js:101-104`), but the UI never sends it — so the relay union for `nevent` links is only hints + well-known, missing the author-outbox the AC/ADR specify (the **most common** case: note `nostr:nevent` links carry the author). The event still resolves via well-known + the nevent's own hints, so non-blocking — but a direct spec miss. **Asked change:** forward the author regardless of mode — `author: target.author` (or pass the whole id/author target; `useEventResolve` reads only `{id,author,relays}`). *No test currently covers by-id+author union — add one.*
+
+2. **`src/api/event/eventReadPath.js:106–111` — the distinct `INVALID_EVENT` ("does not validate") outcome is unreachable in production (real, non-blocking; operator-specified behavior).** The real `SimplePool` gates events through `verifyEvent` at relay-receive (`pool.js:393`), so a signature-failing event is dropped upstream → `events.find(e=>e.id===id)` is `undefined` → `NOT_FOUND`. `buildEvent`'s own `verify()` only ever sees already-verified events, so the `INVALID_EVENT` branch is dead with the real dep (the B3 test reaches it only via an injected fake). **Safety holds** (an unverified event is never shown as `OK` — it becomes `NOT_FOUND`). But the operator explicitly asked for a distinct "does not validate" indication, and Story #1's AC requires the four by-id outcomes to be *mutually distinct* — neither the story nor ADR documents this fold. **Decision needed (see gate):** either (a) make it reachable — the event path fetches with a **no-verify** `SimplePool` (`new SimplePool({ verifyEvent: () => true })`, confirmed supported) so `buildEvent`'s `verify()` is the sole gate; this stays in the event path's own `querySync` so `_shared`'s verifying `querySync` is untouched (the feed relies on it as its only gate); or (b) document the fold-into-`NOT_FOUND` as a known limitation in ADR 0001 + Story #1.
+
+### Non-blocking (hygiene) — fix
+3. **`engineering-team/follow-ups.md` (absent) — the deferred consolidation isn't actually logged** despite ADR 0001, `_shared/relaySource.js`, and this epic asserting it is. **Asked change:** add the entry ("re-point `feedReadPath`/`userNotesReadPath` to `_shared/relaySource.js`, delete their private copies — behavior-preserving, guarded by their read-path suites").
+
+### Nits (optional)
+4. **`src/api/_shared/relaySource.js:4–9,22` — "copied verbatim" overstates it:** `FALLBACK_RELAYS` order differs (here primal/nos.lol/damus; feed/user-notes damus/primal/nos.lol). Harmless (order-agnostic union), but soften the comment or align the order.
+5. **`test/event-page-read-path.test.js` B6 — doesn't assert the by-author outcome carries exactly one item** (asserts the chosen note's content/pubkey only). Cheap to tighten.
+6. **Story #2 1280px-no-overflow AC** has no automated test (deferred to the staging capstone, by design — `bsp-content` is width-capped + `bsp-note-card-text` wraps). Acceptable.
+7. **Story #3 search "resolves like the URL param" loop** is verified at source level (classify is executed; the navigate→re-render→resolve loop is the staging capstone). Acceptable.
+
+## Verdict
+**CHANGES_REQUESTED** — two real (non-blocking) correctness items: #1 (forward the `nevent` author so the by-id outbox leg works — a one-line UI fix + a test) and #2 (the operator-specified "does not validate" outcome, currently unreachable in production — needs an operator decision: deliver via a no-verify event fetch, or document the fold). Plus logging the deferred follow-up (#3). All quality gates otherwise pass; POV-first and no-TA-hardcode invariants honored; strictly additive (`feedReadPath`/`userNotesReadPath`/`NoteCard` byte-unchanged).

--- a/engineering-team/reviews/event-page/1-event-page-implementation.md
+++ b/engineering-team/reviews/event-page/1-event-page-implementation.md
@@ -41,5 +41,17 @@
 6. **Story #2 1280px-no-overflow AC** has no automated test (deferred to the staging capstone, by design — `bsp-content` is width-capped + `bsp-note-card-text` wraps). Acceptable.
 7. **Story #3 search "resolves like the URL param" loop** is verified at source level (classify is executed; the navigate→re-render→resolve loop is the staging capstone). Acceptable.
 
+## Verdict (initial)
+**CHANGES_REQUESTED** — two real (non-blocking) correctness items (#1 `nevent`-author/outbox; #2 unreachable does-not-validate) + log the deferred follow-up (#3). All other gates pass.
+
+## Re-review (post-fix) — 2026-06-18, commit `f227fa22`
+Operator chose "deliver the distinct outcome." The Implementer applied:
+- **#1 resolved.** `BrainstormEvent.jsx` `fetchArg` now forwards `author: target.author` regardless of mode → an `nevent`'s embedded author reaches the read path, so `buildEvent` consults that author's **outbox** in the by-id relay union. Covered by new tests **B13** (by-id+author → outbox in union) and **U11** (page forwards the author).
+- **#2 resolved (delivered).** The event path now fetches via a **no-verify `SimplePool`** (`new SimplePool({ verifyEvent: () => true })`) so `buildEvent`'s own `verify()` is the sole gate — a bad-sig event located by id now surfaces as the distinct **`INVALID_EVENT`** ("does not validate") instead of folding into `NOT_FOUND`. The by-id branch was hardened to pick the **verifying** match among id-collisions (new test **B14**). `_shared/relaySource.realQuerySync` stays verifying (the feed's only gate) — the two `querySync` variants are intentionally distinct (documented in code + the follow-up).
+- **#3 resolved.** The consolidation follow-up is now logged in `engineering-team/follow-ups.md` ("Consolidate relay-sourcing into `_shared/relaySource.js`"), including the don't-unify-the-two-querySync caveat.
+- Nits #4 (single-item assert) and #7 (comment) applied; #5/#6 (1280px + search e2e) remain the staging capstone, by design.
+
+Re-verification: `event-page-read-path` **23/23**, `event-page-ui` **13/13** (the +3 new tests pass); all changed files compile (`node --check` + esbuild). The fix touches only event-page files (feed/note-surfaces read none of them) → no regression; their suites stay green.
+
 ## Verdict
-**CHANGES_REQUESTED** — two real (non-blocking) correctness items: #1 (forward the `nevent` author so the by-id outbox leg works — a one-line UI fix + a test) and #2 (the operator-specified "does not validate" outcome, currently unreachable in production — needs an operator decision: deliver via a no-verify event fetch, or document the fold). Plus logging the deferred follow-up (#3). All quality gates otherwise pass; POV-first and no-TA-hardcode invariants honored; strictly additive (`feedReadPath`/`userNotesReadPath`/`NoteCard` byte-unchanged).
+**PASS** — all acceptance criteria covered by passing tests; ADR-conformant (Option A; `feedReadPath`/`userNotesReadPath`/`NoteCard` byte-unchanged); architecture invariants (POV-first, no TA hardcode) honored; the two real findings fixed and re-verified, the operator-specified does-not-validate outcome now delivered. Ready for the deploy chain (`cycle-staging`).

--- a/engineering-team/stories/event-page/1-event-read-path.md
+++ b/engineering-team/stories/event-page/1-event-read-path.md
@@ -46,4 +46,4 @@ Testable from the outside (input → observable outcome).
 ## Linked artifacts
 - ADR: `engineering-team/decisions/event-page/0001-event-read-path.md`
 - Test plan: `engineering-team/stories/event-page/1-event-read-path.test-plan.md`
-- Review: (filled in after Review)
+- Review: `engineering-team/reviews/event-page/1-event-page-implementation.md` (CHANGES_REQUESTED — 2026-06-18)

--- a/engineering-team/stories/event-page/1-event-read-path.md
+++ b/engineering-team/stories/event-page/1-event-read-path.md
@@ -45,5 +45,5 @@ Testable from the outside (input → observable outcome).
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/event-page/0001-event-read-path.md`
-- Test plan: (filled in after Test Design)
+- Test plan: `engineering-team/stories/event-page/1-event-read-path.test-plan.md`
 - Review: (filled in after Review)

--- a/engineering-team/stories/event-page/1-event-read-path.md
+++ b/engineering-team/stories/event-page/1-event-read-path.md
@@ -44,6 +44,6 @@ Testable from the outside (input → observable outcome).
 - **Source-of-fetch mechanism (relays vs anything local) and the outbox-resolution bootstrap are an Architecture concern**, not product intent. Product intent: look in the union above; return the distinct outcomes. (Local strfry is not a kind-1 archive — established in `note-surfaces` #1 — so events come from relays; enrichment stays local.) Not blocking story approval.
 
 ## Linked artifacts
-- ADR: (filled in after Architecture)
+- ADR: `engineering-team/decisions/event-page/0001-event-read-path.md`
 - Test plan: (filled in after Test Design)
 - Review: (filled in after Review)

--- a/engineering-team/stories/event-page/1-event-read-path.md
+++ b/engineering-team/stories/event-page/1-event-read-path.md
@@ -1,0 +1,49 @@
+# Story 1: Event read path — resolve a kind-1 by event reference or by author, across the relay union
+
+**Status:** Approved
+**Created:** 2026-06-18
+**Type:** Feature
+
+## Background
+The `/event` page (`event-page` #2/#3) needs a way to take a resolved target — **an event id** (from `nevent`/`id`, optionally carrying relay hints) **or an author pubkey** (from `pubkey`/`npub`/`nprofile`, optionally with hints) — and produce either a displayable kind-1 note or a precise reason it can't. This story builds **only that read path**, independent of the page.
+
+It extends the by-author idea from `note-surfaces` #1 with a **richer relay union** and an **event-id** mode, plus **verification** and **kind-gating**. Author display name + avatar (and in-text mention names) come from the instance's **local profile data**, exactly as the feed does — only the *selection* of the raw event differs.
+
+`naddr` is **not** handled here: an `naddr` carries its kind in the coordinate (always addressable, never kind-1), so the page reports "kind ‹N› not yet supported" without any fetch. This read path covers **by-id** and **by-author** only.
+
+Affected: anyone opening `/event`. Additive, read-only.
+
+## User-facing description
+As a visitor opening `/event`, I want the system to locate the referenced event — or the referenced author's most-recent note — across the relays where it's likely to live, verify it, and hand back either a displayable kind-1 or a precise, distinct reason (wrong kind / fails verification / not found / author has no note).
+
+## Acceptance criteria
+Testable from the outside (input → observable outcome).
+
+- [ ] **By event reference.** Given an **event id** (with any supplied relay hints), when the event is requested, the result is exactly one of: **found** (a kind-1 that verifies, as a displayable item); **unsupported-kind** (the located event verifies but is **not** kind-1 — the outcome carries the kind number); **does-not-validate** (an event with that id is located but fails signature/id verification); **not-found** (no event with that id in the relay union). The four are mutually distinct.
+
+- [ ] **By author (latest note).** Given an **author pubkey** (with any supplied hints), when requested, the result is **found** with that author's **single most-recent kind-1** (newest-first, verified) when one exists in the relay union, else a distinct **no-author-note** outcome.
+
+- [ ] **Relay union.** Every fetch consults the **union** of: (a) the **relay hints** supplied with the reference; (b) the author's **outbox** — their published NIP-65 (kind-10002) write relays — when those can be resolved; and (c) the instance's **well-known** relays — the general-purpose relay set resolved by slug relative to this instance's own Tapestry Assistant (never a hardcoded identifier) when locatable and non-empty, else the fixed fallback `relay.primal.net`, `nos.lol`, `relay.damus.io`. The well-known **set-vs-fallback** distinction is observable in the outcome (mirroring the feed).
+
+- [ ] **Verification.** A returned event is always signature/id-verified; an event that fails verification is **never** returned as a found kind-1 (for a by-id request it is the distinct does-not-validate outcome).
+
+- [ ] **Enriched, feed-shaped item.** A returned kind-1 carries the **same displayable item shape the feed serves** — id, author pubkey, timestamp, text, author `{ display name, avatar }`, and resolved `nostr:` mentions — with author/mention names drawn from the instance's **local profile data** (not the external relays the event came from), so the existing shared note card can render it unchanged.
+
+## Concepts touched
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-kind` — kind-1 (target), kind-0 (author/mention display), kind-10002 (author outbox).
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-user` — the event author / looked-up author.
+- `39999:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:the-set-of-general-purpose-relays` — the well-known set (else fallback).
+
+## Out of scope
+- The `/event` page itself — parameter parsing, the search field, the rendered states (`event-page` #2/#3).
+- `naddr` / addressable-event resolution (handled at the page from the coordinate's kind; no fetch).
+- Rendering / supporting any non-kind-1 kind (this path *classifies* the kind; it does not render).
+- Multiple results, threads/replies, pagination; any write/publish; changes to the feed read path, search, ranking, or firmware. The shared `enrichNotes` is reused, not modified.
+
+## Open questions
+- **Source-of-fetch mechanism (relays vs anything local) and the outbox-resolution bootstrap are an Architecture concern**, not product intent. Product intent: look in the union above; return the distinct outcomes. (Local strfry is not a kind-1 archive — established in `note-surfaces` #1 — so events come from relays; enrichment stays local.) Not blocking story approval.
+
+## Linked artifacts
+- ADR: (filled in after Architecture)
+- Test plan: (filled in after Test Design)
+- Review: (filled in after Review)

--- a/engineering-team/stories/event-page/1-event-read-path.md
+++ b/engineering-team/stories/event-page/1-event-read-path.md
@@ -1,6 +1,6 @@
 # Story 1: Event read path — resolve a kind-1 by event reference or by author, across the relay union
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-18
 **Type:** Feature
 
@@ -46,4 +46,4 @@ Testable from the outside (input → observable outcome).
 ## Linked artifacts
 - ADR: `engineering-team/decisions/event-page/0001-event-read-path.md`
 - Test plan: `engineering-team/stories/event-page/1-event-read-path.test-plan.md`
-- Review: `engineering-team/reviews/event-page/1-event-page-implementation.md` (CHANGES_REQUESTED — 2026-06-18)
+- Review: `engineering-team/reviews/event-page/1-event-page-implementation.md` (PASS — 2026-06-18)

--- a/engineering-team/stories/event-page/1-event-read-path.test-plan.md
+++ b/engineering-team/stories/event-page/1-event-read-path.test-plan.md
@@ -1,0 +1,66 @@
+# Test Plan: Story event-page #1 — Event read path
+
+**Story:** `engineering-team/stories/event-page/1-event-read-path.md`
+**ADR:** `engineering-team/decisions/event-page/0001-event-read-path.md`
+**Date:** 2026-06-18
+**Test file:** `test/event-page-read-path.test.js` (wired into `test/test.js`)
+
+## Scope
+Covers **Story #1 only — the backend read path** (`buildEvent` / `handleGetEvent` at `src/api/event/eventReadPath.js`, + the extracted `src/api/_shared/relaySource.js`). The page (#2/#3) is `test/event-page-ui.test.js`.
+
+## Test level & seam
+The outcomes are driven as **observable behavior** against `buildEvent`, with the three I/O boundaries injected as in-memory fakes (mirroring `note-surfaces`/`live-feed`, minus House-PoV):
+
+| Boundary | Fake |
+|---|---|
+| general-purpose relay set | `runCypher() → rows[]` |
+| external relay fetch (by-id / by-author / kind-10002 outbox) | `querySync(relays, filter) → events[]` — **records its `relays` arg** so the union is assertable |
+| local kind-0 (enrichment) | `scanStrfry(filter) → events[]` |
+
+**Honest verification:** fixtures are **genuinely signed** with `nostr-tools` `finalizeEvent`; "invalid" fixtures flip a sig char on a **clean JSON clone** (nostr-tools memoizes verification via a Symbol that object-spread copies — so clones, not spreads, force a real `verifyEvent` re-check). This was confirmed empirically before writing the suite.
+
+## Coverage map
+| Criterion | Test | Level |
+|---|---|---|
+| module/exports | `S1` eventReadPath exports buildEvent+handleGetEvent | structural |
+| Option A extract | `S2` `_shared/relaySource.js` exists + exports (FALLBACK incl. primal/nos.lol/damus) | structural |
+| endpoint | `S3` GET /api/event → handleGetEvent | structural |
+| reuse | `S4` requires `_shared/relaySource` + `_shared/noteEnrichment` (no re-impl) | structural |
+| **by-id** found | `B1` verified kind-1 → OK, feed-shaped item | behavioral |
+| **by-id** kind-gate | `B2` verified non-kind-1 → UNSUPPORTED_KIND (carries kind) | behavioral |
+| **by-id** verify | `B3` id matches but sig fails → INVALID_EVENT | behavioral |
+| **by-id** missing | `B4` no match → NOT_FOUND | behavioral |
+| **invalid input** | `B5` no valid id/author → INVALID, queries nothing | behavioral |
+| **by-author** | `B6` newest **verified** kind-1; skips unverified-newer + foreign author | behavioral |
+| **by-author** none | `B7` no verifiable kind-1 → NO_AUTHOR_NOTE | behavioral |
+| **relay union** | `B8` main fetch relays ⊇ hints + outbox-write + well-known; read-marked excluded | behavioral |
+| **set vs fallback** | `B9` set→"set"; empty→"fallback" with fixed relays in the union | behavioral |
+| fallback on error | `B10` runCypher throws → fallback, no crash | behavioral |
+| **outbox** | `B11` newest kind-10002 wins; only write-eligible r-tags | behavioral |
+| **item shape** | `B12` feed shape; author name from LOCAL kind-0; mentions map | behavioral |
+| handler | `H1` INVALID → 400 (hermetic, no I/O); `H2` source maps INVALID→400 / valid→200 | behavioral/source |
+| regression | `R1` feedReadPath untouched; `R2` userNotesReadPath untouched; `R3` enrichNotes seam intact | regression |
+
+## Edge cases
+- [x] Tampered/bad-sig event located by id → INVALID_EVENT (B3); unverified-newer skipped for the newest **verified** (B6).
+- [x] Foreign-author event excluded in by-author mode (B6).
+- [x] Empty / errored relay set → fallback (B9, B10); read-marked + superseded-older outbox relays excluded (B8, B11).
+- [x] INVALID short-circuits before any I/O (B5).
+
+### Deliberately NOT covered here
+- The page, param decode, search field, `naddr` (Story #2/#3, `event-page-ui.test.js`).
+- Live relay/Neo4j round-trip — the **staging** capstone (the reference `nevent`).
+- Re-pointing feed/user-notes to `_shared/relaySource` — deferred follow-up (R1/R2 assert they're untouched).
+
+## Test infrastructure
+Node runner via `npm test`; new suite exports `run()`, aggregated in `test/test.js`. `nostr-tools` (sign/verify/nip19) resolved via the worktree `node_modules` symlink. No live services; in-memory fakes for all three boundaries.
+
+## How to run
+```
+npm test
+# or just this suite:
+node -e "require('./test/event-page-read-path.test.js').run().then(r=>console.log(JSON.stringify(r)))"
+```
+
+## Verification
+Fails with current code — S/B/H fail because `src/api/event/eventReadPath.js` + `_shared/relaySource.js` don't exist (legible "feature not implemented"); R1–R3 PASS (shipped feed/user-notes + enrichNotes present and unmodified). Confirmed 2026-06-18 (isolated run: 3 pass / 18 fail). Output captured in the gate summary.

--- a/engineering-team/stories/event-page/2-event-page-param-render.md
+++ b/engineering-team/stories/event-page/2-event-page-param-render.md
@@ -46,5 +46,5 @@ None — the six parameters, precedence, invalid-vs-unsupported handling, naddr-
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/event-page/0002-event-page-ui.md`
-- Test plan: (filled in after Test Design)
+- Test plan: `engineering-team/stories/event-page/2-event-page-param-render.test-plan.md`
 - Review: (filled in after Review)

--- a/engineering-team/stories/event-page/2-event-page-param-render.md
+++ b/engineering-team/stories/event-page/2-event-page-param-render.md
@@ -47,4 +47,4 @@ None — the six parameters, precedence, invalid-vs-unsupported handling, naddr-
 ## Linked artifacts
 - ADR: `engineering-team/decisions/event-page/0002-event-page-ui.md`
 - Test plan: `engineering-team/stories/event-page/2-event-page-param-render.test-plan.md`
-- Review: (filled in after Review)
+- Review: `engineering-team/reviews/event-page/1-event-page-implementation.md` (CHANGES_REQUESTED — 2026-06-18)

--- a/engineering-team/stories/event-page/2-event-page-param-render.md
+++ b/engineering-team/stories/event-page/2-event-page-param-render.md
@@ -1,6 +1,6 @@
 # Story 2: `/event` page — resolve a URL parameter and render the event (or the precise outcome)
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-18
 **Type:** Feature
 
@@ -47,4 +47,4 @@ None — the six parameters, precedence, invalid-vs-unsupported handling, naddr-
 ## Linked artifacts
 - ADR: `engineering-team/decisions/event-page/0002-event-page-ui.md`
 - Test plan: `engineering-team/stories/event-page/2-event-page-param-render.test-plan.md`
-- Review: `engineering-team/reviews/event-page/1-event-page-implementation.md` (CHANGES_REQUESTED — 2026-06-18)
+- Review: `engineering-team/reviews/event-page/1-event-page-implementation.md` (PASS — 2026-06-18)

--- a/engineering-team/stories/event-page/2-event-page-param-render.md
+++ b/engineering-team/stories/event-page/2-event-page-param-render.md
@@ -1,0 +1,50 @@
+# Story 2: `/event` page — resolve a URL parameter and render the event (or the precise outcome)
+
+**Status:** Approved
+**Created:** 2026-06-18
+**Type:** Feature
+
+## Background
+The `/event` page is a placeholder today. This story makes it render a **kind-1** event identified by a **supported URL parameter**, reusing the read path (`event-page` #1) and the shared note card. The **search-field fallback** for when no valid parameter is present is a sibling story (`event-page` #3); this story covers the **parameter-driven** path and explicitly defers the no-parameter surface to #3.
+
+Six parameters are supported, in precedence **`nevent` › `id` › `naddr` › `pubkey` › `npub` › `nprofile`**. `naddr` is decoded locally to its kind (always addressable, never kind-1) and reported as not-yet-supported without a fetch.
+
+Affected: anyone opening `/event?…`. Front-end; consumes #1.
+
+## User-facing description
+As someone opening an `/event` link, I want the page to read the identifier from the URL, pick the right one when several are present, and show me the note (rendered like the feed) — or a clear, specific message when it can't (wrong kind, doesn't verify, not found, the author has no note, or my identifier was malformed).
+
+## Acceptance criteria
+Testable from the outside.
+
+- [ ] **Precedence.** Given a URL with **more than one valid** supported parameter, the page resolves using the **first valid** in the order `nevent` › `id` › `naddr` › `pubkey` › `npub` › `nprofile`.
+
+- [ ] **Invalid vs unsupported.** A **supported** parameter whose value is **malformed** (e.g. `?nevent=garbage`) is reported on-page as **invalid** (identifying which parameter). Parameter **names outside the six** are **silently ignored**.
+
+- [ ] **Event reference → render or outcome.** Given a valid `nevent`/`id`, the page shows: the note **rendered like the `/feed` page** (shared note card) when the read path returns a found kind-1; **"kind ‹N› not yet supported"** when it returns another kind; **"this event does not validate"** when verification fails; **"event not found"** when no such event. (Exactly one, matching the read path's outcome.)
+
+- [ ] **`naddr` → unsupported kind.** Given a valid `naddr`, the page shows **"kind ‹N› not yet supported"** (N taken from the naddr coordinate) — no fetch, since addressable events are never kind-1.
+
+- [ ] **Author → latest note or none.** Given a valid `pubkey`/`npub`/`nprofile`, the page shows that author's **most-recent kind-1 rendered like the feed**, or **"no kind-1 note found for this author."**
+
+- [ ] **Public, additive, no overflow.** `/event` is reachable with no login (HTTP 200, never a login wall), the change is additive (with the new view removed the app is unchanged), and at a 1280px-wide viewport the page produces **no horizontal overflow**.
+
+> Canonical outcome wording is operator-delegated; exact punctuation is non-binding so long as each message conveys its meaning. When a valid parameter is present, the search field (`event-page` #3) is **not** shown.
+
+## Concepts touched
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-kind` — kind-1 (rendered), other kinds (gated as "not yet supported").
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-user` — the event author / looked-up author.
+
+## Out of scope
+- The read/fetch/verify/relay logic (that is `event-page` #1).
+- The **no-parameter search field** + its format validation (`event-page` #3).
+- Rendering any non-kind-1 event; threads/replies/reactions; any write/publish.
+- Changing existing note `nostr:` link targets, the feed, profiles, ranking, or firmware.
+
+## Open questions
+None — the six parameters, precedence, invalid-vs-unsupported handling, naddr-as-unsupported-kind, and the kind-1 render were operator-resolved at Planning.
+
+## Linked artifacts
+- ADR: (filled in after Architecture)
+- Test plan: (filled in after Test Design)
+- Review: (filled in after Review)

--- a/engineering-team/stories/event-page/2-event-page-param-render.md
+++ b/engineering-team/stories/event-page/2-event-page-param-render.md
@@ -45,6 +45,6 @@ Testable from the outside.
 None — the six parameters, precedence, invalid-vs-unsupported handling, naddr-as-unsupported-kind, and the kind-1 render were operator-resolved at Planning.
 
 ## Linked artifacts
-- ADR: (filled in after Architecture)
+- ADR: `engineering-team/decisions/event-page/0002-event-page-ui.md`
 - Test plan: (filled in after Test Design)
 - Review: (filled in after Review)

--- a/engineering-team/stories/event-page/2-event-page-param-render.test-plan.md
+++ b/engineering-team/stories/event-page/2-event-page-param-render.test-plan.md
@@ -1,0 +1,47 @@
+# Test Plan: Story event-page #2 — `/event` page (param render)
+
+**Story:** `engineering-team/stories/event-page/2-event-page-param-render.md`
+**ADR:** `engineering-team/decisions/event-page/0002-event-page-ui.md`
+**Date:** 2026-06-18
+**Test file:** `test/event-page-ui.test.js` (shared with Story #3; wired into `test/test.js`)
+
+## Scope
+Covers **Story #2** — the URL-parameter path of the `/event` page: precedence parsing, invalid-vs-unsupported, `naddr`-as-unsupported-kind, and rendering the resolved event/outcome. The shared decode core (`eventParam.js`) and the hook are tested here; the search fallback is Story #3 (same file).
+
+## Test level
+The **decode/precedence/classify core is a pure `ui/src/utils/eventParam.js`** — plain JS + `nip19`, so it is **EXECUTED** in the Node runner via dynamic import (the pattern `nostrEntities` uses in `live-feed-feed-page.test.js` T20–T23), with **nip19-minted, self-validating fixtures**. The React page/hook are asserted at **source** level (no JSX transpile), anchored on the pure exported `renderResolvedEvent` + module-level `EVENT_COPY`. Rendered confirmation is the **staging** capstone.
+
+## Coverage map
+| Criterion | Test | Level |
+|---|---|---|
+| **precedence** | `U1` multiple valid → first by ORDER (nevent>id) | execute |
+| **invalid vs unsupported** | `U2` malformed supported → flagged; unknown name → ignored; first valid still wins | execute |
+| **decode 6 formats** | `U3` nevent/id/pubkey/npub/nprofile → fetch targets; naddr → naddrUnsupported+kind | execute |
+| **render + statuses** | `U5` page renders kind-1 via `<NoteCard>`; branches OK/UNSUPPORTED_KIND/INVALID_EVENT/NOT_FOUND/NO_AUTHOR_NOTE | source |
+| **naddr + no-target** | `U6` naddr → unsupported-kind branch; no target → `<EventSearch>`; uses resolveEventParams + useEventResolve | source |
+| **testability** | `U7` `renderResolvedEvent` named-exported + pure | source |
+| **copy** | `U9` EVENT_COPY has the outcome messages | source |
+| **hook** | `U10` `useEventResolve` fetches /api/event, returns {data,loading,error}, aborts, gates on success | source |
+| regression | `R1` /event route still → BrainstormEvent; `R2` NoteCard reused as-is | regression |
+
+## Edge cases
+- [x] Higher-precedence malformed + lower-precedence valid → valid wins, malformed flagged (U2).
+- [x] `naddr` resolved with no network (kind from the coordinate) (U3/U6).
+- [x] Every read-path status has a render branch (U5); the pure helper has no fetch/hook/router/globals (U7).
+
+### Deliberately NOT covered here
+- The read/fetch/verify/relay logic (Story #1).
+- The search field's submit/notice flow (Story #3, U4/U8 in the same file).
+- Rendered DOM — the **staging** capstone (the reference `nevent`, an author lookup, an `naddr`).
+
+## Test infrastructure
+Node runner; `eventParam.js` dynamically imported (ESM + `nip19`); React files source-asserted (`safeRead` + a `helperBody` slicer). No live services, no JSX transpile, no new tooling.
+
+## How to run
+```
+npm test
+# or: node -e "require('./test/event-page-ui.test.js').run().then(r=>console.log(JSON.stringify(r)))"
+```
+
+## Verification
+Fails with current code — `eventParam.js`, `useEventResolve.js`, and the reworked `BrainstormEvent.jsx` don't exist yet (U-tests fail "feature not implemented"); R1/R2 PASS (the /event route + NoteCard are present, unmodified). Confirmed 2026-06-18 (isolated run: 2 pass / 10 fail across the shared UI file). Output in the gate summary.

--- a/engineering-team/stories/event-page/3-event-page-search.md
+++ b/engineering-team/stories/event-page/3-event-page-search.md
@@ -36,6 +36,6 @@ Testable from the outside.
 None — the trigger condition (no valid parameter), the six accepted formats, the resolve-as-parameter behavior, and the not-recognized notice were operator-resolved at Planning.
 
 ## Linked artifacts
-- ADR: (filled in after Architecture)
+- ADR: `engineering-team/decisions/event-page/0002-event-page-ui.md`
 - Test plan: (filled in after Test Design)
 - Review: (filled in after Review)

--- a/engineering-team/stories/event-page/3-event-page-search.md
+++ b/engineering-team/stories/event-page/3-event-page-search.md
@@ -1,0 +1,41 @@
+# Story 3: `/event` page — the no-parameter search fallback
+
+**Status:** Approved
+**Created:** 2026-06-18
+**Type:** Feature
+
+## Background
+When `/event` is opened with **no valid supported parameter**, there's nothing to resolve. This story adds a **search field** that lets a person paste one of the six supported identifiers and resolve it — exactly as if it had been the URL parameter (`event-page` #2's render path). It is shown **only** when no valid parameter is present.
+
+Affected: anyone who opens a bare `/event` (or one whose only parameters are invalid/unsupported). Front-end; reuses #2's resolution + #1's read path.
+
+## User-facing description
+As someone who lands on `/event` with no usable identifier, I want a clearly-labelled field where I can paste an `nevent`, `id`, `naddr`, `pubkey`, `npub`, or `nprofile` and press Enter to see the event — and if what I typed isn't one of those formats, I want to be told that rather than left guessing.
+
+## Acceptance criteria
+Testable from the outside.
+
+- [ ] **Shown only when no valid parameter.** Given `/event` with **no valid** supported parameter (none supplied, or every supplied supported parameter is malformed, and any other names are unsupported), the page shows a **search field** prompting for one of the six formats (`nevent`, `id`, `naddr`, `pubkey`, `npub`, `nprofile`). Given a **valid** parameter **is** present, the search field is **not** shown.
+
+- [ ] **Submit a valid identifier → resolves.** When a string in **one of the six formats** is entered and submitted (Enter button / Enter key), the page resolves and renders it with **the same outcomes as the equivalent URL parameter** (`event-page` #2) — a rendered kind-1, an "unsupported kind", a "does not validate", a "not found", or an author's latest note / "no note".
+
+- [ ] **Submit a non-matching string → notice.** When a string matching **none** of the six formats is submitted, the page shows a **"not a recognized format"** notice and renders no event (the search field remains so the person can retry).
+
+> Canonical wording is operator-delegated; punctuation non-binding. Whether a successful submit also updates the URL (so the result is shareable) is an Architecture/UX detail, not a product requirement.
+
+## Concepts touched
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-kind` — kind-1 (the eventual render target).
+- `39998:e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36:nostr-user` — the looked-up author / event author.
+
+## Out of scope
+- The read/fetch logic (`event-page` #1) and the parameter-driven render path (`event-page` #2) — this story reuses both.
+- Autocomplete / search history / resolving anything other than the six exact formats (e.g. NIP-05 addresses, free-text search).
+- Any write/publish; changes to the feed, profiles, ranking, or firmware.
+
+## Open questions
+None — the trigger condition (no valid parameter), the six accepted formats, the resolve-as-parameter behavior, and the not-recognized notice were operator-resolved at Planning.
+
+## Linked artifacts
+- ADR: (filled in after Architecture)
+- Test plan: (filled in after Test Design)
+- Review: (filled in after Review)

--- a/engineering-team/stories/event-page/3-event-page-search.md
+++ b/engineering-team/stories/event-page/3-event-page-search.md
@@ -1,6 +1,6 @@
 # Story 3: `/event` page — the no-parameter search fallback
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-06-18
 **Type:** Feature
 
@@ -38,4 +38,4 @@ None — the trigger condition (no valid parameter), the six accepted formats, t
 ## Linked artifacts
 - ADR: `engineering-team/decisions/event-page/0002-event-page-ui.md`
 - Test plan: `engineering-team/stories/event-page/3-event-page-search.test-plan.md`
-- Review: `engineering-team/reviews/event-page/1-event-page-implementation.md` (CHANGES_REQUESTED — 2026-06-18)
+- Review: `engineering-team/reviews/event-page/1-event-page-implementation.md` (PASS — 2026-06-18)

--- a/engineering-team/stories/event-page/3-event-page-search.md
+++ b/engineering-team/stories/event-page/3-event-page-search.md
@@ -38,4 +38,4 @@ None — the trigger condition (no valid parameter), the six accepted formats, t
 ## Linked artifacts
 - ADR: `engineering-team/decisions/event-page/0002-event-page-ui.md`
 - Test plan: `engineering-team/stories/event-page/3-event-page-search.test-plan.md`
-- Review: (filled in after Review)
+- Review: `engineering-team/reviews/event-page/1-event-page-implementation.md` (CHANGES_REQUESTED — 2026-06-18)

--- a/engineering-team/stories/event-page/3-event-page-search.md
+++ b/engineering-team/stories/event-page/3-event-page-search.md
@@ -37,5 +37,5 @@ None — the trigger condition (no valid parameter), the six accepted formats, t
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/event-page/0002-event-page-ui.md`
-- Test plan: (filled in after Test Design)
+- Test plan: `engineering-team/stories/event-page/3-event-page-search.test-plan.md`
 - Review: (filled in after Review)

--- a/engineering-team/stories/event-page/3-event-page-search.test-plan.md
+++ b/engineering-team/stories/event-page/3-event-page-search.test-plan.md
@@ -1,0 +1,43 @@
+# Test Plan: Story event-page #3 — `/event` page (search fallback)
+
+**Story:** `engineering-team/stories/event-page/3-event-page-search.md`
+**ADR:** `engineering-team/decisions/event-page/0002-event-page-ui.md`
+**Date:** 2026-06-18
+**Test file:** `test/event-page-ui.test.js` (shared with Story #2; wired into `test/test.js`)
+
+## Scope
+Covers **Story #3** — the no-parameter search fallback: the `classifyEventInput` core, and the `EventSearch` field that resolves a pasted string by navigating to the canonical URL param (or shows a "not recognized" notice). Shown only when no valid parameter is present.
+
+## Test level
+`classifyEventInput` lives in the pure `ui/src/utils/eventParam.js` → **EXECUTED** with nip19-minted fixtures. The `EventSearch` component + the "shown only when no valid param" wiring are **source** sentinels.
+
+## Coverage map
+| Criterion | Test | Level |
+|---|---|---|
+| **classify → canonical param** | `U4` nevent/npub/nprofile/naddr → their paramName; **bare hex → id** (precedence); junk/empty → null | execute |
+| **shown only when no valid param** | `U6` page renders `<EventSearch>` only when `resolveEventParams` yields no target | source |
+| **submit valid → resolve** | `U8` EventSearch uses classifyEventInput → `setParams`/navigate to the canonical `/event?<type>=<value>` on a match | source |
+| **submit invalid → notice** | `U8` non-matching → `EVENT_COPY.SEARCH_INVALID` notice; input present | source |
+| **copy** | `U9` EVENT_COPY has the search prompt + not-recognized messages | source |
+
+## Edge cases
+- [x] **Hex ambiguity:** a bare 64-hex (valid as both id and pubkey) classifies as **id** by precedence (U4) — the documented search-field rule (paste an npub/nprofile to look up an author by key).
+- [x] Empty input → null → notice path (U4).
+- [x] Search resolution reuses the param-render path by navigating to the canonical URL (U8) — no duplicate fetch logic.
+
+### Deliberately NOT covered here
+- The read path (Story #1) and the param-render branches (Story #2, U1–U3/U5/U7/U10 in the same file).
+- NIP-05 / free-text / autocomplete (out of scope).
+- Rendered DOM of a search submit — the **staging** capstone.
+
+## Test infrastructure
+Same as Story #2's plan — Node runner, `eventParam.js` executed via dynamic import, `EventSearch` source-asserted (sliced from the page source). No live services / JSX transpile / new tooling.
+
+## How to run
+```
+npm test
+# or: node -e "require('./test/event-page-ui.test.js').run().then(r=>console.log(JSON.stringify(r)))"
+```
+
+## Verification
+Fails with current code — `classifyEventInput` (eventParam.js) and `EventSearch` (BrainstormEvent.jsx) don't exist yet (U4/U8 fail "feature not implemented"). Confirmed 2026-06-18 within the shared UI suite (2 pass / 10 fail). Output in the gate summary.

--- a/src/api/_shared/relaySource.js
+++ b/src/api/_shared/relaySource.js
@@ -1,0 +1,98 @@
+/**
+ * Shared relay-sourcing primitives — extracted (ADR event-page/0001, Option A) so the
+ * THIRD consumer of this logic (the event read path) doesn't add a third inline copy.
+ *
+ * These are copied verbatim from src/api/feed/feedReadPath.js (the original home). The
+ * feed and per-user-notes read paths still carry their own private copies for now;
+ * re-pointing them here and deleting those copies is a tracked, behavior-preserving
+ * follow-up (engineering-team/follow-ups.md) — deliberately deferred to keep the
+ * event-page epic additive (it touches no shipped read path).
+ *
+ * Exports: resolveGeneralPurposeRelays, realQuerySync, realScanStrfry, realRunCypher,
+ * FALLBACK_RELAYS, RELAY_SET_SLUG, FETCH_TIMEOUT_MS, NOSTR_TOOLS_PATH, WS_PATH.
+ */
+
+// nostr-tools / ws via the container's absolute path (the fetchEvents.js / feedReadPath.js
+// convention); required lazily inside realQuerySync so this module loads in test/CI.
+const NOSTR_TOOLS_PATH = '/usr/local/lib/node_modules/brainstorm/node_modules/nostr-tools';
+const WS_PATH = '/usr/local/lib/node_modules/brainstorm/node_modules/ws';
+
+const FETCH_TIMEOUT_MS = 8000;
+const FALLBACK_RELAYS = ['wss://relay.primal.net', 'wss://nos.lol', 'wss://relay.damus.io'];
+const RELAY_SET_SLUG = 'the-set-of-general-purpose-relays';
+
+/** Local strfry scan (kind-0 / kind-3 / etc.), parsing JSONL. */
+function realScanStrfry(filter) {
+  const { execSync } = require('child_process');
+  const filterStr = typeof filter === 'string' ? filter : JSON.stringify(filter);
+  const raw = execSync(`strfry scan '${filterStr.replace(/'/g, "\\'")}'`, {
+    timeout: 5000, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const events = [];
+  for (const line of raw.trim().split('\n')) {
+    if (!line) continue;
+    try { events.push(JSON.parse(line)); } catch { /* skip non-event log lines */ }
+  }
+  return events;
+}
+
+/** Relay-set resolution via Neo4j. */
+function realRunCypher(cypher, params) {
+  return require('../../lib/neo4j-driver').runCypher(cypher, params);
+}
+
+/** External event fetch via SimplePool, with a hard timeout. */
+async function realQuerySync(relays, filter) {
+  if (typeof globalThis.WebSocket === 'undefined') {
+    globalThis.WebSocket = require(WS_PATH);
+  }
+  const { SimplePool } = require(NOSTR_TOOLS_PATH);
+  const pool = new SimplePool();
+  try {
+    return await Promise.race([
+      pool.querySync(relays, filter),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), FETCH_TIMEOUT_MS)),
+    ]);
+  } finally {
+    try { pool.close(relays); } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Resolve the general-purpose relay set by slug-from-TA. Empty / error ⇒ the fixed fallback
+ * relays. → { relays: string[], source: 'set' | 'fallback' }.
+ */
+async function resolveGeneralPurposeRelays(runCypher) {
+  try {
+    const ta = require('../../utils/assistantKeys').getOwnerAssistantPubkey();
+    const handle = `39999:${ta}:${RELAY_SET_SLUG}`;
+    const rows = await runCypher(
+      'MATCH (s:Set {uuid:$h})-[:HAS_ELEMENT]->(m:ListItem) WHERE NOT m:Superset ' +
+      'MATCH (m)-[:HAS_TAG]->(jt:NostrEventTag {type:\'json\'}) RETURN jt.value AS json',
+      { h: handle }
+    );
+    const relays = [];
+    for (const row of rows || []) {
+      try {
+        const url = JSON.parse(row.json)?.nostrRelay?.websocketUrl;
+        if (typeof url === 'string' && (url.startsWith('wss://') || url.startsWith('ws://'))) {
+          relays.push(url);
+        }
+      } catch { /* skip unparseable member */ }
+    }
+    if (relays.length > 0) return { relays, source: 'set' };
+  } catch { /* fall through to fallback */ }
+  return { relays: FALLBACK_RELAYS.slice(), source: 'fallback' };
+}
+
+module.exports = {
+  resolveGeneralPurposeRelays,
+  realQuerySync,
+  realScanStrfry,
+  realRunCypher,
+  FALLBACK_RELAYS,
+  RELAY_SET_SLUG,
+  FETCH_TIMEOUT_MS,
+  NOSTR_TOOLS_PATH,
+  WS_PATH,
+};

--- a/src/api/_shared/relaySource.js
+++ b/src/api/_shared/relaySource.js
@@ -2,8 +2,9 @@
  * Shared relay-sourcing primitives — extracted (ADR event-page/0001, Option A) so the
  * THIRD consumer of this logic (the event read path) doesn't add a third inline copy.
  *
- * These are copied verbatim from src/api/feed/feedReadPath.js (the original home). The
- * feed and per-user-notes read paths still carry their own private copies for now;
+ * These are adapted from src/api/feed/feedReadPath.js (the original home) — same logic; the
+ * FALLBACK_RELAYS array lists the same relays in a different order (order is irrelevant — the
+ * union dedups). The feed and per-user-notes read paths still carry their own private copies;
  * re-pointing them here and deleting those copies is a tracked, behavior-preserving
  * follow-up (engineering-team/follow-ups.md) — deliberately deferred to keep the
  * event-page epic additive (it touches no shipped read path).

--- a/src/api/event/eventReadPath.js
+++ b/src/api/event/eventReadPath.js
@@ -25,7 +25,7 @@
  */
 
 const {
-  resolveGeneralPurposeRelays, realQuerySync, realScanStrfry, realRunCypher, NOSTR_TOOLS_PATH,
+  resolveGeneralPurposeRelays, realScanStrfry, realRunCypher, NOSTR_TOOLS_PATH, WS_PATH, FETCH_TIMEOUT_MS,
 } = require('../_shared/relaySource');
 const { enrichNotes } = require('../_shared/noteEnrichment');
 
@@ -53,6 +53,30 @@ function unionRelays(...lists) {
     for (const r of onlyWs(list)) { if (!seen.has(r)) { seen.add(r); out.push(r); } }
   }
   return out;
+}
+
+/**
+ * External fetch for the event path — deliberately a NO-VERIFY SimplePool, so signature-failing
+ * events are delivered to buildEvent (whose own verify() is then the sole gate). This is what
+ * makes the distinct INVALID_EVENT ("does not validate") outcome reachable in production: the
+ * default verifying pool drops bad-sig events at relay-receive, folding them into NOT_FOUND.
+ * Safety is unchanged — buildEvent never returns an unverified event as OK. (The shared
+ * _shared/relaySource.realQuerySync stays verifying for the feed, which has no other gate.)
+ */
+async function realQuerySync(relays, filter) {
+  if (typeof globalThis.WebSocket === 'undefined') {
+    globalThis.WebSocket = require(WS_PATH);
+  }
+  const { SimplePool } = require(NOSTR_TOOLS_PATH);
+  const pool = new SimplePool({ verifyEvent: () => true });
+  try {
+    return await Promise.race([
+      pool.querySync(relays, filter),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), FETCH_TIMEOUT_MS)),
+    ]);
+  } finally {
+    try { pool.close(relays); } catch { /* ignore */ }
+  }
 }
 
 /**
@@ -105,9 +129,13 @@ async function buildEvent(options = {}) {
 
   if (validId) {
     const events = (await querySync(union, { ids: [id] })) || [];
-    const ev = events.find(e => e && e.id === id);
-    if (!ev) return { status: 'NOT_FOUND', relaySource };
-    if (!verify(ev)) return { status: 'INVALID_EVENT', relaySource };
+    const matching = events.filter(e => e && e.id === id);
+    if (matching.length === 0) return { status: 'NOT_FOUND', relaySource };
+    // The fetch isn't verified at the relay layer, so a bad-sig event with the target id is
+    // delivered (→ distinct INVALID_EVENT, not NOT_FOUND). Prefer a VERIFYING match — a valid
+    // copy wins over a co-located spoofed one; only if no match verifies is it INVALID_EVENT.
+    const ev = matching.find(verify);
+    if (!ev) return { status: 'INVALID_EVENT', relaySource };
     if (ev.kind !== 1) return { status: 'UNSUPPORTED_KIND', kind: ev.kind, relaySource };
     const [item] = await enrichNotes([ev], scanStrfry);
     return { status: 'OK', relaySource, item };

--- a/src/api/event/eventReadPath.js
+++ b/src/api/event/eventReadPath.js
@@ -1,0 +1,142 @@
+/**
+ * Event read path (Story event-page #1, ADR event-page/0001 — Option A).
+ *
+ * A self-contained, additive, read-only module that resolves a single kind-1 event for the
+ * /event page: either by event id (from nevent/id) or the most-recent kind-1 by a given author
+ * (from pubkey/npub/nprofile). Events are fetched from a RELAY UNION — supplied hints + the
+ * author's outbox (NIP-65 kind-10002 write relays) + the instance's well-known relays (the
+ * general-purpose set, else the fixed fallback) — verified, kind-gated, and enriched into the
+ * shared feed item shape (author/mention names from LOCAL kind-0).
+ *
+ * naddr is NOT handled here: its kind is in the coordinate (addressable, never kind-1), so the
+ * page reports "kind <N> not yet supported" without a fetch. This path is by-id / by-author only.
+ *
+ * Exports:
+ *   - buildEvent(options) — discriminated `status` union { OK, UNSUPPORTED_KIND, INVALID_EVENT,
+ *     NOT_FOUND, NO_AUTHOR_NOTE, INVALID } (+ `relaySource` { set, fallback } on the fetched
+ *     outcomes; `kind` on UNSUPPORTED_KIND; `item` (feed shape) on OK).
+ *   - handleGetEvent(req, res) — public GET /api/event (INVALID → 400; else 200 { success, ... }).
+ *
+ * Injectable dependency seam (mirrors feedReadPath / userNotesReadPath): buildEvent reads its
+ * three I/O boundaries from options, each defaulting to the real helper (from _shared/relaySource):
+ *   - scanStrfry(filter)     — local kind-0 (via enrichNotes)
+ *   - runCypher(cypher,prms) — general-purpose relay-set resolution
+ *   - querySync(relays,flt)  — external fetch (by-id / by-author / kind-10002 outbox)
+ */
+
+const {
+  resolveGeneralPurposeRelays, realQuerySync, realScanStrfry, realRunCypher, NOSTR_TOOLS_PATH,
+} = require('../_shared/relaySource');
+const { enrichNotes } = require('../_shared/noteEnrichment');
+
+const HEX64 = /^[0-9a-f]{64}$/i;
+const AUTHOR_FETCH_CAP = 10;   // newest batch to verify through for a by-author lookup
+const OUTBOX_FETCH_CAP = 5;    // newest kind-10002s to consider for the outbox
+
+let _verifyEvent;
+function verify(ev) {
+  if (_verifyEvent === undefined) {
+    try { _verifyEvent = require(NOSTR_TOOLS_PATH).verifyEvent; }
+    catch { try { _verifyEvent = require('nostr-tools').verifyEvent; } catch { _verifyEvent = null; } }
+  }
+  if (!_verifyEvent) return false;
+  try { return _verifyEvent(ev) === true; } catch { return false; }
+}
+
+function onlyWs(arr) {
+  return (arr || []).filter(r => typeof r === 'string' && (r.startsWith('wss://') || r.startsWith('ws://')));
+}
+function unionRelays(...lists) {
+  const seen = new Set();
+  const out = [];
+  for (const list of lists) {
+    for (const r of onlyWs(list)) { if (!seen.has(r)) { seen.add(r); out.push(r); } }
+  }
+  return out;
+}
+
+/**
+ * The author's outbox = write-eligible relays from their newest NIP-65 kind-10002, fetched from
+ * the bootstrap relays. Read-marked r-tags are excluded. Missing / none → [].
+ */
+async function fetchOutboxRelays(author, bootstrapRelays, querySync) {
+  if (!author || !HEX64.test(author) || bootstrapRelays.length === 0) return [];
+  let events = [];
+  try { events = (await querySync(bootstrapRelays, { kinds: [10002], authors: [author], limit: OUTBOX_FETCH_CAP })) || []; }
+  catch { return []; }
+  const lists = events.filter(ev => ev && ev.kind === 10002 && ev.pubkey === author);
+  if (lists.length === 0) return [];
+  const newest = lists.reduce((a, b) => (b.created_at > a.created_at ? b : a));
+  const relays = [];
+  for (const t of newest.tags || []) {
+    if (!Array.isArray(t) || t[0] !== 'r' || typeof t[1] !== 'string' || !t[1]) continue;
+    if (t[2] === 'read') continue; // write-eligible only (no marker = read+write)
+    relays.push(t[1]);
+  }
+  return onlyWs(relays);
+}
+
+/**
+ * Resolve a single kind-1 for /event. See the discriminated-outcome contract in the header.
+ * @param {Object} options - { id?, author?, relays? } plus optional injected deps (spread or
+ *   under options.deps): scanStrfry, runCypher, querySync.
+ */
+async function buildEvent(options = {}) {
+  const { id, author, relays, deps } = options;
+  const scanStrfry = deps?.scanStrfry ?? options.scanStrfry ?? realScanStrfry;
+  const runCypher = deps?.runCypher ?? options.runCypher ?? realRunCypher;
+  const querySync = deps?.querySync ?? options.querySync ?? realQuerySync;
+
+  const validId = typeof id === 'string' && HEX64.test(id);
+  const validAuthor = typeof author === 'string' && HEX64.test(author);
+
+  // Mode: by-id wins; else by-author; else INVALID (no relays/Neo4j queried).
+  if (!validId && !validAuthor) return { status: 'INVALID' };
+
+  const hints = onlyWs(relays);
+  const { relays: wellKnown, source: relaySource } = await resolveGeneralPurposeRelays(runCypher);
+
+  // Outbox lookup whenever we know an author (by-author always; by-id when an author hint rode
+  // along, e.g. from an nevent). Bootstrap from hints + well-known.
+  const outbox = validAuthor
+    ? await fetchOutboxRelays(author, unionRelays(hints, wellKnown), querySync)
+    : [];
+  const union = unionRelays(hints, outbox, wellKnown);
+
+  if (validId) {
+    const events = (await querySync(union, { ids: [id] })) || [];
+    const ev = events.find(e => e && e.id === id);
+    if (!ev) return { status: 'NOT_FOUND', relaySource };
+    if (!verify(ev)) return { status: 'INVALID_EVENT', relaySource };
+    if (ev.kind !== 1) return { status: 'UNSUPPORTED_KIND', kind: ev.kind, relaySource };
+    const [item] = await enrichNotes([ev], scanStrfry);
+    return { status: 'OK', relaySource, item };
+  }
+
+  // by-author: newest VERIFIED kind-1 by this author.
+  const events = (await querySync(union, { kinds: [1], authors: [author], limit: AUTHOR_FETCH_CAP })) || [];
+  const candidates = events
+    .filter(e => e && e.kind === 1 && e.pubkey === author)
+    .sort((a, b) => b.created_at - a.created_at);
+  const chosen = candidates.find(verify);
+  if (!chosen) return { status: 'NO_AUTHOR_NOTE', relaySource };
+  const [item] = await enrichNotes([chosen], scanStrfry);
+  return { status: 'OK', relaySource, item };
+}
+
+/** GET /api/event — public, read-only. INVALID → 400; OK/EMPTY-ish outcomes → 200. */
+async function handleGetEvent(req, res) {
+  try {
+    const { id, author, relays } = req.query || {};
+    const relayList = typeof relays === 'string' ? relays.split(',').map(r => r.trim()).filter(Boolean) : undefined;
+    const r = await buildEvent({ id, author, relays: relayList });
+    if (r.status === 'INVALID') {
+      return res.status(400).json({ success: false, ...r, error: 'no valid id or author' });
+    }
+    return res.json({ success: true, ...r });
+  } catch (err) {
+    return res.status(500).json({ success: false, error: err.message });
+  }
+}
+
+module.exports = { buildEvent, handleGetEvent, fetchOutboxRelays };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -83,6 +83,7 @@ const { handleFetchExternalReactions } = require('./reactions/fetchReactions.js'
 const { handleFetchExternalEvents } = require('./relay/fetchEvents.js');
 const { handleGetFeed } = require('./feed/feedReadPath.js');
 const { handleGetUserNotes } = require('./notes/userNotesReadPath.js');
+const { handleGetEvent } = require('./event/eventReadPath.js');
 const { requireOwner, handleGetSettings, handleGetDefaults, handleGetOverrides, handleUpdateSettings, handleResetSetting } = require('./settings/settingsApi.js');
 const { handleGetGrapevinePreferences, handleUpdateGrapevinePreferences } = require('./settings/grapevinePrefApi.js');
 const { handleGetUserPrefs, handleUpdateUserPrefs } = require('./settings/userPrefsApi.js');
@@ -309,6 +310,9 @@ async function register(app) {
 
     // By-author notes read path (public, read-only) — Story note-surfaces #1, ADR note-surfaces/0001
     app.get('/api/user/:pubkey/notes', handleGetUserNotes);
+
+    // Event read path (public, read-only) — Story event-page #1, ADR event-page/0001
+    app.get('/api/event', handleGetEvent);
 
     // Settings endpoints (owner-only except GET merged)
     // /api/grapevine/preferences writes to the HOUSE config (settings.grapevine.searchPreferences)

--- a/test/event-page-read-path.test.js
+++ b/test/event-page-read-path.test.js
@@ -1,0 +1,328 @@
+/**
+ * Story event-page #1: Event read path. ADR event-page/0001.
+ * See engineering-team/stories/event-page/1-event-read-path.test-plan.md
+ *
+ * ADR chose Option A: a self-contained src/api/event/eventReadPath.js exporting
+ * buildEvent({ id, author, relays, deps }) + handleGetEvent, using a NEW
+ * src/api/_shared/relaySource.js (extracted sourcing primitives) + the reused
+ * enrichNotes. It returns a discriminated `status` union
+ *   { OK, UNSUPPORTED_KIND, INVALID_EVENT, NOT_FOUND, NO_AUTHOR_NOTE, INVALID }
+ * plus, on the fetched outcomes, a `relaySource` { set, fallback }; an OK item is
+ * the feed shape { id, pubkey, createdAt, content, author:{displayName,avatar}, mentions }.
+ *
+ * WHY behavioral with REAL signed fixtures: verification is a load-bearing AC
+ * (does-not-validate). We mint genuinely-signed events with nostr-tools so
+ * verifyEvent is exercised honestly. NOTE: nostr-tools memoizes verification via a
+ * Symbol that object-spread COPIES — so every fixture is passed through a JSON clone
+ * (drops the cache) and "invalid" fixtures flip a sig char on the clone, forcing a
+ * real re-check. buildEvent crosses three injected I/O boundaries (scanStrfry /
+ * runCypher / querySync); the relay union (hints + outbox + well-known) is asserted
+ * by recording the relay arg the querySync fake receives.
+ *
+ * ALL S/B/H tests FAIL pre-implementation (modules absent); R* regression sentinels
+ * PASS before AND after (Option A leaves the shipped feed/user-notes read paths
+ * untouched).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { generateSecretKey, getPublicKey, finalizeEvent } = require('nostr-tools');
+
+const MODULE_PATH = path.resolve(__dirname, '../src/api/event/eventReadPath.js');
+const SHARED_PATH = path.resolve(__dirname, '../src/api/_shared/relaySource.js');
+const API_INDEX = path.resolve(__dirname, '../src/api/index.js');
+const FEED_READ_PATH = path.resolve(__dirname, '../src/api/feed/feedReadPath.js');
+const USER_NOTES_PATH = path.resolve(__dirname, '../src/api/notes/userNotesReadPath.js');
+const SHARED_ENRICH = path.resolve(__dirname, '../src/api/_shared/noteEnrichment.js');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+function loadModule() {
+  try { delete require.cache[require.resolve(MODULE_PATH)]; } catch { /* not resolvable yet */ }
+  try { return require(MODULE_PATH); } catch { return null; }
+}
+
+// ── Fixtures: genuinely signed events (clean clones; no carried verify-Symbol) ──
+const SK = generateSecretKey(); const PK = getPublicKey(SK);       // the author
+const SK2 = generateSecretKey(); const PK2 = getPublicKey(SK2);    // a different author
+function signed(sk, tpl) {
+  return JSON.parse(JSON.stringify(finalizeEvent({ created_at: 1000, tags: [], content: '', ...tpl }, sk)));
+}
+// Flip one signature char on a CLEAN clone → verifyEvent recomputes → false (id unchanged).
+function badSig(ev) {
+  const c = JSON.parse(JSON.stringify(ev));
+  c.sig = (c.sig[0] === 'a' ? 'b' : 'a') + c.sig.slice(1);
+  return c;
+}
+function kind0(pubkey, profile) {
+  return { id: 'k0-' + pubkey.slice(0, 6), kind: 0, pubkey, created_at: 50, tags: [], content: JSON.stringify(profile) };
+}
+function kind10002(pubkey, rTags, created_at) {
+  return { id: 'k10-' + created_at, kind: 10002, pubkey, created_at, tags: rTags, content: '' };
+}
+
+const DEFAULT_SET_ROWS = [
+  { json: JSON.stringify({ nostrRelay: { websocketUrl: 'wss://wk-a.example' } }) },
+  { json: JSON.stringify({ nostrRelay: { websocketUrl: 'wss://wk-b.example' } }) },
+];
+
+function makeDeps({ mainEvents = [], kind10002s = [], kind0s = [], runCypher } = {}) {
+  const calls = [];
+  const deps = {
+    scanStrfry: (filter) => {
+      const f = typeof filter === 'string' ? JSON.parse(filter) : filter;
+      if (Array.isArray(f.kinds) && f.kinds.includes(0)) return kind0s;
+      return [];
+    },
+    runCypher: runCypher || (async () => DEFAULT_SET_ROWS),
+    querySync: async (relays, filter) => {
+      const f = filter || {};
+      calls.push({ relays: relays || [], filter: f });
+      if (Array.isArray(f.kinds) && f.kinds.includes(10002)) return kind10002s;
+      return mainEvents;
+    },
+  };
+  return { deps, calls };
+}
+function mainCall(calls) { return calls.find(c => !((c.filter.kinds || []).includes(10002))); }
+
+async function callBuildEvent(mod, opts, deps) {
+  assert(mod && typeof mod.buildEvent === 'function',
+    'src/api/event/eventReadPath.js must export an async `buildEvent` — feature not implemented yet (ADR event-page/0001).');
+  return mod.buildEvent({ ...opts, deps, ...deps });
+}
+
+// ===========================================================================
+// STRUCTURAL
+// ===========================================================================
+
+test('S1: src/api/event/eventReadPath.js exists and exports buildEvent + handleGetEvent (ADR §Decision)', () => {
+  const mod = loadModule();
+  assert(mod !== null, 'src/api/event/eventReadPath.js does not load yet — the Implementer must create the event read-path module (ADR event-page/0001 Option A).');
+  assert(typeof mod.buildEvent === 'function', 'eventReadPath.js must export `buildEvent`.');
+  assert(typeof mod.handleGetEvent === 'function', 'eventReadPath.js must export `handleGetEvent` (the GET /api/event handler).');
+});
+
+test('S2: src/api/_shared/relaySource.js exists and exports the extracted sourcing primitives (ADR §Decision Option A)', () => {
+  const src = safeRead(SHARED_PATH);
+  assert(src.length > 0, 'src/api/_shared/relaySource.js does not exist yet — Option A extracts the shared sourcing here.');
+  let mod = null; try { mod = require(SHARED_PATH); } catch { mod = null; }
+  assert(mod && typeof mod.resolveGeneralPurposeRelays === 'function', 'relaySource.js must export resolveGeneralPurposeRelays.');
+  assert(Array.isArray(mod.FALLBACK_RELAYS) && mod.FALLBACK_RELAYS.some(r => /relay\.primal\.net/.test(r)) && mod.FALLBACK_RELAYS.some(r => /nos\.lol/.test(r)) && mod.FALLBACK_RELAYS.some(r => /relay\.damus\.io/.test(r)),
+    'relaySource.js must export FALLBACK_RELAYS including relay.primal.net, nos.lol, relay.damus.io.');
+});
+
+test('S3: GET /api/event is registered to handleGetEvent in src/api/index.js (ADR §Impl)', () => {
+  const src = safeRead(API_INDEX);
+  assert(/['"]\/api\/event['"]/.test(src), "src/api/index.js must register the public route '/api/event'.");
+  assert(/handleGetEvent/.test(src), 'src/api/index.js must wire /api/event to handleGetEvent.');
+});
+
+test('S4 (reuse): eventReadPath requires _shared/relaySource AND the shared enrichNotes (no re-implementation)', () => {
+  const src = safeRead(MODULE_PATH);
+  assert(src.length > 0, 'eventReadPath.js does not exist yet.');
+  assert(/require\(\s*['"]\.\.\/_shared\/relaySource['"]\s*\)/.test(src),
+    'eventReadPath.js must require the extracted ../_shared/relaySource (Option A: the new path consumes the shared home, no inline 3rd copy).');
+  assert(/require\(\s*['"]\.\.\/_shared\/noteEnrichment['"]\s*\)/.test(src) && /enrichNotes/.test(src),
+    'eventReadPath.js must reuse enrichNotes from ../_shared/noteEnrichment.');
+});
+
+// ===========================================================================
+// BY EVENT ID (AC: by event reference)
+// ===========================================================================
+
+test('B1 (AC by-id): a located, verified kind-1 yields OK with that event as a feed-shaped item', async () => {
+  const mod = loadModule();
+  const ev = signed(SK, { kind: 1, created_at: 200, content: 'hello world' });
+  const { deps, calls } = makeDeps({ mainEvents: [ev], kind0s: [kind0(PK, { name: 'Alice' })] });
+  const r = await callBuildEvent(mod, { id: ev.id }, deps);
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  assert(r.item && r.item.id === ev.id && r.item.pubkey === PK && r.item.content === 'hello world',
+    `OK must carry the located event as the item; got ${JSON.stringify(r.item && { id: r.item.id, content: r.item.content })}.`);
+  assert(mainCall(calls), 'the main fetch must have been issued.');
+});
+
+test('B2 (AC by-id): a located, verified NON-kind-1 yields UNSUPPORTED_KIND carrying the kind', async () => {
+  const mod = loadModule();
+  const ev = signed(SK, { kind: 6, created_at: 200, content: '' }); // a repost
+  const { deps } = makeDeps({ mainEvents: [ev] });
+  const r = await callBuildEvent(mod, { id: ev.id }, deps);
+  assert(r && r.status === 'UNSUPPORTED_KIND', `a non-kind-1 event must yield UNSUPPORTED_KIND; got ${JSON.stringify(r && r.status)}.`);
+  assert(r.kind === 6, `UNSUPPORTED_KIND must carry the kind number (6); got ${JSON.stringify(r.kind)}.`);
+});
+
+test('B3 (AC by-id): an event located by id but failing verification yields INVALID_EVENT (does not validate)', async () => {
+  const mod = loadModule();
+  const ev = signed(SK, { kind: 1, created_at: 200, content: 'real' });
+  const tampered = badSig(ev); // same id, broken signature → verifyEvent false
+  const { deps } = makeDeps({ mainEvents: [tampered] });
+  const r = await callBuildEvent(mod, { id: ev.id }, deps);
+  assert(r && r.status === 'INVALID_EVENT', `an event that fails verification must yield INVALID_EVENT; got ${JSON.stringify(r && r.status)}.`);
+});
+
+test('B4 (AC by-id): no event with that id in the relay union yields NOT_FOUND', async () => {
+  const mod = loadModule();
+  const ev = signed(SK, { kind: 1, created_at: 200, content: 'x' });
+  const { deps } = makeDeps({ mainEvents: [] });
+  const r = await callBuildEvent(mod, { id: ev.id }, deps);
+  assert(r && r.status === 'NOT_FOUND', `no matching event must yield NOT_FOUND; got ${JSON.stringify(r && r.status)}.`);
+});
+
+test('B5 (AC invalid input): neither a valid id nor a valid author yields INVALID and queries nothing', async () => {
+  const mod = loadModule();
+  const { deps, calls } = makeDeps({});
+  const r = await callBuildEvent(mod, { id: 'not-hex', author: '' }, deps);
+  assert(r && r.status === 'INVALID', `a malformed id with no author must yield INVALID; got ${JSON.stringify(r && r.status)}.`);
+  assert(calls.length === 0, 'INVALID must short-circuit before any relay query.');
+});
+
+// ===========================================================================
+// BY AUTHOR (AC: latest note)
+// ===========================================================================
+
+test('B6 (AC by-author): returns the newest VERIFIED kind-1 by the author — skipping an unverified-newer and a foreign-author event', async () => {
+  const mod = loadModule();
+  const authorValidOld = signed(SK, { kind: 1, created_at: 100, content: 'the one' });
+  const authorInvalidNew = badSig(signed(SK, { kind: 1, created_at: 200, content: 'broken newer' }));
+  const foreignValidNewest = signed(SK2, { kind: 1, created_at: 300, content: 'someone else' });
+  const { deps } = makeDeps({ mainEvents: [foreignValidNewest, authorInvalidNew, authorValidOld], kind0s: [kind0(PK, { name: 'Alice' })] });
+  const r = await callBuildEvent(mod, { author: PK }, deps);
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  assert(r.item.content === 'the one' && r.item.pubkey === PK,
+    `must pick the newest VERIFIED kind-1 by the requested author (skip unverified-newer + foreign); got ${JSON.stringify(r.item && { c: r.item.content, pk: r.item.pubkey.slice(0, 6) })}.`);
+});
+
+test('B7 (AC by-author): an author with no verifiable kind-1 yields NO_AUTHOR_NOTE', async () => {
+  const mod = loadModule();
+  const { deps } = makeDeps({ mainEvents: [] });
+  const r = await callBuildEvent(mod, { author: PK }, deps);
+  assert(r && r.status === 'NO_AUTHOR_NOTE', `no kind-1 for the author must yield NO_AUTHOR_NOTE; got ${JSON.stringify(r && r.status)}.`);
+});
+
+// ===========================================================================
+// RELAY UNION + OUTBOX + WELL-KNOWN
+// ===========================================================================
+
+test('B8 (AC relay union): the main fetch consults hints + author outbox (kind-10002 write relays) + well-known set', async () => {
+  const mod = loadModule();
+  const ev = signed(SK, { kind: 1, created_at: 100, content: 'x' });
+  const outbox = kind10002(PK, [['r', 'wss://outbox-write.example'], ['r', 'wss://outbox-read.example', 'read']], 5);
+  const { deps, calls } = makeDeps({ mainEvents: [ev], kind10002s: [outbox] });
+  const r = await callBuildEvent(mod, { author: PK, relays: ['wss://hint.example'] }, deps);
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  const mc = mainCall(calls);
+  assert(mc, 'a main (non-kind-10002) fetch must have been issued.');
+  const set = new Set(mc.relays);
+  assert(set.has('wss://hint.example'), `the union must include the supplied relay hint; got ${JSON.stringify(mc.relays)}.`);
+  assert(set.has('wss://outbox-write.example'), `the union must include the author's WRITE outbox relay; got ${JSON.stringify(mc.relays)}.`);
+  assert(set.has('wss://wk-a.example') && set.has('wss://wk-b.example'), `the union must include the well-known set relays; got ${JSON.stringify(mc.relays)}.`);
+  assert(!set.has('wss://outbox-read.example'), `a READ-marked outbox relay must NOT be added (write relays only); got ${JSON.stringify(mc.relays)}.`);
+});
+
+test('B9 (AC relay source): resolvable set → relaySource "set"; empty set → "fallback" with the fixed relays in the union', async () => {
+  const mod = loadModule();
+  const ev = signed(SK, { kind: 1, created_at: 100, content: 'x' });
+  const setRes = await callBuildEvent(mod, { id: ev.id }, makeDeps({ mainEvents: [ev] }).deps);
+  assert(setRes.relaySource === 'set', `a resolvable set must give relaySource 'set'; got ${JSON.stringify(setRes.relaySource)}.`);
+
+  const fb = makeDeps({ mainEvents: [ev], runCypher: async () => [] });
+  const fbRes = await callBuildEvent(mod, { id: ev.id }, fb.deps);
+  assert(fbRes.relaySource === 'fallback', `an empty set must give relaySource 'fallback'; got ${JSON.stringify(fbRes.relaySource)}.`);
+  const mc = mainCall(fb.calls);
+  assert(mc.relays.some(r => /relay\.primal\.net|nos\.lol|relay\.damus\.io/.test(r)),
+    `the fallback union must include the fixed fallback relays; got ${JSON.stringify(mc.relays)}.`);
+});
+
+test('B10 (AC relay source): a runCypher error degrades to the fallback relays, not a crash', async () => {
+  const mod = loadModule();
+  const ev = signed(SK, { kind: 1, created_at: 100, content: 'x' });
+  const r = await callBuildEvent(mod, { id: ev.id }, makeDeps({ mainEvents: [ev], runCypher: async () => { throw new Error('neo4j down'); } }).deps);
+  assert(r && r.status === 'OK' && r.relaySource === 'fallback',
+    `a relay-set resolution error must degrade to 'fallback', not throw; got ${JSON.stringify(r && { s: r.status, rs: r.relaySource })}.`);
+});
+
+test('B11 (AC outbox): the NEWEST kind-10002 wins and only write-eligible r-tags are used', async () => {
+  const mod = loadModule();
+  const ev = signed(SK, { kind: 1, created_at: 100, content: 'x' });
+  const older = kind10002(PK, [['r', 'wss://older-write.example']], 1);
+  const newer = kind10002(PK, [['r', 'wss://newer-write.example'], ['r', 'wss://newer-read.example', 'read']], 9);
+  const { deps, calls } = makeDeps({ mainEvents: [ev], kind10002s: [older, newer] });
+  await callBuildEvent(mod, { author: PK }, deps);
+  const set = new Set(mainCall(calls).relays);
+  assert(set.has('wss://newer-write.example'), 'the newest kind-10002 write relay must be in the union.');
+  assert(!set.has('wss://older-write.example'), 'an OLDER kind-10002 must be superseded by the newest (its relays not used).');
+  assert(!set.has('wss://newer-read.example'), 'a read-marked relay in the newest kind-10002 must be excluded.');
+});
+
+test('B12 (AC item shape): an OK item is the feed shape with author name from LOCAL kind-0 + a mentions map', async () => {
+  const mod = loadModule();
+  const ev = signed(SK, { kind: 1, created_at: 100, content: 'hi there' });
+  const { deps } = makeDeps({ mainEvents: [ev], kind0s: [kind0(PK, { display_name: 'Alice Local', picture: 'https://local/a.png' })] });
+  const r = await callBuildEvent(mod, { id: ev.id }, deps);
+  assert(r.status === 'OK', `expected OK; got ${JSON.stringify(r.status)}.`);
+  const it = r.item;
+  assert(it && it.id === ev.id && it.pubkey === PK && it.createdAt === 100 && it.content === 'hi there',
+    'item must carry id/pubkey/createdAt/content (createdAt mapped from created_at).');
+  assert(it.author && it.author.displayName === 'Alice Local' && it.author.avatar === 'https://local/a.png',
+    `author name/avatar must come from the LOCAL kind-0 scan; got ${JSON.stringify(it.author)}.`);
+  assert(it.mentions && typeof it.mentions === 'object', 'item must carry a mentions map (feed shape).');
+});
+
+// ===========================================================================
+// HANDLER
+// ===========================================================================
+
+test('H1 (AC invalid): handleGetEvent responds 400 { success:false, status:"INVALID" } for no valid id/author (no live I/O)', async () => {
+  const mod = loadModule();
+  assert(mod && typeof mod.handleGetEvent === 'function', 'handleGetEvent must be exported (feature absent).');
+  let statusCode = 200; let body = null;
+  const req = { query: { id: 'not-hex' } };
+  const res = { status(c) { statusCode = c; return this; }, json(b) { body = b; return this; } };
+  await mod.handleGetEvent(req, res);
+  assert(statusCode === 400, `a malformed/absent id+author must respond 400; got ${statusCode}.`);
+  assert(body && body.success === false && body.status === 'INVALID', `the 400 body must be { success:false, status:'INVALID', ... }; got ${JSON.stringify(body)}.`);
+});
+
+test('H2 (handler mapping): the source maps INVALID → 400 and the valid outcomes → 200 (success body)', () => {
+  const src = safeRead(MODULE_PATH);
+  assert(src.length > 0, 'eventReadPath.js does not exist yet.');
+  assert(/400/.test(src) && /INVALID/.test(src), 'the handler must respond 400 on the INVALID outcome.');
+  assert(/success:\s*true/.test(src), 'the handler must respond { success:true, ...result } for the valid outcomes.');
+});
+
+// ===========================================================================
+// REGRESSION — Option A: the shipped feed/user-notes read paths are NOT modified
+// ===========================================================================
+
+test('R1: feedReadPath.js is untouched — still self-contained (own resolveGeneralPurposeRelays, FEED_CAP=50, exports)', () => {
+  const src = safeRead(FEED_READ_PATH);
+  assert(src.length > 0, 'src/api/feed/feedReadPath.js missing — unexpected.');
+  assert(/function resolveGeneralPurposeRelays/.test(src), 'feedReadPath.js must KEEP its own resolveGeneralPurposeRelays — Option A defers re-pointing it to _shared/relaySource.');
+  assert(/FEED_CAP\s*=\s*50/.test(src) && /module\.exports\s*=\s*\{\s*buildFeed\s*,\s*handleGetFeed\s*\}/.test(src),
+    'feedReadPath.js must be unchanged (FEED_CAP=50; exports buildFeed/handleGetFeed).');
+});
+
+test('R2: userNotesReadPath.js is untouched — still self-contained and exporting its contract', () => {
+  const src = safeRead(USER_NOTES_PATH);
+  assert(src.length > 0, 'src/api/notes/userNotesReadPath.js missing — unexpected.');
+  assert(/function resolveGeneralPurposeRelays/.test(src), 'userNotesReadPath.js must KEEP its own resolveGeneralPurposeRelays — Option A defers re-pointing it.');
+  assert(/NOTES_CAP\s*=\s*50/.test(src) && /handleGetUserNotes/.test(src), 'userNotesReadPath.js must be unchanged (NOTES_CAP=50; exports handleGetUserNotes).');
+});
+
+test('R3: the shared enrichNotes seam still exports enrichNotes (reused, not modified)', () => {
+  const src = safeRead(SHARED_ENRICH);
+  assert(/enrichNotes/.test(src) && /PROFILE_LOOKUP_CAP/.test(src), 'noteEnrichment.js must still export enrichNotes + PROFILE_LOOKUP_CAP (reused unchanged).');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try { await t.fn(); console.log(`  ✓ ${t.name}`); pass++; }
+    catch (err) { console.log(`  ✗ ${t.name}`); console.log(`      ${err.message}`); fail++; }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/event-page-read-path.test.js
+++ b/test/event-page-read-path.test.js
@@ -192,6 +192,8 @@ test('B6 (AC by-author): returns the newest VERIFIED kind-1 by the author — sk
   assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
   assert(r.item.content === 'the one' && r.item.pubkey === PK,
     `must pick the newest VERIFIED kind-1 by the requested author (skip unverified-newer + foreign); got ${JSON.stringify(r.item && { c: r.item.content, pk: r.item.pubkey.slice(0, 6) })}.`);
+  assert(r.item && r.items === undefined,
+    'by-author OK must carry a SINGLE `item` (the latest note), not an `items` array.');
 });
 
 test('B7 (AC by-author): an author with no verifiable kind-1 yields NO_AUTHOR_NOTE', async () => {
@@ -268,6 +270,29 @@ test('B12 (AC item shape): an OK item is the feed shape with author name from LO
   assert(it.author && it.author.displayName === 'Alice Local' && it.author.avatar === 'https://local/a.png',
     `author name/avatar must come from the LOCAL kind-0 scan; got ${JSON.stringify(it.author)}.`);
   assert(it.mentions && typeof it.mentions === 'object', 'item must carry a mentions map (feed shape).');
+});
+
+test('B13 (AC relay union, by-id): a by-id request carrying an author hint (e.g. from an nevent) ALSO consults that author\'s outbox', async () => {
+  const mod = loadModule();
+  const ev = signed(SK, { kind: 1, created_at: 100, content: 'x' });
+  const outbox = kind10002(PK, [['r', 'wss://outbox-write.example']], 5);
+  const { deps, calls } = makeDeps({ mainEvents: [ev], kind10002s: [outbox] });
+  const r = await callBuildEvent(mod, { id: ev.id, author: PK, relays: ['wss://hint.example'] }, deps);
+  assert(r && r.status === 'OK', `expected OK; got ${JSON.stringify(r && r.status)}.`);
+  const set = new Set(mainCall(calls).relays);
+  assert(set.has('wss://outbox-write.example'),
+    `a by-id request with an author hint must include the author's outbox write relay in the union; got ${JSON.stringify(mainCall(calls).relays)}.`);
+  assert(set.has('wss://hint.example'), 'the supplied hint must also be in the union.');
+});
+
+test('B14 (AC by-id, verify): among events sharing the target id, a VERIFYING one wins over a co-located bad-sig event', async () => {
+  const mod = loadModule();
+  const ev = signed(SK, { kind: 1, created_at: 200, content: 'authentic' });
+  const spoof = badSig(ev); // same id, broken signature
+  const { deps } = makeDeps({ mainEvents: [spoof, ev] }); // the bad copy arrives first
+  const r = await callBuildEvent(mod, { id: ev.id }, deps);
+  assert(r && r.status === 'OK', `a verifying copy must win over a co-located spoof → OK (not INVALID_EVENT); got ${JSON.stringify(r && r.status)}.`);
+  assert(r.item && r.item.content === 'authentic', 'the verifying event must be the one returned.');
 });
 
 // ===========================================================================

--- a/test/event-page-ui.test.js
+++ b/test/event-page-ui.test.js
@@ -129,6 +129,15 @@ test('U6 (#2 naddr + search wiring): naddr → "unsupported kind" branch; no val
   assert(/resolveEventParams/.test(src) && /useEventResolve/.test(src), 'the page must use resolveEventParams (decode) + useEventResolve (fetch id/author).');
 });
 
+test('U11 (#1 review): the page forwards the (nevent) author to the read path so the by-id outbox leg is engaged', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormEvent.jsx does not exist yet.');
+  // An nevent is an id-mode target but carries an author whose outbox the server should consult.
+  // fetchArg must forward target.author regardless of mode (review finding #1) — not gate it on author-mode.
+  assert(/author:\s*target\.author/.test(src),
+    'fetchArg must forward `author: target.author` so an nevent target sends its embedded author (→ server consults the author outbox); gating it on author-mode drops it.');
+});
+
 test('U7 (#2 testability): renderResolvedEvent is a named-exported PURE function (no fetch/hook/router/globals)', () => {
   const src = safeRead(PAGE);
   assert(src.length > 0, 'BrainstormEvent.jsx does not exist yet.');

--- a/test/event-page-ui.test.js
+++ b/test/event-page-ui.test.js
@@ -1,0 +1,204 @@
+/**
+ * Stories event-page #2 (param render) + #3 (search fallback). ADR event-page/0002.
+ * See the two .test-plan.md files alongside the stories.
+ *
+ * ADR 0002 chose Option A: a pure ui/src/utils/eventParam.js (resolveEventParams +
+ * classifyEventInput, nip19-based), a ui/src/hooks/useEventResolve.js, a reworked
+ * ui/src/pages/BrainstormEvent.jsx (pure exported renderResolvedEvent + EVENT_COPY),
+ * and an EventSearch field that resolves by navigating to the canonical /event?<type>=<v>.
+ * The /event route already exists in App.jsx (no routing change).
+ *
+ * TEST LEVEL: the pure eventParam.js is EXECUTED (plain JS + nip19, runs in the Node
+ * runner via dynamic import — like nostrEntities in live-feed-feed-page.test.js); the
+ * React page/hook/component are asserted at the SOURCE level (no JSX transpile in the
+ * harness). eventParam.js / the page / hook do not exist pre-implementation, so the
+ * U-tests FAIL now and PASS once built. R* are regression sentinels (additive — the
+ * /event route already exists), PASS before AND after.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { pathToFileURL } = require('url');
+const { nip19, generateSecretKey, getPublicKey } = require('nostr-tools');
+
+const PARAM = path.resolve(__dirname, '../ui/src/utils/eventParam.js');
+const HOOK = path.resolve(__dirname, '../ui/src/hooks/useEventResolve.js');
+const PAGE = path.resolve(__dirname, '../ui/src/pages/BrainstormEvent.jsx');
+const APP = path.resolve(__dirname, '../ui/src/App.jsx');
+const NOTE_CARD = path.resolve(__dirname, '../ui/src/components/NoteCard.jsx');
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+async function loadEsm(absPath) { try { return await import(pathToFileURL(absPath).href); } catch { return null; } }
+function helperBody(src, names) {
+  const m = src.match(new RegExp('function\\s+(' + names.join('|') + ')\\s*\\('));
+  return m ? src.slice(m.index) : src;
+}
+
+// nip19-minted, self-validating fixtures.
+const PK = getPublicKey(generateSecretKey());
+const HEX = 'a'.repeat(64);
+const EVENT_ID = 'b'.repeat(64);
+const NEVENT = nip19.neventEncode({ id: EVENT_ID, author: PK, relays: ['wss://hint.example'] });
+const NPUB = nip19.npubEncode(PK);
+const NPROFILE = nip19.nprofileEncode({ pubkey: PK, relays: ['wss://p.example'] });
+const NADDR = nip19.naddrEncode({ identifier: 'slug', pubkey: PK, kind: 30023 });
+
+// ===========================================================================
+// eventParam.js — EXECUTED (the pure decode/precedence/classify core)
+// ===========================================================================
+
+test('U1 (#2 precedence): resolveEventParams picks the first valid param by precedence (nevent > id)', async () => {
+  const mod = await loadEsm(PARAM);
+  assert(mod && typeof mod.resolveEventParams === 'function',
+    'ui/src/utils/eventParam.js must export resolveEventParams — feature not implemented yet (ADR event-page/0002).');
+  const sp = new URLSearchParams(`nevent=${NEVENT}&id=${EVENT_ID}`);
+  const { target, invalidParams } = mod.resolveEventParams(sp);
+  assert(target && target.mode === 'id' && target.id === EVENT_ID,
+    `with both nevent and id valid, nevent wins (precedence) → mode 'id' with the nevent's id; got ${JSON.stringify(target)}.`);
+  assert(Array.isArray(invalidParams) && invalidParams.length === 0, `no invalid params here; got ${JSON.stringify(invalidParams)}.`);
+});
+
+test('U2 (#2 invalid vs unsupported): malformed supported params are flagged; unknown names ignored; first VALID still wins', async () => {
+  const mod = await loadEsm(PARAM);
+  assert(mod && typeof mod.resolveEventParams === 'function', 'eventParam.js must export resolveEventParams.');
+  // All-invalid + an unsupported name → no target, nevent flagged, foo ignored.
+  const a = mod.resolveEventParams(new URLSearchParams('nevent=garbage&foo=bar'));
+  assert(a.target === null, `all supported params malformed → no target; got ${JSON.stringify(a.target)}.`);
+  assert(a.invalidParams.includes('nevent'), `a malformed supported param must be flagged invalid; got ${JSON.stringify(a.invalidParams)}.`);
+  assert(!a.invalidParams.includes('foo'), `an UNSUPPORTED param name must be ignored, not flagged; got ${JSON.stringify(a.invalidParams)}.`);
+  // Higher-precedence invalid + lower-precedence valid → the valid one wins, the invalid one is flagged.
+  const b = mod.resolveEventParams(new URLSearchParams(`nevent=garbage&id=${EVENT_ID}`));
+  assert(b.target && b.target.mode === 'id' && b.target.id === EVENT_ID, `a malformed higher-precedence param is skipped for the first VALID one; got ${JSON.stringify(b.target)}.`);
+  assert(b.invalidParams.includes('nevent'), `the malformed param must still be reported invalid; got ${JSON.stringify(b.invalidParams)}.`);
+});
+
+test('U3 (#2 decode): each of the 6 params decodes to the right target (nevent/id/pubkey/npub/nprofile → fetch; naddr → unsupported kind)', async () => {
+  const mod = await loadEsm(PARAM);
+  assert(mod && typeof mod.resolveEventParams === 'function', 'eventParam.js must export resolveEventParams.');
+  const one = (qs) => mod.resolveEventParams(new URLSearchParams(qs)).target;
+
+  const ne = one(`nevent=${NEVENT}`);
+  assert(ne && ne.mode === 'id' && ne.id === EVENT_ID && ne.author === PK && Array.isArray(ne.relays) && ne.relays.includes('wss://hint.example'),
+    `nevent → { mode:'id', id, author, relays(hint) }; got ${JSON.stringify(ne)}.`);
+  assert(one(`id=${EVENT_ID}`)?.mode === 'id', 'a 64-hex id → mode id.');
+  assert(one(`pubkey=${HEX}`)?.mode === 'author', 'a 64-hex pubkey → mode author.');
+  assert(one(`npub=${NPUB}`)?.mode === 'author' && one(`npub=${NPUB}`).author === PK, 'npub → mode author with the decoded pubkey.');
+  const np = one(`nprofile=${NPROFILE}`);
+  assert(np && np.mode === 'author' && np.author === PK && Array.isArray(np.relays) && np.relays.includes('wss://p.example'), `nprofile → author + relay hints; got ${JSON.stringify(np)}.`);
+  const na = one(`naddr=${NADDR}`);
+  assert(na && na.mode === 'naddrUnsupported' && na.kind === 30023, `naddr → { mode:'naddrUnsupported', kind } (no fetch); got ${JSON.stringify(na)}.`);
+});
+
+test('U4 (#3 classify): classifyEventInput maps a pasted string to the canonical URL param; bare hex → id (precedence); junk → null', async () => {
+  const mod = await loadEsm(PARAM);
+  assert(mod && typeof mod.classifyEventInput === 'function',
+    'ui/src/utils/eventParam.js must export classifyEventInput — the search-field classifier (ADR event-page/0002).');
+  const c = (s) => mod.classifyEventInput(s);
+  assert(c(NEVENT)?.paramName === 'nevent' && c(NEVENT).value === NEVENT, `nevent → { paramName:'nevent', value }; got ${JSON.stringify(c(NEVENT))}.`);
+  assert(c(NPUB)?.paramName === 'npub', 'npub → paramName npub.');
+  assert(c(NPROFILE)?.paramName === 'nprofile', 'nprofile → paramName nprofile.');
+  assert(c(NADDR)?.paramName === 'naddr', 'naddr → paramName naddr.');
+  assert(c(HEX)?.paramName === 'id', `a bare 64-hex must classify as 'id' (precedence id>pubkey, since the bech32 prefix is what disambiguates otherwise); got ${JSON.stringify(c(HEX))}.`);
+  assert(c('definitely not a nostr identifier') === null, 'a non-matching string → null (drives the "not a recognized format" notice).');
+  assert(c('') === null, 'empty input → null.');
+});
+
+// ===========================================================================
+// BrainstormEvent.jsx — SOURCE sentinels (#2 render + naddr + search wiring)
+// ===========================================================================
+
+test('U5 (#2 render): BrainstormEvent renders the resolved kind-1 via NoteCard and branches every read-path status', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'ui/src/pages/BrainstormEvent.jsx must be reworked from the placeholder (ADR event-page/0002).');
+  assert(/import NoteCard/.test(src) && /<NoteCard\b[^>]*\bitem=\{/.test(src), 'the page must render the resolved kind-1 via the shared <NoteCard item={…} />.');
+  assert(/EVENT_COPY/.test(src), 'the page must define exported EVENT_COPY copy constants.');
+  const body = helperBody(src, ['renderResolvedEvent']);
+  for (const status of ['OK', 'UNSUPPORTED_KIND', 'INVALID_EVENT', 'NOT_FOUND', 'NO_AUTHOR_NOTE']) {
+    assert(new RegExp("['\"]" + status + "['\"]").test(body), `renderResolvedEvent must branch on the '${status}' read-path status.`);
+  }
+});
+
+test('U6 (#2 naddr + search wiring): naddr → "unsupported kind" branch; no valid target → <EventSearch>', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormEvent.jsx does not exist yet.');
+  assert(/naddrUnsupported/.test(src), "the page must handle the 'naddrUnsupported' target (kind from the coordinate → not-yet-supported, no fetch).");
+  assert(/<EventSearch\b/.test(src), 'the page must render <EventSearch /> when there is no valid target (story #3 fallback).');
+  assert(/resolveEventParams/.test(src) && /useEventResolve/.test(src), 'the page must use resolveEventParams (decode) + useEventResolve (fetch id/author).');
+});
+
+test('U7 (#2 testability): renderResolvedEvent is a named-exported PURE function (no fetch/hook/router/globals)', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormEvent.jsx does not exist yet.');
+  assert(/export\s+(function\s+renderResolvedEvent|const\s+renderResolvedEvent\s*=)/.test(src),
+    'BrainstormEvent.jsx must NAMED-export a pure renderResolvedEvent({ data, loading, error }) (the testable state→view unit).');
+  const body = helperBody(src, ['renderResolvedEvent']);
+  for (const banned of ['fetch(', 'useEventResolve(', 'useAuth(', 'useSearchParams(', 'window.', 'document.']) {
+    assert(!body.includes(banned), `the pure renderResolvedEvent must not call ${banned} — it is a pure function of { data, loading, error }.`);
+  }
+});
+
+test('U8 (#3 search): EventSearch classifies input → navigates to the canonical param on valid, shows the notice on invalid', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormEvent.jsx does not exist yet.');
+  const body = helperBody(src, ['EventSearch']);
+  assert(/classifyEventInput/.test(body), 'EventSearch must use classifyEventInput to validate/route the pasted string.');
+  assert(/setParams|navigate\(/.test(body), 'on a valid format, EventSearch must navigate to the canonical /event?<type>=<value> (setParams / navigate).');
+  assert(/SEARCH_INVALID/.test(body), 'on a non-matching string, EventSearch must show the EVENT_COPY.SEARCH_INVALID notice.');
+  assert(/<input\b/.test(body), 'EventSearch must render an input field.');
+});
+
+test('U9 (copy): EVENT_COPY carries the operator-delegated outcome + search messages', () => {
+  const src = safeRead(PAGE);
+  assert(src.length > 0, 'BrainstormEvent.jsx does not exist yet.');
+  // Meaning tokens (punctuation non-binding).
+  assert(/not yet supported/i.test(src), 'EVENT_COPY must include the "kind not yet supported" message.');
+  assert(/not found/i.test(src), 'EVENT_COPY must include the "event not found" message.');
+  assert(/no kind[\s-]?1 note/i.test(src) || /no .*note .*author/i.test(src), 'EVENT_COPY must include the "no kind-1 note for this author" message.');
+  assert(/validate|verif/i.test(src), 'EVENT_COPY must include the "does not validate / could not verify" message.');
+  assert(/recogni[sz]ed/i.test(src) || /not a .*(nevent|format)/i.test(src), 'EVENT_COPY must include the search "not a recognized format" message.');
+});
+
+// ===========================================================================
+// useEventResolve.js — SOURCE sentinels
+// ===========================================================================
+
+test('U10 (#2 hook): useEventResolve fetches /api/event and returns { data, loading, error }, aborting on unmount', () => {
+  const src = safeRead(HOOK);
+  assert(src.length > 0, 'ui/src/hooks/useEventResolve.js does not exist yet (ADR event-page/0002).');
+  assert(/fetch\(\s*[`'"]\/api\/event/.test(src) || (/fetch\(/.test(src) && /\/api\/event/.test(src)),
+    "useEventResolve must call fetch('/api/event…') — the ADR 0001 endpoint.");
+  assert(/return\s*\{[\s\S]{0,120}data[\s\S]{0,120}loading[\s\S]{0,120}error[\s\S]{0,40}\}/.test(src), 'useEventResolve must return { data, loading, error }.');
+  assert(/AbortController/.test(src) && /\.abort\(\)/.test(src), 'useEventResolve must abort the fetch on unmount.');
+  assert(/success/.test(src), 'useEventResolve must gate on the response `success` flag.');
+});
+
+// ===========================================================================
+// REGRESSION
+// ===========================================================================
+
+test('R1: App.jsx still registers the /event route → BrainstormEvent (additive — no routing change)', () => {
+  const src = safeRead(APP);
+  assert(src.length > 0, 'ui/src/App.jsx missing — unexpected.');
+  assert(/path:\s*['"]\/event['"]/.test(src) && /BrainstormEvent/.test(src),
+    'App.jsx must still register /event → BrainstormEvent (the rework is in-place; the route is unchanged).');
+});
+
+test('R2: NoteCard is reused as-is — single { item } prop, bsp-note-card markup (no fork)', () => {
+  const src = safeRead(NOTE_CARD);
+  assert(/export\s+default\s+function\s+NoteCard\s*\(\s*\{\s*item\s*\}/.test(src) && /bsp-note-card/.test(src),
+    'NoteCard must keep its { item } presentational contract — the event page reuses it unchanged.');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try { await t.fn(); console.log(`  ✓ ${t.name}`); pass++; }
+    catch (err) { console.log(`  ✗ ${t.name}`); console.log(`      ${err.message}`); fail++; }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -95,6 +95,8 @@ const liveFeedReadPath = require('./live-feed-read-path.test.js');
 const liveFeedFeedPage = require('./live-feed-feed-page.test.js');
 const noteSurfacesReadPath = require('./note-surfaces-read-path.test.js');
 const noteSurfacesUi = require('./note-surfaces-ui.test.js');
+const eventPageReadPath = require('./event-page-read-path.test.js');
+const eventPageUi = require('./event-page-ui.test.js');
 const verifiedReportersReportColumns = require('./verified-reporters-report-columns.test.js');
 const profileIdentityDetailsPopover = require('./profile-identity-details-popover.test.js');
 const profileFollowsHops = require('./profile-follows-hops.test.js');
@@ -261,6 +263,12 @@ async function main() {
 
   console.log('\nnote-surfaces-ui suite:');
   const noteSurfacesUiResult = await noteSurfacesUi.run();
+
+  console.log('\nevent-page-read-path suite:');
+  const eventPageReadPathResult = await eventPageReadPath.run();
+
+  console.log('\nevent-page-ui suite:');
+  const eventPageUiResult = await eventPageUi.run();
 
   console.log('\nverified-reporters-report-columns suite:');
   const verifiedReportersReportColumnsResult = await verifiedReportersReportColumns.run();
@@ -466,6 +474,12 @@ async function main() {
     `note-surfaces-ui suite:                          ${noteSurfacesUiResult.fail === 0 ? 'PASS' : 'FAIL'} (${noteSurfacesUiResult.pass} passed, ${noteSurfacesUiResult.fail} failed)`
   );
   console.log(
+    `event-page-read-path suite:                      ${eventPageReadPathResult.fail === 0 ? 'PASS' : 'FAIL'} (${eventPageReadPathResult.pass} passed, ${eventPageReadPathResult.fail} failed)`
+  );
+  console.log(
+    `event-page-ui suite:                             ${eventPageUiResult.fail === 0 ? 'PASS' : 'FAIL'} (${eventPageUiResult.pass} passed, ${eventPageUiResult.fail} failed)`
+  );
+  console.log(
     `verified-reporters-report-columns suite:         ${verifiedReportersReportColumnsResult.fail === 0 ? 'PASS' : 'FAIL'} (${verifiedReportersReportColumnsResult.pass} passed, ${verifiedReportersReportColumnsResult.fail} failed)`
   );
   console.log(
@@ -565,6 +579,8 @@ async function main() {
     liveFeedFeedPageResult.fail === 0 &&
     noteSurfacesReadPathResult.fail === 0 &&
     noteSurfacesUiResult.fail === 0 &&
+    eventPageReadPathResult.fail === 0 &&
+    eventPageUiResult.fail === 0 &&
     verifiedReportersReportColumnsResult.fail === 0 &&
     profileIdentityDetailsPopoverResult.fail === 0 &&
     profileFollowsHopsResult.fail === 0 &&

--- a/ui/src/hooks/useEventResolve.js
+++ b/ui/src/hooks/useEventResolve.js
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook: resolve a single event from the read path (`/api/event`, ADR event-page/0001).
+ * Given a decoded target `{ id?, author?, relays? }`, fetch the event (by id) or the author's
+ * latest kind-1 (by author). Returns { data, loading, error }.
+ *
+ * On a `success` body, `data` is the whole result `{ status, relaySource?, item?, kind? }` —
+ * passed through unreshaped (the page reads `status`/`item`/`kind`). A non-success / transport
+ * failure sets `error`. No fetch when neither id nor author is given (naddr / no-target). Aborts
+ * on unmount; mirrors useUserNotes.js / useFeed.js.
+ */
+export default function useEventResolve({ id, author, relays } = {}) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const relayKey = (relays || []).join(',');
+
+  useEffect(() => {
+    if (!id && !author) { setLoading(false); setData(null); setError(null); return; }
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    setData(null);
+
+    const qs = new URLSearchParams();
+    if (id) qs.set('id', id);
+    if (author) qs.set('author', author);
+    if (relayKey) qs.set('relays', relayKey);
+
+    fetch(`/api/event?${qs.toString()}`, { signal: controller.signal })
+      .then(r => r.json())
+      .then(json => {
+        if (json?.success) { setData(json); setError(null); }
+        else { setData(null); setError(json?.error || json?.message || 'Failed to load event'); }
+      })
+      .catch(err => {
+        if (err.name === 'AbortError') return;
+        setError(err.message || 'Fetch failed');
+        setData(null);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [id, author, relayKey]);
+
+  return { data, loading, error };
+}

--- a/ui/src/pages/BrainstormEvent.jsx
+++ b/ui/src/pages/BrainstormEvent.jsx
@@ -1,23 +1,61 @@
+import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import BrainstormUserMenu from '../components/BrainstormUserMenu';
+import NoteCard from '../components/NoteCard';
+import useEventResolve from '../hooks/useEventResolve';
+import { resolveEventParams, classifyEventInput } from '../utils/eventParam';
 
 /**
- * Placeholder for the public single-event view (/event). Reachable from the feed's
- * per-note "Copy Note Link" action, which builds /event?nevent=<nevent>. The page
- * also accepts ?id=<hex> so either identifier resolves once the real view is built.
+ * Stories event-page #2 + #3 / ADR event-page/0002: the public single-event view (/event).
  *
- * Front-end only and intentionally minimal: it confirms the route is live and echoes
- * back the identifier it received. The actual event rendering is a work in progress.
+ * Front-end only. It decodes the URL params (resolveEventParams, precedence
+ * nevent > id > naddr > pubkey > npub > nprofile), fetches id/author targets via the read path
+ * (useEventResolve → /api/event, ADR 0001), and renders the kind-1 like /feed (NoteCard) or the
+ * precise outcome message. `naddr` is reported as a not-yet-supported kind from its coordinate
+ * (no fetch). With no valid param it shows the <EventSearch> field. Body rendering for id/author
+ * targets is delegated to the PURE, named-exported renderResolvedEvent.
  */
+
+// Operator-delegated copy (stories #2/#3). Punctuation non-binding; meaning is exact.
+export const EVENT_COPY = {
+  HEADING: 'Event',
+  LOADING: 'Loading…',
+  COULDNT_LOAD: "Couldn't load this event right now.",
+  unsupportedKind: (k) => `Kind ${k} events are not yet supported.`,
+  INVALID_EVENT: 'This event could not be verified — its signature or id does not validate.',
+  NOT_FOUND: 'Event not found on the relays we checked.',
+  NO_AUTHOR_NOTE: 'No kind-1 note found for this author.',
+  invalidParams: (names) => `Ignoring invalid parameter${names.length > 1 ? 's' : ''}: ${names.join(', ')}.`,
+  SEARCH_PROMPT: 'Paste an nevent, id, naddr, npub, pubkey, or nprofile.',
+  SEARCH_INVALID: 'That isn’t a recognized nevent, id, naddr, npub, pubkey, or nprofile.',
+};
+
+const RENDER_STATUSES = ['OK', 'UNSUPPORTED_KIND', 'INVALID_EVENT', 'NOT_FOUND', 'NO_AUTHOR_NOTE'];
+
 export default function BrainstormEvent() {
   const { user, login, logout } = useAuth();
   const [params] = useSearchParams();
-  const nevent = params.get('nevent');
-  const naddr = params.get('naddr');
-  const id = params.get('id');
-  const identifier = nevent || naddr || id || null;
-  const identifierLabel = nevent ? 'nevent' : naddr ? 'naddr' : 'event id';
+  const { target, invalidParams } = resolveEventParams(params);
+
+  // Only id/author targets fetch; naddr / no-target pass an empty arg so the hook no-ops.
+  const fetchArg = target && (target.mode === 'id' || target.mode === 'author')
+    ? {
+        id: target.mode === 'id' ? target.id : undefined,
+        author: target.mode === 'author' ? target.author : undefined,
+        relays: target.relays,
+      }
+    : {};
+  const { data, loading, error } = useEventResolve(fetchArg);
+
+  let body;
+  if (!target) {
+    body = <EventSearch />;
+  } else if (target.mode === 'naddrUnsupported') {
+    body = <div className="bsp-empty">{EVENT_COPY.unsupportedKind(target.kind)}</div>;
+  } else {
+    body = renderResolvedEvent({ data, loading, error });
+  }
 
   return (
     <div className="bsp-page">
@@ -31,18 +69,81 @@ export default function BrainstormEvent() {
         </div>
       </div>
 
-      <div className="bsp-content" style={{ maxWidth: 680, margin: '0 auto', padding: '2rem 1.5rem' }}>
-        <h1 style={{ fontSize: '1.5rem', marginBottom: '1rem' }}>Event</h1>
-        <p style={{ lineHeight: 1.7, fontSize: '0.95rem', opacity: 0.85 }}>
-          This is a placeholder page — the single-event view is a work in progress.
-        </p>
-        {identifier && (
-          <p className="bsp-event-identifier">
-            <span className="bsp-event-identifier-label">{identifierLabel}:</span>{' '}
-            <code className="bsp-event-identifier-value">{identifier}</code>
-          </p>
+      <div className="bsp-content bsp-event-content">
+        <h1 className="bsp-event-heading">{EVENT_COPY.HEADING}</h1>
+        {invalidParams.length > 0 && (
+          <div className="bsp-empty bsp-event-invalid">{EVENT_COPY.invalidParams(invalidParams)}</div>
         )}
+        {body}
       </div>
     </div>
   );
+}
+
+/**
+ * The no-parameter search fallback (story #3): a field that resolves a pasted identifier by
+ * navigating to the canonical /event?<type>=<value> (so #2's render path handles it + the result
+ * is shareable), or shows the "not recognized" notice.
+ */
+function EventSearch() {
+  const [, setParams] = useSearchParams();
+  const [input, setInput] = useState('');
+  const [notice, setNotice] = useState('');
+
+  const submit = (e) => {
+    e.preventDefault();
+    const c = classifyEventInput(input);
+    if (c) { setNotice(''); setParams({ [c.paramName]: c.value }); }
+    else { setNotice(EVENT_COPY.SEARCH_INVALID); }
+  };
+
+  return (
+    <form className="bsp-event-search" onSubmit={submit}>
+      <label className="bsp-event-search-label">{EVENT_COPY.SEARCH_PROMPT}</label>
+      <div className="bsp-event-search-row">
+        <input
+          className="bsp-event-search-input"
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="nevent1… · npub1… · 64-hex id"
+          aria-label={EVENT_COPY.SEARCH_PROMPT}
+        />
+        <button className="bsp-event-search-btn" type="submit">Enter</button>
+      </div>
+      {notice && <div className="bsp-empty bsp-event-search-notice">{notice}</div>}
+    </form>
+  );
+}
+
+/**
+ * Pure state→view mapping for an id/author target. A function only of its args — no fetch, no
+ * hook, no router, no browser globals — so the outcomes are an isolated, testable unit. Renders
+ * the kind-1 via the shared NoteCard on OK; a precise message for each other read-path status;
+ * a transient loading line; and a neutral defensive line for transport failures / unknown status.
+ */
+export function renderResolvedEvent({ data, loading, error }) {
+  if (loading && !data) {
+    return <div className="bsp-event-loading">{EVENT_COPY.LOADING}</div>;
+  }
+  const status = data && data.status;
+  if (error || !data || !RENDER_STATUSES.includes(status)) {
+    return <div className="bsp-empty">{EVENT_COPY.COULDNT_LOAD}</div>;
+  }
+  if (status === 'OK') {
+    return <NoteCard item={data.item} />;
+  }
+  if (status === 'UNSUPPORTED_KIND') {
+    return <div className="bsp-empty">{EVENT_COPY.unsupportedKind(data.kind)}</div>;
+  }
+  if (status === 'INVALID_EVENT') {
+    return <div className="bsp-empty">{EVENT_COPY.INVALID_EVENT}</div>;
+  }
+  if (status === 'NOT_FOUND') {
+    return <div className="bsp-empty">{EVENT_COPY.NOT_FOUND}</div>;
+  }
+  if (status === 'NO_AUTHOR_NOTE') {
+    return <div className="bsp-empty">{EVENT_COPY.NO_AUTHOR_NOTE}</div>;
+  }
+  return <div className="bsp-empty">{EVENT_COPY.COULDNT_LOAD}</div>;
 }

--- a/ui/src/pages/BrainstormEvent.jsx
+++ b/ui/src/pages/BrainstormEvent.jsx
@@ -42,7 +42,9 @@ export default function BrainstormEvent() {
   const fetchArg = target && (target.mode === 'id' || target.mode === 'author')
     ? {
         id: target.mode === 'id' ? target.id : undefined,
-        author: target.mode === 'author' ? target.author : undefined,
+        // Forward the author whenever it's known: for an nevent (id-mode) this is the embedded
+        // author, so the server also consults that author's outbox in the relay union (review #1).
+        author: target.author || undefined,
         relays: target.relays,
       }
     : {};

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -7379,6 +7379,70 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   overflow-wrap: anywhere;
 }
 
+/* /event single-event view (BrainstormEvent.jsx) — event-page epic. The kind-1 is rendered
+   by the shared NoteCard (already wraps + bsp-content is width-capped, so no 1280px overflow);
+   only layout tokens for the heading, search field, and notices here. */
+.bsp-event-content {
+  max-width: 700px;
+  width: 100%;
+  box-sizing: border-box;
+}
+.bsp-event-heading {
+  font-size: 1.5rem;
+  margin: 0 0 1rem;
+}
+.bsp-event-loading {
+  padding: 2rem;
+  text-align: center;
+  opacity: 0.6;
+}
+.bsp-event-invalid {
+  margin-bottom: 1rem;
+  opacity: 0.75;
+}
+.bsp-event-search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
+}
+.bsp-event-search-label {
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+.bsp-event-search-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.bsp-event-search-input {
+  flex: 1 1 18rem;
+  min-width: 0;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 8px;
+  background: rgba(255,255,255,0.03);
+  color: inherit;
+  font-size: 0.9rem;
+  box-sizing: border-box;
+}
+.bsp-event-search-btn {
+  padding: 0.55rem 1.1rem;
+  border-radius: 8px;
+  border: 1px solid rgba(165,180,252,0.4);
+  background: rgba(165,180,252,0.12);
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+.bsp-event-search-btn:hover {
+  background: rgba(165,180,252,0.2);
+}
+.bsp-event-search-notice {
+  margin-top: 0.25rem;
+  text-align: left;
+}
+
 .table-pagination {
   display: flex;
   align-items: center;

--- a/ui/src/utils/eventParam.js
+++ b/ui/src/utils/eventParam.js
@@ -1,0 +1,91 @@
+import { nip19 } from 'nostr-tools';
+
+/**
+ * Pure decode/precedence/classify core for the /event page (ADR event-page/0002).
+ * No React, no DOM, no network — so it is unit-testable and the page stays a thin shell.
+ *
+ * The page supports six identifier formats. Precedence (operator-confirmed):
+ *   nevent > id > naddr > pubkey > npub > nprofile
+ *
+ * A `target` is one of:
+ *   { mode: 'id', id, author?, relays? }          // fetch the event by id (nevent/id)
+ *   { mode: 'author', author, relays? }           // fetch the author's latest kind-1 (pubkey/npub/nprofile)
+ *   { mode: 'naddrUnsupported', kind }            // naddr → addressable, never kind-1 → no fetch
+ */
+
+const HEX64 = /^[0-9a-f]{64}$/i;
+const ORDER = ['nevent', 'id', 'naddr', 'pubkey', 'npub', 'nprofile'];
+
+// Decode a single (paramName, value) into a target, or null if malformed / wrong type.
+function decodeOne(name, value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  try {
+    switch (name) {
+      case 'id':
+        return HEX64.test(value) ? { mode: 'id', id: value.toLowerCase() } : null;
+      case 'pubkey':
+        return HEX64.test(value) ? { mode: 'author', author: value.toLowerCase() } : null;
+      case 'nevent': {
+        const d = nip19.decode(value);
+        if (d.type !== 'nevent' || !d.data || !d.data.id) return null;
+        return { mode: 'id', id: d.data.id, author: d.data.author || null, relays: d.data.relays || [] };
+      }
+      case 'npub': {
+        const d = nip19.decode(value);
+        if (d.type !== 'npub' || !d.data) return null;
+        return { mode: 'author', author: d.data };
+      }
+      case 'nprofile': {
+        const d = nip19.decode(value);
+        if (d.type !== 'nprofile' || !d.data || !d.data.pubkey) return null;
+        return { mode: 'author', author: d.data.pubkey, relays: d.data.relays || [] };
+      }
+      case 'naddr': {
+        const d = nip19.decode(value);
+        if (d.type !== 'naddr' || !d.data || typeof d.data.kind !== 'number') return null;
+        return { mode: 'naddrUnsupported', kind: d.data.kind };
+      }
+      default:
+        return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a URLSearchParams into { target, invalidParams }.
+ *  - target: the first VALID supported param by precedence (or null).
+ *  - invalidParams: every PRESENT supported param whose value failed to decode (malformed).
+ *    Param names outside the six are ignored entirely (not reported).
+ */
+export function resolveEventParams(searchParams) {
+  let target = null;
+  const invalidParams = [];
+  for (const name of ORDER) {
+    if (!searchParams || !searchParams.has(name)) continue;
+    const t = decodeOne(name, searchParams.get(name));
+    if (t) { if (!target) target = t; }
+    else invalidParams.push(name);
+  }
+  return { target, invalidParams };
+}
+
+/**
+ * Classify a pasted search string into the canonical URL parameter to navigate to, or null
+ * when it matches none of the six formats. Bech32 entities dispatch by prefix; a bare 64-hex
+ * is treated as an event `id` (precedence id > pubkey — the param name is what disambiguates
+ * the two otherwise). Returns { paramName, value } | null.
+ */
+export function classifyEventInput(raw) {
+  const str = (raw || '').trim();
+  if (!str) return null;
+  const prefixes = [['nevent1', 'nevent'], ['naddr1', 'naddr'], ['nprofile1', 'nprofile'], ['npub1', 'npub']];
+  for (const [prefix, name] of prefixes) {
+    if (str.startsWith(prefix)) {
+      return decodeOne(name, str) ? { paramName: name, value: str } : null;
+    }
+  }
+  if (HEX64.test(str)) return { paramName: 'id', value: str.toLowerCase() };
+  return null;
+}


### PR DESCRIPTION
## Summary

Fleshes out the placeholder `/event` page into a working single-event view (kind-1 only). It resolves one of six identifier formats — `nevent`, `id`, `naddr`, `pubkey`, `npub`, `nprofile` (precedence in that order) — or, with no valid param, shows a search field. `nevent`/`id` fetch the event; `pubkey`/`npub`/`nprofile` fetch the author's most-recent kind-1; `naddr` reports "kind ‹N› not yet supported" (addressable, never kind-1). Built through the full harness (Planning → Architecture → Test → Implement → Review **PASS**), strictly additive.

## Changes

- **New** `src/api/event/eventReadPath.js` — `GET /api/event?id=&author=&relays=` (`buildEvent`/`handleGetEvent`): relay union = hints + author **outbox** (NIP-65 kind-10002 write relays) + well-known (general-purpose set, else damus/primal/nos.lol). Verifies (`verifyEvent`), kind-gates, reuses `enrichNotes`. Discriminated outcomes `OK`/`UNSUPPORTED_KIND`/`INVALID_EVENT`/`NOT_FOUND`/`NO_AUTHOR_NOTE`/`INVALID` (handler `INVALID`→400). Uses a **no-verify** fetch so `buildEvent` is the sole verify gate (the distinct "does not validate" outcome is reachable).
- **New** `src/api/_shared/relaySource.js` — extracted relay-sourcing primitives (Option A; `feedReadPath`/`userNotesReadPath` left byte-unchanged — re-pointing logged in `follow-ups.md`).
- **New** `ui/src/utils/eventParam.js` (decode/precedence/classify), `ui/src/hooks/useEventResolve.js`.
- **Reworked** `ui/src/pages/BrainstormEvent.jsx` (pure `renderResolvedEvent` + `EventSearch` + `EVENT_COPY`); route registration in `src/api/index.js`; minimal CSS. No `App.jsx` change (route pre-existed); `NoteCard` reused unchanged.
- Tests: `test/event-page-read-path.test.js` (23), `test/event-page-ui.test.js` (13); 3 stories + 2 ADRs + 3 test plans + review under `engineering-team/`.

## Test plan

- [ ] After merge: deploy-staging.yml runs.
- [ ] `GET /api/event?nevent=nevent1qgsp3yzapfwkyw4cr2vt4xx9s27474lj2pkxhqyfqh79n826pv3fkzqqyqqqp6qpavk7mqhh4zg3fc90rcmnlwt7e68zqf37lg6zeah8n98nq34s3f8` → `{ success:true, status:OK, item:… }`.
- [ ] `GET /api/event` (no params) → HTTP 400.
- [ ] `/event?nevent=<ref>` renders a kind-1 NoteCard; bare `/event` shows the search field; `/event?naddr=<…>` shows "kind ‹N› not yet supported".
- [ ] Regression: `/feed`, `/user/:pubkey/notes`, and profile pages unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)