### PR TITLE
fix: default-deny for unauthenticated mutations [tags] (security-auth-exposure #2)

### DIFF
--- a/src/api/strfry/commands/publishEvent.js
+++ b/src/api/strfry/commands/publishEvent.js
@@ -7,6 +7,7 @@
  */
 const { exec } = require('child_process');
 const { getOwnerAssistantKeys } = require('../../../utils/assistantKeys');
+const { isOwner } = require('../../../middleware/auth');
 
 // Lazy-load nostr-tools (ESM-friendly path inside Docker)
 let _nt = null;
@@ -28,6 +29,13 @@ async function handlePublishEvent(req, res) {
     let signedEvent;
 
     if (signAs === 'assistant') {
+      // Signing as the Tapestry Assistant is privileged: only the owner (session)
+      // or a genuinely-direct-local caller (req.localTrusted, stamped by the auth
+      // middleware) may mint TA-signed events. Client-signed publishing below is
+      // permissionless. (ADR security-auth-exposure/0002.)
+      if (!isOwner(req) && !req.localTrusted) {
+        return res.status(403).json({ success: false, error: 'Signing as the assistant requires owner authentication' });
+      }
       // Sign with Tapestry Assistant private key
       const taKeys = await getOwnerAssistantKeys();
       if (!taKeys || !taKeys.privkey) {

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -326,7 +326,13 @@ async function authMiddleware(req, res, next) {
     const isLoopbackPeer = ['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(remoteAddr);
     const viaProxy = !!(req.headers && (req.headers['x-forwarded-for'] || req.headers['x-real-ip']));
     const isDirectLocal = isLoopbackPeer && !viaProxy;
-    if (isDirectLocal && (req.path.startsWith('/api/normalize') || req.path.startsWith('/api/neo4j'))) {
+    // Broadened to all /api paths (ADR security-auth-exposure/0002): a genuinely-
+    // direct-local call (loopback + no proxy header) is the operator, the
+    // in-process firmware-install bridge, or a server-side loopback cron (e.g. the
+    // trusted-list refreshers, which curl 127.0.0.1 directly) — all trusted. The
+    // signal is externally unspoofable (nginx always sets X-Forwarded-For; a direct
+    // hit to the app port has a non-loopback peer), so this never trusts remote traffic.
+    if (isDirectLocal && req.path.startsWith('/api/')) {
         req.localTrusted = true;
         return next();
     }
@@ -433,66 +439,38 @@ async function authMiddleware(req, res, next) {
         // User is authenticated and has appropriate permissions
         return next();
     } else {
-        // For API calls that modify data, return unauthorized status
-        const writeEndpoints = [
-            '/post-graperank-config',
-            '/api/post-blacklist-config',
-            '/post-whitelist-config',
-            '/generate-blacklist',
-            '/export-whitelist',
-            '/generate-graperank',
-            '/generate-pagerank',
-            '/personalized-pagerank',
-            '/generate-verified-followers',
-            '/generate-reports',
-            '/generate-nip85',
-            '/systemd-services',
-            '/brainstorm-control',
-            '/toggle-strfry-filteredContent',  // New endpoint for enabling/disabling
-            '/delete-all-relationships',
-            '/batch-transfer',
-            '/reconciliation',
-            '/calculate-hops',
-            '/neo4j-setup-constraints-and-indexes',
-            '/run-script',
-            '/process-all-active-customers',
-            '/create-all-customer-relays',
-            '/sign-up-new-customer',
-            '/delete-customer',
-            '/change-customer-status',
-            '/service-management/control',
-            '/add-new-customer',
-            '/update-customer-display-name',
-            '/backup-customers',
-            '/backups',
-            '/backups/download',
-            '/restore/upload',
-            '/restore/sets',
-            '/restore/customer',
-            '/api/normalize'
-        ];
-        
-        // Check if the current path is a write endpoint
-        const isWriteEndpoint = writeEndpoints.some(endpoint => 
-            req.path.includes(endpoint) && (req.method === 'POST' || req.path.includes('?action=enable') || req.path.includes('?action=disable'))
-        );
+        // Default-DENY for mutations (ADR security-auth-exposure/0002): any
+        // state-changing request from an unauthenticated caller is rejected unless
+        // its path is explicitly public. This replaces the old hand-maintained
+        // `writeEndpoints` allowlist, which was POST-only (so PUT/PATCH/DELETE
+        // mutations like `DELETE .../meili/wipe` slipped through) and left every
+        // unlisted mutation — e.g. `/api/firmware/install` — reachable by anyone.
+        const MUTATING = ['POST', 'PUT', 'PATCH', 'DELETE'];
+        // Mutations that must stay reachable without a session. Each defers its own
+        // finer gate to the handler: `/api/neo4j/query` gates write-Cypher (ADR 0001);
+        // `/api/strfry/publish` gates signAs:'assistant' (ADR 0002); client-signed
+        // publishing is permissionless by design. Exact-match — an allowlist must
+        // never over-match a private path.
+        const PUBLIC_MUTATIONS = ['/api/neo4j/query', '/api/strfry/publish'];
+        if (MUTATING.includes(req.method) && !PUBLIC_MUTATIONS.includes(req.path)) {
+            return res.status(401).json({ error: 'Authentication required for this action' });
+        }
 
-        // Sensitive GET endpoints that also require authentication
+        // Sensitive GET reads that also require authentication.
         const protectedGetEndpoints = [
             '/backups',
             '/backups/download',
             '/restore/sets',
             '/get-customer-relay-keys'
         ];
-        const isProtectedGetEndpoint = protectedGetEndpoints.some(endpoint => 
+        const isProtectedGetEndpoint = protectedGetEndpoints.some(endpoint =>
             req.path.includes(endpoint) && req.method === 'GET'
         );
-        
-        if (isWriteEndpoint || isProtectedGetEndpoint) {
+        if (isProtectedGetEndpoint) {
             return res.status(401).json({ error: 'Authentication required for this action' });
         }
-        
-        // Allow read-only API access
+
+        // Public read-only API access.
         return next();
     }
 }


### PR DESCRIPTION
## Summary

**Surgical security fix to the `feat/tags` sandbox** (→ `tags.brainstorm.world`) — cherry-pick of the code-only commit (`012f889b`), already live on staging (#394) and production (#395). Completes AC-7 (all three instances).

Flips the auth middleware to **default-deny for mutations**: unauthenticated `POST/PUT/PATCH/DELETE` → 401 unless on the exact-match public allowlist. Closes the previously-unguarded admin mutations (`firmware/install`, `tapestry-key/*`, `run-task`, `strfry/wipe`, `DELETE meili/wipe`, unauth TA-signing). Builds on story-1 (already on feat/tags).

## Changes (code only, 2 files)

- `src/middleware/auth.js` — method-based default-deny + exact-match `PUBLIC_MUTATIONS`; `writeEndpoints` deleted; honest-local bypass broadened to all `/api/*`.
- `src/api/strfry/commands/publishEvent.js` — `signAs:'assistant'` gated on owner/`localTrusted`.

Identical to the staging + prod deploys (both smoke-verified).

## Test plan

- [ ] After merge: deploy-tags.yml runs.
- [ ] unauth firmware/install + DELETE meili/wipe → 401; strfry/publish assistant → 403; neo4j read → 200; site loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)