### PR TITLE
product flow: second-brain phases 2-4 (user-modeling + scope + domain)

### DIFF
--- a/product-team/domain/second-brain.md
+++ b/product-team/domain/second-brain.md
@@ -1,0 +1,127 @@
+# Domain Model: Second Brain (display name: "Tapestry Harness")
+
+**Slug:** second-brain
+**Date:** 2026-07-21
+**Modeler phase:** Domain Modeling (Phase 4)
+
+> Conceptual model only — what the product knows about, not how it stores it. No tables, columns, foreign keys, or indexes.
+
+**The model's spine (operator-ruled, 2026-07-21):** the brain is *both ledger and snapshot, like a physical brain*. Two kinds of knowledge coexist: **durable intent** (goals, kept resources — edited rarely, deliberately) and **append-only record** (judgments, proposals, work — dated facts that are added, never rewritten). *Current standing is always derived by reading both*, never stored as a mutable flag that overwrites history. Every entity below declares which kind it is.
+
+Orientation performed against the live concept graph before modeling (summaries + one-hop reads of both existing work-item concepts), per the house rule.
+
+## Entities
+
+### Goal
+- **Description:** something the owner wants achieved — large or small, decomposable until pieces are session-sized.
+- **Kind:** durable intent.
+- **Concept mapping:** existing — `39998:<TA>:tapestry-owner-goal` ("goals of the owner / operator of this tapestry instance"), **adopted and extended**, not re-derived. Its extension currently holds a handful of real elements plus known hygiene defects (see Notes).
+- **Attributes:**
+  | Attribute | Type | Required | Notes |
+  |---|---|---|---|
+  | name | text | yes | short, human |
+  | statement | text | yes | the goal in the owner's words |
+  | deliverable | text | viable leaves only | what "done" produces |
+  | boundary | text | viable leaves only | what pursuing it may not touch |
+  | parent | ref:Goal | no | decomposition position (one parent in v1 — a tree) |
+  | category | ref:Category | no | one flat list in v1 |
+  | origin | text | yes | who captured it: the owner, or a session's proposal |
+  | captured-on | date | yes | |
+
+### External Resource
+- **Description:** a pointer to knowledge that lives outside the brain — the brain organizes it, never contains it.
+- **Kind:** durable intent (its *freshness* is derived from dated verifications).
+- **Concept mapping:** **new** concept; follows the established pointer-element pattern the graph already uses for event references.
+- **Attributes:**
+  | Attribute | Type | Required | Notes |
+  |---|---|---|---|
+  | title | text | yes | what a human calls it |
+  | locator-kind | text | yes | one of: file path, vault note, nostr event, repository, web address |
+  | locator | text/URL | yes | the pointer itself |
+  | why-kept | text | no | the owner's "why this is in my brain" |
+  | keywords | text list | no | the retrieval surface |
+  | noted-on | date | yes | |
+  | last-verified | date | no | freshness anchor |
+
+### Priority Signal
+- **Description:** one dated judgment of relative value between goals — v1's first framing is the pairwise choice ("if you could do one today, which?"), and the framing itself is expected to be replaced as better ones are found.
+- **Kind:** append-only record. Signals accumulate; none is ever edited.
+- **Concept mapping:** **new**.
+- **Attributes:**
+  | Attribute | Type | Required | Notes |
+  |---|---|---|---|
+  | prefers | ref:Goal | yes | |
+  | over | ref:Goal | yes | |
+  | reason | text | no | one line |
+  | judged-by | text | yes | the owner, in v1 |
+  | judged-on | date | yes | |
+  | framing | text | yes | names the method that produced it (pairwise, in v1) — so a replaced framing's signals stay interpretable |
+
+### Proposal
+- **Description:** the system's candidate for "what next" — one goal nominated with its why-now, shown against the runners-up it beat; the owner's decision completes it.
+- **Kind:** append-only record. The accumulated proposals + decisions are the calibration corpus the autonomy phases are gated on.
+- **Concept mapping:** **new**.
+- **Attributes:**
+  | Attribute | Type | Required | Notes |
+  |---|---|---|---|
+  | nominates | ref:Goal | yes | |
+  | why-now | text | yes | comparative, legible in ten seconds |
+  | passed-over | refs:Goal | yes | the runners-up, each with a one-line why-not |
+  | made-on | date | yes | |
+  | decision | text | derived-open | open → approved \| skipped (expiry arrives in Phase 2) |
+  | decision-reason | text | skips: yes | the teaching signal |
+  | decided-on | date | no | |
+
+### Work Record
+- **Description:** the fact that work happened — which session served which goal, what it produced, where it left things.
+- **Kind:** append-only record. Recording work never rewrites the goal it served.
+- **Concept mapping:** **new**.
+- **Attributes:**
+  | Attribute | Type | Required | Notes |
+  |---|---|---|---|
+  | session | text | yes | which session (human-launched in v1) |
+  | served | ref:Goal | yes | |
+  | produced | refs:External Resource | no | deliverables are pointers, not payloads |
+  | summary | text | yes | where things stand against the deliverable |
+  | questions | text list | no | at most a couple, plain English |
+  | happened-on | date | yes | |
+
+### Category
+- **Description:** a named collection grouping goals by the kind of attention they need (one flat list in v1).
+- **Kind:** durable intent.
+- **Concept mapping:** existing mechanism — the graph's native set machinery under the goal concept; new *instances*, no new machinery.
+- **Attributes:** name (text, required); purpose (text, required — discoverable in-graph, per the Second Operator guard).
+
+## Relationships
+
+Named and directional:
+
+- Goal **decomposes into** Goal (parent → children; a tree in v1 — richer structures are a named deferral)
+- Goal **points at** External Resource
+- Proposal **nominates** Goal; Proposal **passed over** Goal
+- Priority Signal **prefers** Goal **over** Goal
+- Work Record **serves** Goal; Work Record **produced** External Resource
+- Category **collects** Goal
+- Goal **is realized by** Engineering Project (see open-question resolution below)
+
+## States and lifecycle
+
+- **Goal:** captured → *(decomposed | viable)* → achieved | abandoned. In v1 these standings are **derived** from dated facts (a goal is "viable" because it has a deliverable and boundary and no children; "achieved" because a dated owner note or work record says so) — never a mutable status flag that overwrites history. The machine-enforced lifecycle with an observable *accepted* event, claims/leases, and review verdicts is **Phase 2** and is named, not modeled, here.
+- **External Resource:** live → stale → dead — derived from `last-verified` age, not stored.
+- **Proposal:** open → approved | skipped. (Auto-expiry: Phase 2.)
+
+## New vs. existing (Tapestry products)
+
+- **Maps to existing concepts:** Goal (`39998:<TA>:tapestry-owner-goal`, adopted + extended); Category (native set machinery, new instances only); Engineering Project (`39998:<TA>:project-for-the-engineering-team`, related — see below).
+- **Genuinely new:** External Resource, Priority Signal, Proposal, Work Record.
+- **Named, deferred, not modeled:** Claim/Lease, Review Verdict, Acceptance Tier, Launch Answer, Charter (Phases 2–3); Search Index (Phase 4); Improvement Proposal (Phase 5); Shared Subset (Phase 7).
+
+### Open question #4, resolved (proposed): relate, don't merge — yet
+
+`project-for-the-engineering-team` (5 elements) and `tapestry-owner-goal` are two work-item nouns in one graph. **V1 relates them**: an engineering project is one way a goal gets *realized* — "Goal **is realized by** Engineering Project" — so goals can point at engineering work without migrating anything. **Whether to merge** (engineering projects become goals in a "build software" category) is a real decision with migration consequences; it is assigned to **Phase 2** alongside the lifecycle work, where the acceptance model will make the right answer obvious. Two nouns tolerated for one phase, on purpose, with the reconciliation scheduled — not a graveyard.
+
+## Notes for later phases
+
+- **Hygiene (v1, already in scope):** the stray membership edge from the concept header to `concept-header-superset` was verified live today on **both** work-item concepts — it is systemic, not goal-specific. The goal concept's element wiring also looks irregular (elements appear to hang off the header rather than the superset). The v1 hygiene-validation item covers cleaning both and asserting the class-thread invariant on the goal extension.
+- **Assessment shape:** the operator's original impact/effort/probability triple is *not* modeled as bare attributes on Goal — relative-value judgments live in Priority Signal as dated, attributed, framing-tagged facts (roundtable amendment; keeps the calibration study possible and the framing replaceable).
+- **Attribution:** every append-only fact carries who and when. Multi-author futures (sessions proposing, second operators) are already accommodated by `origin` / `judged-by` / `session` — no redesign needed when they arrive.

--- a/product-team/journeys/second-brain-delegating-owner.md
+++ b/product-team/journeys/second-brain-delegating-owner.md
@@ -1,0 +1,53 @@
+# Journey: The Delegating Owner
+
+**Slug:** second-brain-delegating-owner
+**Persona:** `product-team/personas/second-brain-delegating-owner.md`
+**Date:** 2026-07-21
+
+From first capture to trusted delegation. The first-visit experience requires no new account — the owner already operates the instance; what must feel effortless is the first *capture*.
+
+## Steps
+
+### 1. First capture (the first visit)
+- **Trigger:** mid-conversation or mid-thought, a goal surfaces: "I want the search page to handle typos."
+- **Action:** the owner says it, in whatever words they have. Nothing more.
+- **Expected experience:** the goal exists in the brain — named, findable, attributed, dated — without the owner filling in a form or learning a vocabulary. Confirmation is one plain sentence, not a record dump.
+- **Emotional state:** *unburdened* — "it's captured, I can stop holding it."
+
+### 2. Decomposition, together
+- **Trigger:** a captured goal is too big for anything to carry in one sitting.
+- **Action:** the owner talks through the goal; the system proposes smaller pieces, each with a stated deliverable and boundary; the owner corrects in plain language.
+- **Expected experience:** a big vague ambition becomes a tree of session-sized pieces the owner recognizes as their own thinking, sharpened.
+- **Emotional state:** *clarified* — the mountain has switchbacks now.
+
+### 3. The first proposal
+- **Trigger:** viable pieces exist; the system's cadence arrives at "what next?"
+- **Action:** the owner reads one proposal: the piece, why now, why this one over the two runners-up — and says yes, or skips with a reason.
+- **Expected experience:** the comparison is legible in ten seconds; a skip-with-reason is one line and visibly *teaches* the system.
+- **Emotional state:** *in command* — choosing, not chauffeuring.
+
+### 4. Morning review
+- **Trigger:** work happened while the owner was away (initially: launched by them; later: autonomously).
+- **Action:** the owner opens one surface and reads downward.
+- **Expected experience:** the operator's own spec, verbatim from discovery: *significant progress on some set of goals, still working on some, and one or two questions posed in plain English, not jargon.* Everything the system did, decided, or skipped is on this one surface, attached to the goal it served.
+- **Emotional state:** *oriented, not anxious.*
+
+### 5. Retrieval in anger
+- **Trigger:** six weeks later — "where was that thing about the relay config?"
+- **Action:** keyword search, then look at what the hit is connected to (the owner's own stated method).
+- **Expected experience:** the pointer surfaces with enough context (what it is, why it's in the brain, when last verified) to act on immediately; connected goals and resources are one hop away.
+- **Emotional state:** *vindicated* — the brain remembered so they didn't have to.
+
+### 6. Trust graduation
+- **Trigger:** a category of work has accumulated a track record (proposals the owner kept approving; deliverables reviews kept passing).
+- **Action:** the owner loosens the tier for that category — review-only acceptance, no ratification.
+- **Expected experience:** the system makes strides in their absence, and the morning review proves it; the tier change itself was the owner's explicit, revocable act.
+- **Emotional state:** *leveraged* — the Director-run feeling, made routine.
+
+## Friction points
+
+- **Step 1 is the whole product.** If capture costs more than a text file, the graph starves and every later step is theater. (Instrument it: capture counts, retrieval counts — the diary-study framing.)
+- **Step 4 collapses if the record splits** across the brain and the scheduler's own logs — the audit must live where the goals live.
+- **Step 3's scores can be noise** early on; showing false precision would corrode trust before it forms. Comparisons and reasons, not decimals.
+- **Ratification queue growth** silently reintroduces the bottleneck — queue age must be visible, and stale proposals must expire rather than accumulate guilt.
+- **One jargon word** in a morning-review question breaks the register contract with this persona.

--- a/product-team/journeys/second-brain-fresh-context-session.md
+++ b/product-team/journeys/second-brain-fresh-context-session.md
@@ -1,0 +1,43 @@
+# Journey: The Fresh-Context Session
+
+**Slug:** second-brain-fresh-context-session
+**Persona:** `product-team/personas/second-brain-fresh-context-session.md`
+**Date:** 2026-07-21
+
+The machine journey. Its "first visit" is orientation from an empty context window; its "account" is the owner-gated access it inherits from running where it runs. Per the traceability guard, every step here exists to serve a step in the owner's journey (cited inline).
+
+## Steps
+
+### 1. Orientation (the first visit)
+- **Trigger:** the session starts — cron tick, heartbeat, or the owner's hand — with empty context.
+- **Action:** a bounded read of the brain's summary surface, then one-hop reads of what today's work touches.
+- **Expected experience:** within a fixed, corpus-independent budget (on the order of a few thousand tokens), the session knows what exists, what matters now, and where its goal sits. It never rereads the whole brain. *(Serves owner steps 3–4: cheap orientation is what makes many small sessions affordable.)*
+- **Emotional state:** n/a — but the design stance is: the session should never need to guess.
+
+### 2. Goal receipt
+- **Trigger:** the session is pointed at (or selects) one viable goal.
+- **Action:** it reads the goal's deliverable and scope, stated verbatim, as fixed at claim time.
+- **Expected experience:** an unambiguous job with a boundary — what "done" produces, what it may not touch. If the goal is bigger than its budget, the correct move (propose decomposition, don't attempt) is obvious from the structure itself. *(Serves owner step 2: decomposition; owner step 6: scope is what makes trust safe to extend.)*
+
+### 3. Working through pointers
+- **Trigger:** the work needs knowledge that lives outside the graph.
+- **Action:** crawl from the goal to its linked resources; dereference each pointer in its native store (file, vault note, event, repo, URL).
+- **Expected experience:** pointers carry enough identity and freshness to be trusted or verified cheaply; content stays external; nothing requires copying volume into the brain. *(Serves owner step 5: what the session maintains here is what the owner later retrieves in anger.)*
+
+### 4. Write-back
+- **Trigger:** progress happened — an outcome, a discovery, a dead end, a new idea.
+- **Action:** record it as durable, addressable facts attached to the goal: what was done, what was produced (as pointers), what was decided and why. New goal ideas are proposed, never launched, from inside a session.
+- **Expected experience:** writes are safe (schema is contract, not convention), attributable, and append-shaped — recording activity never rewrites the goal's identity. *(Serves owner step 4: the morning review is assembled from exactly these facts.)*
+
+### 5. Hand-off
+- **Trigger:** the deliverable is produced, the budget is spent, or the scope boundary is reached.
+- **Action:** the session states where things stand against the deliverable, surfaces at most a question or two for the owner, and ends.
+- **Expected experience:** the next session's step 1 is cheaper because this session ran — the graph, not the context window, carries the continuity. *(Serves owner steps 4 and 6: legible endings are what reviews and trust are built from.)*
+
+## Friction points
+
+- **Orientation cost creeping upward with corpus size** — the summary surface must stay bounded or step 1 silently eats the budget that step 3 needed.
+- **A stale pointer mid-task** — the session either wastes budget verifying everything or produces a deliverable built on a 404. Freshness metadata is load-bearing.
+- **Two sessions colliding on one goal** — claim/lease semantics must make "who is working on this" unambiguous.
+- **Schema ambiguity at write-back** — the moment a session hesitates about *how* to record a fact, it will record it inconsistently, and the brain accumulates dialects.
+- **The session redesigning the harness** — scope leakage from "achieve the goal" into "improve the system" must route through proposals, never direct edits.

--- a/product-team/journeys/second-brain-second-operator.md
+++ b/product-team/journeys/second-brain-second-operator.md
@@ -1,0 +1,32 @@
+# Journey: The Second Operator
+
+**Slug:** second-brain-second-operator
+**Persona:** `product-team/personas/second-brain-second-operator.md`
+**Date:** 2026-07-21
+
+The generalization journey — deliberately short. It is the Delegating Owner's journey re-run on a fresh instance by someone with none of the reference operator's context; only the steps that *differ* are modeled.
+
+## Steps
+
+### 1. Cold start (the first visit)
+- **Trigger:** their instance is running; they've heard the delegation loop works; their goal graph is empty.
+- **Action:** they look at the brain for the first time.
+- **Expected experience:** an empty brain that still offers an obvious first action — capture a goal in plain words — with the system's own concepts (what categories exist, what a goal is) discoverable by the owner's universal method: search, then look at what it's connected to. Nothing assumes the reference instance's history.
+- **Emotional state:** *invited, not confronted.*
+
+### 2. First capture on unfamiliar ground
+- **Trigger:** they state their first goal.
+- **Action:** same as the Delegating Owner's step 1.
+- **Expected experience:** identical to the reference instance's behavior — because nothing in the loop depends on whose instance it is. Their assistant's identity, their trust graph, their stores.
+- **Emotional state:** *reassured* — it works here too.
+
+### 3. Convergence
+- **Trigger:** the loop is running.
+- **Action:** they proceed through capture → decompose → delegate → review exactly as the primary journey describes.
+- **Expected experience:** from here, their journey **is** the Delegating Owner's journey, steps 2–6.
+
+## Friction points
+
+- **Any hardcoded reference-instance identity** (the assistant pubkey lesson) — breaks step 2 invisibly: things sign under one identity and are searched under another.
+- **Convention that lives in the reference operator's head** — if a category's meaning isn't discoverable in-graph, the second operator mislabels from day one and the dialect problem begins.
+- **Documentation that narrates history instead of stating behavior** — this persona reads what the system says today, not the design conversation that produced it.

--- a/product-team/personas/second-brain-delegating-owner.md
+++ b/product-team/personas/second-brain-delegating-owner.md
@@ -1,0 +1,30 @@
+# Persona: The Delegating Owner
+
+**Slug:** second-brain-delegating-owner
+**Priority:** Primary
+**Date:** 2026-07-21
+
+## Who they are
+
+The owner/operator of a Tapestry instance who has more ambitions than hands. Runs multiple projects at once; thinks in goals, not tasks; keeps asking the Elon question — *"is the thing I'm doing right now the most important thing I could be doing?"* — and knows that almost nobody attacks that question systematically. Deeply technical in their own domains but does not know (or want to know) the internals of every memory file their agents keep; their stated discovery method is "find it with keyword search and see what it's connected to." Currently the terminal bottleneck: nothing happens unless they personally notice, choose, launch, and accept it. Values correctness over speed — "no rush jobs" — and would rather a system earn autonomy slowly than fake it fast.
+
+## What they want
+
+Their goals achieved — including in their absence — with their own judgment applied only where it genuinely matters.
+
+## Their core loop
+
+Capture a goal in plain language → see it decomposed into pieces something else can carry → let the system propose (later: launch) the highest-value next piece → review an outcome-first digest and answer one or two plain-English questions → trust the system with a little more next time. Each pass around the loop makes the graph richer, the proposals sharper, and the owner's attention more leveraged.
+
+## What they won't tolerate
+
+- **Being the bottleneck by design.** Ratifying every tiny step is the thing this product exists to end.
+- **Capture that costs more than a text file.** If recording a goal is ceremony, the graph starves and this becomes the sixth ignored surface.
+- **Jargon.** Questions and digests come in plain English; "persona," "acceptance criteria," "kind 39999" never appear in anything addressed to them.
+- **Split-brain auditing.** "What happened overnight and why" must have one answer surface, not a trail across two systems.
+- **Irreversible embarrassment.** Recoverable mistakes are the cost of autonomy; *an embarrassing message to the world* is the line that makes them rein the whole thing in.
+- **Rush jobs.** A wrong answer fast is worse than a right answer tomorrow.
+
+## Notes
+
+This persona is the instance owner generally, not one individual — but its first instantiation is the reference operator, whose verbatim rulings (delegation-first; ledger-and-snapshot; tiered acceptance; $200/month ceiling) are recorded in the discovery brief and bind later phases. Every requirement in this product ultimately traces to a step in this persona's journeys — see the traceability guard in `second-brain-fresh-context-session.md`.

--- a/product-team/personas/second-brain-fresh-context-session.md
+++ b/product-team/personas/second-brain-fresh-context-session.md
@@ -1,0 +1,32 @@
+# Persona: The Fresh-Context Session
+
+**Slug:** second-brain-fresh-context-session
+**Priority:** Primary (machine persona — see traceability guard below)
+**Date:** 2026-07-21
+
+> **Traceability guard (operator-ratified, 2026-07-21).** This persona exists to give the machine-facing surface a named user: its tolerances are real design inputs. But **no requirement may be justified by this persona alone.** Every requirement citing The Fresh-Context Session must also trace to a step in a Delegating Owner journey — the session serves the owner's delegation loop; it never independently justifies a feature. A requirement that traces only here is a defect at PRD assembly.
+
+## Who they are
+
+An agent session that wakes with an empty context window and a job to do. It has no memory of yesterday except what the substrate gives it; its patience is a token budget; its first-visit experience is orientation — and orientation cost is the difference between a session that spends itself understanding and a session that spends itself achieving. It is honest about its own limits: a weaker model needs smaller goals; any model needs an unambiguous scope. It may be one of many — sessions come and go; the graph is what persists.
+
+## What they want
+
+To orient in seconds, act within an unambiguous scope, and leave the graph richer than it found it.
+
+## Their core loop
+
+Orient (a bounded read of the graph's summary surface) → receive or select one goal with its deliverable and scope stated verbatim → work through pointers (crawl the graph, dereference external stores) → write outcomes back as durable, addressable facts → hand off cleanly, so the next session's orientation is cheaper than this one's.
+
+## What they won't tolerate
+
+- **Orientation that grows with the corpus.** Rereading flat files scales linearly; a summary surface must stay bounded no matter how big the brain gets.
+- **Ambiguous structure.** A schema that is convention rather than contract forces re-inferring the owner's intent every session — and makes write-back dangerous.
+- **Stale pointers.** A locator that 404s mid-task burns budget and produces wrong deliverables.
+- **Unaddressable memory.** If two sessions cannot refer to the same thing by the same name, they cannot build on each other.
+- **Category errors.** A concept's definition confused with its instances leads the session to act on the wrong data — the exact hygiene failure the class thread exists to prevent.
+- **Scope leakage.** A goal without a stated boundary invites the session to redesign the system it's supposed to be serving.
+
+## Notes
+
+One machine persona, deliberately. The executor-session and reviewer-session roles will want different things from the graph *eventually* — split this persona only when their journeys demonstrably diverge (expected at the autonomous-execution phase, not before). Per the calibration rule: if two personas never want different things, they're one.

--- a/product-team/personas/second-brain-second-operator.md
+++ b/product-team/personas/second-brain-second-operator.md
@@ -1,0 +1,27 @@
+# Persona: The Second Operator
+
+**Slug:** second-brain-second-operator
+**Priority:** Secondary
+**Date:** 2026-07-21
+
+## Who they are
+
+A Tapestry owner who did not build this system. They run their own instance, have their own goals, their own external stores, and their own agents — and none of the reference operator's context. They discover conventions by reading what the system presents, not by remembering design conversations. They are the near-term test of the product's honesty: every "works on my instance" assumption breaks on theirs first. (Named instantiations expected soon after v1: the two active collaborators. Eventually: every tapestry owner.)
+
+## What they want
+
+The same delegation loop the reference operator gets, on their own instance, without adopting anyone else's workflow or archaeology.
+
+## Their core loop
+
+Identical in shape to The Delegating Owner's loop — capture, decompose, delegate, review, extend trust — but bootstrapped from an empty goal graph on a fresh instance, which makes the *first* pass around the loop the make-or-break experience.
+
+## What they won't tolerate
+
+- **The reference operator's fingerprints.** Hardcoded identities, paths, or assumptions that only hold on the original instance (the house rule against hardcoding the per-deployment assistant identity exists precisely because this failure already happened once).
+- **Undocumented conventions.** If the meaning of a category or a relationship lives in one person's head, the product doesn't generalize.
+- **A cold start with no path in.** An empty goal graph must still offer an obvious first action.
+
+## Notes
+
+This persona keeps v1 honest without expanding v1's scope: nothing is *built for* them yet, but nothing may be built that structurally excludes them. Peers (trust-graded sharing via the grapevine) remain a different, deferred persona landscape — do not fold them in here.

--- a/product-team/scope/second-brain.md
+++ b/product-team/scope/second-brain.md
@@ -1,0 +1,109 @@
+# Scope: Second Brain (display name: "Tapestry Harness")
+
+**Slug:** second-brain
+**Date:** 2026-07-21
+**Manager phase:** Scope & Prioritization (Phase 3)
+
+## Features extracted
+
+Every feature implied by the three journeys, flat:
+
+- Plain-language goal capture (owner speaks; brain records; one-sentence confirmation)
+- Goal decomposition into session-sized pieces, each with a stated deliverable and boundary
+- Pointers from goals to external resources (files, vault notes, nostr events, repos, URLs) with identity and freshness
+- Bounded orientation surface for sessions (corpus-independent cost)
+- Session-read loop (every session orients from the goal graph; outputs reference the goal served)
+- Recurring "what next?" proposal with comparative rationale (this one over the runners-up)
+- Skip-with-reason (the owner's decision log — the calibration instrument)
+- Priority signals as dated, attributed pairwise/ordinal choices
+- Goal lifecycle states and an observable "accepted" event
+- Independent review of deliverables; acceptance tiers per goal category; batch ratification
+- Proposal auto-expiry; ratification-queue age visibility
+- Brain-side launch/no-launch answer given reported capacity
+- Claim/lease semantics (which session holds which goal)
+- Write-back of every scheduler decision into the brain (asks and reports; never chooses)
+- Autonomous session launch under concurrency limits, category whitelist, armed charter, kill switch
+- Activity observability (what ran, is running, will run)
+- Morning-review digest (one surface; plain-English questions)
+- Retrieval via keyword search + connections
+- Keyword index over the brain's contents; staged search rounds (keyword → crawl → external stores)
+- Owner-data export/backup and restore
+- Goal-structure hygiene validation (the live category-error defect gets cleaned)
+- Non-publishing (private) write mode
+- No reference-instance hardcodes; conventions discoverable in-graph; empty-graph first action
+- Self-improvement goal category routed through governed proposal-only path
+- Local-model compatibility; semantic recall
+- Grapevine sharing of trusted subsets
+
+## MVP boundary
+
+**Theme: "Capture, Decompose, Propose."** The full delegation loop *minus autonomous launch*: the owner captures and decomposes goals, sessions orient from them, and the system proposes the next piece — the owner launches. Delegation-first per the operator's ruling: the proposer ships in v1; the launcher earns its way in.
+
+### In scope (must ship)
+
+- [ ] Plain-language goal capture — cheaper than a text file, confirmed in one sentence
+- [ ] Decomposition into session-sized pieces, each with deliverable + boundary
+- [ ] Pointers to external resources with identity + freshness (content stays external)
+- [ ] Bounded session orientation + the session-read loop (outputs reference the goal served)
+- [ ] Propose-only cadence: comparative "what next?" proposals; approve / skip-with-reason logged
+- [ ] Priority signals recorded as dated pairwise/ordinal choices — **recorded, never acted on autonomously**
+- [ ] Owner-data export/backup + one journaled restore drill (clobber protection until the installer fix lands as its own engineering work)
+- [ ] Goal-structure hygiene validation (zero category-error edges in the goal extension)
+- [ ] Minimal read view of goals on the existing owner surface (a view, not an app)
+- [ ] Second-Operator guard: no reference-instance hardcodes; conventions discoverable in-graph
+
+### Out of scope (deferred)
+
+- Goal lifecycle/acceptance states + independent review gates → Phase 2
+- Acceptance tiers, batch ratification, proposal auto-expiry, queue-age metric → Phase 2
+- Brain-side launch/no-launch answer; claim/lease semantics; scheduler write-back contract → Phase 2
+- Non-publishing (private) write mode → Phase 2 *(operator-ruled: the pilot does not gate on it)*
+- Autonomous launch (concurrency 1, category whitelist, armed charter, kill switch, metric-gated entry) → Phase 3
+- Activity observability surface → Phase 3, **inherited from the separate task-timeline engineering book** (operator-ruled: armed and run before Phase-3 planning begins; not part of this product's surface)
+- Morning-review digest as a designed surface → Phase 3 (v1's review is the proposal log + read view)
+- Keyword index over the brain; staged search rounds → Phase 4
+- Self-improvement category via the governed proposal-only path → Phase 5
+- Local-model validation; semantic recall → Phase 6 *(operator-ruled: local-model compatibility is a v1 design lens — bounded orientation, small chunks, no frontier-context assumptions — but not a tested v1 requirement)*
+- Grapevine sharing of trusted subsets (the search-mission bridge) → Phase 7
+- Peers as users, embedded content viewers, health/monitoring surfaces, graph-visualization canvases → not scheduled; re-propose through discovery if ever wanted
+
+## Phase roadmap
+
+- **MVP — "Capture, Decompose, Propose":** the delegation loop minus launch; doubles as a diary study and the score-calibration instrument.
+- **Phase 2 — "Goal Engine & Review":** lifecycle + observable acceptance, review gates, acceptance tiers, ratification mitigations, brain-side selection answer, scheduler write-back contract, private mode.
+- **Phase 3 — "Gated Autonomy Pilot":** autonomous launch at concurrency 1 on non-repo categories (graph maintenance, vault map-of-content building), armed charter, kill switch; entry is metric-gated (see below); observability inherited from the task-timeline book.
+- **Phase 4 — "Search Depth":** keyword index over the brain; keyword → crawl → external-store rounds.
+- **Phase 5 — "Self-Improvement Wiring":** the improve-the-harness category routed through the governed, proposal-only path.
+- **Phase 6 — "Model Capabilities":** local-model validation of the decomposition thesis; semantic recall.
+- **Phase 7 — "Sharing":** grapevine-graded trusted subsets — the supply-side bridge to the outward search mission.
+
+## Success metrics
+
+All observable by inspection of the graph, the proposal log, and git — no new instrumentation.
+
+**MVP (within 6 weeks of shipping):**
+- ≥ 20 goals in the brain, each with ≥ 1 external pointer, authored across ≥ 10 distinct days (sustained use, not a seeding spree)
+- ≥ 5 agent-session outputs that reference the goal they served
+- ≥ 15 proposals with a logged approve or skip-with-reason decision
+- The frozen legacy surface (the heartbeat checklist) gains zero new rows
+- 1 export + restore drill performed and journaled
+- ≥ 3 journaled retrievals-in-anger that succeeded via search + connections
+- Hygiene check passes: zero category-error edges in the goal extension
+
+**Phase 2 (before Phase 3 may be planned):**
+- 100% of active goals show timestamped lifecycle transitions
+- Proposal→launch agreement ≥ 50% over ≥ 15 logged decisions (the Phase-3 entry gate)
+- Median open-proposal age flat or falling over 4 consecutive weeks
+
+**Phase 3 (pilot verdict):**
+- ≥ 5 autonomous sessions, each with an independent review verdict recorded
+- ≥ 1 rejection observed — a 100% acceptance rate means review-as-decoration and reads as **failure**, not success
+- Zero ceiling breaches
+
+## Tradeoffs
+
+- **We gain a trusted launcher by cutting the launcher.** Autonomy waits for a calibration corpus (the ≥15-decision log) instead of shipping on vibes — the emotional center of the idea arrives in Phase 3, but arrives earned.
+- **We gain shipping speed by accepting convention-only privacy through the pilot** (operator-ruled); mechanism-enforced privacy is Phase 2's job.
+- **We gain product focus by keeping observability in the task-timeline engineering book** rather than growing this product's surface — at the cost of a cross-book dependency the operator must arm.
+- **We gain honest success criteria by making the diary study the bar**: usage across days and retrievals-in-anger, not demo counts.
+- **We accept developer-grade ergonomics in v1** (a read view, not an app; capture through conversation) because the only v1 user is the primary persona — provided capture stays cheaper than a text file, which remains the product's load-bearing bet.


### PR DESCRIPTION
Operator-approved personas + journeys (Phase 2) and scope (Phase 3) for `second-brain`. Docs-only; touches `product-team/` exclusively. One phase commit each, per the harness convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)