### PR TITLE
fix(tag-federation): federate pin reads (pins + most-pinned)

### DIFF
--- a/engineering-team/stories/_intake.md
+++ b/engineering-team/stories/_intake.md
@@ -1092,3 +1092,22 @@ Small future-readiness items the 2026-06-18 multi-lens review (`reviews/live-fee
 - **`NoteCard` execution/render test** — the no-pubkey/unlinked + placeholder-avatar branches are source-text + browser-verified only (the node harness can't transpile JSX). If a render-test path is ever added, cover these edges.
 
 **Classification:** Cleanup/hardening. **Priority:** Low — fold into the surface stories.
+
+---
+
+## 2026-06-19 — Piece 2: federate pin export-status (NIP-51 / TL) across deployments
+
+**Raw context (verbatim intent):**
+
+> On staging, a user's pins now appear (Piece 1 federated the pin reads), but their "exported / ok-fresh" NIP-51 export-status badges don't reflect reality — exports made on another deployment show as not-exported. Pins (kind-39999) are mirrored to dcosl so they federate; the export/TL events are NOT.
+
+**Findings (confirmed 2026-06-19, empirically):**
+
+- The pin events (kind-39999 `z=tag-pinning`) **are** mirrored to dcosl (the `aTagFederationRelays` target), so Piece 1 (`fix/tag-federation-pins`) federated the pin read paths — `handlePins`, `aggregateTagPins` (most-pinned), the per-tag viewer-pin check, and the pinned-tag name lookup — and pins + most-pinned now work cross-deployment.
+- The **export-status enrichment** reads **kind-30000 (NIP-51)** and **kind-30382 (TL)**, which the **dcosl mirror does not carry** (it mirrors 9998/9999/39998/39999 only). Verified: `kind:30000 authors:[user]` on dcosl → **0 events**. So `enrichRowsWithTLStatus` and `enrichRowsWithNip51ExportStatus` were deliberately **left local** in Piece 1 (a `federatedScan`→dcosl swap would be a no-op).
+
+**Why it's a separate, larger change:** surfacing export status cross-deployment needs reading the **viewer's per-user NIP-65 write-relays + the well-known fallback relays** (where `publishNip51ExportForPin` actually sends kind-30000), which is a **per-viewer relay set**, not the global `aTagFederationRelays`. That's a new read shape (resolve viewer NIP-65 → query those relays for kind-30000/30382 → enrich), distinct from the `strfryScan`→`federatedScan` swap pattern.
+
+**Boundary guard in place:** `test/tag-read-union.test.js` ("PIECE 2 BOUNDARY") asserts the two enrichment scans stay local until this is designed, so a future contributor doesn't naively point them at dcosl.
+
+**Classification:** Feature/enhancement. **Priority:** Medium (cosmetic-but-misleading: pins show, badges lie). **Phase path:** needs Planning → Architecture (per-viewer relay-read design) at minimum; not a one-liner.

--- a/src/api/profile-tags/index.js
+++ b/src/api/profile-tags/index.js
@@ -631,7 +631,7 @@ async function aggregateProfilesTagged({ tagEventId, povSuffix, minRank }) {
 async function aggregateTagPins({ povSuffix, minRank, viewerPubkey }) {
   const wotFiltering = !!povSuffix && Number.isFinite(minRank);
 
-  const pinEvents = await strfryScan({
+  const pinEvents = await federatedScan({
     kinds: [39999],
     '#z': [TAG_PINNING_Z_TAG],
   });
@@ -717,7 +717,7 @@ async function handleTagById(req, res) {
     let viewerPin = null;
     if (isHexPubkey(viewerPubkey)) {
       try {
-        const pinEvents = await strfryScan({
+        const pinEvents = await federatedScan({
           kinds: [39999],
           '#z': [TAG_PINNING_Z_TAG],
           authors: [viewerPubkey],
@@ -1378,7 +1378,7 @@ async function handlePins(req, res) {
     });
   }
   try {
-    const pinEvents = await strfryScan({
+    const pinEvents = await federatedScan({
       kinds: [39999],
       '#z': [TAG_PINNING_Z_TAG],
       authors: [viewerPubkey],
@@ -1398,7 +1398,7 @@ async function handlePins(req, res) {
     const uniqueTagIds = [...new Set(pinsWithTagIds.map((p) => p.tagEventId))];
     let tagEventsById = new Map();
     if (uniqueTagIds.length > 0) {
-      const tagEvents = await strfryScan({ kinds: [39999], ids: uniqueTagIds });
+      const tagEvents = await federatedScan({ kinds: [39999], ids: uniqueTagIds });
       for (const ev of tagEvents) tagEventsById.set(ev.id, ev);
     }
 

--- a/test/tag-read-union.test.js
+++ b/test/tag-read-union.test.js
@@ -177,6 +177,38 @@ t('REGRESSION (blank detail/index/authored-by): the remaining browse/visibility 
   }
 });
 
+t('PINS (Piece 1): the pin read paths federate so pins + most-pinned work cross-deployment', () => {
+  // Bugfix fix/tag-federation-pins: a viewer's pins (kind-39999 z=tag-pinning) and the
+  // all-author pin counts ("most-pinned" sort) were local-only, so pins published on one
+  // deployment didn't surface on another (dcosl mirrors 39999, so the events ARE reachable
+  // — the read just wasn't unioning). handlePins (viewer's own pins) and aggregateTagPins
+  // (all-author counts, WoT-filtered → powers most-pinned) must federate.
+  const src = readSrc(SRC);
+  for (const fn of ['handlePins', 'aggregateTagPins']) {
+    const body = src.match(new RegExp(`async function ${fn}[\\s\\S]*?\\n\\}`));
+    assert(body, `could not locate ${fn}`);
+    assert(/federatedScan\s*\(/.test(body[0]),
+      `${fn} must use federatedScan — pins (39999) are mirrored to the federation relays; ` +
+      'local-only made pins blank and most-pinned wrong on non-publishing deployments');
+  }
+});
+
+t('PIECE 2 BOUNDARY: NIP-51 export / TL status enrichment stays local (kind 30000/30382 not on dcosl)', () => {
+  // The export-status badges read kind-30000 (NIP-51) / kind-30382 (TL), which the dcosl
+  // mirror does NOT carry (it mirrors 9998/9999/39998/39999). Federating them to dcosl
+  // would not help; surfacing them cross-deployment needs the viewer's per-user NIP-65
+  // write-relays — a separate, larger change (Piece 2, tracked in _intake.md). Until then
+  // these enrichment scans deliberately stay local. This test guards that boundary.
+  const src = readSrc(SRC);
+  for (const fn of ['enrichRowsWithTLStatus', 'enrichRowsWithNip51ExportStatus']) {
+    const body = src.match(new RegExp(`async function ${fn}[\\s\\S]*?\\n\\}`));
+    assert(body, `could not locate ${fn}`);
+    assert(!/federatedScan\s*\(/.test(body[0]),
+      `${fn} must stay local-only (Piece 2) — kind 30000/30382 are not on the dcosl mirror; ` +
+      'federating to dcosl is a no-op and the real fix needs the viewer NIP-65 write-relays');
+  }
+});
+
 t('SEARCH-IS-LOCAL stays intact after the detail/index fix (computeTagMatches not federated)', () => {
   // Guard the boundary: the blank-page fix federates browse surfaces only and must
   // NOT have leaked federation into the search path (ADR 0001 search-is-local).


### PR DESCRIPTION
## Summary

Follow-up to #323. A viewer's pins (kind-39999 `z=tag-pinning`) are mirrored to the federation relays (dcosl), but the pin read paths were local-only — so pins published on one deployment didn't surface on another (e.g. pins made on tags.brainstorm.world were absent on staging), and "most-pinned" was wrong. This federates the pin reads.

Confirmed empirically: the 6 pin events for the reporting user ARE on dcosl; staging's `handlePins` returned 0 because it scanned local strfry only.

## Changes

- `src/api/profile-tags/index.js` — `strfryScan` → `federatedScan` at the 4 pin-read sites:
  - `handlePins` (viewer's own pins) + its pinned-tag name lookup
  - `aggregateTagPins` (all-author, WoT-filtered pin counts → powers most-pinned)
  - `handleTagById` per-tag "pinned by me" check
- **Left local (Piece 2):** `enrichRowsWithTLStatus` / `enrichRowsWithNip51ExportStatus` read kind-30000/30382, which dcosl does NOT mirror — federating to dcosl is a no-op. Cross-deployment export status needs the viewer's NIP-65 write-relays (tracked in `engineering-team/stories/_intake.md`).
- Search stays local (ADR-0001). `test/tag-read-union.test.js` +2 guards (pins federate; export/TL stay local). 18/18.

## Test plan

- [x] `node test/tag-read-union.test.js` 18/18; `pin-a-tag`, `tag-index`, `tag-detail` green.
- [x] Verified on dcosl: user's 6 pins present (kind-39999); exports (kind-30000) absent.
- [ ] After merge: deploy-staging.yml runs.
- [ ] Smoke: `/api/profile-tags/pins?viewerPubkey=<user>` on staging returns the pins; `/tags?sort=most-pinned` populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)