### PR TITLE
fix(tag-federation): federate tag detail, index & authored-by reads

### DIFF
--- a/src/api/profile-tags/index.js
+++ b/src/api/profile-tags/index.js
@@ -689,7 +689,7 @@ async function handleTagById(req, res) {
     });
   }
   try {
-    const events = await strfryScan({ kinds: [39999], ids: [tagEventId] });
+    const events = await federatedScan({ kinds: [39999], ids: [tagEventId] });
     if (events.length === 0) {
       return res.status(404).json({ success: false, error: 'tag not found' });
     }
@@ -959,7 +959,7 @@ async function handleTagIndex(req, res) {
     });
     const wotFiltering = !!povSuffix && Number.isFinite(minRank);
 
-    const assertions = await strfryScan({
+    const assertions = await federatedScan({
       kinds: [39999],
       '#z': [NOSTR_USER_TAG_Z_TAG],
     });
@@ -1029,7 +1029,7 @@ async function handleTagIndex(req, res) {
 
     // Batch-scan tag-elements for every referenced tagEventId.
     const tagEventIds = Array.from(byTag.keys());
-    const tagEvents = await strfryScan({ kinds: [39999], ids: tagEventIds });
+    const tagEvents = await federatedScan({ kinds: [39999], ids: tagEventIds });
     const tagByEventId = new Map();
     for (const ev of tagEvents) {
       const payload = parseTagPayload(ev);
@@ -1175,7 +1175,7 @@ async function handleAuthoredBy(req, res) {
     const wotFiltering = !!povSuffix && Number.isFinite(minRank);
 
     // Step 1: pull every nostr-user-tag assertion authored by the profile owner.
-    const ownerEvents = await strfryScan({
+    const ownerEvents = await federatedScan({
       kinds: [39999],
       '#z': [NOSTR_USER_TAG_Z_TAG],
       authors: [authorPubkey],
@@ -1242,7 +1242,7 @@ async function handleAuthoredBy(req, res) {
     // Step 4: parent-tag enrichment. Drop rows whose parent tag-element isn't
     // locally available or fails to parse.
     const tagEventIds = Array.from(new Set(surviving.map((c) => c.tagEventId)));
-    const tagElementEvents = await strfryScan({ kinds: [39999], ids: tagEventIds });
+    const tagElementEvents = await federatedScan({ kinds: [39999], ids: tagEventIds });
     const tagByEventId = new Map();
     for (const ev of tagElementEvents) {
       const payload = parseTagPayload(ev);
@@ -1265,7 +1265,7 @@ async function handleAuthoredBy(req, res) {
     // Step 5: parent-tag scan — yields BOTH parent-tag aggregate counts
     // (Reading A) AND per-(tag, target) peer counts (Reading B) in one walk.
     const remainingTagIds = Array.from(new Set(surviving2.map((c) => c.tagEventId)));
-    const parentAssertions = await strfryScan({
+    const parentAssertions = await federatedScan({
       kinds: [39999],
       '#z': [NOSTR_USER_TAG_Z_TAG],
       '#e': remainingTagIds,

--- a/test/tag-read-union.test.js
+++ b/test/tag-read-union.test.js
@@ -159,6 +159,33 @@ t('AC-1 (wiring): the visibility read paths scan via federatedScan, not bare str
     'handleAvailableTags must use federatedScan (browse/visibility surface)');
 });
 
+t('REGRESSION (blank detail/index/authored-by): the remaining browse/visibility handlers federate too', () => {
+  // Bugfix fix/tag-federation-detail-index: the original read-union landing only
+  // wired federatedScan into available-tags / tags-for-profile / wot-tags /
+  // aggregateProfilesTagged — the PROFILE-page path. The tag DETAIL (handleTagById),
+  // tag INDEX (handleTagIndex), and AUTHORED-BY (handleAuthoredBy) handlers stayed
+  // local-only, so on a deployment whose tags live on remote relays those pages
+  // were blank (handleTagById 404'd "tag not found"; handleTagIndex returned []).
+  // These are browse/visibility surfaces (NOT search), so they MUST federate.
+  const src = readSrc(SRC);
+  for (const fn of ['handleTagById', 'handleTagIndex', 'handleAuthoredBy']) {
+    const body = src.match(new RegExp(`async function ${fn}[\\s\\S]*?\\n\\}`));
+    assert(body, `could not locate ${fn}`);
+    assert(/federatedScan\s*\(/.test(body[0]),
+      `${fn} must use federatedScan for its tag/assertion visibility scans (blank-page bugfix) — ` +
+      'detail/index/authored-by are browse surfaces and must union the remote leg');
+  }
+});
+
+t('SEARCH-IS-LOCAL stays intact after the detail/index fix (computeTagMatches not federated)', () => {
+  // Guard the boundary: the blank-page fix federates browse surfaces only and must
+  // NOT have leaked federation into the search path (ADR 0001 search-is-local).
+  const src = readSrc(SRC);
+  const cm = src.match(/async function computeTagMatches[\s\S]*?\n\}/);
+  assert(cm && !/federatedScan\s*\(/.test(cm[0]),
+    'computeTagMatches must remain local-only (search-is-local) even after the browse-surface fix');
+});
+
 t('SEARCH-IS-LOCAL: findTagsByNameSubstring does NOT federate (both callers are search; ADR 0001 ratified principle)', () => {
   const src = readSrc(SRC);
   // findTagsByNameSubstring feeds ONLY the search path (computeTagMatches + the meili


### PR DESCRIPTION
## Summary

The tag read-union (local ∪ DList relays) was only wired into the profile-page path — `available-tags`, `tags-for-profile`, `wot-tags`, and `aggregateProfilesTagged`. The tag **detail**, tag **index**, and **authored-by** handlers stayed local-only, so on a federation-enabled deployment (where tags live on remote relays) those pages were blank: `handleTagById` returned `404 "tag not found"` and `handleTagIndex` returned `[]`. This switches their tag/assertion visibility scans to `federatedScan` so they union the remote leg like the profile page already does.

## Changes

- `src/api/profile-tags/index.js` — `strfryScan` → `federatedScan` at 6 visibility-read sites:
  - `handleTagById` (tag detail metadata)
  - `handleTagIndex` (index assertions + tag-element metadata)
  - `handleAuthoredBy` (assertions + tag-element metadata + parent-assertion counts)
- Deliberately **unchanged**: search (`findTagsByNameSubstring`, `computeTagMatches`) stays local per ADR-0001 "search-is-local"; pins / TL / NIP-51 export reads (viewer-authored) stay local (separate decision).
- `test/tag-read-union.test.js` — added 2 regression guards (browse handlers federate; search stays local). 16/16 pass.

## Test plan

- [x] `node test/tag-read-union.test.js` → 16/16; adjacent `tag-detail`, `tag-index`, `tag-detail-write` suites green.
- [x] Verified locally against live dcosl (read-union → `wss://dcosl.brainstorm.world`): index returned 1420 tags, detail resolved — both previously blank/404.
- [ ] After merge: deploy-staging.yml runs.
- [ ] Smoke test on staging.brainstorm.world: `/tags` index populates; a tag detail page populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)