### PR TITLE
chore: re-arm verified-muters Direction-mode book

### DIFF
--- a/engineering-team/audits/verified-muters/book.md
+++ b/engineering-team/audits/verified-muters/book.md
@@ -37,10 +37,10 @@ This book runs under the Director harness — [`/direct-feature`](../../../.clau
 
 Arming is **one commit on the `staging` branch whose diff touches only the four bullets below**, filling in:
 
-- **Armed:** No *(→ `Yes — <ISO-8601 UTC datetime>` at re-arm)*
-- **Deadline:** — *(→ re-arming instant + 96 hours, as an ISO-8601 UTC datetime)*
-- **Baseline:** — *(→ the `origin/staging` SHA at re-arming, which must include this amendment. No `verified-muters` epic stories, ADRs, or source may exist at that SHA; `book.md`, its `_intake.md` entry, and the Director `journal.md` are anchor/audit inputs, not epic work.)*
-- **Pinned governing versions:** — *(→ the commit SHAs of `engineering-team/roles/director.md`, `.claude/skills/direct-feature/SKILL.md`, and `.claude/agents/gate-judge.md` at re-arming.)*
+- **Armed:** Yes — 2026-06-21T15:40:33Z
+- **Deadline:** 2026-06-25T15:40:33Z *(re-arming instant + 96 hours)*
+- **Baseline:** `70ed1f7a2a5e74e6c300c98813221e4a2944b297` *(origin/staging at re-arm, incl. the #331 amendment. No `verified-muters` epic stories/ADRs/reviews exist, and none of this book's deliverables exist — the muters list endpoint (`mutersWithMetrics.js` / `get-grapevine-muters`), `BrainstormMuters.jsx` / `useGrapevineMuters.js`, and the `verifiedMuterCount` wiring into `handleGetUserCounts` are all absent. The pre-existing `calculate*MuterCounts.sh` data-layer scripts and the `verifiedMuterCount` already returned by `handleGetUserData` are foundation this book surfaces, NOT epic work — do not mistake them for contamination at Stage 0.)*
+- **Pinned governing versions:** `engineering-team/roles/director.md` f314bbba · `.claude/skills/direct-feature/SKILL.md` f314bbba · `.claude/agents/gate-judge.md` 3a2657b2
 
 A missing or ambiguous Armed/Deadline line means the book is not armed; the Director must refuse to run.
 


### PR DESCRIPTION
## Re-arms the verified-muters book (on the amended pre-registration)

Follows [#331](https://github.com/nous-clawds4/tapestry/pull/331) (the test-baseline amendment). **Diff touches only the four Arming bullets.**

| Field | Value |
|---|---|
| **Armed** | `2026-06-21T15:40:33Z` |
| **Deadline** | `2026-06-25T15:40:33Z` (+96h) |
| **Baseline** | `70ed1f7a2a5e74e6c300c98813221e4a2944b297` (origin/staging = #331 merge) |
| **Pinned** | director `f314bbba` · SKILL `f314bbba` · gate-judge `3a2657b2` |

Verified clean at branch time: no `verified-muters` epic stories/ADRs/reviews, and none of the book's deliverables (muters endpoint, list page/hook, `handleGetUserCounts` wiring). The pre-existing `calculate*MuterCounts.sh` scripts and `handleGetUserData`'s `verifiedMuterCount` are the data-layer foundation the book surfaces — flagged in the Baseline line so Stage 0 won't mistake them for contamination.

**Merging this PR is your re-arming act.** After merge, tell me and I'll resume `/direct-feature` from Stage 0 — snapshot the passing-suite baseline, then start Planning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)