### PR TITLE
fix: /users page calls POST /api/neo4j/query (run-query removed) — feat/tags

### DIFF
--- a/src/firmware/install.js
+++ b/src/firmware/install.js
@@ -84,14 +84,14 @@ async function apiGet(endpoint, params = {}) {
 
 /**
  * Run a Cypher query via the POST endpoint (avoids URL length limits).
- * Returns the same shape as the GET run-query endpoint for backward compat.
+ * Returns the `cypherResults` CSV shape (parsed by parseCsvRows below).
  */
 async function runCypherApi(cypher, params = {}) {
   return apiPost('/api/neo4j/query', { cypher, params });
 }
 
 /**
- * Parse CSV-style results from the Neo4j run-query API.
+ * Parse CSV-style results from the Neo4j query API (the `cypherResults` field).
  * First line is headers, subsequent lines are values (quoted strings stripped).
  */
 function parseCsvRows(csvText) {

--- a/ui/src/pages/users/Index.jsx
+++ b/ui/src/pages/users/Index.jsx
@@ -24,11 +24,18 @@ export default function UsersIndex() {
         setLoading(true);
         setError(null);
 
-        // Fetch Neo4j users and strfry kind 0 events in parallel
+        // Fetch Neo4j users and strfry kind 0 events in parallel.
+        // Neo4j: POST /api/neo4j/query (the GET run-query endpoint was removed
+        // 2026-07-19); this is a read, so no auth gate applies. The response still
+        // carries `cypherResults` in the same CSV shape parsed below.
         const [neo4jRes, strfryRes] = await Promise.all([
-          fetch(`/api/neo4j/run-query?cypher=${encodeURIComponent(
-            'MATCH (u:NostrUser) RETURN u.pubkey AS pubkey ORDER BY u.pubkey'
-          )}`).then(r => r.json()),
+          fetch('/api/neo4j/query', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              cypher: 'MATCH (u:NostrUser) RETURN u.pubkey AS pubkey ORDER BY u.pubkey',
+            }),
+          }).then(r => r.json()),
           fetch(`/api/strfry/scan?filter=${encodeURIComponent(
             JSON.stringify({ kinds: [0] })
           )}`).then(r => r.json()).catch(() => ({ events: [] })),


### PR DESCRIPTION
## Summary

**Surgical cherry-pick** of the runtime fix `18e330aa` (staging PR #397, prod PR #398) to `feat/tags` — the third of the three instances. Carries **only** the Users-page regression fix.

The Users page (`/users`) fetched `GET /api/neo4j/run-query` on mount; that endpoint was deleted 2026-07-19 (security prelude) and shipped to all three instances, breaking the page's Neo4j list (404). Swapped to `POST /api/neo4j/query`, which preserves the `cypherResults` CSV shape the page parses.

## Changes

- `ui/src/pages/users/Index.jsx` — GET run-query → POST /api/neo4j/query with `{cypher}` body
- `src/firmware/install.js` — reword two stale comments

## Verification

- Verified live on **staging** (#397) and **production** (#398): deployed bundle 0 `run-query` / 9 `neo4j/query`; `GET run-query` → 404; Users query returns rows.

## Test plan

- [ ] After merge: tags deploy runs.
- [ ] Smoke `tags.brainstorm.world`: bundle uses `neo4j/query`, not `run-query`; site healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)