### PR TITLE
fix: close unauthenticated write-surface exposure [tags] (security-auth-exposure #1)

### DIFF
--- a/src/api/neo4j/queryPost.js
+++ b/src/api/neo4j/queryPost.js
@@ -11,6 +11,7 @@
  */
 
 const { runCypher, writeCypher } = require('../../lib/neo4j-driver');
+const { isOwner } = require('../../middleware/auth');
 
 // Detect write operations that require WRITE access mode
 const WRITE_KEYWORDS = /\b(CREATE|MERGE|DELETE|SET|REMOVE|DETACH|DROP|CALL\s*\{)\b/i;
@@ -25,6 +26,16 @@ async function queryPost(req, res) {
 
     try {
         const isWrite = WRITE_KEYWORDS.test(cypherCommand);
+
+        // Write Cypher (CREATE/MERGE/DELETE/SET/…) mutates the graph, so it is
+        // owner-only. Reads stay open — this endpoint is the read backbone of the
+        // browsing UI. A genuinely-local request (req.localTrusted, stamped by the
+        // auth middleware for the in-process bridge and direct-local operator) is
+        // authorized too. (ADR security-auth-exposure/0001.)
+        if (isWrite && !isOwner(req) && !req.localTrusted) {
+            return res.status(403).json({ success: false, error: 'Write queries require owner authentication' });
+        }
+
         const rows = isWrite
             ? await writeCypher(cypherCommand, params)
             : await runCypher(cypherCommand, params);

--- a/src/firmware/install.js
+++ b/src/firmware/install.js
@@ -1346,11 +1346,13 @@ function createInternalBridge(app) {
         query: Object.fromEntries(url.searchParams),
         params: {},
         body: method === 'POST' ? bodyOrParams : {},
-        headers: { 'content-type': 'application/json', 'x-forwarded-for': '127.0.0.1' },
+        // No proxy-forwarding header here: this is an in-process trusted call,
+        // not a proxied request. Its absence makes it honestly direct-local so
+        // the auth middleware stamps req.localTrusted. (ADR security-auth-exposure/0001.)
+        headers: { 'content-type': 'application/json' },
         get: (h) => {
           const key = h.toLowerCase();
           if (key === 'content-type') return 'application/json';
-          if (key === 'x-forwarded-for') return '127.0.0.1';
           return undefined;
         },
         connection: { remoteAddress: '127.0.0.1' },

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -314,12 +314,20 @@ async function authMiddleware(req, res, next) {
         return next();
     }
     
-    // Allow localhost/Docker-host CLI access to normalize endpoints (trusted local operator)
-    // Guard against missing connection (e.g., internal HTTP requests from firmware install)
+    // Allow GENUINELY-DIRECT local access to normalize/neo4j (the trusted local
+    // operator and the in-process firmware-install bridge). "Local" means the socket
+    // peer is loopback AND the request carries no proxy-forwarding header: every nginx
+    // hop in front of the app sets X-Forwarded-For ($proxy_add_x_forwarded_for), so a
+    // proxied/external request always has one — a spoofed `X-Forwarded-For: 127.0.0.1`
+    // is still a *present* header and is therefore treated as remote. `trust proxy`
+    // stays OFF so req.ip is the real socket peer. (ADR security-auth-exposure/0001.)
     let remoteAddr = '';
     try { remoteAddr = req.ip || req.connection?.remoteAddress || ''; } catch { }
-    const isLocal = ['127.0.0.1', '::1', '::ffff:127.0.0.1', '172.18.0.1', '::ffff:172.18.0.1'].includes(remoteAddr);
-    if (isLocal && (req.path.startsWith('/api/normalize') || req.path.startsWith('/api/neo4j'))) {
+    const isLoopbackPeer = ['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(remoteAddr);
+    const viaProxy = !!(req.headers && (req.headers['x-forwarded-for'] || req.headers['x-real-ip']));
+    const isDirectLocal = isLoopbackPeer && !viaProxy;
+    if (isDirectLocal && (req.path.startsWith('/api/normalize') || req.path.startsWith('/api/neo4j'))) {
+        req.localTrusted = true;
         return next();
     }
 


### PR DESCRIPTION
## Summary

**Surgical security fix to the `feat/tags` sandbox** (→ `tags.brainstorm.world`) — cherry-pick of the code-only commit (`1fbf4a53`), already live on staging (#391) and production (#392). `tags.brainstorm.world` has the same exposure.

The localhost bypass treated all nginx-proxied traffic as local, exposing `/api/normalize/*` writes and `POST /api/neo4j/query` unauthenticated. Fix keys "local" on the absence of a forwarding header and gates write Cypher on owner auth; reads stay open.

## Changes (code only, 3 files)

- `src/middleware/auth.js` — honest-local bypass + `req.localTrusted`, drops Docker-bridge IP, trust proxy off.
- `src/api/neo4j/queryPost.js` — write-gate `isWrite && !isOwner && !localTrusted → 403`.
- `src/firmware/install.js` — removes forged `x-forwarded-for` from the in-process bridge.

Identical to the staging + prod deploys (both smoke-verified: unauth normalize→401, write→403, read→200, public reads→200, firmware install OK).

## Test plan

- [ ] After merge: deploy-tags.yml runs.
- [ ] unauth `/api/normalize`→401; unauth write `/api/neo4j/query`→403; read→200; site loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)