### PR TITLE
Link Trusted Assertions page to the NIP-85 spec

### DIFF
--- a/ui/src/pages/developers/TrustedAssertions.jsx
+++ b/ui/src/pages/developers/TrustedAssertions.jsx
@@ -16,6 +16,14 @@ export default function DevelopersTrustedAssertions() {
         and apply its own trust perspective without depending on this instance.
       </p>
 
+      <p style={S.p}>
+        Read about Trusted Assertions in the{' '}
+        <a href="https://github.com/nostr-protocol/nips/blob/master/85.md" target="_blank" rel="noreferrer">
+          NIP-85
+        </a>{' '}
+        specification.
+      </p>
+
       <p style={{ ...S.p, marginTop: '2rem', opacity: 0.6 }}>Documentation coming soon.</p>
     </DevPage>
   );


### PR DESCRIPTION
## Summary

Adds one sentence to the `/developers/trusted-assertions` placeholder page pointing at the normative spec: "Read about Trusted Assertions in the [NIP-85](https://github.com/nostr-protocol/nips/blob/master/85.md) specification."

NIP-85's own title is *Trusted Assertions*, so it is exactly the right reference for the kind-30382 format the page describes. Follow-up to #409.

## Changes

- `ui/src/pages/developers/TrustedAssertions.jsx` — one paragraph added, above the "Documentation coming soon" line.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs.
- [ ] `/developers/trusted-assertions` renders the new sentence.
- [ ] The NIP-85 link points to `https://github.com/nostr-protocol/nips/blob/master/85.md` and opens in a new tab (`target="_blank"`, `rel="noreferrer"`).
- [ ] No console errors; rest of the page unchanged.

Verified locally on :7778 — renders correctly, link href/target/rel confirmed via DOM, and the target URL returns HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)