### PR TITLE
chore: arm verified-muters Direction-mode book

### DIFF
--- a/engineering-team/audits/verified-muters/book.md
+++ b/engineering-team/audits/verified-muters/book.md
@@ -35,10 +35,10 @@ This book runs under the Director harness — [`/direct-feature`](../../../.clau
 
 Arming is **one commit on the `staging` branch whose diff touches only this subsection**, filling in:
 
-- **Armed:** No *(→ `Yes — <ISO-8601 UTC datetime>`)*
-- **Deadline:** — *(→ arming instant + 96 hours, as an ISO-8601 UTC datetime; the arming commit's timestamp is the tiebreaker if prose and git disagree. 96h is the recommended window for a feature this small; the operator may set another value at arming.)*
-- **Baseline:** — *(→ the `origin/staging` SHA at arming. No stories, ADRs, or source changes for the `verified-muters` epic may exist at that SHA — pre-existing work voids the run. This `book.md` and its `_intake.md` entry are anchor inputs, not epic work, and are expected to be present at the baseline.)*
-- **Pinned governing versions:** — *(→ the commit SHAs of `engineering-team/roles/director.md`, `.claude/skills/direct-feature/SKILL.md`, and `.claude/agents/gate-judge.md` at arming. Scoring uses the pinned versions; any mid-run diff to the rubrics, judge protocol, stopping rules, or the judge agent is a goalpost amendment by definition.)*
+- **Armed:** Yes — 2026-06-21T14:31:30Z
+- **Deadline:** 2026-06-25T14:31:30Z *(arming instant + 96 hours)*
+- **Baseline:** `d1954c382d1c44783f310b182ac1415d10debde1` *(origin/staging at arming — the PR #329 merge; no `verified-muters` epic stories/ADRs/source exist at this SHA)*
+- **Pinned governing versions:** `engineering-team/roles/director.md` f314bbba · `.claude/skills/direct-feature/SKILL.md` f314bbba · `.claude/agents/gate-judge.md` 3a2657b2
 
 A missing or ambiguous Armed/Deadline line means the book is not armed; the Director must refuse to run.
 


### PR DESCRIPTION
## Arms the Verified Muters Direction-mode book

Flips the `### Arming` subsection of `engineering-team/audits/verified-muters/book.md` from un-armed to armed. **The diff touches only the four Arming bullets** (4 insertions / 4 deletions, one file) — per the pre-registration's "one commit whose diff touches only this subsection."

| Field | Value |
|---|---|
| **Armed** | `2026-06-21T14:31:30Z` |
| **Deadline** | `2026-06-25T14:31:30Z` (arming instant + 96h) |
| **Baseline** | `d1954c382d1c44783f310b182ac1415d10debde1` (origin/staging = PR #329 merge) |
| **Pinned** | director.md `f314bbba` · direct-feature/SKILL.md `f314bbba` · gate-judge.md `3a2657b2` |

Verified at branch time: **no `verified-muters` epic stories/ADRs/source exist at the baseline** (clean — the run produces them).

## This is the arming act

**Merging this PR is the operator's deliberate arming** — it puts `Armed: Yes` on `staging` and starts the 96h experiment clock. After merge, run **`/direct-feature`** ("run the verified-muters book").

The clock is anchored to this commit's timestamp; if you merge much later than ~now and want the full 96h from merge, ping me to refresh the two datetimes before you merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)