### PR TITLE
Docs housekeeping: BIBLE relationship primitives + status flips

### DIFF
--- a/BIBLE.md
+++ b/BIBLE.md
@@ -5,7 +5,7 @@
 >
 > Specifics of the reference deployment at `tapestry.brainstorm.world` (deploy targets, droplet specs, CI/CD workflows, branch protection ruleset, active team, tracking issues, operational gotchas we've hit) live in a sibling document: [OPERATIONS.md](./OPERATIONS.md). If you're forking this repo to run your own instance, BIBLE is the doc you want — OPERATIONS describes someone else's running instance.
 
-**Last updated:** 2026-07-02 (header refresh; content last changed 2026-06-20 — preferences audit §6.1 + §6.2; session persistence; user-counts; cycle-* skills)
+**Last updated:** 2026-07-23 (content: §11 relationship primitives + probe; §13 set-detail route + owner placement affordances — graph-curation-ui #1 / relationship-primitives book)
 
 ---
 
@@ -409,6 +409,9 @@ Base URL: `http://localhost:8080`
 | POST | `/api/normalize/create-property` | Create a property for a concept |
 | POST | `/api/normalize/generate-property-tree` | Generate property tree from JSON Schema (idempotent) |
 | POST | `/api/normalize/prune-superset-edges` | Prune redundant direct Superset edges |
+| POST | `/api/normalize/add-relationship` | Add ONE typed edge `(fromUuid)-[relType]->(toUuid)` between two existing nodes — strfry-free reference-graph edit; owner-gated; relType whitelist `HAS_ELEMENT`/`IS_A_SUPERSET_OF` (either spelling); idempotent (`created`/`already-existed`); graph-changing success carries a firmware-install-overwrite hazard `note` |
+| POST | `/api/normalize/delete-relationship` | Delete that same single typed, directed edge — same gate/whitelist/idempotency (`deleted`/`not-found`), same hazard `note` |
+| GET | `/api/normalize/relationship-primitives` | Read-only, credential-free deployment probe advertising the two primitives (registration evidence, not health) |
 | POST | `/api/normalize/add-node-as-element` | Wire an existing node as element of a concept |
 | POST | `/api/normalize/link-concepts` | Create IS_A_SUPERSET_OF between concepts |
 | POST | `/api/normalize/enumerate` | Create ENUMERATES relationship |
@@ -682,11 +685,12 @@ Legacy Brainstorm HTML pages are served at `/legacy/` (not part of the React SPA
 │       ├── elements/             Element list
 │       │   ├── new               Create element
 │       │   ├── add-node          Add existing node as element
-│       │   └── :elemUuid         Element detail
+│       │   └── :elemUuid         Element detail (owner: Placements panel — move/add/remove)
 │       ├── properties/           Property list
 │       │   └── new               Create property
-│       ├── dag/                  Organization (Sets) view
-│       │   └── new-set           Create set
+│       ├── dag/                  Organization (Sets) view (owner: per-row Place/move…)
+│       │   ├── new-set           Create set
+│       │   └── :setUuid          Set detail — supersets/subsets/elements (owner: add to set, remove direct placements)
 │       ├── visualization         Graph visualization (placeholder)
 │       └── schema                JSON Schema editor
 ├── lists/                        Simple Lists (raw DList browser)

--- a/docs/RELATIONSHIP_PRIMITIVES_HANDOFF.md
+++ b/docs/RELATIONSHIP_PRIMITIVES_HANDOFF.md
@@ -1,6 +1,6 @@
 # Relationship Primitives — Build Handoff
 
-**Status:** 🔴 OPEN — feature **not started**. The book is scaffolded (unarmed); no story, ADR, tests, or code exist yet. Flip to ✅ ADDRESSED once the endpoints ship to all three instances.
+**Status:** ✅ ADDRESSED — built by the armed Direction-mode `relationship-primitives` book (closed 2026-07-22; stories, ADRs, tests, and audit under `engineering-team/{stories,decisions,audits}/relationship-primitives/`). Endpoints live on local, staging, tapestry.brainstorm.world (PR #416) and tags.brainstorm.world (merge `30e4ff68`) as of 2026-07-23; an owner-facing UI shipped as `graph-curation-ui` #1. Body below kept for history.
 
 **Created:** 2026-07-20, at the end of a long session that scoped this feature, then pivoted to a security fix (below) before building it. Written so a fresh session can pick it up cold.
 **Builds on:** [`engineering-team/audits/relationship-primitives/book.md`](../engineering-team/audits/relationship-primitives/book.md) (the book of work, unarmed Direction-mode pre-registration); the intake entry **"2026-07-18 — Feature: primitive relationship add/delete endpoints (Neo4j-only, strfry-free)"** in [`engineering-team/stories/_intake.md`](../engineering-team/stories/_intake.md) (~line 1659) — its verified architectural background and open Planning questions are the real spec.

--- a/engineering-team/epics/graph-curation-ui.md
+++ b/engineering-team/epics/graph-curation-ui.md
@@ -23,7 +23,8 @@ top-level superset.
 
 1. `stories/graph-curation-ui/1-move-nodes-between-sets-ui.md` — place / move / remove
    placements from the set detail page, the element detail page, and the Organization (Sets)
-   overview; both placement kinds (element, subset). **Approved** (2026-07-22).
+   overview; both placement kinds (element, subset). **Done** (review PASS 2026-07-22; live on
+   staging, tapestry.brainstorm.world, and tags.brainstorm.world as of 2026-07-23).
 
 ## Key facts / guardrails
 


### PR DESCRIPTION
## Summary

Post-ship housekeeping for the relationship-primitives + graph-curation-ui work. Doc-class fast-track (no code).

## Changes

- **BIBLE.md** — §11 API Reference: rows for `add-relationship`, `delete-relationship`, and the read-only probe; §13 UI tree: the (previously missing) `dag/:setUuid` set-detail route + the owner placement affordances; `Last updated` refreshed — clears the standing harness-lint L9 violation (`npm test` lint suite now 0 violations).
- **docs/RELATIONSHIP_PRIMITIVES_HANDOFF.md** — Status `🔴 OPEN → ✅ ADDRESSED` (its flip condition — endpoints on all instances — is met; body kept for history).
- **engineering-team/epics/graph-curation-ui.md** — story 1 `Approved → Done` with ship record.

## Test plan

- [x] `bash scripts/harness-lint.sh` → clean (0 violations)
- [ ] After merge: deploy-staging.yml runs (doc-only rebuild); reachability ping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)