### PR TITLE
fix: default-deny for unauthenticated mutations (security-auth-exposure #2)

### DIFF
--- a/engineering-team/decisions/security-auth-exposure/0002-default-deny-for-mutations.md
+++ b/engineering-team/decisions/security-auth-exposure/0002-default-deny-for-mutations.md
@@ -1,0 +1,90 @@
+# ADR 0002: Default-deny for unauthenticated mutations
+
+**Status:** Proposed
+**Date:** 2026-07-20
+**Story:** `engineering-team/stories/security-auth-exposure/2-default-deny-mutating-endpoints.md`
+**Extends:** ADR `security-auth-exposure/0001` (the honest-local bypass) — this broadens it; it does not supersede it.
+
+## Context
+
+`authMiddleware` (`src/middleware/auth.js`) is default-**open**: its unauthenticated branch 401s only paths matching a hand-maintained `writeEndpoints` list, then falls through to `return next()` (`:496`). A full inventory (this story's Architecture sweep):
+
+- **117 distinct mutating routes** (`POST/PUT/PATCH/DELETE`) in `src/`.
+- **55 reachable unauthenticated today** — **44 truly unguarded** (no middleware, no internal check) + 11 that self-guard.
+- The 44 unguarded are **all admin/owner operations** — `POST /api/firmware/install` (reinstall the seed), 6× `/api/tapestry-key/*` (key-store writes), `POST /api/run-task` (arbitrary task), `POST /api/strfry/wipe`, `DELETE /api/search/profiles/meili/wipe`, NIP-85 publishing, negentropy sync, io import/export, scheduled-tasks, algos-config, `POST /api/trusted-list/publish` (unauth **TA-signing**). None should be anonymously callable.
+
+Two structural facts, both verified:
+
+- **The `?action=` mutation check is dead code** (`auth.js:477`): Express's `req.path` excludes the query string, so `req.path.includes('?action=…')` is always false — and **no GET route mutates** (the two `req.query.action` handlers are POST-reached). So the old list also can't catch `PUT/PATCH/DELETE` (it gated `POST` only — e.g. `DELETE meili/wipe` slips through). Mutation detection must be **method-based**.
+- **The authenticated branch already handles logged-in users.** Default-deny lives only in the *unauthenticated* branch, so it affects only sessionless callers — logged-in non-owner users (follows, mutes, reports, tagging, pins, exports) are unaffected.
+
+Constraints the flip must honor (from the story + the inventory):
+
+1. **`/api/neo4j/query` must stay reachable sessionless** — story 1 keeps unauth *reads* working (the browsing UI depends on them); the handler already gates *writes*. It is a `POST`, so a naive method-based deny would re-break browsing.
+2. **`/api/strfry/publish` must stay reachable sessionless** — it is the server dependency of *all* client-signed publishing; one surface (`ProfileTagsSection`, `ui/src/components/ProfileTagsSection.jsx`, rendered on the public profile page) lets a logged-out nostr user tag a profile. It is dual-mode: `signAs:'client'` (caller-signed) vs `signAs:'assistant'` (server signs as the TA — privileged, currently unauth-callable = a hole).
+3. **Server-side loopback self-calls must not be 401'd.** The trusted-list cron (`refresh-all-pinned-tags`, `refresh-applicability-lists`) curls `http://127.0.0.1:$PORT` directly with no session and self-checks "loopback + no reverse-proxy header" (`src/api/trustedList/index.js:201-213`, per ADR `tag-stack-merge-hardening/0001 B3` — the same signal ADR 0001 uses). The firmware-install in-process bridge is the other such caller.
+4. **Route-level `requireOwner` guards** (6 routes) and **public reads** (deploy-safety status, concept-graph, strfry scan) must keep working.
+
+No concept-graph concepts in scope. Operator-selected sub-decision (2026-07-20): keep `/api/strfry/publish` public and gate its TA-signing path, rather than requiring login + a UI change.
+
+## Options considered
+
+### Option A — Default-deny in the unauth branch + tiny public allowlist + broaden the honest-local bypass *(chosen)*
+Method-based default-deny for sessionless mutations; a minimal, exact-match public-mutation allowlist; broaden ADR 0001's bypass so any genuinely-direct-local call (loopback + no proxy header) is trusted for all paths (covers cron + bridge); gate `signAs:'assistant'` in the publish handler.
+
+### Option B — Audit-and-protect: add each exposed route to the existing lists
+Enumerate the 44 and append them to `writeEndpoints`. **Rejected** — the operator chose the systemic flip at Planning; this leaves the default open (the next new endpoint is public again) and inherits the POST-only / dead-`?action` bugs.
+
+### Sub-decision for `/api/strfry/publish` — keep-public-and-gate-TA *(chosen)* vs require-login-and-gate-UI
+Chosen: allowlist it (anyone may publish their **own** signed event — aligned with decentralized-first/permissionless publishing) and gate `signAs:'assistant'` to owner/localTrusted in the handler. Preserves the logged-out flow, closes the TA-signing hole, no UI change. The alternative (require any session + gate `ProfileTagsSection` behind login) was rejected as it changes UX and widens the diff into the UI.
+
+## Decision
+
+**Option A.** Four coordinated changes.
+
+1. **`src/middleware/auth.js` — default-deny for mutations (unauth branch).** Replace the `writeEndpoints`/`isWriteEndpoint` machinery with:
+   - `const MUTATING = ['POST','PUT','PATCH','DELETE'];`
+   - `const PUBLIC_MUTATIONS = ['/api/neo4j/query', '/api/strfry/publish'];` — **exact-path** match (`PUBLIC_MUTATIONS.includes(req.path)`), not substring (an allowlist must not over-match).
+   - `if (MUTATING.includes(req.method) && !PUBLIC_MUTATIONS.includes(req.path)) return res.status(401).json({ error: 'Authentication required for this action' });`
+   - Keep `protectedGetEndpoints` (sensitive GET reads) exactly as-is. The final `return next()` now serves only reads and allowlisted mutations. `writeEndpoints` is deleted (subsumed).
+
+2. **`src/middleware/auth.js` — broaden the honest-local bypass.** Change the ADR-0001 bypass condition from `isDirectLocal && (path.startsWith('/api/normalize') || path.startsWith('/api/neo4j'))` to `isDirectLocal && req.path.startsWith('/api/')` (still stamping `req.localTrusted = true; return next()`). Justification: `isDirectLocal` (loopback peer + no `X-Forwarded-For`/`X-Real-IP`) is **externally unspoofable** — nginx always adds the header, and a direct-to-`:7778` external caller has a non-loopback peer — so this only ever trusts genuinely-in-container callers (the operator, the firmware bridge, the trusted-list cron), which are already trusted. This is what prevents the cron from being 401'd by change 1.
+
+3. **`src/api/strfry/commands/publishEvent.js` — gate TA-signing.** At the top of the `signAs === 'assistant'` branch: `if (!isOwner(req) && !req.localTrusted) return res.status(403).json({ success:false, error:'Signing as the assistant requires owner authentication' });` — import `isOwner` from `../../../middleware/auth`. The `signAs:'client'` path is unchanged (caller-signed events remain public).
+
+4. No change to the authenticated branch or the route-level `requireOwner` guards — they already do the right thing.
+
+**How the cases resolve (deployed instance):**
+
+| Caller | Path / method | Result |
+|---|---|---|
+| Anon, proxied | `POST /api/firmware/install` (or any of the 44) | **401** (default-deny) |
+| Anon, proxied | `POST /api/neo4j/query` read | 200 (allowlisted → handler; reads open) |
+| Anon, proxied | `POST /api/neo4j/query` write | 403 (allowlisted → handler; story-1 gate) |
+| Logged-out nostr user | `POST /api/strfry/publish` `signAs:'client'` | publishes (allowlisted; permissionless) |
+| Anyone | `POST /api/strfry/publish` `signAs:'assistant'` | 403 unless owner/localTrusted (hole closed) |
+| Logged-in non-owner | any tagging/notes/pins/export | unaffected (authenticated branch) |
+| Trusted-list cron / firmware bridge | loopback + no XFF, any `/api/*` | trusted (broadened bypass) |
+| Public read | `GET /api/deploy-safety/status`, concept-graph | 200 (mutation-only deny) |
+
+## Consequences
+
+- **Closes 44+ unauthenticated mutations by construction**, including `firmware/install`, `tapestry-key/*`, `run-task`, `strfry/wipe`, `meili/wipe` (DELETE), and the unauth-TA-signing `trusted-list/publish` — plus every *future* mutating endpoint is private by default (the point of the story).
+- **Preserves** public browsing (`neo4j/query` reads), logged-out client-signed tagging (`strfry/publish`), the trusted-list cron, the firmware bridge, owner flows, and public reads.
+- **Broadens the local-trust surface** to all in-container callers (from ADR 0001's two path prefixes). Safe because the signal is externally unspoofable; documented as a deploy invariant (every proxy hop sets `X-Forwarded-For` — already relied on by ADR 0001 and `tag-stack-merge-hardening/0001`).
+- **Residual / out of scope:** (a) an anonymous caller can still POST an *own-signed* event to local strfry — this is a relay accepting signed events (permissionless publish; spam is a relay write-policy/rate-limit concern, not auth). (b) Authenticated-**non-owner** privilege granularity — a logged-in guest can still reach non-owner-listed mutations via the authenticated branch (unchanged from today); tightening that is a separate story. (c) `ProfileTagsSection` being ungated where its siblings require login is a UX inconsistency the operator may address separately.
+- **Firmware reinstall required?** No — auth/publish code only; no concept definitions change.
+
+## Implementation notes
+
+- `src/middleware/auth.js:435-497` — replace the `else` (unauth) branch's `writeEndpoints`/`isWriteEndpoint` block with the method-based default-deny + `PUBLIC_MUTATIONS` exact-match above; retain `protectedGetEndpoints` and the trailing `return next()`.
+- `src/middleware/auth.js:~325` — broaden the bypass path condition to `req.path.startsWith('/api/')`.
+- `src/api/strfry/commands/publishEvent.js:~29` — add the owner/localTrusted gate at the start of the `signAs === 'assistant'` branch; `const { isOwner } = require('../../../middleware/auth')`.
+- **Test-file changes are Phase 3 (Tester's lane).** What must be covered: (1) unauth `POST/PUT/PATCH/DELETE` to a non-allowlisted path (esp. `firmware/install`, and a `DELETE`) → 401; (2) unauth `POST /api/neo4j/query` read → not 401 (allowlisted), write → 403 (story-1 gate still reached); (3) unauth `POST /api/strfry/publish` `signAs:'client'` → not 401, `signAs:'assistant'` → 403; (4) `req.localTrusted` (loopback+no-XFF) mutation to an arbitrary `/api/*` path → allowed (cron/bridge); (5) public GET reads (deploy-safety) → 200; (6) an owner-session mutation → allowed (authenticated branch unaffected).
+
+## Out of scope
+
+- Authenticated-non-owner privilege tightening (a logged-in guest reaching non-owner mutations).
+- Gating `ProfileTagsSection` behind login (the rejected sub-option).
+- Rate-limiting / spam control on `/api/strfry/publish` (relay write-policy layer).
+- The operator ops companions (Neo4j password rotation, Bolt/HTTP port firewalling) — book-tracked.

--- a/engineering-team/epics/security-auth-exposure.md
+++ b/engineering-team/epics/security-auth-exposure.md
@@ -17,7 +17,7 @@ The write surface signs events **as the instance's Tapestry Assistant** and can 
 
 1. `stories/security-auth-exposure/1-close-unauthenticated-write-surface.md` — reject unauthenticated callers on the `/api/normalize/*` writes and `POST /api/neo4j/query`, resistant to the `X-Forwarded-For: 127.0.0.1` spoof, without breaking the owner UI, the public read endpoints (including the deploy-safety curl the cycle skills depend on), or firmware install. Ships to staging → prod → feat/tags. **Done** (review PASS 2026-07-19; code verified local — deploy to the three instances pending).
 
-2. `stories/security-auth-exposure/2-default-deny-mutating-endpoints.md` — flip the central auth middleware from default-open to **default-deny for mutations**: `POST/PUT/PATCH/DELETE` (and `?action=`-style state changes) require auth unless a route is on an explicit, documented public-mutation allowlist. Closes the known unauthenticated-callable `POST /api/firmware/install` gap by construction. Ships to staging → prod → feat/tags. **Approved**.
+2. `stories/security-auth-exposure/2-default-deny-mutating-endpoints.md` — flip the central auth middleware from default-open to **default-deny for mutations**: `POST/PUT/PATCH/DELETE` (and `?action=`-style state changes) require auth unless a route is on an explicit, documented public-mutation allowlist. Closes the known unauthenticated-callable `POST /api/firmware/install` gap by construction. Ships to staging → prod → feat/tags. **Done** (review PASS 2026-07-20; code verified local — deploy pending).
 
 *(Further stories drawn at Planning as the work proceeds.)*
 

--- a/engineering-team/epics/security-auth-exposure.md
+++ b/engineering-team/epics/security-auth-exposure.md
@@ -17,7 +17,9 @@ The write surface signs events **as the instance's Tapestry Assistant** and can 
 
 1. `stories/security-auth-exposure/1-close-unauthenticated-write-surface.md` — reject unauthenticated callers on the `/api/normalize/*` writes and `POST /api/neo4j/query`, resistant to the `X-Forwarded-For: 127.0.0.1` spoof, without breaking the owner UI, the public read endpoints (including the deploy-safety curl the cycle skills depend on), or firmware install. Ships to staging → prod → feat/tags. **Done** (review PASS 2026-07-19; code verified local — deploy to the three instances pending).
 
-*(Further stories drawn at Planning as the work proceeds — see the book's indicative list: the middleware default-open posture audit is the expected follow-up.)*
+2. `stories/security-auth-exposure/2-default-deny-mutating-endpoints.md` — flip the central auth middleware from default-open to **default-deny for mutations**: `POST/PUT/PATCH/DELETE` (and `?action=`-style state changes) require auth unless a route is on an explicit, documented public-mutation allowlist. Closes the known unauthenticated-callable `POST /api/firmware/install` gap by construction. Ships to staging → prod → feat/tags. **Approved**.
+
+*(Further stories drawn at Planning as the work proceeds.)*
 
 ## Key facts / guardrails
 

--- a/engineering-team/reviews/security-auth-exposure/2-default-deny-mutating-endpoints.md
+++ b/engineering-team/reviews/security-auth-exposure/2-default-deny-mutating-endpoints.md
@@ -1,0 +1,90 @@
+# Review: Story 2 — Default-deny for unauthenticated mutations
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-07-20
+**Diff:** `git diff origin/staging...HEAD` — implementation commit `012f889b` (2 source files); tests `e3f18e5e`; ADR `28a6a9bb`.
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `npm test` — **PASS.** Reviewer re-ran the target suite: `default-deny-mutations: 14 passed, 0 failed, 0 skipped`, and story-1's suite still 14/0. Full-suite reviewer re-run: **Overall PASS, 0 FAIL lines, 51 skipped** (env-dependent H-class; +1 vs story-1's 50 is unrelated).
+- [x] `npm run test:playwright` — not applicable (no UI change).
+- [x] _Lint / Typecheck / Build — not configured; skipped (JS-without-build)._
+
+## Spec adherence
+
+- [x] Every acceptance criterion verified **independently on the live stack**, not just via the suite:
+
+| AC | Check | Result |
+|---|---|---|
+| AC-1 | unauth `POST /api/firmware/install` | **401** |
+| AC-1 | unauth `PUT /api/user-prefs`, `POST /api/run-task` | **401** (verb-agnostic; the old list was POST-only) |
+| AC-1 | unauth `DELETE …/meili/wipe` | **401** (verb blind spot closed) |
+| AC-2 | allowlist `POST /api/neo4j/query` read | 200 (reaches handler; story-1 gate) |
+| AC-2 | `POST /api/strfry/publish` `signAs:client` | 400 (not the 403 gate — client publish preserved) |
+| AC-3 | `POST /api/strfry/publish` `signAs:assistant` unauth | **403** ("Signing as the assistant requires owner authentication") |
+| AC-4 | authenticated-session mutation | passes middleware (authenticated branch untouched — see below) |
+| AC-5 | `GET /api/concept-graph/summaries`, `/api/deploy-safety/status` | 200 |
+| AC-6 | **real firmware install via loopback** | `39/39`, `missing:[]`, no auth-gate blocks in logs |
+| AC-7 | ships to three instances | deploy-time (Stage 2) |
+| legit-public | `POST /api/auth/verify-user` | 400 (reaches handler — auth-prefix skip-list intact) |
+
+- [x] No criterion silently dropped. AC-4 (owner) is covered by the unchanged authenticated branch + the `publishEvent` gate's `isOwner` (symmetric to the live `localTrusted` proof); AC-7 is deploy. Both appropriately deferred, not dropped.
+- [x] No behavior added beyond the ADR — the diff is exactly the three specified changes.
+
+## ADR adherence
+
+- [x] Matches ADR 0002's implementation notes exactly: method-based default-deny with exact-match `PUBLIC_MUTATIONS = ['/api/neo4j/query','/api/strfry/publish']` (`auth.js`), `writeEndpoints` deleted, `protectedGetEndpoints` kept; bypass broadened to `req.path.startsWith('/api/')`; `signAs:'assistant'` gated on `isOwner(req) || req.localTrusted` in `publishEvent.js`.
+- [x] Exact-match allowlist (`.includes(req.path)`) is correct and fail-closed — a trailing-slash or sub-path variant denies rather than over-matches. The two entries are exact route paths.
+- [x] No new dependencies; `publishEvent → middleware/auth` require adds no package and has **no circular-require breakage** (verified: both resolve to functions).
+
+## The bypass broadening — scrutinized (largest blast-radius change)
+
+The change widens ADR 0001's honest-local bypass from two path prefixes to all `/api/*`. I verified it is safe on three axes:
+
+1. **Externally unspoofable.** `isDirectLocal` requires a loopback socket peer AND no `X-Forwarded-For`/`X-Real-IP`. On a deployed instance an external request either comes via nginx (header present) or hits the published app port with a non-loopback peer — neither can produce it. Unchanged from ADR 0001; only the path scope grew.
+2. **Route-level guards remain in force.** The critical test: a **loopback** `POST /api/admin/add` and `/api/concept/*/pull-community-class-thread` (both `requireOwner`) return **401** — the global bypass calls `next()`, then the route guard blocks. So broadening does **not** defeat owner-gated routes; it only lets in-container callers reach the *un*guarded endpoints (the operator, the firmware bridge, the trusted-list cron — all trusted, and the reason the cron doesn't 401).
+3. **Contrast confirmed.** Loopback `trusted-list/refresh-all-pinned-tags` passes auth and runs the handler (curl timeout on real work); the *proxied* call to the same path is denied **401 in ~10ms**.
+
+Net: the local-trust surface grew to all in-container callers, which are already trusted (shell access or the app's own self-calls); no external exposure. Sound.
+
+## Concept-graph integrity
+
+- [x] No handles or concept definitions changed.
+- [x] **Firmware reinstall:** not required by the change — and a full loopback reinstall was run as the AC-6 test and succeeded (39/39), so the graph is intact and the internal bridge is unaffected.
+
+## Things tests can't catch
+
+- [x] No secrets committed; the change *reduces* exposure.
+- [x] No leftover debug logging / commented-out code. The removed `writeEndpoints` list is a deletion, not a comment-out. Added comments cite the ADR.
+- [x] Error paths: clean 401 (deny) and 403 (TA-signing) JSON; `req.headers &&` guard from ADR 0001 preserved.
+- [x] Concurrency: none introduced.
+- [x] **Security (the point):** the unauthenticated mutation surface is now default-closed. 44 previously-unguarded admin mutations (incl. `firmware/install`, `tapestry-key/*`, `run-task`, `strfry/wipe`, `meili/wipe`, and the unauth-TA-signing `trusted-list/publish` + this endpoint's `signAs:'assistant'`) are closed by construction, and every future mutating endpoint is private by default.
+
+## House rules check
+
+- [x] Concept Graph API authority respected (untouched).
+- [x] No new lint/typecheck/build tooling.
+
+## Findings
+
+### Blocking
+None.
+
+### Non-blocking
+1. **Residual (by design, ADR-documented):** an anonymous caller can still `POST /api/strfry/publish` an *own-signed* event to local strfry — a relay accepting signed events (permissionless publish; spam is a relay write-policy/rate-limit concern, out of scope). Flagged, not a defect.
+2. **Authenticated-non-owner privilege granularity (out of scope, worth a backlog note):** the authenticated branch still `next()`s any logged-in user for non-owner-listed mutations. This story deliberately targets *unauthenticated* mutations; tightening logged-in-guest access is a candidate follow-up.
+3. **`src/api/strfry/commands/publishEvent.js:10`** — `isOwner` imported at module top (destructure). Resolves correctly in the live load order (verified); a lazy `require(...).isOwner` inside the handler would be immune to future reorderings. Optional, not required.
+
+### Harness friction
+None new. (The pre-existing `test.js` `overallOk` severed-block defect, OPEN.md #43, is untouched; the new suite is correctly in the live chain.)
+
+## Verdict
+**PASS**
+
+The diff is exactly ADR 0002; every acceptance criterion is verified live (AC-1/2/3/5/6 directly, AC-4 by the unchanged authenticated branch + structural symmetry, AC-7 at deploy). The highest-risk change — broadening the honest-local bypass — is verified safe: it is externally unspoofable and does not defeat route-level owner guards. The real loopback firmware install (39/39, no auth blocks) closes the one criterion the automated tests cover only structurally. No blocking findings; the two residuals are accepted-by-design and ADR-documented.
+
+Remaining before the book closes: ship to **staging → prod → feat/tags** (AC-7), and the operator-side companions (rotate the Neo4j password; firewall Bolt `7687`/`7474`) — still not addressed by code.
+
+## On PASS (same commit)
+- [x] Story `**Status:**` flipped to `Done`.
+- [x] Completion detection run — see below.

--- a/engineering-team/stories/security-auth-exposure/2-default-deny-mutating-endpoints.md
+++ b/engineering-team/stories/security-auth-exposure/2-default-deny-mutating-endpoints.md
@@ -1,0 +1,47 @@
+# Story 2: Default-deny for unauthenticated mutating endpoints
+
+**Status:** Approved
+**Created:** 2026-07-20
+**Type:** Bug (security / authorization)
+**Epic:** `security-auth-exposure`
+
+## Background
+
+The auth middleware is default-**open**: an unauthenticated request that matches no entry on the write/owner allowlists falls through to `return next()` (`src/middleware/auth.js:496`). With **118 mutating routes** (`POST/PUT/PATCH/DELETE`) in `src/`, security depends on someone remembering to list each one — and misses are silent and public. The confirmed concrete gap: `POST /api/firmware/install` is on no list, so an anonymous caller can trigger a full firmware reinstall (a heavy Neo4j operation — a DoS / graph-disruption vector).
+
+Story 1 closed the two named surfaces (`/api/normalize/*`, `/api/neo4j/query`) individually and deferred the general posture here. This story closes it at the root: make mutations **private by default**, so a newly-added or overlooked endpoint is never silently public. (Realizes book frame bullet 7 — "the disposition of the default must be a conscious, recorded decision.")
+
+## User-facing description
+
+As the instance owner, I want every state-changing endpoint to require authentication unless it is explicitly and deliberately marked public, so that no mutating endpoint — present or future — is exposed to the internet just because someone forgot to add it to an allowlist.
+
+## Acceptance criteria
+
+- [ ] Given a deployed instance, when an **unauthenticated** mutating request (`POST/PUT/PATCH/DELETE`, and any `?action=`-style state change) hits a route that is **not** on an explicit public-mutation allowlist, then it is rejected 401/403 and the handler does not execute — the default is **deny**.
+- [ ] Specifically, unauthenticated `POST /api/firmware/install` → 401/403 (the confirmed gap, now closed by the default rather than a one-off entry).
+- [ ] Every mutating endpoint that is **intentionally public** (the auth/login flow, and any other deliberately-anonymous mutation) is on an **explicit, documented** allowlist and continues to work unauthenticated. That allowlist is the "conscious, recorded decision."
+- [ ] No regression to authenticated flows: owner-only and customer-or-owner mutating endpoints still require and accept the appropriate session.
+- [ ] Story-1 behavior preserved: the honest-local bypass + `req.localTrusted` still authorize the firmware-install internal bridge and the direct-local operator; public **read** endpoints stay reachable unauthenticated (incl. the deploy-safety curl the cycle skills depend on).
+- [ ] Broad regression: the app and its UI continue to function end-to-end (this changes the central auth middleware).
+- [ ] Delivered to **staging, production, and `feat/tags`** (all three carry the posture).
+
+## Concepts touched
+
+None — auth-middleware infrastructure. No concept-graph concepts in scope.
+
+## Out of scope
+
+- The residual unauthenticated **read**-Cypher exposure (accepted in story 1 / ADR 0001).
+- Operator companions — Neo4j password rotation, Bolt/HTTP port firewalling (book-tracked, not code).
+- Rate-limiting or other hardening beyond the auth decision.
+- Consolidating the two parallel allowlists (authenticated-branch vs unauthenticated-branch) into one — the Architect may do so if it's the cleanest way to implement default-deny, but it isn't required as its own goal.
+
+## Open questions
+
+- **Enumerating the legitimately-public mutations is the crux** — Architecture must inventory all 118 mutating routes and classify each (owner / customer / authenticated / intentionally-public), because a missed *public* one breaks a real flow and a missed *private* one stays exposed. Staging smoke is the safety net; the classification is the work.
+- **"Mutating" is not purely method-based** — the current middleware already recognizes `?action=enable/disable` state changes on some GETs. Architecture must define what counts as a mutation (method + the `?action=` pattern) and confirm no mutating GET slips through as a "read."
+
+## Linked artifacts
+- ADR: *(after Architecture)*
+- Test plan: *(after Test Design)*
+- Review: *(after Review)*

--- a/engineering-team/stories/security-auth-exposure/2-default-deny-mutating-endpoints.md
+++ b/engineering-team/stories/security-auth-exposure/2-default-deny-mutating-endpoints.md
@@ -1,6 +1,6 @@
 # Story 2: Default-deny for unauthenticated mutating endpoints
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-07-20
 **Type:** Bug (security / authorization)
 **Epic:** `security-auth-exposure`
@@ -44,4 +44,4 @@ None — auth-middleware infrastructure. No concept-graph concepts in scope.
 ## Linked artifacts
 - ADR: `engineering-team/decisions/security-auth-exposure/0002-default-deny-for-mutations.md`
 - Test plan: `engineering-team/stories/security-auth-exposure/2-default-deny-mutating-endpoints.test-plan.md` (tests: `test/default-deny-mutations.test.js`)
-- Review: *(after Review)*
+- Review: `engineering-team/reviews/security-auth-exposure/2-default-deny-mutating-endpoints.md` (PASS)

--- a/engineering-team/stories/security-auth-exposure/2-default-deny-mutating-endpoints.md
+++ b/engineering-team/stories/security-auth-exposure/2-default-deny-mutating-endpoints.md
@@ -43,5 +43,5 @@ None — auth-middleware infrastructure. No concept-graph concepts in scope.
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/security-auth-exposure/0002-default-deny-for-mutations.md`
-- Test plan: *(after Test Design)*
+- Test plan: `engineering-team/stories/security-auth-exposure/2-default-deny-mutating-endpoints.test-plan.md` (tests: `test/default-deny-mutations.test.js`)
 - Review: *(after Review)*

--- a/engineering-team/stories/security-auth-exposure/2-default-deny-mutating-endpoints.md
+++ b/engineering-team/stories/security-auth-exposure/2-default-deny-mutating-endpoints.md
@@ -42,6 +42,6 @@ None — auth-middleware infrastructure. No concept-graph concepts in scope.
 - **"Mutating" is not purely method-based** — the current middleware already recognizes `?action=enable/disable` state changes on some GETs. Architecture must define what counts as a mutation (method + the `?action=` pattern) and confirm no mutating GET slips through as a "read."
 
 ## Linked artifacts
-- ADR: *(after Architecture)*
+- ADR: `engineering-team/decisions/security-auth-exposure/0002-default-deny-for-mutations.md`
 - Test plan: *(after Test Design)*
 - Review: *(after Review)*

--- a/engineering-team/stories/security-auth-exposure/2-default-deny-mutating-endpoints.test-plan.md
+++ b/engineering-team/stories/security-auth-exposure/2-default-deny-mutating-endpoints.test-plan.md
@@ -1,0 +1,95 @@
+# Test Plan: Story 2 — Default-deny for unauthenticated mutations
+
+**Story:** `engineering-team/stories/security-auth-exposure/2-default-deny-mutating-endpoints.md`
+**ADR:** `engineering-team/decisions/security-auth-exposure/0002-default-deny-for-mutations.md`
+**Date:** 2026-07-20
+
+## Approach
+
+Stack-free, matching the story-1 suite. Two seams:
+
+- **`authMiddleware`** — called directly with mock `req`/`res`/`next`. Two request shapes: `proxied()` (an external request — `X-Forwarded-For` present, no session) and `directLocal()` (loopback peer, no forwarding header — the cron/bridge). The deny/allow paths short-circuit before any DB, so no stack.
+- **`publishEvent.handlePublishEvent`** — exercised only at its early-return paths: the new 403 assistant-gate and the 400 client-validation, both of which return before any signing/`exec`. The container-path `nostr-tools` require is lazy (`getNostrTools`) and never reached.
+
+All in `test/default-deny-mutations.test.js`, registered in `test/test.js`'s **live** `overallOk` chain (after the story-1 suite, before the line-882-area terminator — the block below it is severed, OPEN.md #43).
+
+## Coverage map
+
+| Criterion | Test name | Level | Fails pre-impl? |
+|---|---|---|---|
+| AC-1 (deny unlisted mutation) | `AC1: unauthenticated POST /api/firmware/install (proxied) is denied 401` | unit | **yes** |
+| AC-1 (DELETE verb) | `AC1: unauthenticated DELETE /api/search/profiles/meili/wipe … 401` | unit | **yes** |
+| AC-1 (PUT verb) | `AC1: unauthenticated PUT /api/user-prefs (proxied) is denied 401` | unit | **yes** |
+| AC-2 / allowlist | `allowlist: … POST /api/neo4j/query (proxied) passes the middleware` | unit | no (guard) |
+| AC-2 / allowlist | `allowlist: … POST /api/strfry/publish (proxied) passes the middleware` | unit | no (guard) |
+| AC (cron / broadened bypass) | `AC (cron): a direct-local POST to /api/trusted-list/* … req.localTrusted` | unit | **yes** |
+| AC-1 (remote ≠ cron) | `AC1: a PROXIED unauthenticated POST to /api/trusted-list/* is denied 401` | unit | **yes** |
+| AC-5 (public reads) | `AC5: a public GET read (deploy-safety status, proxied) … passes` | unit | no (guard) |
+| AC (no regression) | `AC (no regression): an authenticated-session mutation is unaffected` | unit | no (guard) |
+| AC-3 (TA-signing gate) | `AC3: unauthenticated signAs:"assistant" is denied 403` | unit | **yes** |
+| AC-3 (client stays public) | `AC3: signAs:"client" is NOT blocked by the assistant-gate` | unit | no (guard) |
+| AC-1/AC-2 shape | `S: auth middleware does method-based default-deny with an exact-match public allowlist` | source | **yes** |
+| bypass broadening | `S: the honest-local bypass is broadened beyond normalize/neo4j` | source | **yes** |
+| AC-3 shape | `S: publishEvent gates signAs:"assistant" on owner OR localTrusted` | source | **yes** |
+
+**AC-4 (owner mutations still work)** is covered by the authenticated-session guard (a logged-in mutation passes the middleware) plus the `publishEvent` assistant-gate's structural check (`isOwner` in the same OR-position as `localTrusted`, symmetric to the live `localTrusted` proof). A browser owner-session smoke is a deploy-time item (NIP-07 unscriptable), per the ADR.
+
+**AC-6 (delivered to three instances)** is a deploy criterion, not a unit test.
+
+## Edge cases
+
+- [x] Non-POST mutations (`PUT`, `DELETE`) — the old list was POST-only; both now denied.
+- [x] The two allowlisted paths stay reachable (handler does the finer gate).
+- [x] Direct-local (cron/bridge) still trusted for a non-normalize/non-neo4j path (the broadening).
+- [x] A *remote* caller to the same cron path is denied (the bypass is not a hole).
+- [x] `signAs:'client'` (permissionless publish) not caught by the assistant-gate.
+- [x] Authenticated branch untouched (no regression to logged-in users).
+
+## Test infrastructure
+
+- **Framework:** Node built-in runner (`node test/test.js`); no new deps.
+- **Stack:** none — middleware called directly; publish handler hit only at early returns.
+- **Firmware state:** none.
+- **Fixtures:** inline mock `req`/`res`.
+
+## How to run
+
+```
+node test/default-deny-mutations.test.js   # this suite alone
+npm test                                    # full suite (this is in the live gate)
+```
+
+## Verification
+
+New tests fail with current code. Confirmed 2026-07-20 (pre-implementation), suite standalone:
+
+```
+--- default-deny for unauthenticated mutations (epic security-auth-exposure, Story 2) ---
+  FAIL  AC1: unauthenticated POST /api/firmware/install (proxied) is denied 401
+        firmware/install was allowed through — an unlisted mutation is still default-open.
+  FAIL  AC1: unauthenticated DELETE /api/search/profiles/meili/wipe (proxied) is denied 401 (verb blind spot)
+        a DELETE mutation must be denied unauth; got next=true status=null.
+  FAIL  AC1: unauthenticated PUT /api/user-prefs (proxied) is denied 401
+        a PUT mutation must be denied unauth; got next=true status=null.
+  PASS  allowlist: unauthenticated POST /api/neo4j/query (proxied) passes the middleware (handler gates writes)
+  PASS  allowlist: unauthenticated POST /api/strfry/publish (proxied) passes the middleware (handler gates TA-signing)
+  FAIL  AC (cron): a direct-local POST to /api/trusted-list/* is trusted and stamped req.localTrusted (broadened bypass)
+        a direct-local call must be stamped req.localTrusted so it is recognized as trusted for all paths.
+  FAIL  AC1: a PROXIED unauthenticated POST to /api/trusted-list/* is denied 401 (remote cannot invoke the cron)
+        a remote caller must not reach the cron; got next=true status=null.
+  PASS  AC5: a public GET read (deploy-safety status, proxied) is unaffected — passes
+  PASS  AC (no regression): an authenticated-session mutation is unaffected (authenticated branch)
+  FAIL  AC3: unauthenticated signAs:"assistant" is denied 403 (no TA-signing without owner/localTrusted)
+        expected 403 for unauthenticated TA-signing, got 500.
+  PASS  AC3: signAs:"client" is NOT blocked by the assistant-gate (public client-signed publish)
+  FAIL  S: auth middleware does method-based default-deny with an exact-match public allowlist
+        auth.js does not list /api/strfry/publish on the public-mutation allowlist.
+  FAIL  S: the honest-local bypass is broadened beyond normalize/neo4j (covers all /api paths)
+        the honest-local bypass is still restricted to /api/normalize||/api/neo4j — it must be broadened to all /api paths (ADR 0002).
+  FAIL  S: publishEvent gates signAs:"assistant" on owner OR localTrusted (isOwner imported, 403)
+        publishEvent does not import/use isOwner from the auth middleware.
+
+default-deny-mutations: 5 passed, 9 failed, 0 skipped
+```
+
+The 9 failures are all "feature-missing" — the mutation is allowed through (default-open), the cron bypass isn't broadened, the assistant-gate is absent (the request proceeds to sign, 500-ing only because the host lacks the TA key — on a deployed instance it would mint a TA event, which is the hole). The 5 passing guards confirm the harness is sound (allowlist paths, public reads, and the authenticated branch behave, and the modules load). The Implementer makes the 9 pass without touching this file.

--- a/src/api/strfry/commands/publishEvent.js
+++ b/src/api/strfry/commands/publishEvent.js
@@ -7,6 +7,7 @@
  */
 const { exec } = require('child_process');
 const { getOwnerAssistantKeys } = require('../../../utils/assistantKeys');
+const { isOwner } = require('../../../middleware/auth');
 
 // Lazy-load nostr-tools (ESM-friendly path inside Docker)
 let _nt = null;
@@ -28,6 +29,13 @@ async function handlePublishEvent(req, res) {
     let signedEvent;
 
     if (signAs === 'assistant') {
+      // Signing as the Tapestry Assistant is privileged: only the owner (session)
+      // or a genuinely-direct-local caller (req.localTrusted, stamped by the auth
+      // middleware) may mint TA-signed events. Client-signed publishing below is
+      // permissionless. (ADR security-auth-exposure/0002.)
+      if (!isOwner(req) && !req.localTrusted) {
+        return res.status(403).json({ success: false, error: 'Signing as the assistant requires owner authentication' });
+      }
       // Sign with Tapestry Assistant private key
       const taKeys = await getOwnerAssistantKeys();
       if (!taKeys || !taKeys.privkey) {

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -326,7 +326,13 @@ async function authMiddleware(req, res, next) {
     const isLoopbackPeer = ['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(remoteAddr);
     const viaProxy = !!(req.headers && (req.headers['x-forwarded-for'] || req.headers['x-real-ip']));
     const isDirectLocal = isLoopbackPeer && !viaProxy;
-    if (isDirectLocal && (req.path.startsWith('/api/normalize') || req.path.startsWith('/api/neo4j'))) {
+    // Broadened to all /api paths (ADR security-auth-exposure/0002): a genuinely-
+    // direct-local call (loopback + no proxy header) is the operator, the
+    // in-process firmware-install bridge, or a server-side loopback cron (e.g. the
+    // trusted-list refreshers, which curl 127.0.0.1 directly) — all trusted. The
+    // signal is externally unspoofable (nginx always sets X-Forwarded-For; a direct
+    // hit to the app port has a non-loopback peer), so this never trusts remote traffic.
+    if (isDirectLocal && req.path.startsWith('/api/')) {
         req.localTrusted = true;
         return next();
     }
@@ -433,66 +439,38 @@ async function authMiddleware(req, res, next) {
         // User is authenticated and has appropriate permissions
         return next();
     } else {
-        // For API calls that modify data, return unauthorized status
-        const writeEndpoints = [
-            '/post-graperank-config',
-            '/api/post-blacklist-config',
-            '/post-whitelist-config',
-            '/generate-blacklist',
-            '/export-whitelist',
-            '/generate-graperank',
-            '/generate-pagerank',
-            '/personalized-pagerank',
-            '/generate-verified-followers',
-            '/generate-reports',
-            '/generate-nip85',
-            '/systemd-services',
-            '/brainstorm-control',
-            '/toggle-strfry-filteredContent',  // New endpoint for enabling/disabling
-            '/delete-all-relationships',
-            '/batch-transfer',
-            '/reconciliation',
-            '/calculate-hops',
-            '/neo4j-setup-constraints-and-indexes',
-            '/run-script',
-            '/process-all-active-customers',
-            '/create-all-customer-relays',
-            '/sign-up-new-customer',
-            '/delete-customer',
-            '/change-customer-status',
-            '/service-management/control',
-            '/add-new-customer',
-            '/update-customer-display-name',
-            '/backup-customers',
-            '/backups',
-            '/backups/download',
-            '/restore/upload',
-            '/restore/sets',
-            '/restore/customer',
-            '/api/normalize'
-        ];
-        
-        // Check if the current path is a write endpoint
-        const isWriteEndpoint = writeEndpoints.some(endpoint => 
-            req.path.includes(endpoint) && (req.method === 'POST' || req.path.includes('?action=enable') || req.path.includes('?action=disable'))
-        );
+        // Default-DENY for mutations (ADR security-auth-exposure/0002): any
+        // state-changing request from an unauthenticated caller is rejected unless
+        // its path is explicitly public. This replaces the old hand-maintained
+        // `writeEndpoints` allowlist, which was POST-only (so PUT/PATCH/DELETE
+        // mutations like `DELETE .../meili/wipe` slipped through) and left every
+        // unlisted mutation — e.g. `/api/firmware/install` — reachable by anyone.
+        const MUTATING = ['POST', 'PUT', 'PATCH', 'DELETE'];
+        // Mutations that must stay reachable without a session. Each defers its own
+        // finer gate to the handler: `/api/neo4j/query` gates write-Cypher (ADR 0001);
+        // `/api/strfry/publish` gates signAs:'assistant' (ADR 0002); client-signed
+        // publishing is permissionless by design. Exact-match — an allowlist must
+        // never over-match a private path.
+        const PUBLIC_MUTATIONS = ['/api/neo4j/query', '/api/strfry/publish'];
+        if (MUTATING.includes(req.method) && !PUBLIC_MUTATIONS.includes(req.path)) {
+            return res.status(401).json({ error: 'Authentication required for this action' });
+        }
 
-        // Sensitive GET endpoints that also require authentication
+        // Sensitive GET reads that also require authentication.
         const protectedGetEndpoints = [
             '/backups',
             '/backups/download',
             '/restore/sets',
             '/get-customer-relay-keys'
         ];
-        const isProtectedGetEndpoint = protectedGetEndpoints.some(endpoint => 
+        const isProtectedGetEndpoint = protectedGetEndpoints.some(endpoint =>
             req.path.includes(endpoint) && req.method === 'GET'
         );
-        
-        if (isWriteEndpoint || isProtectedGetEndpoint) {
+        if (isProtectedGetEndpoint) {
             return res.status(401).json({ error: 'Authentication required for this action' });
         }
-        
-        // Allow read-only API access
+
+        // Public read-only API access.
         return next();
     }
 }

--- a/test/default-deny-mutations.test.js
+++ b/test/default-deny-mutations.test.js
@@ -1,0 +1,198 @@
+/**
+ * Story 2 (epic: security-auth-exposure) — Default-deny for unauthenticated mutations.
+ *
+ * Story: engineering-team/stories/security-auth-exposure/2-default-deny-mutating-endpoints.md
+ * ADR:   engineering-team/decisions/security-auth-exposure/0002-default-deny-for-mutations.md
+ *
+ * Stack-free (no Neo4j/Redis/strfry): the auth middleware is called directly with
+ * mock req/res/next, and the publish handler is exercised only at its early-return
+ * paths (the new 403 assistant-gate and the 400 client-validation) which return
+ * before any signing/exec — so the lazy container-path nostr-tools require is never hit.
+ *
+ * NEW behaviour under test (fails until ADR-0002 lands):
+ *   • the unauth branch DENIES any mutation (POST/PUT/PATCH/DELETE) not on the tiny
+ *     exact-match allowlist [/api/neo4j/query, /api/strfry/publish] — closing
+ *     /api/firmware/install, the DELETE meili/wipe blind spot, PUT /api/user-prefs, etc.
+ *   • the honest-local bypass is BROADENED to all /api paths (so the loopback
+ *     trusted-list cron + firmware bridge stay trusted).
+ *   • publishEvent gates signAs:'assistant' on owner/localTrusted (closes the
+ *     unauthenticated TA-signing hole) while keeping signAs:'client' public.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const AUTH = path.join(ROOT, 'src/middleware/auth.js');
+const PUBLISH = path.join(ROOT, 'src/api/strfry/commands/publishEvent.js');
+
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+function readSafe(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return null; } }
+
+/* ─────────────── Mocks ─────────────── */
+
+function mkRes() {
+  return {
+    statusCode: null, body: null,
+    status(c) { this.statusCode = c; return this; },
+    json(o) { this.body = o; return this; },
+  };
+}
+
+// A proxied external request (nginx sets X-Forwarded-For), no session.
+function proxied(over = {}) {
+  return {
+    method: 'POST', path: '/api/x', query: {}, body: {},
+    headers: { 'x-forwarded-for': '203.0.113.7' },
+    ip: '127.0.0.1', connection: { remoteAddress: '127.0.0.1' }, session: {},
+    ...over,
+  };
+}
+
+// A genuinely-direct local request: loopback peer, NO forwarding header.
+function directLocal(over = {}) {
+  return {
+    method: 'POST', path: '/api/x', query: {}, body: {},
+    headers: {}, ip: '127.0.0.1', connection: { remoteAddress: '127.0.0.1' }, session: {},
+    ...over,
+  };
+}
+
+async function callAuth(req) {
+  const res = mkRes();
+  let nextCalled = false;
+  const next = () => { nextCalled = true; };
+  const { authMiddleware } = require(AUTH);
+  await authMiddleware(req, res, next);
+  return { res, nextCalled, req };
+}
+
+async function callPublish(body, reqOver = {}) {
+  const { handlePublishEvent } = require(PUBLISH);
+  const req = { method: 'POST', path: '/api/strfry/publish', headers: {}, session: {}, body, ...reqOver };
+  const res = mkRes();
+  await handlePublishEvent(req, res);
+  return { res };
+}
+
+/* ─────────────── Tests ─────────────── */
+
+const tests = [];
+function t(name, fn) { tests.push([name, fn]); }
+
+// ── Middleware: default-deny for mutations ──
+
+t('AC1: unauthenticated POST /api/firmware/install (proxied) is denied 401', async () => {
+  const { res, nextCalled } = await callAuth(proxied({ method: 'POST', path: '/api/firmware/install' }));
+  assert(!nextCalled, 'firmware/install was allowed through — an unlisted mutation is still default-open.');
+  assert(res.statusCode === 401, `expected 401 for an unauthenticated firmware install, got ${res.statusCode}.`);
+});
+
+t('AC1: unauthenticated DELETE /api/search/profiles/meili/wipe (proxied) is denied 401 (verb blind spot)', async () => {
+  const { res, nextCalled } = await callAuth(proxied({ method: 'DELETE', path: '/api/search/profiles/meili/wipe' }));
+  assert(!nextCalled && res.statusCode === 401, `a DELETE mutation must be denied unauth; got next=${nextCalled} status=${res.statusCode}.`);
+});
+
+t('AC1: unauthenticated PUT /api/user-prefs (proxied) is denied 401', async () => {
+  const { res, nextCalled } = await callAuth(proxied({ method: 'PUT', path: '/api/user-prefs' }));
+  assert(!nextCalled && res.statusCode === 401, `a PUT mutation must be denied unauth; got next=${nextCalled} status=${res.statusCode}.`);
+});
+
+t('allowlist: unauthenticated POST /api/neo4j/query (proxied) passes the middleware (handler gates writes)', async () => {
+  const { res, nextCalled } = await callAuth(proxied({ method: 'POST', path: '/api/neo4j/query' }));
+  assert(nextCalled && res.statusCode === null, `neo4j/query must stay reachable (story-1 reads); got next=${nextCalled} status=${res.statusCode}.`);
+});
+
+t('allowlist: unauthenticated POST /api/strfry/publish (proxied) passes the middleware (handler gates TA-signing)', async () => {
+  const { res, nextCalled } = await callAuth(proxied({ method: 'POST', path: '/api/strfry/publish' }));
+  assert(nextCalled && res.statusCode === null, `strfry/publish must stay reachable (client-signed publish); got next=${nextCalled} status=${res.statusCode}.`);
+});
+
+t('AC (cron): a direct-local POST to /api/trusted-list/* is trusted and stamped req.localTrusted (broadened bypass)', async () => {
+  const { nextCalled, req } = await callAuth(directLocal({ method: 'POST', path: '/api/trusted-list/refresh-all-pinned-tags' }));
+  assert(nextCalled, 'the loopback trusted-list cron was blocked — the honest-local bypass must cover all /api paths, not just normalize/neo4j.');
+  assert(req.localTrusted === true, 'a direct-local call must be stamped req.localTrusted so it is recognized as trusted for all paths.');
+});
+
+t('AC1: a PROXIED unauthenticated POST to /api/trusted-list/* is denied 401 (remote cannot invoke the cron)', async () => {
+  const { res, nextCalled } = await callAuth(proxied({ method: 'POST', path: '/api/trusted-list/refresh-all-pinned-tags' }));
+  assert(!nextCalled && res.statusCode === 401, `a remote caller must not reach the cron; got next=${nextCalled} status=${res.statusCode}.`);
+});
+
+t('AC5: a public GET read (deploy-safety status, proxied) is unaffected — passes', async () => {
+  const { res, nextCalled } = await callAuth(proxied({ method: 'GET', path: '/api/deploy-safety/status' }));
+  assert(nextCalled && res.statusCode === null, `public reads must stay reachable; got next=${nextCalled} status=${res.statusCode}.`);
+});
+
+t('AC (no regression): an authenticated-session mutation is unaffected (authenticated branch)', async () => {
+  const { nextCalled, res } = await callAuth(proxied({
+    method: 'POST', path: '/api/firmware/install',
+    session: { authenticated: true, pubkey: 'deadbeef' },
+  }));
+  assert(nextCalled && res.statusCode === null, `a logged-in user's request must pass the middleware; got next=${nextCalled} status=${res.statusCode}.`);
+});
+
+// ── publishEvent: TA-signing gate ──
+
+t('AC3: unauthenticated signAs:"assistant" is denied 403 (no TA-signing without owner/localTrusted)', async () => {
+  const { res } = await callPublish({ event: { kind: 1, tags: [], content: '' }, signAs: 'assistant' }, { session: {} });
+  assert(res.statusCode === 403, `expected 403 for unauthenticated TA-signing, got ${res.statusCode}.`);
+});
+
+t('AC3: signAs:"client" is NOT blocked by the assistant-gate (public client-signed publish)', async () => {
+  // A client event missing sig returns 400 (validation) — the point is it is NOT the 403 assistant-gate.
+  const { res } = await callPublish({ event: { kind: 1 }, signAs: 'client' }, { session: {} });
+  assert(res.statusCode !== 403, `client-signed publish must not hit the assistant-gate; got ${res.statusCode}.`);
+});
+
+// ── Source sentinels ──
+
+t('S: auth middleware does method-based default-deny with an exact-match public allowlist', async () => {
+  const src = readSafe(AUTH) || '';
+  assert(/['"]\/api\/strfry\/publish['"]/.test(src), 'auth.js does not list /api/strfry/publish on the public-mutation allowlist.');
+  assert(/['"]\/api\/neo4j\/query['"]/.test(src), 'auth.js does not list /api/neo4j/query on the public-mutation allowlist.');
+  assert(/PATCH/.test(src) && /DELETE/.test(src), 'auth.js unauth branch is not method-based (no PATCH/DELETE handling) — still POST-only.');
+});
+
+t('S: the honest-local bypass is broadened beyond normalize/neo4j (covers all /api paths)', async () => {
+  const src = readSafe(AUTH) || '';
+  // Story-1 scoped the bypass to normalize||neo4j; the broadened form must no longer
+  // gate the localTrusted path on those two prefixes exclusively.
+  assert(/req\.localTrusted\s*=\s*true/.test(src), 'auth.js no longer stamps req.localTrusted on the trusted-local path.');
+  assert(!/startsWith\('\/api\/normalize'\)\s*\|\|\s*req\.path\.startsWith\('\/api\/neo4j'\)/.test(src),
+    'the honest-local bypass is still restricted to /api/normalize||/api/neo4j — it must be broadened to all /api paths (ADR 0002).');
+});
+
+t('S: publishEvent gates signAs:"assistant" on owner OR localTrusted (isOwner imported, 403)', async () => {
+  const src = readSafe(PUBLISH) || '';
+  assert(/require\(['"][^'"]*middleware\/auth['"]\)/.test(src) && /isOwner/.test(src), 'publishEvent does not import/use isOwner from the auth middleware.');
+  assert(/req\.localTrusted/.test(src), 'publishEvent does not honor req.localTrusted for the assistant path.');
+  assert(/\b403\b/.test(src), 'publishEvent has no 403 rejection for unauthorized TA-signing.');
+});
+
+/* ─────────────── Run ─────────────── */
+
+async function run() {
+  console.log('\n--- default-deny for unauthenticated mutations (epic security-auth-exposure, Story 2) ---');
+  let pass = 0, fail = 0, skipped = 0;
+  const failures = [];
+  for (const [name, fn] of tests) {
+    try {
+      const r = await fn();
+      if (r === 'SKIP') { console.log(`  SKIP  ${name}`); skipped++; }
+      else { console.log(`  PASS  ${name}`); pass++; }
+    } catch (err) {
+      console.log(`  FAIL  ${name}\n        ${err.message}`);
+      failures.push({ name, message: err.message });
+      fail++;
+    }
+  }
+  console.log(`\ndefault-deny-mutations: ${pass} passed, ${fail} failed, ${skipped} skipped`);
+  return { pass, fail, failures, skipped };
+}
+
+if (require.main === module) {
+  run().then(({ fail }) => process.exit(fail === 0 ? 0 : 1)).catch((e) => { console.error(e); process.exit(1); });
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -161,6 +161,7 @@ const safeToMergeCheck = require('./safe-to-merge-check.test.js');
 // epic: deploy-safety-gate — Story 3 (Scheduled Tasks panel aggregate countdown)
 const nextTaskCountdown = require('./next-task-countdown.test.js');
 const closeUnauthWriteSurface = require('./close-unauth-write-surface.test.js');
+const defaultDenyMutations = require('./default-deny-mutations.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...');
@@ -447,6 +448,7 @@ async function main() {
   console.log('\nnext-task-countdown suite:');
   const nextTaskCountdownResult = await nextTaskCountdown.run();
   const closeUnauthWriteSurfaceResult = await closeUnauthWriteSurface.run();
+  const defaultDenyMutationsResult = await defaultDenyMutations.run();
 
   console.log('\nTest Results');
   console.log('-------------');
@@ -884,7 +886,9 @@ async function main() {
     nextTaskCountdownResult.fail === 0 &&
     // security-auth-exposure #1 — close the unauthenticated write-surface.
     // (LIVE chain — before the terminator; the block below is severed, OPEN.md #43.)
-    closeUnauthWriteSurfaceResult.fail === 0;
+    closeUnauthWriteSurfaceResult.fail === 0 &&
+    // security-auth-exposure #2 — default-deny for unauthenticated mutations.
+    defaultDenyMutationsResult.fail === 0;
     harnessLintResult.fail === 0 &&
     harnessStatsResult.fail === 0 &&
     sessionStartResult.fail === 0 &&
@@ -920,7 +924,7 @@ async function main() {
     harnessLintResult, harnessStatsResult, sessionStartResult, stackFreeNpmTestResult,
     ciTestJobResult, syncPanelTagFiltersResult, routerStreamTagFiltersResult,
     noteTaggingRawEventsInspectorHttpResult, deploySafetyStatusResult, safeToMergeCheckResult, nextTaskCountdownResult,
-    closeUnauthWriteSurfaceResult,
+    closeUnauthWriteSurfaceResult, defaultDenyMutationsResult,
   ].reduce((sum, r) => sum + ((r && r.skipped) || 0), 0);
   console.log(`Total skipped:                                   ${totalSkipped}`);
   console.log(`Overall:                                         ${overallOk ? 'PASS' : 'FAIL'}`);


### PR DESCRIPTION
## Summary

Second story of the security-auth-exposure book. Flips the central auth middleware from **default-open** to **default-deny for mutations**: an unauthenticated `POST/PUT/PATCH/DELETE` is rejected unless its path is on a tiny exact-match public allowlist. Closes 44 previously-unguarded admin mutations by construction — incl. `POST /api/firmware/install`, `tapestry-key/*`, `run-task`, `strfry/wipe`, `DELETE meili/wipe`, and the unauth-TA-signing paths — and makes every *future* mutating endpoint private by default.

Full harness: story → ADR 0002 → failing tests → impl → review (PASS). Builds on story-1 (already live on all three instances).

## Changes (2 source files)

- `src/middleware/auth.js` — unauth branch → method-based default-deny; `PUBLIC_MUTATIONS = ['/api/neo4j/query','/api/strfry/publish']` (exact-match); deleted the POST-only `writeEndpoints`; kept `protectedGetEndpoints`. **Broadened** the honest-local bypass to all `/api/*` (keeps the loopback trusted-list cron + firmware bridge trusted; externally unspoofable).
- `src/api/strfry/commands/publishEvent.js` — gate `signAs:'assistant'` → 403 unless owner/`localTrusted` (closes the unauth TA-signing hole; client-signed publish stays permissionless).

## Verified locally

Target suite 14/0; full `npm test` Overall PASS, 0 regressions. Live: unauth firmware/install + PUT user-prefs + run-task + DELETE meili/wipe → 401; strfry/publish assistant → 403, client → 400; neo4j read + public reads → 200; **route-level requireOwner still blocks loopback callers** (admin/add → 401); real loopback firmware install 39/39, no auth-gate blocks.

## Still open after this (NOT this PR)

- Rotate the Neo4j password + firewall Bolt `7687`/`7474` — operator ops (highest urgency).
- Residual: anon own-signed publish stays public (permissionless, relay-layer); authenticated-non-owner granularity — candidate future story.

## Test plan

- [ ] After merge: deploy-staging.yml runs.
- [ ] unauth `POST /api/firmware/install` → 401; `DELETE …/meili/wipe` → 401.
- [ ] `strfry/publish` `signAs:assistant` → 403; `signAs:client` → 400.
- [ ] `neo4j/query` read → 200; public reads → 200; concepts UI browses.
- [ ] Broad regression — site loads (2nd consecutive shared-auth change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)