### PR TITLE
fix: /users page calls POST /api/neo4j/query (run-query removed) — prod

### DIFF
--- a/src/firmware/install.js
+++ b/src/firmware/install.js
@@ -84,14 +84,14 @@ async function apiGet(endpoint, params = {}) {
 
 /**
  * Run a Cypher query via the POST endpoint (avoids URL length limits).
- * Returns the same shape as the GET run-query endpoint for backward compat.
+ * Returns the `cypherResults` CSV shape (parsed by parseCsvRows below).
  */
 async function runCypherApi(cypher, params = {}) {
   return apiPost('/api/neo4j/query', { cypher, params });
 }
 
 /**
- * Parse CSV-style results from the Neo4j run-query API.
+ * Parse CSV-style results from the Neo4j query API (the `cypherResults` field).
  * First line is headers, subsequent lines are values (quoted strings stripped).
  */
 function parseCsvRows(csvText) {

--- a/ui/src/pages/users/Index.jsx
+++ b/ui/src/pages/users/Index.jsx
@@ -24,11 +24,18 @@ export default function UsersIndex() {
         setLoading(true);
         setError(null);
 
-        // Fetch Neo4j users and strfry kind 0 events in parallel
+        // Fetch Neo4j users and strfry kind 0 events in parallel.
+        // Neo4j: POST /api/neo4j/query (the GET run-query endpoint was removed
+        // 2026-07-19); this is a read, so no auth gate applies. The response still
+        // carries `cypherResults` in the same CSV shape parsed below.
         const [neo4jRes, strfryRes] = await Promise.all([
-          fetch(`/api/neo4j/run-query?cypher=${encodeURIComponent(
-            'MATCH (u:NostrUser) RETURN u.pubkey AS pubkey ORDER BY u.pubkey'
-          )}`).then(r => r.json()),
+          fetch('/api/neo4j/query', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              cypher: 'MATCH (u:NostrUser) RETURN u.pubkey AS pubkey ORDER BY u.pubkey',
+            }),
+          }).then(r => r.json()),
           fetch(`/api/strfry/scan?filter=${encodeURIComponent(
             JSON.stringify({ kinds: [0] })
           )}`).then(r => r.json()).catch(() => ({ events: [] })),


### PR DESCRIPTION
## Summary

**Surgical cherry-pick** of the runtime fix `18e330aa` (staging PR #397) to production — carries **only** the Users-page regression fix, not the doc/book-close changes (those stay on staging, reaching main via the normal sync).

The Users page (`/users`) fetched `GET /api/neo4j/run-query` on mount to list NostrUser pubkeys. That endpoint was deleted 2026-07-19 (security prelude — unauthenticated RCE + credential leak) and shipped to all three instances, so the page's Neo4j list broke (404) on prod too. Swapped to `POST /api/neo4j/query`, which preserves the `cypherResults` CSV shape the page parses (verified live on staging); it's a read query, so no auth gate applies.

## Changes

- `ui/src/pages/users/Index.jsx` — GET run-query → POST /api/neo4j/query with `{cypher}` body (parse unchanged)
- `src/firmware/install.js` — reword two stale comments naming the old endpoint

## Verification

- Verified live on **staging** (PR #397): deployed bundle contains 0 `run-query`, 9 `neo4j/query`; `GET run-query` → 404; the Users query returns rows.
- `npm test` Overall PASS (regression guard `test/users-page-neo4j-endpoint.test.js` in the live gate) — on the staging branch; this cherry-pick is source-only.

## Test plan

- [ ] After merge: production deploy runs.
- [ ] Smoke `tapestry.brainstorm.world`: deployed bundle has 0 `run-query` / uses `neo4j/query`; site healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)