### PR TITLE
harden: owner-gate strfry/wipe + hide non-owner admin controls — prod

### DIFF
--- a/src/api/strfry/wipe.js
+++ b/src/api/strfry/wipe.js
@@ -3,8 +3,17 @@
  * Deletes all events from the local strfry relay.
  */
 const { exec } = require('child_process');
+const { isOwner } = require('../../middleware/auth');
 
 async function handleWipeStrfry(req, res) {
+  // Wiping the local relay is a destructive, owner-grade operation. Require the
+  // owner OR a genuinely-local operator (req.localTrusted = loopback + no proxy
+  // header), mirroring the neo4j/query write-gate and strfry/publish assistant-gate
+  // (ADR security-auth-exposure 0001/0002). Default-deny already blocks the
+  // unauthenticated case; this also blocks an authenticated non-owner.
+  if (!isOwner(req) && !req.localTrusted) {
+    return res.status(403).json({ success: false, error: 'Wiping strfry requires owner authentication' });
+  }
   try {
     // First get the count
     const countResult = await new Promise((resolve, reject) => {

--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -20,6 +20,8 @@ function formatAge(createdAt) {
 /* ─── Onboarding ──────────────────────────────────────────── */
 
 function WelcomeCard({ taProfile, onSetupProfile, onSurpriseMe }) {
+  const { user } = useAuth();
+  const isOwner = user?.classification === 'owner' || user?.classification === 'admin';
   const hasProfile = taProfile && (taProfile.name || taProfile.picture);
 
   if (hasProfile) return null;
@@ -44,9 +46,11 @@ function WelcomeCard({ taProfile, onSetupProfile, onSurpriseMe }) {
             <button className="btn btn-primary" onClick={onSetupProfile}>
               🎨 Set up my Assistant's profile
             </button>
-            <button className="btn" onClick={onSurpriseMe}>
-              🎲 Surprise me
-            </button>
+            {isOwner && (
+              <button className="btn" onClick={onSurpriseMe}>
+                🎲 Surprise me
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/ui/src/pages/lists/NewDList.jsx
+++ b/ui/src/pages/lists/NewDList.jsx
@@ -7,6 +7,7 @@ import { headerDTag, randomDTag } from '../../utils/dtag';
 export default function NewDList() {
   const navigate = useNavigate();
   const { user } = useAuth();
+  const isOwner = user?.classification === 'owner' || user?.classification === 'admin';
 
   // Form state
   const [singular, setSingular] = useState('');
@@ -256,16 +257,18 @@ export default function NewDList() {
               {user && <small> — {user.profile?.display_name || user.profile?.name || user.pubkey?.slice(0, 12) + '…'}</small>}
             </span>
           </label>
-          <label className="radio-label">
-            <input
-              type="radio"
-              checked={signAs === 'assistant'}
-              onChange={() => setSignAs('assistant')}
-            />
-            <span>
-              <strong>Tapestry Assistant</strong> (server-side signing)
-            </span>
-          </label>
+          {isOwner && (
+            <label className="radio-label">
+              <input
+                type="radio"
+                checked={signAs === 'assistant'}
+                onChange={() => setSignAs('assistant')}
+              />
+              <span>
+                <strong>Tapestry Assistant</strong> (server-side signing)
+              </span>
+            </label>
+          )}
         </div>
       </div>
 

--- a/ui/src/pages/lists/NewDListItem.jsx
+++ b/ui/src/pages/lists/NewDListItem.jsx
@@ -16,6 +16,7 @@ function getAllTags(event, name) {
 export default function NewDListItem() {
   const navigate = useNavigate();
   const { user } = useAuth();
+  const isOwner = user?.classification === 'owner' || user?.classification === 'admin';
   const { event: parentEvent } = useOutletContext();
 
   // Derive parent list info
@@ -328,16 +329,18 @@ export default function NewDListItem() {
               {user && <small> — {user.profile?.display_name || user.profile?.name || user.pubkey?.slice(0, 12) + '…'}</small>}
             </span>
           </label>
-          <label className="radio-label">
-            <input
-              type="radio"
-              checked={signAs === 'assistant'}
-              onChange={() => setSignAs('assistant')}
-            />
-            <span>
-              <strong>Tapestry Assistant</strong> (server-side signing)
-            </span>
-          </label>
+          {isOwner && (
+            <label className="radio-label">
+              <input
+                type="radio"
+                checked={signAs === 'assistant'}
+                onChange={() => setSignAs('assistant')}
+              />
+              <span>
+                <strong>Tapestry Assistant</strong> (server-side signing)
+              </span>
+            </label>
+          )}
         </div>
       </div>
 

--- a/ui/src/pages/settings/DatabaseSettings.jsx
+++ b/ui/src/pages/settings/DatabaseSettings.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useAuth } from '../../context/AuthContext';
 
 function useDatabaseStats() {
   const [stats, setStats] = useState(null);
@@ -39,6 +40,8 @@ function useDatabaseStats() {
 }
 
 export default function DatabaseSettings() {
+  const { user } = useAuth();
+  const isOwner = user?.classification === 'owner' || user?.classification === 'admin';
   const { stats, loading: statsLoading, refresh } = useDatabaseStats();
   const [wipingNeo4j, setWipingNeo4j] = useState(false);
   const [wipingStrfry, setWipingStrfry] = useState(false);
@@ -194,7 +197,8 @@ export default function DatabaseSettings() {
           These actions are <strong>irreversible</strong>. All data will be permanently deleted.
         </p>
 
-        {/* Wipe Neo4j */}
+        {/* Wipe Neo4j — owner-only: write Cypher (DETACH DELETE) 403s for non-owners */}
+        {isOwner && (
         <div className="settings-group" style={{ padding: '0.75rem 1rem', marginBottom: '0.75rem' }}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <div>
@@ -231,8 +235,10 @@ export default function DatabaseSettings() {
             )}
           </div>
         </div>
+        )}
 
-        {/* Wipe Strfry */}
+        {/* Wipe Strfry — owner-only: /api/strfry/wipe now 403s for non-owners */}
+        {isOwner && (
         <div className="settings-group" style={{ padding: '0.75rem 1rem' }}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <div>
@@ -269,6 +275,7 @@ export default function DatabaseSettings() {
             )}
           </div>
         </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

**Surgical cherry-pick** of runtime commit `7873f156` (staging PR #400) to production. Runtime only — the test + OPEN.md row stay on staging.

- **Security:** `POST /api/strfry/wipe` gains the `isOwner || localTrusted → else 403` gate (it execs `strfry delete`, wipes all events; default-deny blocked unauth but not an authenticated non-owner). Mirrors queryPost/publishEvent (ADR security-auth-exposure 0001/0002).
- **UX:** hides the control-panel controls that now 403 for non-owners (TA-sign radios, "Surprise me", Neo4j + strfry wipe buttons).

Verified on staging (#400): unauth wipe → 401 and events NOT wiped; site healthy.

## Test plan
- [ ] Prod deploy runs; smoke: unauth `POST /api/strfry/wipe` → 401 and count not zeroed; site healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)