### PR TITLE
product flow: second-brain phases 5-7 (design + PRD + stories queue)

### DIFF
--- a/product-team/guides/second-brain-design-guide.md
+++ b/product-team/guides/second-brain-design-guide.md
@@ -1,0 +1,112 @@
+# Design Guide: Second Brain (display name: "Tapestry Harness")
+
+**Slug:** second-brain
+**Date:** 2026-07-21
+
+> Visual rules, design tokens, component patterns, and wireframe references. Binding during engineering review. Honors `product-team/guardrails/design.md`.
+> Wireframes: [`second-brain-wireframes.html`](./second-brain-wireframes.html)
+
+## Grounding — mirror, don't invent
+
+The v1 surface is **a view inside the existing owner-gated control panel**, not an app. It inherits the app's GitHub-dark identity and token set verbatim (the verified-reporters precedent: a reviewer should not be able to tell this was built at a different time). This product introduces **no new visual identity and no new tokens** — only three owner-facing views and a handful of components, all owner-gated. Nothing here ever appears on the visitor-facing search surface.
+
+## Design principles
+
+Non-negotiable; enforced in engineering review.
+
+1. **A review loop, not a dashboard.** Every screen answers one owner question — "what do I have?", "what next?", "what happened?" — with one primary action. No metrics walls, no vanity charts, no graph-visualization canvas (the existing concept pages remain the browse surface for graph structure).
+2. **Comparisons, not decimals.** Relative value renders as plain comparative language ("proposed over X because…"), never as gauges, sliders, stars, or falsely precise numbers. Until calibration proves a score means something, showing it as a number is a design defect.
+3. **One spine.** Everything that happened — proposals, decisions, work — renders attached to the goal it served. The owner never assembles a story across surfaces.
+4. **Plain language on every owner-facing string.** The register rule from the journeys is a *visual* rule here: questions and confirmations are single sentences; no jargon ("element," "kind," "schema") in any owner-visible label. A jargon word in the UI fails review.
+5. **Skip-with-reason is a first-class control.** The skip affordance is as prominent as approve, and its one-line reason field is required — it is the calibration instrument, not an afterthought.
+6. **Pointer cards open native.** A resource card shows identity + freshness and opens the resource in its own home (editor, vault, client, browser). No embedded viewers of any kind.
+7. **Empty states are the onboarding.** The cold-start view (Second Operator journey, step 1) is designed first: an empty brain states what will appear and offers exactly one action — capture a goal in plain words.
+8. **Tokens only; no icon libraries.** Indicators are typography, the unicode glyphs the app already uses (ⓘ ▸ ●), colored shapes, or hand-crafted SVG. No hex/px literals in components.
+9. **The do-not-design list is binding:** no agent chat UI, no score gauges, no publish/privacy toggle (v1 privacy is a convention — the only honest treatment is a quiet indicator line, not a control), no health/monitoring surfaces, nothing visitor-facing.
+
+## Visual identity
+
+Inherits the app's identity verbatim; semantic application only.
+
+- **Color palette:** one accent `--accent` for all interactive elements (links, buttons, focus). Semantic colors only as exceptions: `--green` (achieved standing, approve confirmation), `--orange` (stale pointer freshness), `--red` (dead pointer, error states). Standing and freshness are always carried by the **word**, with color reinforcing — never color alone.
+- **Typography:** app body font throughout. View title 1.4rem; goal name 1rem weight 600; metadata 0.85rem muted; the proposal's why-now is body-size (1rem) — it is content, not chrome.
+- **Spacing:** existing `.bsp-content` rhythm; cards on an 8px scale (`--space-2` multiples); tree indentation 20px per depth level.
+- **Elevation:** flat, as the app is; cards use the existing subtle surface tints; no shadows beyond the existing modal layer.
+
+## Design tokens
+
+Existing app tokens (from `ui/src/styles.css :root`) — this product adds **no new tokens**. One derived tint is permitted for the open-proposal card emphasis, token-driven: `rgba(88,166,255,0.08)` (the accent at 8%).
+
+```css
+:root {
+  /* color — inherited, reference only */
+  --accent: #58a6ff;          /* all interactive elements */
+  --accent-hover: #79c0ff;
+  --bg: #0d1117;
+  --surface: #161b22;
+  --surface-2: #21262d;
+  --border: #30363d;
+  --text: #e6edf3;
+  --text-muted: #8b949e;
+  --green: #3fb950;            /* achieved / approve */
+  --orange: #d29922;           /* stale */
+  --red: #f85149;              /* dead / error */
+  /* radius */
+  --radius: 8px;
+  /* spacing */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 16px;
+  --space-4: 24px;
+}
+```
+
+## Component patterns
+
+### Goal row (tree item)
+- **Visual:** disclosure glyph `▸` (rotates 90° open) + goal name (600) + standing word in muted small caps (`captured / viable / achieved / abandoned`; achieved in `--green`, abandoned muted) + category chip (surface-2 pill, 0.8rem) + pointer count as text ("3 pointers"). Children indent 20px.
+- **Behavior:** row click opens Goal detail; disclosure toggles children without navigation. Standing is derived, so it renders read-only — there is no status dropdown anywhere in v1.
+- **Empty / loading / error:** a goal with no children and no deliverable shows an inline muted hint "needs a deliverable and boundary before it can be proposed." Loading: three skeleton rows with name-width shimmer bars. Error: inline row "Couldn't load this goal's details — retry" with retry as the accent link.
+
+### Pointer card (External Resource)
+- **Visual:** kind marker as typography (`file` `vault` `event` `repo` `web` — 0.75rem uppercase muted, no icons) + title (600, accent link) + locator preview (truncated middle, monospace 0.8rem muted) + freshness line ("verified 3 days ago" muted; "not verified in 40 days" in `--orange`; "unreachable at last check" in `--red`). Optional why-kept as one italic line.
+- **Behavior:** title opens the resource in its native home (new tab / OS handler). No preview, no embed.
+- **Empty / loading / error:** goal with no pointers: "Nothing attached yet — resources this goal needs will appear here." Loading: two skeleton cards. Error: the freshness line doubles as the error surface (states what failed and when).
+
+### Proposal card
+- **Visual:** the emphasis card of the product — accent-tinted background (the one derived tint), `--radius`, `--space-3` padding. Contents top-down: "**Next:** {goal name}" · why-now as 1–2 body sentences · a "considered instead" block listing exactly the passed-over goals, each one line: name + muted why-not · action row.
+- **Behavior:** two equal-weight buttons: **Approve** (accent, solid) and **Skip…** (accent, outline — ellipsis signals a reason is coming). Approve confirms in one quiet sentence and the card retires to the goal's record. Skip expands the inline reason field (see below). Open proposals sort newest-first; a decided proposal never renders in the queue again.
+- **Empty / loading / error:** queue empty: "No proposal right now — the next one appears when there are viable goals to choose between." Loading: one skeleton card with three shimmer lines. Error: "The proposer couldn't run — its last message: {plain-English reason}. Nothing was decided for you."
+
+### Skip-with-reason (inline)
+- **Visual:** a single-line input on the contrasting input background (guardrail: inputs visually distinct), placeholder "why not this one, in a few words", with **Skip** (accent) and **Cancel** (text link).
+- **Behavior:** reason required — Skip stays disabled until non-empty; Enter submits; Escape cancels. On submit, one quiet sentence: "Skipped — noted."
+
+### Capture confirmation
+- **Visual/behavior:** capture happens in conversation, not in this UI; when the view is open during a capture, the new goal row appears with a 2-second `--surface-2` highlight fade. Any in-view confirmation is one plain sentence, never a record dump or a toast stack.
+
+### Record entries (on Goal detail)
+- **Visual:** a single chronological list under the goal — each entry one line + optional expandable body: date (muted, absolute) · type word (`proposed / approved / skipped / worked / noted`) · one-sentence summary. Work entries list produced pointers as pointer cards.
+- **Behavior:** append-only rendering — no edit affordances on record entries, ever (the ledger is the ledger).
+
+## Screen inventory
+
+| Screen | Purpose | Wireframe |
+|---|---|---|
+| Goals view | The tree: capture's landing place; browse, filter by category | `second-brain-wireframes.html` §1 |
+| Goal detail | One goal's intent + pointers + its full record on one spine | `second-brain-wireframes.html` §2 |
+| Proposal queue | Open "what next?" proposals; approve / skip-with-reason | `second-brain-wireframes.html` §3 |
+| Cold start (empty state of Goals view) | The onboarding: one action, plain words | `second-brain-wireframes.html` §4 |
+
+Morning-review digest is **Phase 3** and not designed here.
+
+## Responsive behavior
+
+Desktop-first (an owner tool). ≥1024px: Goals view and detail may sit two-column (tree left 320px, detail right). 768–1024px: single column, detail replaces tree with a back link. <768px: cards go full-bleed with `--space-3` gutters; the proposal action row stacks (Approve above Skip); tree indentation drops to 12px. Nothing hides — everything reflows.
+
+## Accessibility baseline
+
+- Contrast: inherited token pairs already meet WCAG AA on `--bg`/`--surface` (text 12.9:1, muted 4.6:1); semantic words never rely on color alone (principle 2/4).
+- Touch targets ≥ 44×44px on all actions; the disclosure glyph's hit area is the full row height.
+- Keyboard: full tab order (tree rows → detail → proposal actions); Enter opens/approves only when focused (no global hotkeys in v1); Escape cancels the skip field; visible focus ring in `--accent` on every interactive element.
+- The proposal card is a `region` with a plain-language label; record lists are chronological lists, not tables.

--- a/product-team/guides/second-brain-style-guide.md
+++ b/product-team/guides/second-brain-style-guide.md
@@ -1,0 +1,39 @@
+# Style Guide: Second Brain (display name: "Tapestry Harness")
+
+**Slug:** second-brain
+**Date:** 2026-07-21
+
+> Governs all user-facing text in the product. Binding during engineering review. Built from `product-team/guardrails/language.md` plus this product's voice.
+
+## Voice
+
+A capable aide reporting to the person it works for. Calm, brief, concrete, second person. It states what happened and what it needs; it never performs enthusiasm, never apologizes theatrically, never narrates its own machinery. The owner said it best: questions come *"in plain english, not jargon that I don't understand."* If a sentence would sound odd said aloud across a desk, it fails.
+
+## Language rules
+
+Base guardrails apply in full (no LLM tics, no superlative inflation, no passive deflection, no emoji, no exclamation marks in UI copy, active voice, short sentences, concrete over vague). Product-specific rules:
+
+- **No system vocabulary in owner-facing text.** Banned words anywhere the owner reads: *element, kind, schema, event, pubkey, superset, concept header, persona, acceptance criteria, lease, payload, endpoint.* Say the plain thing: "goal," "resource," "recorded."
+- **Tell the owner what happened to their world, not what the system did.** "Goal captured." — not "Element created and republished."
+- **Comparisons, not decimals.** Relative value is expressed in words and rankings; a numeric score never appears in owner-facing copy in v1.
+- **Questions earn their interruption.** At most two per session hand-off; each one answerable in a sentence; each states what the answer unblocks.
+- **Standing words are canonical and lowercase:** *captured, viable, achieved, abandoned* (goals); *current, stale, unreachable* (resources); *open, approved, skipped* (proposals). No synonyms, no invented states.
+
+## UI copy patterns
+
+- **Button labels:** verb (+ noun where ambiguous): "Approve," "Skip…," "Cancel," "Export brain." The ellipsis on "Skip…" signals a reason is expected.
+- **Empty states:** say what will appear and give the one action. Canonical cold start: *"Your brain is empty — that's the right place to start. Tell your assistant a goal in plain words and it will appear here."*
+- **Error messages:** what went wrong, in whose terms, and what to do: *"Couldn't reach this resource at its address — check it moved, or mark it retired."* Never "Something went wrong."
+- **Confirmations:** one sentence, the fact, no ceremony: *"Goal captured."* · *"Skipped — noted."* · *"Restore drill complete — your brain matches the export."*
+- **The proposal register (canonical skeleton):** *"Next: {goal}."* + why-now in one or two sentences + *"considered instead"* + one line per runner-up. The skip prompt is *"why not this one, in a few words."*
+- **The privacy line (indicator, never a toggle):** *"This brain stays on this machine — nothing here is published."*
+
+## Forbidden phrases
+
+Beyond the base list:
+
+- Celebration theater: "Great job," "You're all set," "Awesome."
+- Anthropomorphic guilt or eagerness: "Sorry about that," "I'd love to," "Happy to help."
+- Progress theater: percentages or precision the system doesn't actually have ("87% complete").
+- Urgency theater: "Don't forget," "You still need to," red badges with counts on anything but errors.
+- Machine self-narration: "Publishing…", "Syncing state," "Running query."

--- a/product-team/guides/second-brain-wireframes.html
+++ b/product-team/guides/second-brain-wireframes.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>second-brain — wireframes</title>
+<style>
+  :root{
+    --accent:#58a6ff; --accent-hover:#79c0ff; --bg:#0d1117; --surface:#161b22;
+    --surface-2:#21262d; --border:#30363d; --text:#e6edf3; --text-muted:#8b949e;
+    --green:#3fb950; --orange:#d29922; --red:#f85149; --radius:8px;
+    --space-1:4px; --space-2:8px; --space-3:16px; --space-4:24px;
+  }
+  *{box-sizing:border-box}
+  body{background:var(--bg);color:var(--text);font:15px/1.5 -apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;margin:0;padding:var(--space-4)}
+  h1{font-size:1.1rem;color:var(--text-muted);font-weight:600;margin:0 0 var(--space-4)}
+  h2{font-size:1rem;color:var(--text-muted);border-top:1px solid var(--border);padding-top:var(--space-4);margin-top:var(--space-4)}
+  .frame{max-width:860px;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:var(--space-4);margin-bottom:var(--space-4)}
+  .view-title{font-size:1.4rem;font-weight:600;margin:0 0 var(--space-3)}
+  .note{color:var(--text-muted);font-size:.85rem;margin:var(--space-2) 0 var(--space-3)}
+  /* goal tree */
+  .grow{display:flex;align-items:center;gap:var(--space-2);padding:10px var(--space-2);border-radius:6px;min-height:44px}
+  .grow:hover{background:var(--surface-2)}
+  .disc{color:var(--text-muted);width:16px;display:inline-block}
+  .gname{font-weight:600}
+  .standing{font-size:.75rem;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted)}
+  .standing.achieved{color:var(--green)}
+  .chip{background:var(--surface-2);border-radius:999px;padding:1px 10px;font-size:.8rem;color:var(--text-muted)}
+  .meta{font-size:.85rem;color:var(--text-muted);margin-left:auto}
+  .indent1{margin-left:20px}.indent2{margin-left:40px}
+  .hint{color:var(--text-muted);font-size:.85rem;font-style:italic;margin-left:36px}
+  /* pointer card */
+  .pcard{border:1px solid var(--border);border-radius:var(--radius);padding:var(--space-3);margin:var(--space-2) 0;background:var(--bg)}
+  .pkind{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-muted)}
+  .ptitle{color:var(--accent);font-weight:600;text-decoration:none}
+  .ptitle:hover{color:var(--accent-hover)}
+  .ploc{font-family:ui-monospace,Menlo,monospace;font-size:.8rem;color:var(--text-muted);margin-top:2px}
+  .fresh{font-size:.85rem;color:var(--text-muted);margin-top:var(--space-1)}
+  .fresh.stale{color:var(--orange)} .fresh.dead{color:var(--red)}
+  .why{font-style:italic;color:var(--text-muted);font-size:.9rem;margin-top:var(--space-1)}
+  /* proposal card */
+  .prop{background:rgba(88,166,255,0.08);border:1px solid var(--border);border-radius:var(--radius);padding:var(--space-3);margin:var(--space-3) 0}
+  .prop .next{font-weight:600}
+  .whynow{margin:var(--space-2) 0}
+  .considered{border-top:1px solid var(--border);margin-top:var(--space-3);padding-top:var(--space-2)}
+  .considered .label{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-muted)}
+  .also{display:flex;gap:var(--space-2);font-size:.9rem;padding:3px 0}
+  .also .whynot{color:var(--text-muted)}
+  .actions{display:flex;gap:var(--space-2);margin-top:var(--space-3)}
+  .btn{min-height:44px;padding:0 var(--space-4);border-radius:6px;font-weight:600;font-size:.95rem;cursor:pointer;border:1px solid transparent}
+  .btn.approve{background:var(--accent);color:#0d1117}
+  .btn.skip{background:transparent;color:var(--accent);border-color:var(--accent)}
+  .btn.cancel{background:none;border:none;color:var(--text-muted);text-decoration:underline}
+  .skipfield{display:flex;gap:var(--space-2);margin-top:var(--space-3)}
+  .skipfield input{flex:1;background:var(--surface-2);border:1px solid var(--border);border-radius:6px;color:var(--text);padding:10px var(--space-3);font-size:.95rem}
+  .skipfield input::placeholder{color:var(--text-muted)}
+  /* record */
+  .rec{border-left:2px solid var(--border);margin:var(--space-3) 0 0 var(--space-2);padding-left:var(--space-3)}
+  .rentry{display:flex;gap:var(--space-2);padding:6px 0;font-size:.9rem;align-items:baseline}
+  .rdate{color:var(--text-muted);font-size:.8rem;min-width:86px}
+  .rtype{font-size:.75rem;text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted);min-width:70px}
+  .rtype.approved{color:var(--green)}
+  /* empty & loading */
+  .empty{text-align:center;padding:var(--space-4)}
+  .empty .big{font-size:1.05rem;font-weight:600;margin-bottom:var(--space-2)}
+  .empty .how{color:var(--text-muted)}
+  .skel{height:14px;border-radius:4px;background:linear-gradient(90deg,var(--surface-2) 25%,var(--border) 50%,var(--surface-2) 75%);background-size:200% 100%;animation:sh 1.4s infinite;margin:12px 0}
+  @keyframes sh{0%{background-position:200% 0}100%{background-position:-200% 0}}
+  .privacy{font-size:.8rem;color:var(--text-muted);margin-top:var(--space-3)}
+</style>
+</head>
+<body>
+<h1>second-brain — v1 wireframes (owner-gated control panel views; tokens inherited, none added)</h1>
+
+<h2>§1 Goals view — the tree</h2>
+<div class="frame">
+  <div class="view-title">Goals</div>
+  <div class="note">Filter: <span class="chip">all</span> <span class="chip">graph upkeep</span> <span class="chip">vault maps</span> <span class="chip">engineering</span></div>
+  <div class="grow"><span class="disc">▾</span><span class="gname">Typo-tolerant search</span><span class="standing">captured</span><span class="chip">engineering</span><span class="meta">2 pieces · 1 pointer</span></div>
+  <div class="grow indent1"><span class="disc">·</span><span class="gname">Pick the matching approach</span><span class="standing">viable</span><span class="meta">1 pointer</span></div>
+  <div class="grow indent1"><span class="disc">·</span><span class="gname">Wire it into the search page</span><span class="standing">viable</span><span class="meta">—</span></div>
+  <div class="grow"><span class="disc">▸</span><span class="gname">Vault map for physics notes</span><span class="standing">captured</span><span class="chip">vault maps</span><span class="meta">3 pieces</span></div>
+  <div class="grow"><span class="disc">·</span><span class="gname">Prune duplicate relay entries</span><span class="standing achieved">achieved</span><span class="chip">graph upkeep</span><span class="meta">done Jul 18</span></div>
+  <div class="grow"><span class="disc">·</span><span class="gname">Write the August newsletter</span><span class="standing">captured</span><span class="meta">—</span></div>
+  <div class="hint">needs a deliverable and boundary before it can be proposed</div>
+  <div class="privacy">This brain stays on this machine — nothing here is published.</div>
+</div>
+
+<h2>§2 Goal detail — one spine</h2>
+<div class="frame">
+  <div class="note"><a class="ptitle" href="#">← Goals</a></div>
+  <div class="view-title">Pick the matching approach</div>
+  <div class="note">viable · engineering · part of “Typo-tolerant search” · captured Jul 20 by you</div>
+  <p><strong>Done means:</strong> a one-page comparison of the candidate approaches with a recommendation.<br>
+  <strong>Stays inside:</strong> research and writing only — no code changes anywhere.</p>
+  <div class="pcard">
+    <div class="pkind">web</div>
+    <a class="ptitle" href="#">Fuzzy matching survey — typo tolerance in search engines</a>
+    <div class="ploc">https://example.org/articles/fuzzy-match…survey</div>
+    <div class="fresh">verified 3 days ago</div>
+    <div class="why">the survey that framed the options</div>
+  </div>
+  <div class="pcard">
+    <div class="pkind">vault</div>
+    <a class="ptitle" href="#">Search ideas — scratch note</a>
+    <div class="ploc">Vault/Projects/search-ideas.md</div>
+    <div class="fresh stale">not verified in 40 days</div>
+  </div>
+  <div class="rec">
+    <div class="rentry"><span class="rdate">Jul 21 09:12</span><span class="rtype">proposed</span><span>nominated over “Vault map” — smaller and unblocks the parent</span></div>
+    <div class="rentry"><span class="rdate">Jul 21 09:30</span><span class="rtype approved">approved</span><span>you launched a session on it</span></div>
+    <div class="rentry"><span class="rdate">Jul 21 11:04</span><span class="rtype">worked</span><span>session s-0721a: draft comparison started — one question for you</span></div>
+  </div>
+</div>
+
+<h2>§3 Proposal queue — approve / skip-with-reason</h2>
+<div class="frame">
+  <div class="view-title">What next?</div>
+  <div class="prop">
+    <div class="next">Next: Pick the matching approach</div>
+    <div class="whynow">Smallest viable piece of your highest-priority goal, and it unblocks its sibling. One session should finish it.</div>
+    <div class="considered">
+      <div class="label">considered instead</div>
+      <div class="also"><span>Vault map for physics notes</span><span class="whynot">— bigger; no session has scoped it yet</span></div>
+      <div class="also"><span>Prune duplicate relay entries</span><span class="whynot">— routine; loses nothing by waiting</span></div>
+    </div>
+    <div class="actions"><button class="btn approve">Approve</button><button class="btn skip">Skip…</button></div>
+  </div>
+  <div class="prop">
+    <div class="next">Next: Write the August newsletter</div>
+    <div class="whynow">Time-sensitive this week; everything else can wait a day.</div>
+    <div class="considered">
+      <div class="label">considered instead</div>
+      <div class="also"><span>Pick the matching approach</span><span class="whynot">— already has an open proposal</span></div>
+    </div>
+    <div class="skipfield">
+      <input placeholder="why not this one, in a few words" value="newsletter needs the launch date first">
+      <button class="btn approve">Skip</button><button class="btn cancel">Cancel</button>
+    </div>
+  </div>
+</div>
+
+<h2>§4 Cold start — the empty state is the onboarding</h2>
+<div class="frame">
+  <div class="view-title">Goals</div>
+  <div class="empty">
+    <div class="big">Your brain is empty — that's the right place to start.</div>
+    <div class="how">Tell your assistant a goal in plain words — “I want …” — and it will appear here.<br>Big or small; big ones get broken into pieces together.</div>
+  </div>
+</div>
+
+<h2>§5 Loading — skeleton, never a bare spinner</h2>
+<div class="frame">
+  <div class="view-title">Goals</div>
+  <div class="skel" style="width:60%"></div>
+  <div class="skel" style="width:45%"></div>
+  <div class="skel" style="width:52%"></div>
+</div>
+</body>
+</html>

--- a/product-team/prd/second-brain.md
+++ b/product-team/prd/second-brain.md
@@ -1,0 +1,155 @@
+# Second Brain (display name: "Tapestry Harness") — Product Requirements Document
+
+**Slug:** second-brain
+**Date:** 2026-07-21
+**Status:** Draft
+**Companion guides:** `guides/second-brain-style-guide.md`, `guides/second-brain-design-guide.md` (+ `guides/second-brain-wireframes.html`)
+
+> Self-contained. A reader understands the product without opening the phase artifacts.
+
+## 1. Product Vision
+
+The Tapestry owner is the terminal bottleneck on everything getting done: work happens only when they personally notice it, choose it, launch it, and accept it — and the choosing is the weakest link. Deciding what deserves the next unit of attention is the owner's Big Challenge, attacked today ad hoc, in their head. The knowledge that would let anything else make those calls is scattered across surfaces opaque even to the owner, written for agents rather than people; every agent session starts amnesiac.
+
+The Second Brain makes the owner's concept graph the durable substrate for goals, knowledge pointers, and judgment — so that agent sessions orient in seconds, work gets chosen deliberately, and, in later phases, achievement continues in the owner's absence. **Delegation is the product; memory is the tool that makes delegation trustworthy.** The proof of concept already happened here once: an autonomous run carried a feature end-to-end with no human at the gates. This product makes that routine instead of ceremonial.
+
+Positioning within the mission: the outward search vision ("anything curated by a trusted community is searchable") quietly assumes people maintain curated, trustworthy knowledge stores. Self-interest is the only motivation that scales. Owners curate their own second brains; the trust graph later turns private curation into the shared, trusted content the outward mission consumes. The bridge is deferred in scope, not in framing: if the second brain never produces a sharable trusted subset, it is a private hobby, not a strategic axis.
+
+## 2. Positioning & Competitive Context
+
+No product combines the three properties this one is built from (verified by research, 2026-07-21):
+
+1. **Owner-curated ontology** with a concept's definition held separate from its instances,
+2. **Autonomous agent goal execution** against that ontology,
+3. **Trust-graded sharing** with peers.
+
+Each incumbent category is structurally locked to its corner. Modern note tools (Obsidian, Logseq) grew typed properties and agent access, but their substrate remains prose files where structure is convention, not contract — nothing an agent can rely on at write-back, and no sharing between publish-everything and private. Agent-memory frameworks (Mem0, Zep, Letta) are extraction pipelines with a curation escape hatch, not curated references with an extraction assistant: the graph's content is what a model induced, with no editorial layer and no class hierarchy. Vector retrieval answers "what sounds like this?", never "what does this goal depend on?" — the industry's own pivot to graph-hybrid memory concedes it cannot be the reference. The autonomous-agent generation solved persistence with prose files the agent rewrites or opaque synthesized memory the owner cannot audit: agency without structure. Near-neighbors each hold corners — Tana (curated supertags, app-bound AI), Anytype (typed objects + agent API, membership-only sharing), Cognee (ontology-validated extraction, no sharing), OriginTrail (decentralized agent memory, but token-economy trust and published assets, not a private brain).
+
+This team already runs all three pieces: a live concept graph with class-thread discipline, a personal web-of-trust engine, and a gated autonomous-execution harness with one unattended feature delivery on record.
+
+## 3. User Personas
+
+### The Delegating Owner (primary)
+An instance owner with more ambitions than hands, who keeps asking "is this the most important thing I could be doing?" and knows most people never attack that question systematically. Technical in their own domains; discovers systems by keyword search plus following connections; currently the bottleneck on everything. **Wants:** goals achieved, including in their absence, with their judgment applied only where it matters. **Core loop:** capture → decompose → let the system propose → review and answer plain-English questions → extend a little more trust. **Won't tolerate:** being the bottleneck by design; capture costlier than a text file; jargon; audits split across surfaces; irreversible embarrassment (an outward message to the world is the rein-it-in line); rush jobs.
+
+### The Fresh-Context Session (primary, machine persona — governed by the traceability guard)
+An agent session that wakes with an empty context window; its patience is a token budget; its first visit is orientation. **Wants:** to orient in seconds, act inside an unambiguous scope, and leave the graph richer. **Core loop:** orient (bounded read) → receive one goal with deliverable and boundary verbatim → work through pointers → write outcomes back as durable facts → hand off so the next session is cheaper. **Won't tolerate:** orientation cost that grows with the corpus; structure that is convention rather than contract; stale pointers; unaddressable memory; definition/instance category errors; scope leakage.
+
+> **Traceability guard (operator-ratified):** no requirement may be justified by the machine persona alone. Every requirement citing The Fresh-Context Session must also trace to a step in a Delegating Owner journey. A requirement tracing only to the machine persona is a defect in this PRD.
+
+### The Second Operator (secondary)
+An owner who did not build this system, running their own instance with their own corpus — the near-term generalization test (two named collaborators expected soon; eventually every owner). **Wants:** the same delegation loop without adopting anyone else's archaeology. **Won't tolerate:** reference-instance hardcodes; conventions living in one person's head; a cold start with no obvious first action.
+
+## 4. User Journeys
+
+### The Delegating Owner
+1. **First capture.** Mid-thought, a goal surfaces; the owner says it in plain words; it exists in the brain — named, findable, dated — confirmed in one sentence. *Feels: unburdened.*
+2. **Decomposition, together.** A big goal becomes a tree of session-sized pieces, each with a deliverable and a boundary, in the owner's own sharpened language. *Feels: clarified.*
+3. **The first proposal.** The system nominates one piece with why-now and the runners-up it beat; the owner approves, or skips with a one-line reason that visibly teaches the system. *Feels: in command.*
+4. **Morning review.** One surface, read downward: significant progress on some goals, still working on others, one or two questions in plain English. Everything done, decided, or skipped is attached to the goal it served. *Feels: oriented, not anxious.*
+5. **Retrieval in anger.** Six weeks later: keyword search, then look at what it's connected to; the pointer surfaces with what it is, why it's kept, and when last verified. *Feels: vindicated.*
+6. **Trust graduation.** A category accumulates a track record; the owner loosens its tier — an explicit, revocable act. The system makes strides in their absence and the morning review proves it. *Feels: leveraged.*
+
+### The Fresh-Context Session
+1. **Orientation** within a fixed, corpus-independent budget: what exists, what matters, where its goal sits. 2. **Goal receipt:** deliverable and boundary verbatim as fixed at claim time. 3. **Working through pointers:** crawl to linked resources, dereference each in its native store; content never migrates into the brain. 4. **Write-back:** durable, attributable, append-shaped facts on the goal; new ideas are proposed, never launched, from inside a session. 5. **Hand-off:** where things stand against the deliverable, at most a question or two; the next session's orientation is cheaper because this one ran.
+
+### The Second Operator
+Cold start on an empty brain that still offers one obvious action (say a goal in plain words), with the system's own concepts discoverable by search-plus-connections; from the first capture on, their journey is the Delegating Owner's.
+
+## 5. Feature Specification
+
+Capabilities, not screens (screens are §5.8, from the design guide). Every capability carries its trace.
+
+### 5.1 Goal capture
+- **Purpose:** get a goal out of the owner's head at below text-file cost. *(Owner journey 1.)*
+- **Behavior:** the owner states a goal in plain language, in conversation; the brain records it with name, statement, origin, and date; confirmation is one plain sentence. No form, no required fields beyond the words themselves.
+- **Owner actions:** capture; rename; abandon (recorded as a dated fact, not a deletion).
+
+### 5.2 Decomposition
+- **Purpose:** turn ambitions into session-sized pieces something else can carry. *(Owner journey 2; session journey 2.)*
+- **Behavior:** in conversation, a goal acquires child goals, each viable only when it has a stated deliverable (what "done" produces) and boundary (what pursuing it may not touch). One parent per goal in v1. A goal with children is never itself proposed.
+
+### 5.3 Resource pointers
+- **Purpose:** the brain organizes knowledge; it never contains it. *(Owner journey 5; session journey 3.)*
+- **Behavior:** a goal points at external resources — file, vault note, nostr event, repository, web address — each with title, locator, optional why-kept and keywords, and a last-verified date. Freshness standing (current / stale / unreachable) is derived from verification age, worded per the style guide. Content stays in its native home.
+
+### 5.4 Session orientation and the read loop
+- **Purpose:** end session amnesia. *(Session journey 1/4; owner journey 4 — this is what makes many small sessions affordable.)*
+- **Behavior:** every agent session begins by orienting from the brain within a bounded, corpus-independent budget; every session's output references the goal it served; work performed is recorded as an append-only work record (session, goal served, resources produced, one-sentence standing, at most two plain-English questions).
+
+### 5.5 Proposals and decisions
+- **Purpose:** move "what next?" out of the owner's head into an auditable, teachable loop. *(Owner journey 3; the calibration corpus for every later autonomy phase.)*
+- **Behavior:** the system periodically nominates exactly one viable goal, with a why-now legible in ten seconds and the named runners-up it passed over, each with a one-line why-not. The owner approves (and launches the session themselves, in v1) or skips; a skip requires a one-line reason. Decisions and reasons are recorded as dated facts. Open proposals are decided or remain open; nothing is decided silently.
+
+### 5.6 Priority signals
+- **Purpose:** capture the owner's relative-value judgment in a replaceable framing. *(Owner journeys 3/6; the operator's own epistemology: 99 wrong framings, find the right one by iterating.)*
+- **Behavior:** the owner records pairwise choices ("solve one today: which?") with an optional one-line reason; each signal is dated, attributed, and tagged with the framing that produced it, so a replaced framing's history stays interpretable. Signals are **recorded, never acted on autonomously, in v1** — proposals may cite them as rationale; nothing launches from them.
+
+### 5.7 Safeguards: export and hygiene
+- **Purpose:** the brain must be trustworthy before it is trusted. *(Owner persona: no rush jobs; the known reinstall-clobber hazard.)*
+- **Behavior:** the owner can export the brain's owner-authored content and has performed one verified restore drill; a hygiene check validates the goal structures against the graph's own class discipline (the two known live defects — stray membership edges on both work-item concepts — are cleaned, and the check would catch their recurrence).
+
+### 5.8 Screens (v1 — from the design guide, which is binding)
+Three owner-gated views inside the existing control panel, inheriting the app's identity with no new tokens: the **Goals view** (tree, category filter, cold-start empty state as onboarding), the **Goal detail** (intent + pointers + the goal's full append-only record on one spine), and the **Proposal queue** (emphasis cards with "considered instead" and equal-weight Approve / Skip-with-reason). Empty, loading, and error states are designed; the do-not-design list (no graph canvas, no gauges, no agent chat, no privacy toggle, nothing visitor-facing) is review-enforceable.
+
+### 5.9 Second-operator guard
+- **Purpose:** nothing ships that structurally excludes another owner's instance. *(Second Operator journey.)*
+- **Behavior:** no reference-instance identities or paths are baked in; every category and convention the product introduces is discoverable in-graph by search-plus-connections; the empty brain offers one obvious first action.
+
+## 6. Data Model
+
+Six entities on one spine — the operator's ruling, verbatim: the brain is *both ledger and snapshot, like a physical brain*. **Durable intent** (edited rarely, deliberately) and **append-only record** (dated facts, never rewritten); current standing is always derived from reading both, never stored as a flag that overwrites history.
+
+- **Goal** *(durable intent; adopts and extends the existing `39998:<TA>:tapestry-owner-goal` concept)* — name, statement, deliverable and boundary (required for viable leaves), one optional parent, optional category, origin, captured-on.
+- **External Resource** *(durable intent; new concept on the graph's established pointer-element pattern)* — title, locator-kind (file / vault note / nostr event / repository / web address), locator, why-kept, keywords, noted-on, last-verified.
+- **Priority Signal** *(append-only; new)* — prefers goal / over goal, reason, judged-by, judged-on, framing tag.
+- **Proposal** *(append-only; new)* — nominates goal, why-now, passed-over goals with why-nots, made-on; decision (open → approved | skipped), decision-reason (required on skip), decided-on.
+- **Work Record** *(append-only; new)* — session, goal served, resources produced, one-sentence summary, up to two questions, happened-on.
+- **Category** *(durable intent; existing set machinery, new instances only)* — name, purpose (discoverable in-graph). One flat list in v1.
+
+Relationships: Goal *decomposes into* Goal (a tree in v1); Goal *points at* External Resource; Proposal *nominates / passed over* Goal; Priority Signal *prefers…over* Goals; Work Record *serves* Goal and *produced* External Resources; Category *collects* Goal; Goal *is realized by* Engineering Project (the existing `39998:<TA>:project-for-the-engineering-team` concept — related in v1; merge decision scheduled to Phase 2).
+
+Lifecycles: Goal standing (captured → decomposed | viable → achieved | abandoned) is **derived** from dated facts; resource freshness (current → stale → unreachable) is derived from verification age; proposals go open → approved | skipped (auto-expiry arrives in Phase 2).
+
+## 7. Policy Constitution
+
+The rules that govern behavior and who may change it. These outrank every capability above.
+
+1. **The brain decides; the metabolism asks and reports.** Any external scheduler or heartbeat may only ask "what next?" (reporting its capacity), execute what the brain answers, and report every action back into the brain, attached to the goal it served. Selection judgment, policy values, and the record of intent, decision, and outcome live in the brain. A scheduler-side decision log is a defect.
+2. **Append-only record.** Recorded facts (signals, proposals, decisions, work) are never edited or deleted. Corrections are new facts.
+3. **Sessions propose, never launch.** A goal idea born inside a session enters as a proposal-shaped capture; nothing spawns work but the owner (v1) or the explicitly governed launcher (Phase 3+).
+4. **Privacy is a stated posture, honestly presented.** V1: the brain stays on the owner's machine by convention — no outbound sync of goal data; the UI states this as an indicator, never a toggle. A mechanism-enforced non-publishing mode is Phase 2. The autonomy pilot may run under the convention (operator-ruled).
+5. **Autonomy is earned by category, granted by the owner.** Acceptance tiers per category loosen only by the owner's explicit, revocable act, informed by recorded track record. Entry into any autonomous launching is metric-gated (§10). Outward-facing actions (publishing, messaging people) sit in the highest tier indefinitely.
+6. **Policy changes are the owner's alone.** No accepted deliverable — including an "improve the harness" deliverable — may alter selection policy, tiers, caps, or this constitution without a separate, explicit owner act. Self-improvement work produces proposals; applying them is the owner's move. The prioritization framing (§5.6) is a replaceable slot: replacements are proposed with evidence and ratified by the owner.
+7. **Plain language is a contract.** Everything addressed to the owner — proposals, questions, confirmations, errors — obeys the style guide's register. Jargon in owner-facing output is a review-blocking defect.
+8. **Existing structures are adopted, never re-derived.** Goal and Category ride existing graph machinery (`tapestry-owner-goal`, native sets); new concepts follow the graph's established pointer pattern; the per-deployment assistant identity is always resolved at runtime, never hardcoded.
+9. **In-flight engineering is referenced, never re-specified.** Two engineering efforts proceed outside this product and are load-bearing dependencies: the relationship add/delete primitives (an armed autonomous run) and firmware-reinstall protection for owner-authored data. No story from this PRD re-implements or re-specifies them; stories that need them declare the dependency and wait.
+
+## 8. Scope Boundaries
+
+### 8.1 In Scope (must ship)
+Goal capture · decomposition · resource pointers · bounded session orientation + read loop · propose-only cadence with approve/skip-with-reason · priority signals (recorded only) · export/backup + one restore drill · hygiene validation · the three v1 views · second-operator guard.
+
+### 8.2 Stretch
+None. The MVP is deliberately without a stretch list; anything beyond In Scope waits for its named phase.
+
+### 8.3 Out of Scope (deferred, each to a named phase)
+Lifecycle/acceptance states, review gates, tiers, batch ratification, proposal expiry, queue-age metric, brain-side launch answer, claim/lease, scheduler write-back contract, private write mode, engineering-project merge decision → **Phase 2**. Autonomous launch, charter, kill switch, morning-review digest, observability (inherited from the separate task-timeline engineering book, operator-armed before Phase-3 planning) → **Phase 3**. Brain keyword index, staged search rounds → **Phase 4**. Self-improvement wiring → **Phase 5**. Local-model validation, semantic recall → **Phase 6**. Trust-graded sharing → **Phase 7**. Peers as users, embedded viewers, health/monitoring surfaces, graph canvases → unscheduled; re-enter through discovery or not at all.
+
+## 9. Phase Roadmap
+
+**MVP "Capture, Decompose, Propose"** → **P2 "Goal Engine & Review"** → **P3 "Gated Autonomy Pilot"** (entry metric-gated; non-repo categories; concurrency 1) → **P4 "Search Depth"** → **P5 "Self-Improvement Wiring"** → **P6 "Model Capabilities"** → **P7 "Sharing"**. Local-model compatibility is a binding *design lens* from v1 (bounded orientation, small pieces, no frontier-context assumptions) and a tested requirement only at P6 (operator-ruled).
+
+## 10. Success Metrics
+
+**MVP, within 6 weeks of shipping (all countable by inspection):** ≥20 goals each with ≥1 pointer authored across ≥10 distinct days · ≥5 session outputs referencing their goal · ≥15 proposals with logged decisions (skips carry reasons) · the frozen legacy checklist gains zero rows · 1 journaled export/restore drill · ≥3 journaled retrievals-in-anger via search+connections · hygiene check green.
+**P2 (gate to P3 planning):** 100% of active goals show dated transitions · proposal→launch agreement ≥50% over ≥15 decisions · median open-proposal age flat or falling over 4 weeks.
+**P3 (pilot verdict):** ≥5 autonomous sessions each independently reviewed · ≥1 rejection observed (a 100% acceptance rate reads as review-decoration and scores as failure) · zero ceiling breaches.
+
+## 11. Open Questions
+
+1. **Acceptance-tier boundaries (P2).** Which goal categories may reach "accepted" on independent review alone? Options: an operator-authored per-category table; earned automatic graduation on track-record thresholds; a hybrid (table with earned defaults proposed by the system, ratified by the owner).
+2. **Who authors priority signals beyond the owner (P2+).** Options: owner-only indefinitely; sessions may *propose* signals the owner ratifies; sessions author signals in low-stakes categories once tiers exist.
+3. **Engineering-project merge (P2).** Merge `project-for-the-engineering-team` elements into goals under an engineering category, or keep the relation permanent. Options as stated; decide when the acceptance model lands.
+4. **Morning-digest channel (P3).** In-panel view, conversational delivery, or both. The unit-of-review spec (owner journey 4) is fixed; the channel is not.
+5. **Framing-replacement mechanics (P5, sketch at P2).** How a candidate prioritization framing is trialed against the incumbent — parallel recording, A/B proposal batches, or evidence review — before the owner ratifies a swap.

--- a/product-team/stories-queue.md
+++ b/product-team/stories-queue.md
@@ -1,4 +1,217 @@
-# Stories Queue: Verified Reporters
+# Stories Queue: Second Brain
+
+**Slug:** second-brain
+**Date:** 2026-07-21
+**Source PRD:** `product-team/prd/second-brain.md`
+**Companion guides:** `product-team/guides/second-brain-design-guide.md`, `product-team/guides/second-brain-style-guide.md` (+ `second-brain-wireframes.html`)
+**Status:** Ready for promotion
+
+8 stories across 1 block, in dependency order. Engineering should be able to demo capture-to-view after Story 1, and the full propose/decide loop after Story 6.
+
+**Handoff note (for the engineering Product Owner):** create one epic umbrella `engineering-team/epics/second-brain.md` and a folder `engineering-team/stories/second-brain/`, then promote each story below via `/plan-feature`, referencing the PRD and guides. The queue order is the pickup order. Owner-facing copy comes **verbatim** from the style guide; the PRD's §7 Policy Constitution binds every story. Two in-flight engineering books are declared dependencies where noted and are **referenced, never re-specified**: `relationship-primitives` (armed Direction-mode run) and the future firmware clobber-protection work.
+
+---
+
+## Block 1 — Second Brain MVP: Capture, Decompose, Propose
+*Suggested epic-slug: `second-brain`*
+
+The delegation loop minus autonomous launch: goals live in the brain, sessions orient from them, the system proposes, the owner decides and launches.
+
+---
+
+## Story 1: Capture a goal and see it
+
+**PRD section(s):** §5.1, §5.8, §6, §7.7–7.8
+**Persona(s):** The Delegating Owner
+**Block:** Second Brain MVP
+**Suggested epic-slug:** `second-brain`
+
+**Description:** The owner states a goal in plain words and it exists in the brain — visible in the Goals view — proving the capture-to-view path end-to-end.
+
+**Acceptance criteria:**
+- [ ] When the owner states a goal in conversation, a goal is recorded with its name, statement, origin, and capture date, and the confirmation is one plain sentence.
+- [ ] The Goals view shows the goal in the tree with the standing word "captured" and its metadata, per the design guide.
+- [ ] Goals recorded before this product shipped (the existing goal concept's elements) appear in the same view — the brain adopts the existing concept rather than creating a parallel one.
+- [ ] With no goals, the view shows the canonical cold-start empty state, and it offers exactly one action.
+- [ ] The view carries the privacy indicator line verbatim from the style guide, as an indicator, not a control.
+- [ ] No owner-facing string uses a banned jargon word; standing words are the canonical set.
+
+**Dependencies:** None.
+
+**Notes for engineering:** The brain adopts `39998:<TA>:tapestry-owner-goal` (PRD §6) — the assistant identity is always resolved at runtime, never hardcoded (house rule; PRD §7.8). Abandonment is a dated fact, not a deletion (§7.2). The read view lives in the existing owner-gated control panel and inherits its tokens (design guide: mirror, don't invent).
+
+---
+
+## Story 2: Structures the brain can trust
+
+**PRD section(s):** §5.7 (hygiene), §7.8
+**Persona(s):** The Delegating Owner; The Fresh-Context Session (a session must be able to trust what it reads — traces to owner journey 4 via the read loop)
+**Block:** Second Brain MVP
+**Suggested epic-slug:** `second-brain`
+
+**Description:** A hygiene check validates the goal structures against the graph's own class discipline, and the two known live defects are cleaned.
+
+**Acceptance criteria:**
+- [ ] A repeatable check inspects the goal structures and reports zero structure problems when the structures are sound.
+- [ ] The two known stray membership edges (on the goal concept and its engineering-project sibling) are gone after cleanup.
+- [ ] If a structure defect of the known kinds recurs, the check reports it specifically (which structure, what kind of problem), not generically.
+- [ ] The cleanup does not lose any existing goal: every goal element present before cleanup is present after.
+
+**Dependencies:** May depend on the in-flight `relationship-primitives` engineering book for single-edge cleanup operations — declare and wait; never re-implement its endpoints.
+
+**Notes for engineering:** The defects were verified live 2026-07-21 (stray header-to-`concept-header-superset` membership edges on both work-item concepts; irregular element wiring on the goal concept). Firmware-reinstall behavior is out of scope here (operator decision, 2026-07-18) — this story cleans and detects; it does not change the installer.
+
+---
+
+## Story 3: Break a goal into pieces
+
+**PRD section(s):** §5.2, §5.8, §6
+**Persona(s):** The Delegating Owner
+**Block:** Second Brain MVP
+**Suggested epic-slug:** `second-brain`
+
+**Description:** In conversation, a goal acquires session-sized child goals, each viable only when it has a stated deliverable and boundary.
+
+**Acceptance criteria:**
+- [ ] The owner can add child goals to a goal in conversation; each child records its own name and statement; a goal has at most one parent.
+- [ ] A leaf goal with both a deliverable ("done means") and a boundary ("stays inside") shows the standing word "viable"; a leaf missing either shows "captured" with the inline hint from the design guide.
+- [ ] A goal with children shows "captured" (or "achieved"/"abandoned" as recorded) — never "viable" — and is never eligible for proposals.
+- [ ] The Goals view renders the nesting with disclosure, per the design guide.
+- [ ] The Goal detail shows the deliverable and boundary in the owner's words, labelled "Done means" and "Stays inside".
+
+**Dependencies:** Story 1 must ship first (goals must exist and render).
+
+**Notes for engineering:** Decomposition position is durable intent (PRD §6): the child's parent reference is part of the goal's own record, so the structure survives regardless of how edges are materialized. If edge materialization is wanted, it depends on the `relationship-primitives` book (declared dependency; a net-new relationship type is that book's documented post-book whitelist extension — do not extend the whitelist inside this story).
+
+---
+
+## Story 4: Attach the world — pointers and the goal's page
+
+**PRD section(s):** §5.3, §5.8, §6
+**Persona(s):** The Delegating Owner; The Fresh-Context Session
+**Block:** Second Brain MVP
+**Suggested epic-slug:** `second-brain`
+
+**Description:** Goals point at external resources — files, vault notes, nostr events, repositories, web addresses — and the Goal detail shows intent, pointers, and record on one spine.
+
+**Acceptance criteria:**
+- [ ] The owner can attach a resource to a goal with a kind, a locator, and a title; why-kept and keywords are optional.
+- [ ] The pointer card renders kind, title, locator preview, and a freshness line whose wording follows the style guide ("verified N days ago" / stale / unreachable), per the design guide.
+- [ ] Opening a pointer opens the resource in its native home; nothing is embedded or copied into the brain.
+- [ ] Freshness standing is derived from the last-verified date; verifying a resource updates it.
+- [ ] The Goal detail presents intent (statement, done-means, stays-inside), pointers, and the goal's record entries as one chronological spine, per the design guide.
+- [ ] Record entries render append-only: no edit affordance exists on any record entry.
+
+**Dependencies:** Story 1 must ship first. Story 3 is not required (a childless goal can carry pointers).
+
+**Notes for engineering:** External Resource is a new concept following the graph's established pointer-element pattern (PRD §6). Content never migrates into the brain (§5.3); the pointer card is the whole surface.
+
+---
+
+## Story 5: Sessions read the brain
+
+**PRD section(s):** §5.4, §6, §7.1–7.3
+**Persona(s):** The Fresh-Context Session (traceability guard satisfied: serves owner journey steps 4–5 — the record is what the owner reviews, and what retrieval finds)
+**Block:** Second Brain MVP
+**Suggested epic-slug:** `second-brain`
+
+**Description:** Every agent session orients from the brain within a bounded budget, references the goal it serves, and leaves an append-only work record on that goal.
+
+**Acceptance criteria:**
+- [ ] A fresh session can state which goals exist and which goal it is serving after a bounded orientation — without reading every goal in the brain, and at a cost that does not grow with the number of goals.
+- [ ] The session's output names the goal it served.
+- [ ] After a session, the goal's spine shows a work record: the session, a one-sentence standing summary, any produced resources as pointers, and at most two plain-English questions.
+- [ ] Work records are dated, attributed, and append-only.
+- [ ] A goal idea arising inside a session is recorded as a capture attributed to the session — it never launches anything (Policy Constitution §7.3).
+
+**Dependencies:** Stories 1 and 4 must ship first (goals and pointers must exist for records to reference).
+
+**Notes for engineering:** The bounded orientation is the machine persona's load-bearing tolerance — the design intent is that orientation cost stays flat as the corpus grows. The session-read loop is what makes the frozen legacy checklist stay frozen (success metric); the work record is the raw material of the future morning review (Phase 3 — do not build the digest now).
+
+---
+
+## Story 6: The proposal loop
+
+**PRD section(s):** §5.5, §5.8, §7.1–7.2, §7.7
+**Persona(s):** The Delegating Owner
+**Block:** Second Brain MVP
+**Suggested epic-slug:** `second-brain`
+
+**Description:** The system periodically nominates exactly one viable goal with comparative rationale; the owner approves (and launches) or skips with a reason; every decision is recorded.
+
+**Acceptance criteria:**
+- [ ] A proposal nominates exactly one viable goal, with a why-now readable in ten seconds and the named runners-up it passed over, each with a one-line why-not, in the canonical register.
+- [ ] The Proposal queue renders open proposals as the design guide's emphasis cards with equal-weight Approve and Skip actions.
+- [ ] Approve records an approved decision with its date; the owner launches the session themselves; the proposal leaves the queue and appears on the goal's record.
+- [ ] Skip requires a one-line reason before it can complete, records the skip and reason, and confirms with the canonical sentence.
+- [ ] No proposal is ever decided silently: every proposal is open, approved, or skipped, and its state is visible on the nominated goal's spine.
+- [ ] No numeric score appears in any owner-facing proposal copy.
+
+**Dependencies:** Stories 3 and 5 must ship first (viable goals must exist; decisions and records share the spine).
+
+**Notes for engineering:** The proposer's cadence and selection heuristic are deliberately unspecified product-side beyond "nominates one viable goal with comparative rationale" — the Architect chooses the simplest honest mechanism; the accumulated decisions are the calibration corpus the Phase-3 entry metric counts (agreement ≥50% over ≥15 decisions), so the decision record's completeness is the point. Proposal auto-expiry is Phase 2 — do not build it.
+
+---
+
+## Story 7: Teach it what matters — priority signals
+
+**PRD section(s):** §5.6, §6, §7.6
+**Persona(s):** The Delegating Owner
+**Block:** Second Brain MVP
+**Suggested epic-slug:** `second-brain`
+
+**Description:** The owner records pairwise choices between goals — dated, attributed, framing-tagged — which proposals may cite but which never launch anything.
+
+**Acceptance criteria:**
+- [ ] The owner can record a choice between two goals ("solve one today: which?") with an optional one-line reason.
+- [ ] Each signal records who judged, when, and the framing that produced it.
+- [ ] Signals are append-only and visible on the goals they touch.
+- [ ] A proposal's why-now may cite recorded signals in plain words; signals alone never cause a launch or a decision.
+- [ ] Replacing the framing later leaves earlier signals interpretable (their framing tag still identifies how they were produced).
+
+**Dependencies:** Story 1 must ship first; pairs naturally after Story 6 but does not require it.
+
+**Notes for engineering:** The framing is a replaceable slot by design (PRD §7.6; the operator's stated epistemology). V1 ships pairwise only; no score aggregation, no ranking display — the signals are data for the future, not a feature surface now.
+
+---
+
+## Story 8: The brain survives — export and restore
+
+**PRD section(s):** §5.7, §7.4
+**Persona(s):** The Delegating Owner; The Second Operator (the export is also the portability seed)
+**Block:** Second Brain MVP
+**Suggested epic-slug:** `second-brain`
+
+**Description:** The owner can export the brain's owner-authored content and has proven, once, that a restore reproduces it.
+
+**Acceptance criteria:**
+- [ ] An export produces a dated artifact containing the owner-authored brain content: goals (with decomposition positions), resources, signals, proposals and decisions, and work records.
+- [ ] A restore drill against a scratch target reproduces the exported goals, pointers, and records, and the drill's result is journaled.
+- [ ] The export completes without touching or publishing anything outward (Policy Constitution §7.4).
+- [ ] Running export twice with no changes in between produces equivalent content.
+
+**Dependencies:** Story 1 must ship first (there must be something to export). Fuller protection against reinstall-clobber is the separate firmware-protection engineering work — referenced, not re-specified; until it lands, this export **is** the protection.
+
+**Notes for engineering:** Scope is the owner-authored second-brain content, not a whole-database backup. "Scratch target" means any environment that is not the live brain — the drill must not risk the thing it protects.
+
+---
+
+## Sequence summary
+1. **Story 1 — Capture and see** (end-to-end proof; demoable immediately).
+2. **Story 2 — Hygiene** (clean before building on the structures; may wait on relationship-primitives).
+3. **Story 3 — Decomposition** (viability = deliverable + boundary).
+4. **Story 4 — Pointers + Goal detail** (the one-spine page).
+5. **Story 5 — Session read loop** (ends session amnesia; work records).
+6. **Story 6 — Proposal loop** (the product's heart; the calibration corpus begins).
+7. **Story 7 — Priority signals** (the replaceable framing, recorded only).
+8. **Story 8 — Export + restore drill** (the trust floor).
+
+**Deferred to later phases (not in this queue):** lifecycle/acceptance, review gates, tiers, expiry, launch answer, claim/lease, private mode, engineering-project merge (Phase 2); autonomous launch, charter, digest, observability (Phase 3, observability via the task-timeline book); brain search index and rounds (Phase 4); self-improvement wiring (Phase 5); local models, semantic recall (Phase 6); sharing (Phase 7).
+
+---
+---
+
+# Stories Queue: Verified Reporters *(consumed — retained for history)*
 
 **Slug:** verified-reporters
 **Date:** 2026-06-07


### PR DESCRIPTION
Operator-approved design guide + wireframes for `second-brain`. Docs-only; `product-team/guides/` exclusively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)