### PR TITLE
feat: JSON Viewer toggle for Firmware Explorer

### DIFF
--- a/ui/src/components/JsonView.jsx
+++ b/ui/src/components/JsonView.jsx
@@ -1,0 +1,157 @@
+import { useState } from 'react';
+
+/*
+ * JsonView — a small, dependency-free collapsible JSON tree viewer.
+ *
+ * Renders arbitrary JSON as an indented, syntax-coloured tree where every
+ * object/array can be expanded or collapsed. Nodes at or below `collapseDepth`
+ * start collapsed so deep structures (e.g. JSON Schemas) don't render as a wall.
+ * "Expand all" / "Collapse all" remount the tree so each node re-derives its
+ * initial state from the forced depth.
+ */
+
+function typeOf(value) {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value; // 'object' | 'string' | 'number' | 'boolean'
+}
+
+function PrimitiveValue({ value }) {
+  switch (typeOf(value)) {
+    case 'string':
+      return <span className="jsonview-string">"{value}"</span>;
+    case 'number':
+      return <span className="jsonview-number">{String(value)}</span>;
+    case 'boolean':
+      return <span className="jsonview-boolean">{String(value)}</span>;
+    case 'null':
+      return <span className="jsonview-null">null</span>;
+    default:
+      return <span>{String(value)}</span>;
+  }
+}
+
+function countLabel(type, count) {
+  if (type === 'array') return `${count} ${count === 1 ? 'item' : 'items'}`;
+  return `${count} ${count === 1 ? 'key' : 'keys'}`;
+}
+
+function JsonNode({ nodeKey, value, depth, collapseDepth, trailingComma }) {
+  const type = typeOf(value);
+  const isContainer = type === 'object' || type === 'array';
+  const [collapsed, setCollapsed] = useState(depth >= collapseDepth);
+
+  const indent = { paddingLeft: `${depth * 1.25}rem` };
+  const keyEl = nodeKey !== null && nodeKey !== undefined ? (
+    <>
+      <span className="jsonview-key">{nodeKey}</span>
+      <span className="jsonview-punct">: </span>
+    </>
+  ) : null;
+
+  // Primitive leaf
+  if (!isContainer) {
+    return (
+      <div className="jsonview-row" style={indent}>
+        <span className="jsonview-caret jsonview-caret-empty" />
+        {keyEl}
+        <PrimitiveValue value={value} />
+        {trailingComma && <span className="jsonview-punct">,</span>}
+      </div>
+    );
+  }
+
+  const entries = type === 'array'
+    ? value.map((v, i) => [i, v])
+    : Object.entries(value);
+  const open = type === 'array' ? '[' : '{';
+  const close = type === 'array' ? ']' : '}';
+
+  // Empty container renders on a single line
+  if (entries.length === 0) {
+    return (
+      <div className="jsonview-row" style={indent}>
+        <span className="jsonview-caret jsonview-caret-empty" />
+        {keyEl}
+        <span className="jsonview-punct">{open}{close}</span>
+        {trailingComma && <span className="jsonview-punct">,</span>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="jsonview-node">
+      <div
+        className="jsonview-row jsonview-toggle"
+        style={indent}
+        onClick={() => setCollapsed(c => !c)}
+      >
+        <span className="jsonview-caret">{collapsed ? '▸' : '▾'}</span>
+        {keyEl}
+        <span className="jsonview-punct">{open}</span>
+        {collapsed && (
+          <>
+            <span className="jsonview-summary">{countLabel(type, entries.length)}</span>
+            <span className="jsonview-punct">{close}</span>
+            {trailingComma && <span className="jsonview-punct">,</span>}
+          </>
+        )}
+      </div>
+
+      {!collapsed && (
+        <>
+          {entries.map(([k, v], i) => (
+            <JsonNode
+              key={k}
+              nodeKey={type === 'array' ? null : k}
+              value={v}
+              depth={depth + 1}
+              collapseDepth={collapseDepth}
+              trailingComma={i < entries.length - 1}
+            />
+          ))}
+          <div className="jsonview-row" style={indent}>
+            <span className="jsonview-caret jsonview-caret-empty" />
+            <span className="jsonview-punct">{close}</span>
+            {trailingComma && <span className="jsonview-punct">,</span>}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function JsonView({ data, collapseDepth = 3 }) {
+  // Bumping `remountKey` forces every JsonNode to re-initialise its collapsed
+  // state from `forcedDepth` — how Expand all / Collapse all take effect.
+  const [forcedDepth, setForcedDepth] = useState(collapseDepth);
+  const [remountKey, setRemountKey] = useState(0);
+
+  function expandAll() {
+    setForcedDepth(Infinity);
+    setRemountKey(k => k + 1);
+  }
+  function collapseAll() {
+    setForcedDepth(1); // root open, everything beneath it collapsed
+    setRemountKey(k => k + 1);
+  }
+
+  return (
+    <div className="jsonview">
+      <div className="jsonview-controls">
+        <button className="jsonview-ctrl-btn" onClick={expandAll}>Expand all</button>
+        <button className="jsonview-ctrl-btn" onClick={collapseAll}>Collapse all</button>
+      </div>
+      <div className="jsonview-tree">
+        <JsonNode
+          key={remountKey}
+          nodeKey={null}
+          value={data}
+          depth={0}
+          collapseDepth={forcedDepth}
+          trailingComma={false}
+        />
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/settings/FirmwareExplorer.jsx
+++ b/ui/src/pages/settings/FirmwareExplorer.jsx
@@ -3,6 +3,7 @@ import {
   fetchFirmwareManifest, fetchFirmwareConcept,
   fetchFirmwareVersions, fetchInstallStatus, installFirmware,
 } from '../../api/firmware';
+import JsonView from '../../components/JsonView';
 
 const CORE_NODES = [
   { key: 'overview',        label: 'Overview' },
@@ -879,6 +880,7 @@ function IntegrationDetail({ type, item, manifest }) {
 function FirmwareNodeJson({ data, nodeKey }) {
   const nodeInfo = CORE_NODES.find(n => n.key === nodeKey);
   const node = data.nodes[nodeKey];
+  const [viewMode, setViewMode] = useState('viewer'); // 'viewer' | 'raw'
 
   if (!node?.uuid) {
     return (
@@ -906,10 +908,28 @@ function FirmwareNodeJson({ data, nodeKey }) {
         <span className="firmware-json-meta">
           {node.name} · <code className="uuid-short" title={node.uuid}>{node.uuid?.slice(-16)}</code>
         </span>
+        <div className="firmware-view-toggle">
+          {[
+            { key: 'viewer', label: 'Viewer' },
+            { key: 'raw', label: 'Raw JSON' },
+          ].map(opt => (
+            <button
+              key={opt.key}
+              className={`firmware-view-btn ${viewMode === opt.key ? 'active' : ''}`}
+              onClick={() => setViewMode(opt.key)}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
       </div>
-      <pre className="firmware-json-pre">
-        {JSON.stringify(node.json, null, 2)}
-      </pre>
+      {viewMode === 'viewer' ? (
+        <JsonView data={node.json} />
+      ) : (
+        <pre className="firmware-json-pre">
+          {JSON.stringify(node.json, null, 2)}
+        </pre>
+      )}
     </div>
   );
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1913,7 +1913,8 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
 .firmware-json-header {
   display: flex;
   align-items: baseline;
-  gap: 1rem;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
   margin-bottom: 1rem;
 }
 
@@ -1936,6 +1937,111 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   overflow-x: auto;
   white-space: pre;
   max-height: 50vh;
+}
+
+/* ── JSON view toggle (Viewer / Raw JSON) ── */
+.firmware-view-toggle {
+  margin-left: auto;
+  align-self: center;
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.firmware-view-btn {
+  padding: 0.25rem 0.6rem;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.firmware-view-btn:hover {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.05);
+}
+.firmware-view-btn.active {
+  background: rgba(99, 102, 241, 0.18);
+  color: #a5b4fc;
+}
+.firmware-view-btn + .firmware-view-btn {
+  border-left: 1px solid var(--border);
+}
+
+/* ── JSON tree viewer (JsonView component) ── */
+.jsonview {
+  --jv-key: #79c0ff;
+  --jv-string: #7ee787;
+  --jv-number: #f0883e;
+  --jv-boolean: #d2a8ff;
+  --jv-null: #8b949e;
+  --jv-punct: #8b949e;
+  background: var(--bg-code, #1e1e2e);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.jsonview-controls {
+  display: flex;
+  gap: 0.4rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+.jsonview-ctrl-btn {
+  padding: 0.2rem 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.jsonview-ctrl-btn:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+}
+.jsonview-tree {
+  padding: 0.75rem 1rem;
+  overflow: auto;
+  max-height: 50vh;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  color: var(--text-code, #cdd6f4);
+}
+.jsonview-row {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.jsonview-toggle {
+  cursor: pointer;
+  border-radius: 3px;
+}
+.jsonview-toggle:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+.jsonview-caret {
+  display: inline-block;
+  width: 1.1rem;
+  color: var(--jv-punct);
+  user-select: none;
+  font-size: 0.7rem;
+}
+.jsonview-caret-empty {
+  visibility: hidden;
+}
+.jsonview-key { color: var(--jv-key); }
+.jsonview-string { color: var(--jv-string); }
+.jsonview-number { color: var(--jv-number); }
+.jsonview-boolean { color: var(--jv-boolean); }
+.jsonview-null { color: var(--jv-null); font-style: italic; }
+.jsonview-punct { color: var(--jv-punct); }
+.jsonview-summary {
+  color: var(--jv-null);
+  font-style: italic;
+  opacity: 0.8;
+  margin: 0 0.4rem;
 }
 
 .firmware-missing-node,


### PR DESCRIPTION
## Summary

Settings → Firmware Explorer showed each core node's JSON as raw pretty-printed text only. This adds a **Viewer / Raw JSON** toggle on the per-node JSON, defaulting to a collapsible, syntax-highlighted tree viewer. The raw view stays one click away and is otherwise unchanged.

## Changes

- **`ui/src/components/JsonView.jsx`** (new) — small, dependency-free collapsible JSON tree viewer: per-node expand/collapse (▸/▾), syntax colouring (keys/strings/numbers/booleans/null), collapsed summaries (`{ 4 keys }`), Expand all / Collapse all, and depth-based auto-collapse (≥ 3) so deep JSON Schemas don't render as a wall. No new npm dependencies (honors the JS-without-build house rule).
- **`ui/src/pages/settings/FirmwareExplorer.jsx`** — wire the toggle into `FirmwareNodeJson`; `viewer` is the default view.
- **`ui/src/styles.css`** — toggle pill + tree-viewer styles, reusing the existing palette variables.

## Test plan

- [ ] After merge: deploy-staging.yml runs.
- [ ] Smoke test on staging.brainstorm.world.
- [ ] Navigate to `/tapestry/settings/firmware`, select a concept + a core node (e.g. Concept Header) — Viewer renders by default with a collapsible coloured tree.
- [ ] Toggle to **Raw JSON** — original `<pre>` output; toggle back to **Viewer**.
- [ ] Expand all / Collapse all behave; deep nodes (JSON Schema) start collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)