### PR TITLE
spec(protocols): Shared Concepts NIP (nip-reorg #1)

### DIFF
--- a/engineering-team/audits/nip-reorg/book.md
+++ b/engineering-team/audits/nip-reorg/book.md
@@ -1,0 +1,25 @@
+# Book: nip-reorg
+
+**Status:** Open
+**Opened:** 2026-07-12 (eager)
+**Type:** Bounded ask (no PRD)
+**Epics:** `nip-reorg` (sole epic; planned stories 1–4)
+
+**Intent anchor:** [`docs/NIP_REORG_DESIGN_HANDOFF.md`](../../../docs/NIP_REORG_DESIGN_HANDOFF.md) (merged PR #344, 2026-07-12) — the scoping capture whose §5 ratification plan this book realizes. Anchor provenance: **acceptance-frame (eager)**; confidence: **high**.
+
+## Acceptance frame (the ask, restated and confirmed at kickoff)
+
+Reorganize the shared-concept protocol surface into NIPs per the handoff's settled decisions D1–D8, without settling the deliberately-deferred subset/ancestor-stamping design (O1):
+
+1. **Shared Concepts** (`protocols/drafts/shared-concepts.md`) exists — the b-consuming policy NIP (affiliation, deference, observer-resolved aggregation, clouds, W1 identity trajectory), written under the D2 vocabulary policy; inherit-from § Aggregation reduced to a pointer.
+2. **Class Thread Relationships** — `class-thread-tags.md` renamed, substance unchanged, inbound links fixed.
+3. **Stamping** (`protocols/drafts/stamping.md`) exists — the multi-`z` convention moved out of tapestry-concepts (which keeps a pointer), the read-side contract stated, and O1 present as an explicit open section with a new worksheet entry.
+4. **Index & cross-refs coherent** — `protocols/README.md` rows per the status ladder; W1/W11 re-pointers; `tags.md`/`communities.md` reference Stamping rather than restating dual-`z`; BIBLE pointers consistent.
+
+Throughout: each wire fact normative in exactly one place; no "canonical"/"consensus" in living-spec normative text; ADRs and worksheet history unrewritten.
+
+**Done looks like:** all four stories PASS and shipped to staging; the handoff doc flips to ✅ SUPERSEDED.
+
+## Close
+
+_(open)_

--- a/engineering-team/decisions/nip-reorg/0001-shared-concepts-nip.md
+++ b/engineering-team/decisions/nip-reorg/0001-shared-concepts-nip.md
@@ -1,0 +1,72 @@
+# ADR 0001: Shared Concepts NIP — structure, migration boundaries, and O2 resolution
+
+**Status:** Accepted
+**Date:** 2026-07-12
+**Story:** `engineering-team/stories/nip-reorg/1-shared-concepts-nip.md`
+
+## Context
+
+Story nip-reorg #1 requires a new policy NIP (`protocols/drafts/shared-concepts.md`) per handoff D1–D3 ([`docs/NIP_REORG_DESIGN_HANDOFF.md`](../../../docs/NIP_REORG_DESIGN_HANDOFF.md)): the layer that explains how independent authors converge on shared concepts, consuming the `b` primitive without restating it. The policy content today is scattered across four homes with three different vocabularies:
+
+- [`protocols/drafts/inherit-from.md`](../../../protocols/drafts/inherit-from.md) § "Aggregation: who defers to a definition" — deference vs discovery, protocol policy stranded in a primitive spec;
+- [`protocols/drafts/tapestry-concepts.md`](../../../protocols/drafts/tapestry-concepts.md) § "Multi-`z` stamping" — the ADR 0033 cloud model, entangled with stamp mechanics that S3 will extract;
+- BIBLE §22 + glossary — the "grapevine → firmware → none" precedence, in implementation terms;
+- [`protocols/worksheet.md`](../../../protocols/worksheet.md) W1 — the open cross-deployment identity problem.
+
+Constraints: the D2 vocabulary policy (no "canonical"/"consensus" in living-spec normative text); the README boundary rule ("each wire format normative in exactly one place"); story AC6 (S1 touches no `protocols/` file other than the new spec, inherit-from, and the README row); docs-mode (no code, no firmware; Test Design skipped).
+
+## Options considered
+
+### Option A — New policy spec + pointer edit in inherit-from (chosen)
+`drafts/shared-concepts.md` becomes the normative home for affiliation/deference/aggregation/cloud/identity policy; inherit-from § Aggregation shrinks to a pointer, keeping only tag-mechanics. Pros: realizes D1 exactly; the primitive spec becomes purely mechanical; one reading path for implementers. Cons: two transient duplications until S3/S4, which must be explicitly tracked (see Decision).
+
+### Option B — Expand inherit-from into a combined primitive+policy spec
+Rejected: violates D1's split, mixes stability tiers (ratified mechanics with open policy), and makes eventual separate publication impossible without a later re-split.
+
+### Option C — Grow the policy inside tapestry-concepts
+Rejected: wrong layer — tapestry-concepts is the data-model NIP, and the epic's direction (S3) is to *shrink* it by extracting § Multi-`z`, not grow it.
+
+## Decision
+
+**Option A**, with **O2 resolved as "ratified selector in, open problem referenced"**: the spec states normatively the *ratified* precedence (`grapevine-resolved → firmware-blessed → none`, per ADR 0033 / BIBLE §22's trajectory) because the cloud model is incomplete without its selector — but the *unresolved* identity question (how independent deployments agree which header a concept converges on) is stated as open and pointed at W1, which remains the sole tracker.
+
+No fact gets a second normative home *at end of epic*; the two transient duplications are scheduled:
+
+1. cloud prose duplicated with tapestry-concepts § Multi-`z` bullets **until S3** flips that section to a pointer;
+2. the selector duplicated with BIBLE §22's implementation framing **until S4** audits §22 for pointer alignment (the §25/§26 precedent).
+
+## Consequences
+
+- Implementers get one policy document; inherit-from becomes strictly mechanics (its § Scope keeps only wire semantics).
+- S3 and S4 inherit two explicit cleanup obligations — if the epic stalls after S1, the duplications persist flagged but unresolved.
+- The D2 vocabulary lands in living-spec text for the first time; older ADRs/worksheet keep historical wording, which the reviewer must not "fix."
+- **Firmware reinstall required?** No (docs-only).
+
+## Implementation notes
+
+**1. Create `protocols/drafts/shared-concepts.md`** — title "Shared Concepts", with this section outline:
+
+- *Repo-metadata header:* Status 📝 pre-NIP; Canonical: not yet published; an Implementation line mirroring inherit-from's (pointer-`b` seeding **implemented** — `community-reference` ADR 0034 / `tag-federation` ADR 0002; the resolver, aggregation, and cloud computation **not implemented** on any deployment); Sources: `community-reference` ADR 0033, inherit-from.md § Aggregation (extraction origin), worksheet W1, `docs/B_TAG_AFFILIATION_DESIGN_HANDOFF.md`, `docs/NIP_REORG_DESIGN_HANDOFF.md`.
+- *Intro* — what a shared concept is (a concept whose handle is in conventional use among independent authors); explicit statement: **this NIP defines no new wire format** (everything rides `z` and `b`).
+- *Terminology* — the three defined terms: **deference** (what an inherit-typed `b` claims; the aggregable signal), **convergence** (the process by which conventions arise — gradual, measurable in degree, never final), **convention** (the outcome). State the observer-relative rule once, normatively: every aggregate in this spec is *an observer's view*, never a global fact.
+- *Relationship to other specs* — DList (base), Tapestry Concepts (data model), Inherit-From (the `b` primitive this spec consumes), class-thread-tags **by its current filename** (S2 renames; S4 sweeps links), Communities/Tags as downstream consumers.
+- *Declared affiliation* — pointer-`b` on one's own header as the published affiliation/navigation claim; firmware `communityReference` seeding referenced as the reference deployment's cold-start behavior (one sentence + ADR cite, not a restatement).
+- *Deference* — inherit-`b`; trust-coupling handled by pointer to inherit-from § Security considerations (no duplication).
+- *Aggregated deference (observer-resolved)* — **migrated** from inherit-from § Aggregation: deference aggregation counts inherit-typed edges only (a bookmark is not agreement — the rationale sentence comes along); discovery walks include both types. Written in D2 vocabulary (the section's old "Consensus (deference)" label becomes deference aggregation).
+- *Clouds* — ADR 0033 restated in D2 vocabulary: derived top-k of an observer's aggregated deference; never a published object/manifest; mutual pointer-`b` = navigation, not gate; rotation emergent; bootstrap-from-singleton; the precedence selector; an italic *design-only* callout mirroring tapestry-concepts' ("gated on the resolver and on-wire `b`-tags; cap/formula/cold-start contents deferred").
+- *Cross-deployment identity* — the problem in one paragraph, the trajectory (firmware-blessed pointer → registry-as-DList → deference aggregation), and "open, tracked as W1."
+- *Security considerations* — seeded/casual correspondence must never masquerade as deference (why pointer-typed edges carry zero aggregation weight).
+
+**2. Edit `protocols/drafts/inherit-from.md`:**
+- § "Aggregation: who defers to a definition" → retain the heading, replace the body with: the one-sentence relay-mechanics fact that belongs to the primitive (the type element is non-indexed, so `#b` filters return both types; consumers filter locally) + a pointer to Shared Concepts for the aggregation policy.
+- § Scope (v1), one vocabulary alignment: "zero **consensus** weight" → "zero **aggregation** weight" (same meaning, D2-compliant; flagged here since it's outside § Aggregation).
+- Nothing else in the file changes (the spec-map sentence and family table are S4's sweep).
+
+**3. Add the README index row** (mirror existing format):
+`| Shared Concepts (b-consuming policy) | [drafts/shared-concepts.md](./drafts/shared-concepts.md) | 📝 pre-NIP | **Working copy here** (policy layer over Inherit-From; extraction of its § Aggregation) | nip-reorg #1 ✅ |`
+
+**4. Reviewer verification plan (docs-mode):** grep the new spec for `canonical|consensus` — zero hits outside clearly-cited historical titles; confirm every relative link resolves on disk; confirm the diff touches only the three files above (+ story link-back); `npm test` green.
+
+## Out of scope
+
+Stamp mechanics (personal-`z` requirement, cap, re-stamp — S3's Stamping NIP); the class-thread rename (S2); W1/W11 worksheet re-pointers and the BIBLE §22 pointer audit (S4); settling O1 (subset/ancestor stamping); any resolver/cloud implementation.

--- a/engineering-team/epics/nip-reorg.md
+++ b/engineering-team/epics/nip-reorg.md
@@ -1,0 +1,23 @@
+# Epic: nip-reorg
+
+**Created:** 2026-07-12
+**Status:** Active
+
+## Goal
+
+Reorganize the shared-concept protocol surface into the four-NIP layered organization settled in [`docs/NIP_REORG_DESIGN_HANDOFF.md`](../../docs/NIP_REORG_DESIGN_HANDOFF.md) (D1–D8): the `b` primitive stays in inherit-from; a new **Shared Concepts** policy NIP; **Class Thread Relationships** (rename of class-thread-tags); a new **Stamping** NIP holding the multi-`z` convention and the open subset question. Every wire fact normative in exactly one place; the D2 vocabulary policy (retire "canonical" and "consensus"; deference / convergence / convention) applied throughout the living specs.
+
+This is docs-mode work (protocol-spec workflow §3): deliverables are `protocols/` prose + pointer edits, no code, Test Design skipped per story.
+
+## Stories (per handoff §5)
+
+1. `stories/nip-reorg/1-shared-concepts-nip.md` — **S1: Shared Concepts** — new `protocols/drafts/shared-concepts.md`; absorbs inherit-from § Aggregation; minimal README index row (gate decision 2026-07-12).
+2. _(planned)_ **S2: Class Thread Relationships** — rename + title sweep of `class-thread-tags.md`.
+3. _(planned)_ **S3: Stamping** — new `protocols/drafts/stamping.md`; tapestry-concepts § Multi-`z` → pointer; the O1 open section; new worksheet entry.
+4. _(planned)_ **S4: Index & cross-ref sweep** — remaining `protocols/README.md` rows; W1/W11 re-pointers; `tags.md`/`communities.md` reference Stamping; BIBLE pointer consistency.
+
+S1–S3 order-independent in substance; S4 last.
+
+## Not on this epic's path
+
+Settling O1 (subset/ancestor stamping — gets its own `/discuss`); target-typed tag *definitions* (tags/W10 lineage); the pins dual-`z` implementation lag (eng-team story candidate); any resolver/cloud implementation.

--- a/engineering-team/reviews/nip-reorg/1-shared-concepts-nip.md
+++ b/engineering-team/reviews/nip-reorg/1-shared-concepts-nip.md
@@ -1,0 +1,94 @@
+# Review: Story 1 — Author the Shared Concepts NIP
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-07-12
+**Mode:** docs-mode (protocol-spec workflow §3 — accuracy/consistency audit; Test Design skipped by design)
+**Diff:** `git diff a34358c7..14be2631` (commit `14be2631`, branch `docs/nip-reorg-s1-shared-concepts`, base `origin/staging` @ `5f326fac`)
+**Files touched:** `protocols/drafts/shared-concepts.md` (new, 84 lines), `protocols/drafts/inherit-from.md` (2 hunks), `protocols/README.md` (1 row) — exactly the three files ADR note 4 authorizes; no non-`.md` file in the diff (verified by `--name-only`).
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` at `14be2631` — **FAIL overall, with exactly the caveated environmental failure set**: 11 suites (`profile-tags` 10p/3f, `profile-tags-publish` 6p/1f, `tag-detail-publish` 7p/2f, `tag-index-publish` 8p/1f, `profile-tag-polish` 7p/4f, `pin-a-tag-publish` 1p/6f, `tl-publication-from-pins` 9p/1f, `tl-publication-from-pins-publish` 2p/5f, `customize-pin-curation-publish` 0p/3f, `most-pinned-tag-index-publish` 0p/7f, `tag-detail-curated-view-and-pin-polish-publish` 0p/1f), 25 skips.
+- [x] `npm test` at clean base `a34358c7` — **identical**: same 11 suites, same per-suite pass/fail counts, same 25 skips. The failures are the known stale-bind-mounted-Docker-stack condition (empty graph, #305 checkout), not regressions; the diff contains no source or test files, and the differential run proves zero new failures. Binding gate is CI's stack-free job.
+- [x] No new failure appears on the branch vs base.
+- [x] _Playwright — not applicable (no browser/UI change; docs only)._
+- [x] _Lint/typecheck/build not configured — skipped._ No tooling added (no `package.json` change in diff).
+
+## Spec adherence (AC-by-AC, docs-mode)
+
+- [x] **AC1 — the spec exists.** `protocols/drafts/shared-concepts.md:1-5` carries the repo-metadata header: Status 📝 pre-NIP (`:2`), Canonical: not yet published (`:3`), Implementation line mirroring inherit-from's (`:4` vs `inherit-from.md:4` — implemented pointer-`b` seed / not-implemented resolver+aggregation+cloud), and Sources naming all five required items (`:5`): `community-reference` ADR 0033, inherit-from.md § Aggregation as extraction origin, worksheet W1, `docs/B_TAG_AFFILIATION_DESIGN_HANDOFF.md`, `docs/NIP_REORG_DESIGN_HANDOFF.md`.
+- [x] **AC2 — required content, as identifiable sections.**
+  - What a shared concept is, D2 convention-as-outcome vocabulary: `:12` (intro), `:20` (Terminology — "A shared concept is a concept whose handle is in conventional use").
+  - Declared affiliation (pointer-`b`): `:31-41`.
+  - Deference (inherit-`b`): `:43-47`.
+  - Aggregated deference, observer-resolved, with the deference-aggregation vs discovery-walk distinction migrated from inherit-from: `:49-56`.
+  - Cloud model per ADR 0033: `:58-68` — derived top-k `:60`; never a published manifest `:62`; mutual pointer-`b` navigation-not-gate `:63`; emergent rotation `:64`; firmware-blessed cold-start precedence `:65`; bootstrap-from-singleton `:66`.
+  - Cross-deployment identity trajectory with W1 explicitly named as the open tracker: `:70-78` (`:72` "tracked as worksheet W1"; `:78` "does not resolve W1").
+  - Explicit no-new-wire-format statement: `:12`.
+- [x] **AC3 — vocabulary policy.** `grep -in 'canonical\|consensus' protocols/drafts/shared-concepts.md` → exactly one hit: `:3` — the `**Canonical:**` metadata field name inside the block marked "not part of the spec text" (`:1`). Zero hits in normative text. `grep -in 'consensus' protocols/drafts/inherit-from.md` → zero hits post-edit. Every description of the aggregated-deference signal carries the observer-relative qualifier: `:12` ("how an observer resolves"), `:22` (the normative observer-relative rule), `:49` (section title "(observer-resolved)"), `:53` ("the observer weighs … from the observer's point of view"), `:60` ("an observer's aggregated deference"), `:65` ("the observer's trust-weighted aggregate"), `:84` ("from the observer's point of view").
+- [x] **AC4 — single normative home.** `inherit-from.md:88-90`: § "Aggregation: who defers to a definition" retains its heading and is reduced to a pointer at Shared Concepts plus the one mechanical relay fact (type element non-indexed; `#b` returns both types; filter locally) — exactly ADR note 2. The migrated distinctions now live only in `shared-concepts.md:51-54`.
+- [x] **AC5 — discoverable.** `protocols/README.md:58` — index row in the spec-index table, 📝 pre-NIP, format mirrors neighboring rows and ADR note 3 (backticks around `b`/`nip-reorg` are the table's existing convention).
+- [x] **AC6 — nothing else moves.** Diff stat: 3 files only; `tapestry-concepts.md` § Multi-`z` untouched (S3); no other `protocols/` file changed. `npm test` differential vs base: identical (see gates).
+
+## ADR adherence
+
+- [x] **Section outline (ADR note 1) followed exactly:** header `:1-5`; intro `:9-12`; Terminology with the three defined terms + the observer-relative rule stated once, normatively `:14-22`; Relationship to other specs `:24-29` (DList, Tapestry Concepts, Inherit-From, class-thread-tags **by current filename** `:28` per the ADR — S2 renames, S4 sweeps; Tags/Communities as downstream `:29`); Declared affiliation `:31-41` (firmware seeding = brief cite of ADR 0034 / tag-federation ADR 0002, not a restatement); Deference `:43-47` (trust-coupling by pointer to Inherit-From § Security considerations at `:18`); Aggregated deference `:49-56` (migrated text; old "Consensus (deference)" label → "Deference aggregation"; rationale sentence "a bookmark is not agreement" carried along `:53`); Clouds `:58-68` with the italic design-only callout `:68` mirroring tapestry-concepts'; Cross-deployment identity `:70-78`; Security considerations `:80-84`.
+- [x] **O2 resolution honored:** the ratified selector precedence is stated normatively (`:65`), the unresolved identity question is stated as open and pointed at W1 (`:72`, `:78`); W1 remains the sole tracker (worksheet untouched by this diff — its re-pointer is S4 per the story's out-of-scope).
+- [x] **inherit-from edits (ADR note 2):** § Aggregation body → pointer + mechanical fact (`:88-90`); § Scope (v1) "zero **consensus** weight" → "zero **aggregation** weight" (`:82`). Nothing else in the file changed (diff shows exactly two hunks).
+- [x] No unauthorized dependencies/tooling (docs only).
+- **Deviations (flagged, judged non-blocking — see Findings):** (1) § Security's second paragraph (`:84`, observer-weighting as sybil gate) goes beyond the ADR outline's single point; (2) `inherit-from.md:82` also rewrites "In aggregation (below)" → "In aggregation ([Shared Concepts](./shared-concepts.md))", one word beyond the ADR's stated single vocabulary alignment in that section.
+
+## Accuracy audit (are the claims true?)
+
+- [x] **Implementation-status claims (`:4`, `:41`).** Verified in source: the pointer-`b` firmware emitter exists — `src/firmware/install.js:1001` (`pass_communityReferences`), `:1059` (`['b', cr.headerATag, 'pointer']` appended), `:1057` (never-clobber), `:1261` (`seededB` stub gate) — matching `community-reference` ADR 0034's decision; `tag-federation` ADR 0002 is precisely the "applied to the tag concepts" manifest step the spec cites. The "resolver … not implemented" claim matches inherit-from.md:4 and ADR 0033's design-only framing.
+- [x] **Fidelity of the migrated Aggregation text** (vs `git show a34358c7:protocols/drafts/inherit-from.md` § Aggregation, visible in the diff hunk): the child→target preamble, the inherit-only counting rule with "everyone who defers to this definition", the "a bookmark is not agreement" rationale, and the both-types discovery-walk bullet (incl. the `#z`-union example) are preserved at `shared-concepts.md:51-54`; only D2 vocabulary changed ("Consensus (deference) aggregation" → "Deference aggregation"; "masquerade as consensus" → "masquerade as deference", per the handoff §4 table). The original's W1 sentence moved to § Cross-deployment identity (`:72`) — its ADR-designated home. The added GrapeRank parenthetical (`:53`) is sourced (ADR 0033 Option A: "GrapeRank-weighted from the observer's PoV") and correctly marked reference-deployment-specific.
+- [x] **Cloud model fidelity** (vs `community-reference` ADR 0033 Decision 1-2/7-8 and `tapestry-concepts.md:53-57`): all five bullets map 1:1 to ratified fixed points; no invented properties; no dropped *cloud* properties (ADR 0033's items 3-6 — affiliation anchor, stamping rule, lazy re-emit, containment-only — are stamping-side and belong to S3 per this story's ADR outline; correctly absent here). The design-only callout (`:68`) matches tapestry-concepts' (`:55`) including the deferred cap (~5)/formula/cold-start list (ADR 0033 Decision 7 confirms "~5"). "Gated on on-wire inherit-typed `b` tags" is an accurate refinement of ADR 0033's "on-wire `b`-tags" now that pointer-`b` is on-wire (ADR 0034/tag-federation 0002).
+- [x] **W1 trajectory** (vs `protocols/worksheet.md:9-21`): the three stages match W1's candidate directions (firmware-blessed pointer "accepted temporarily" `:74`≈W1:17; registry-as-DList, "Grapevine-ranked" rendered observer-relative `:75`≈W1:18; deference aggregation `:76`≈W1:19) and the handoff D3 trajectory. Openness preserved: "Candidate end state" (`:76`), "does not resolve W1" (`:78`) — consistent with W1's "none ratified".
+- [x] **W1 anchor:** `../worksheet.md#w1--cross-deployment-concept-identity` matches the actual heading `## W1 — Cross-deployment concept identity` (worksheet.md:9; em-dash collapses to the double hyphen). Same style as the pre-existing W6 link, whose heading (worksheet.md:57) is unchanged.
+
+## Cross-references
+
+- [x] Every relative link target in the three changed files exists on disk (verified: `nips/decentralized-lists.md`, `drafts/tapestry-concepts.md`, `drafts/class-thread-tags.md`, `drafts/tags.md`, `drafts/communities.md`, `drafts/inherit-from.md`, `drafts/shared-concepts.md`, `worksheet.md`).
+- [x] Links use current filenames — `class-thread-tags.md` (`:28`), not the future S2 rename.
+- [x] Prose §-citations name real sections: Inherit-From § Security considerations (inherit-from.md:84), § "Aggregation" (`:88`), § "Resolution"; Tapestry Concepts § "Multi-`z` stamping" (tapestry-concepts.md:53, a bold run-in heading — the corpus's own citation style for it).
+
+## Boundary / duplication audit
+
+- [x] The two **scheduled transient duplications** are present exactly as the ADR's Decision acknowledges: cloud prose vs `tapestry-concepts.md:55-57` (until S3), selector vs BIBLE §22's framing (until S4).
+- [x] No additional normative duplication: `b` resolution semantics, override rules, first-listed-wins, closure — all pointered, never restated (`:27` "This NIP defines no `b` semantics of its own"; `:45`, `:56`). Relay mechanics summarized in one parenthetical with the normative home named (`:56`).
+- [ ] Two *illustrative* restatements noted (non-blocking, below): the wire-shape example at `:36` and the absent-type parenthetical at `:45`.
+
+## Concept-graph integrity / house rules
+
+- [x] Docs-mode: no concept definitions changed; **no firmware reinstall required** (ADR Consequences, confirmed — no `firmware/` or `src/` file in diff).
+- [x] Handle forms in examples are correct `kind:pubkey:slug` shapes with placeholders (`:36`, `:72`); no hardcoded deployment pubkeys (grep for `82b75e47`/`919ba08a` → none) — the spec practices the key-neutrality it preaches.
+- [x] No new lint/typecheck/build tooling; Concept Graph API authority untouched.
+- [x] No secrets, no debug text, no scope creep beyond the three authorized files.
+
+## Findings
+
+### Blocking
+
+None.
+
+### Non-blocking
+
+1. **`protocols/drafts/shared-concepts.md:36`** — the fenced `["b", "39998:<sharedHeaderAuthor>:<d-tag>", "pointer"]` example restates the `b` wire shape whose normative home is `inherit-from.md:25`. Clearly illustrative (the spec twice disclaims defining `b` semantics), but if the primitive's format ever changed this example goes stale silently. Optional: S4's sweep should include examples in its cross-check list.
+2. **`protocols/drafts/shared-concepts.md:39,53,82`** — "zero aggregation weight" is stated unqualified, while the primitive scopes it "in v1; graded weighting is deferred to the future registry ADR" (`inherit-from.md:82`). `:82`'s "hard rule inherited from the primitive" correctly delegates authority, but if the registry ADR ever grades pointer weight, three sentences here need revision. Optional: add "in v1" once (e.g. at `:53`).
+3. **`protocols/drafts/shared-concepts.md:84`** — § Security's second paragraph (observer weighting as the sybil gate) exceeds the ADR outline's single stated point. It is accurate (grounded in ADR 0033's GrapeRank-from-observer-PoV design) and materially improves the security section; flagged only as an ADR-outline deviation.
+4. **`protocols/drafts/inherit-from.md:82`** — "In aggregation (below)" → "In aggregation ([Shared Concepts](./shared-concepts.md))" is one edit beyond the ADR note 2's stated single vocabulary alignment in § Scope. It is necessary (leaving "(below)" would dangle after the § Aggregation body moved) and consistent with the ADR's intent.
+
+### Harness friction
+
+1. None new. (The 11-suite environmental failure of the local bind-mounted stack is already-known state — see the local-dev-stack memory note; the binding gate is CI's stack-free job.)
+
+## Verdict
+
+**PASS**
+
+The diff is exactly the three files the ADR authorizes; all six ACs verified with evidence; the migrated text preserves meaning with only the D2 vocabulary change; every corpus claim checked out against ADR 0033/0034, tag-federation ADR 0002, `src/firmware/install.js`, tapestry-concepts § Multi-`z`, and worksheet W1; all cross-references resolve; the vocabulary gate is clean; and the test gate is regression-free (differential run against the clean base shows an identical failure set). The four non-blocking notes are polish/S4-sweep candidates, not defects.
+
+## On PASS (same commit)
+
+- [ ] Story `**Status:**` flip to `Done` — **deferred to the parent agent** (this review session was instructed to write only this report and not to edit other files or commit). **Mandatory in the same commit as this review:** harness-lint **L1** fires (`review …/1-shared-concepts-nip.md is PASS-final but story status is 'Approved'`) and `npm test`/CI stack-free will FAIL until `engineering-team/stories/nip-reorg/1-shared-concepts-nip.md` reads `**Status:** Done` (verified by running `scripts/harness-lint.sh` with this report on disk). Also fill the story's `Review:` link.
+- [ ] Completion detection — the book/epic is **not** complete: S2 (class-thread rename), S3 (Stamping NIP), S4 (index & cross-ref sweep) remain open per the handoff §5 plan. No close-book offer.

--- a/engineering-team/stories/nip-reorg/1-shared-concepts-nip.md
+++ b/engineering-team/stories/nip-reorg/1-shared-concepts-nip.md
@@ -38,6 +38,6 @@ None mutated (docs-mode; no concept-graph or firmware change). Referenced machin
 
 ## Linked artifacts
 
-- ADR: (filled in after Architecture phase)
+- ADR: [`engineering-team/decisions/nip-reorg/0001-shared-concepts-nip.md`](../../decisions/nip-reorg/0001-shared-concepts-nip.md) (O2 resolved: ratified selector in, open problem referenced via W1)
 - Test plan: skipped — docs-mode
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/nip-reorg/1-shared-concepts-nip.md
+++ b/engineering-team/stories/nip-reorg/1-shared-concepts-nip.md
@@ -1,6 +1,6 @@
 # Story 1: Author the Shared Concepts NIP
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-07-12
 **Type:** Doc
 
@@ -40,4 +40,4 @@ None mutated (docs-mode; no concept-graph or firmware change). Referenced machin
 
 - ADR: [`engineering-team/decisions/nip-reorg/0001-shared-concepts-nip.md`](../../decisions/nip-reorg/0001-shared-concepts-nip.md) (O2 resolved: ratified selector in, open problem referenced via W1)
 - Test plan: skipped — docs-mode
-- Review: (filled in after Review phase)
+- Review: [`engineering-team/reviews/nip-reorg/1-shared-concepts-nip.md`](../../reviews/nip-reorg/1-shared-concepts-nip.md) — PASS (2026-07-12; 4 non-blocking findings routed to S4)

--- a/engineering-team/stories/nip-reorg/1-shared-concepts-nip.md
+++ b/engineering-team/stories/nip-reorg/1-shared-concepts-nip.md
@@ -1,0 +1,43 @@
+# Story 1: Author the Shared Concepts NIP
+
+**Status:** Approved
+**Created:** 2026-07-12
+**Type:** Doc
+
+## Background
+
+The 2026-07-12 protocol-spec scoping session (captured in [`docs/NIP_REORG_DESIGN_HANDOFF.md`](../../../docs/NIP_REORG_DESIGN_HANDOFF.md), merged via PR #344) settled a reorganization of the shared-concept protocol surface into a primitive/policy split (handoff D1–D8). Today the policy layer — how independent authors converge on shared concepts — is scattered across `protocols/drafts/inherit-from.md` § Aggregation, `protocols/drafts/tapestry-concepts.md` § Multi-`z`, `community-reference` ADR 0033, worksheet W1, and BIBLE §22. An implementer has no single document to read, and the scattered text still uses vocabulary ("consensus") the design rejects (handoff D2). This story delivers the centerpiece new document; the epic's S2–S4 handle the class-thread rename, the Stamping extraction, and the cross-reference sweep.
+
+## User-facing description
+
+As an implementer of an independent deployment (or a future ratifying session), I want one policy NIP that explains how shared concepts work — affiliation, deference, aggregation, clouds, identity — so that I can interoperate without reverse-engineering policy from a primitive spec, ADR history, and worksheet entries.
+
+## Acceptance criteria
+
+- [ ] **AC1 — the spec exists.** `protocols/drafts/shared-concepts.md` is present with the standard repo-metadata header (Status: 📝 pre-NIP; Canonical: not yet published; Sources naming at minimum: `community-reference` ADR 0033, `inherit-from.md` § Aggregation as origin of migrated text, worksheet W1, `docs/B_TAG_AFFILIATION_DESIGN_HANDOFF.md`, `docs/NIP_REORG_DESIGN_HANDOFF.md`).
+- [ ] **AC2 — required content.** The spec covers, as identifiable sections: what a shared concept is (handoff D2 vocabulary: convention as outcome); declared affiliation (pointer-`b`); deference (inherit-`b`); aggregated deference, observer-resolved — including the deference-aggregation vs discovery-walk distinction migrated from inherit-from; the cloud model per ADR 0033 (derived top-k, never a published manifest, mutual pointer-`b` as navigation not gate, emergent rotation, bootstrap-from-singleton, firmware-blessed cold-start precedence); the cross-deployment identity trajectory with W1 explicitly named as the open tracker; and an explicit statement that this NIP defines **no new wire format**.
+- [ ] **AC3 — vocabulary policy holds.** Grep of the new spec finds zero occurrences of "canonical" or "consensus" in normative text (permitted only inside clearly-marked historical citations such as ADR titles); every description of the aggregated-deference signal carries the observer-relative qualifier.
+- [ ] **AC4 — single normative home.** `inherit-from.md` § "Aggregation: who defers to a definition" is reduced to a short cross-reference pointing at the new spec; the migrated distinctions are normative in exactly one place.
+- [ ] **AC5 — discoverable.** `protocols/README.md` gains a minimal index row for the new draft (📝 pre-NIP). *(Gate decision 2026-07-12: row lands here to preserve the index-every-spec invariant; S4 remains the full re-pointer sweep.)*
+- [ ] **AC6 — nothing else moves.** No other `protocols/` file changes in this story (`tapestry-concepts.md` § Multi-`z` untouched — that's S3); `npm test` stays green.
+
+## Concepts touched
+
+None mutated (docs-mode; no concept-graph or firmware change). Referenced machinery: the `b` tag ([inherit-from](../../../protocols/drafts/inherit-from.md)), the `z` parent pointer ([decentralized-lists](../../../protocols/nips/decentralized-lists.md) / [tapestry-concepts](../../../protocols/drafts/tapestry-concepts.md)). The tag concepts (`39998:82b75e474dda005e912bcbb910391c60c2b89cc7faf5d3c30b7c59a324973833:tag` family) may appear as *examples* only.
+
+## Out of scope
+
+- The Stamping NIP and the tapestry-concepts § Multi-`z` extraction (S3); the class-thread rename (S2); worksheet W1/W11 re-pointers, downstream `tags.md`/`communities.md` cross-refs, BIBLE pointer consistency (S4).
+- Settling O1 (subset/ancestor stamping) — deferred by design (handoff D6).
+- Any implementation: the resolver and cloud computation remain unbuilt; the spec must state its design-only status as tapestry-concepts does today.
+
+## Open questions
+
+- **O2** (how much W1 restates inside vs. references) — delegated to Architecture with two guardrails: W1 stays the open-problem tracker, and no fact gets a second normative home.
+- Test Design is skipped per docs-mode (protocol-spec workflow §3); the Reviewer's audit is accuracy/consistency + cross-reference resolution + `npm test` regression.
+
+## Linked artifacts
+
+- ADR: (filled in after Architecture phase)
+- Test plan: skipped — docs-mode
+- Review: (filled in after Review phase)

--- a/protocols/README.md
+++ b/protocols/README.md
@@ -55,6 +55,7 @@ The initial migration (protocols-directory epic, stories 1–7) is **complete** 
 | Communities | [drafts/communities.md](./drafts/communities.md) | 📝 pre-NIP | **Working copy here** (in-flight feature; BIBLE §22 untouched — see ADR 0004; `COMMUNITY_ENDORSEMENTS_DLIST.md` superseded for membership per ADR 0004 D1) | story 6 ✅ |
 | Tags & Taggings | [drafts/tags.md](./drafts/tags.md) | 📝 pre-NIP | **Working copy here** (in-flight feature on `feat/pubkey-tagging-target`) | story 7 ✅ |
 | Tapestry Assistant Designation & Dual-Author Header Resolution (companion to NIP-85) | [drafts/assistant-designation.md](./drafts/assistant-designation.md) | 📝 pre-NIP | **Working copy here** (BIBLE §953 Assistant Keys holds the pointer) | `community-reference` #35 |
+| Shared Concepts (`b`-consuming policy) | [drafts/shared-concepts.md](./drafts/shared-concepts.md) | 📝 pre-NIP | **Working copy here** (policy layer over Inherit-From; extraction of its § Aggregation) | `nip-reorg` #1 ✅ |
 
 Branch-path notation: `branch:path` means the file exists at that path on the named (unmerged) branch — read it with `git show <branch>:<path>`. Migration **copies** content from those branches; it never implies merging them.
 

--- a/protocols/drafts/inherit-from.md
+++ b/protocols/drafts/inherit-from.md
@@ -79,7 +79,7 @@ A node's *stated fields* are the fields its own definition states. The precise b
 
 ## Scope (v1)
 
-The type registry is **closed at two values** (`"pointer"`, `"inherit"`); new values require a new ADR. In aggregation (below), pointer-typed edges carry **zero consensus weight** in v1; graded weighting is deferred to the future registry ADR. Field-level override only — a stated field replaces the inherited one wholesale. The **set-valued override algebra** — how a child adds/removes/replaces individual *elements* of an inherited set — is explicitly deferred to the first consumer that needs it, tracked as worksheet [W6](../worksheet.md#w6--set-valued-override-algebra-for-resolved-definition); when designed, it operates over the inherit-typed deference closure only.
+The type registry is **closed at two values** (`"pointer"`, `"inherit"`); new values require a new ADR. In aggregation ([Shared Concepts](./shared-concepts.md)), pointer-typed edges carry **zero aggregation weight** in v1; graded weighting is deferred to the future registry ADR. Field-level override only — a stated field replaces the inherited one wholesale. The **set-valued override algebra** — how a child adds/removes/replaces individual *elements* of an inherited set — is explicitly deferred to the first consumer that needs it, tracked as worksheet [W6](../worksheet.md#w6--set-valued-override-algebra-for-resolved-definition); when designed, it operates over the inherit-typed deference closure only.
 
 ## Security considerations
 
@@ -87,12 +87,7 @@ The type registry is **closed at two values** (`"pointer"`, `"inherit"`); new va
 
 ## Aggregation: who defers to a definition
 
-Because the derived relationships point child→target, a target's **incoming** edges enumerate its relationships — but the two types feed **different questions**:
-
-- **Consensus (deference) aggregation** counts **inherit-typed edges only**: a target's incoming `INHERITS_FROM` edges enumerate exactly "everyone who defers to this definition" — a trust-weightable signal an observer can rank. Pointer-typed edges carry zero weight here (v1): a bookmark is not agreement, and counting it would let seeded or casual correspondence masquerade as consensus. Its use as a mechanism for cross-deployment concept identity is an open protocol problem, tracked as worksheet [W1](../worksheet.md#w1--cross-deployment-concept-identity).
-- **Discovery (correspondence) walks** include **both types**: "enumerate the headers that point at this definition" (e.g. to union their items' `#z` indexes) wants every correspondence claim, pointer and inherit alike.
-
-Because the type element is non-indexed, a relay-side `#b` filter returns both types; aggregators fetch, then filter by type locally.
+The policy reading of a target's incoming `b`-derived edges — deference aggregation vs. discovery walks, observer weighting, and the cloud model built on them — is specified in [Shared Concepts](./shared-concepts.md). One mechanical fact belongs with the primitive: because the type element is non-indexed, a relay-side `#b` filter returns both types; aggregators fetch, then filter by type locally.
 
 ## Place in the editorial-relationship family
 

--- a/protocols/drafts/shared-concepts.md
+++ b/protocols/drafts/shared-concepts.md
@@ -1,0 +1,84 @@
+> **Repo metadata — not part of the spec text.**
+> **Status:** 📝 pre-NIP
+> **Canonical:** not yet published
+> **Implementation (reference deployment):** the **pointer-`b` affiliation seed** is **implemented** (firmware emitter — `community-reference` ADR 0034, applied to the tag concepts via `tag-federation` ADR 0002). The **resolver, deference aggregation, and cloud computation** (§ "Aggregated deference", § "Clouds") are **not implemented** on any deployment; the cloud model is ratified design (`community-reference` ADR 0033), gated on on-wire inherit-typed `b` tags.
+> **Sources:** `community-reference` ADR 0033 (cloud formation; graduated worksheet W11); [inherit-from.md](./inherit-from.md) § "Aggregation" (origin of the migrated aggregation text, per `nip-reorg` ADR 0001); worksheet [W1](../worksheet.md#w1--cross-deployment-concept-identity); `docs/B_TAG_AFFILIATION_DESIGN_HANDOFF.md`; `docs/NIP_REORG_DESIGN_HANDOFF.md`.
+
+---
+
+Shared Concepts
+=====
+
+This NIP defines the **policy layer** by which independent authors converge on **shared concepts** — concepts whose handles are in conventional use beyond their original author. It specifies **no new wire format**: everything here rides the `z` parent pointer ([Decentralized Lists](../nips/decentralized-lists.md), [Tapestry Concepts](./tapestry-concepts.md)) and the typed `b` tag ([Inherit-From & Resolved Definition](./inherit-from.md)). What this NIP adds is the *reading*: how affiliation is declared, how deference is aggregated, and how an observer resolves which headers a shared concept has converged on.
+
+## Terminology
+
+Three terms, one per referent — signal, process, outcome:
+
+- **Deference** — the claim carried by an inherit-typed `b` tag: "my definition is this parent's, unless I state otherwise." Deference is the **aggregable signal**: it is explicit, signed, revocable, and costly in the sense that it subscribes its author to the parent's future edits (see [Inherit-From](./inherit-from.md) § Security considerations).
+- **Convergence** — the **process** by which shared conventions arise: gradual, measurable in degree, and never final. Convergence increases as independent authors defer to (or affiliate with) the same definition, and it can shift.
+- **Convention** — the **outcome**: a handle is *in conventional use* when independent authors affiliate with it and defer to it. A **shared concept** is a concept whose handle is in conventional use.
+
+**The observer-relative rule (normative).** Every aggregate defined in this specification is **an observer's view** — computed from the events that observer has seen, weighted from that observer's point of view. Nothing in this NIP defines, and no conforming implementation may present, a global fact about *the* community's definition. Two observers MAY legitimately resolve different clouds for the same concept, and both are correct.
+
+## Relationship to other specs
+
+- [Decentralized Lists](../nips/decentralized-lists.md) supplies the kinds and the `z` parent pointer; [Tapestry Concepts](./tapestry-concepts.md) constrains `z` to the a-tag form and defines concept anatomy. This NIP treats "concept" in their sense.
+- [Inherit-From & Resolved Definition](./inherit-from.md) supplies the **primitive** this NIP consumes: the typed `b` tag and its resolution semantics. This NIP defines no `b` semantics of its own — only the aggregate reading of `b`-derived edges.
+- [Class-thread membership tags](./class-thread-tags.md) (`n`, `s`) express structure *within* a curator's graph; they are orthogonal to this NIP's cross-author policy and appear here only in discovery-walk examples.
+- Downstream consumers: [Tags & Taggings](./tags.md) and [Communities](./communities.md) apply shared concepts to specific domains; the multi-`z` stamping convention for published items is specified in [Tapestry Concepts](./tapestry-concepts.md) § "Multi-`z` stamping" (planned to graduate to its own Stamping NIP — `nip-reorg` S3).
+
+## Declared affiliation
+
+An author affiliates their own header with a shared definition by carrying a **pointer-typed `b` tag** on it:
+
+```json
+["b", "39998:<sharedHeaderAuthor>:<d-tag>", "pointer"]
+```
+
+Affiliation is **navigation, not agreement**: it says "my concept corresponds to that one," names the community the author has chosen, and gives consumers a path to walk — while carrying no deference, no trust-coupling, and **zero aggregation weight** (§ "Aggregated deference"). Affiliation is the author's own declaration; no third party can affiliate a header the author didn't sign.
+
+In the reference deployment, a cold-start affiliation is **seeded** at firmware install — a pointer-typed `b` published on the deployment's own header, targeting the concept named by the firmware manifest (`community-reference` ADR 0034; applied to the tag concepts by `tag-federation` ADR 0002). A seed is an affiliation like any other: pointer-typed, never deference.
+
+## Deference
+
+An author defers to a shared definition by carrying an **inherit-typed `b` tag** — live definitional deference, with the override and resolution semantics specified in [Inherit-From](./inherit-from.md). Deference is the strong claim: it couples the child to the parent's future edits, which is exactly why it is the signal worth aggregating and why it must be explicit (an absent type reads as `"pointer"`, never as deference).
+
+This NIP adds nothing to the per-node semantics; it defines only what the *aggregate* of many authors' deference means to an observer.
+
+## Aggregated deference (observer-resolved)
+
+Because `b`-derived relationships point child→target, a target's **incoming** edges enumerate its relationships — but the two `b` types feed **different questions**:
+
+- **Deference aggregation** counts **inherit-typed edges only**: a target's incoming `INHERITS_FROM` edges enumerate exactly "everyone who defers to this definition" — a signal the observer weighs (in the reference deployment, by each deferring author's GrapeRank influence from the observer's point of view) and ranks. Pointer-typed edges carry **zero weight**: a bookmark is not agreement, and counting it would let seeded or casual correspondence masquerade as deference.
+- **Discovery walks** include **both types**: "enumerate the headers that point at this definition" (e.g. to union their items' `#z` indexes) wants every correspondence claim, pointer and inherit alike.
+
+Relay-side mechanics (the `#b` filter returns both types; consumers filter locally) are specified with the primitive — [Inherit-From](./inherit-from.md) § "Aggregation".
+
+## Clouds
+
+The **cloud** of headers for a shared concept is the **derived top-k of an observer's aggregated deference** for that concept. Properties, all ratified (`community-reference` ADR 0033):
+
+- **Never a published object.** There is no signed "cloud" event, no manifest, no curator — a published membership list would reintroduce a privileged center. The cloud exists only as a computation an observer (or an author, at write time) performs.
+- **Membership is deference rank.** Mutual pointer-typed `b` edges among a concept's authors are the author's **navigation** to the cloud — follow your header's `b` to the community it points at — **not** a membership gate.
+- **Rotation is emergent.** Nobody governs membership; it changes as the signal changes, and there is nothing to "detect" — an author (at write time) and a consumer (at read time) each simply recompute.
+- **Selector precedence:** *deference-resolved top-k* (the observer's trust-weighted aggregate — "grapevine-resolved" in the reference deployment) → *firmware-blessed cluster* (cold start) → *none*.
+- **Bootstrap from a singleton.** An organic concept's cloud begins as its founder's header alone and thickens as deference accumulates.
+
+*Design-only status: the resolver and cloud computation exist on no deployment; implementation is gated on on-wire inherit-typed `b` tags. The exact cap (~5), the ranking formula, and the firmware cold-start cluster contents are deliberately deferred to implementation (`community-reference` ADR 0033).*
+
+## Cross-deployment identity
+
+Concept handles embed their publisher's pubkey (`39998:<pubkey>:<slug>`), so every event that joins a concept via `z` bakes that pubkey into signed history — and a universal spec cannot hardcode one deployment's key. **How independent deployments and implementations agree on which header a shared concept converges on is an open protocol problem**, tracked as worksheet [W1](../worksheet.md#w1--cross-deployment-concept-identity). The trajectory:
+
+1. **Firmware-blessed pointer** — a centralized editorial cold start, accepted temporarily (the seed of § "Declared affiliation").
+2. **Registry-as-DList** — the per-concept pointer becomes a community-curated, observer-ranked DList.
+3. **Deference aggregation** — this NIP's clouds: "which definition the authors my web of trust ranks actually defer to." Candidate end state.
+
+This specification defines the aggregate machinery; it does not resolve W1.
+
+## Security considerations
+
+**Correspondence must never masquerade as deference.** Affiliation is cheap by design — seedable by firmware, publishable in bulk, revocable without cost — so any aggregate that counted pointer-typed edges would let a deployment or a spammer manufacture apparent convergence out of bookmarks. Hence the hard rule inherited from the primitive: only explicitly **inherit-typed** edges enter deference aggregation; absent or pointer types carry zero weight.
+
+**Observer weighting is the second gate.** Deference aggregation ranks the *deferring authors* from the observer's point of view: convergence among authors the observer's web of trust ranks at zero contributes nothing to that observer's cloud. A sybil flock deferring to its own header converges only for observers who trust the flock.


### PR DESCRIPTION
## Summary

First ratification story of the `nip-reorg` epic (design record: `docs/NIP_REORG_DESIGN_HANDOFF.md`, PR #344). Authors the **Shared Concepts** policy NIP — the layer by which independent authors converge on shared concepts: declared affiliation (pointer-`b`), deference (inherit-`b`), observer-resolved aggregated deference (migrated out of inherit-from § Aggregation), the ADR-0033 cloud model restated under the D2 vocabulary policy (no "canonical"/"consensus" in normative text), and the W1 identity trajectory with W1 remaining the open tracker. Full per-story cycle in docs-mode: story → ADR → spec → independent review (PASS).

## Changes

- `protocols/drafts/shared-concepts.md` — new policy NIP (defines no new wire format)
- `protocols/drafts/inherit-from.md` — § Aggregation reduced to relay-mechanics fact + pointer; § Scope "zero consensus weight" → "zero aggregation weight"
- `protocols/README.md` — Shared Concepts index row (📝 pre-NIP)
- `engineering-team/` — epic `nip-reorg`, eager book, story #1 (Done), ADR 0001, review (PASS)

## Test plan

- [x] `npm test` stack-free portion green locally; 11 stack-dependent suite failures verified identical on clean base (stale local stack; differential run in review)
- [x] Vocabulary grep, link resolution, harness-lint clean
- [ ] After merge: deploy-staging.yml runs.
- [ ] Smoke test on staging.brainstorm.world (docs-only — Tiers 1/2/3/5; no UI change).
- [ ] Spec present on origin/staging; README index row renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)