### PR TITLE
feat(tapestries): Create a Tapestry — members-only authoring (owner-gated)

### DIFF
--- a/engineering-team/decisions/tapestries/0003-create-tapestry-authoring.md
+++ b/engineering-team/decisions/tapestries/0003-create-tapestry-authoring.md
@@ -1,0 +1,213 @@
+# ADR 0003: Create-a-Tapestry — members-only authoring, owner-gated, with a signing selector
+
+**Status:** Proposed
+**Date:** 2026-07-24
+**Story:** `engineering-team/stories/tapestries/3-create-tapestry.md`
+
+## Context
+
+Story `tapestries` #3 turns the inert `NewTapestry.jsx` placeholder (route `/tapestry/tapestries/new`)
+into a working authoring page. It is a **members-only** slice: the owner sets title + description and
+picks member concepts; we publish a real, explorable **kind-39999** tapestry element. Authoring the
+cross-concept integrations *between* members is deferred (fast-follow). The approved ACs (quoted):
+
+- **Owner-gated** — non-owner/admin visitors get no working create affordance on the directory or
+  `/new`; the owner/admin does.
+- **Compose** — Title (required) + Description (optional) + select **≥1** existing concept by name.
+- **Publish shape** — submit publishes a kind-39999 element **z-tagged** `39998:<TA>:tapestry` whose
+  `json` tag holds the `tapestry` block + a `graph` block with **one concept-header node and one
+  `*-concept-graph` import per selected concept**.
+- **Signing selector, owner-enforced** — "my own key" → NIP-07-signed (author = owner); "Tapestry
+  Assistant" → server-signed as TA; a **TA-sign request from a non-owner session is server-refused**.
+- **Round-trips** — on success the owner reaches the new Tapestry; it appears in the directory and
+  renders on the Exploration page with members listed.
+- **Validation & failure are visible** — no title / zero concepts blocks submit (nothing published);
+  a signer/relay failure shows a clear error, no partial/duplicate tapestry.
+
+**Environment.** The local Docker stack is **down** and its Neo4j/strfry graph is **empty**; the live
+concept graph can't be exercised locally. v1 must be verifiable via the stack-free Node test runner +
+`vite build` + mocked Playwright. `<TA>` is the runtime-resolved owner-assistant pubkey — **never
+hardcoded** (CLAUDE.md); client reads it via `useConfig().taPubkey`.
+
+**Verified facts (planning + this phase):**
+
+- **Wire shape (ground truth):** the seed element `39999:<TA>:tapestry-for-dog-ca3b675e`
+  (`tests/brainstorm/tapestry-exploration.spec.js` `ELEMENT_JSON`; directory z-tag in
+  `tests/brainstorm/tapestries-nav-and-directory.spec.js:49`) is:
+  `tags: [['d',dTag],['name',…],['z','39998:<TA>:tapestry'],['json', JSON.stringify({tapestry:{slug,title,description}, graph:{graphType:'tapestry', nodes:[{slug,uuid,name}], relationshipTypes, relationships, imports:[{slug,uuid}]}})]]`, `content:''`.
+- **Concept-header shape** (`firmware/active/concepts/dog/concept-header.json`): a concept header
+  carries `word.slug` = the **descriptive** slug (`concept-header-for-the-concept-of-dogs`) and
+  `conceptHeader.oNames.singular` = the **display** name (`dog`). Its addressable event's **d-tag is
+  the short slug** (`dog`), so its coordinate is `39998:<TA>:dog`. This is exactly the shape a seed
+  tapestry node uses: `{slug:'concept-header-for-the-concept-of-dogs', uuid:'39998:<TA>:dog', name:'dog'}`.
+- **Import convention:** the seed's imports are `39999:<TA>:<short-slug>-concept-graph` — runtime-
+  *derived* addressable events (not static firmware). Resolution is by **uuid only**
+  (`useTapestryGraph.js:19-24`); the import entry's `slug` is cosmetic.
+- **Read-time composition** (`tapestryGraphModel.js`): `inferNodeType` types a node as `conceptHeader`
+  purely by `uuid.startsWith('39998:')` (:33); `composeGraph` **dedups nodes by `slug`** (:56-68). So
+  a node deduplicates with the same concept coming from a resolved import **iff their `slug`s match**.
+- **Publish endpoint** (`src/api/strfry/commands/publishEvent.js`): `POST /api/strfry/publish {event,
+  signAs}`. `signAs:'client'` = client already NIP-07-signed, permissionless; `signAs:'assistant'` =
+  server re-signs `{kind,created_at,tags,content}` with the TA key, **gated to `isOwner(req) ||
+  req.localTrusted`** (403 otherwise).
+- **Client helpers:** `queryRelay` (`ui/src/api/relay.js`) → `/api/strfry/scan`; `publishEverywhere`
+  (`nostrPublish.js:134`) and `publishOrThrow` (`publishProfileTag.js:24`) for local+external publish;
+  `hasAdminAccess(user)` (`ui/src/utils/auth.js:6`); `useAuth()` (`user.classification`), `useConfig()`
+  (`taPubkey`); `getActiveSignerOrThrow` (`signerGuard.js`).
+
+## Options considered
+
+### Decision 1 — Concept-picker data source
+
+**Option A (chosen) — strfry scan of concept headers.** `queryRelay({kinds:[39998],
+authors:[taPubkey]})`; per event derive `{ handle: 39998:<pubkey>:<d-tag>, shortSlug: <d-tag>,
+descriptiveSlug: json.word.slug, name: json.conceptHeader.oNames.singular }`.
+- Pros: one canonical read path (same strfry-first stance ADR `tapestries/0002` Decision 2 took —
+  "never depend on Neo4j for tapestry data"); returns the `word.slug` we need for clean read-time
+  dedup (Decision 2); no new backend.
+- Cons: must parse the header's `json` tag; returns every kind-39998 (incl. meta-concepts like
+  `tapestry` itself) — acceptable for a picker.
+
+**Option B (rejected) — Neo4j `GET /api/concept-graph/summaries`.** Returns clean `{handle,name}`.
+- Rejected: reintroduces the exact Neo4j dependency ADR `tapestries/0002` §F2 warns against (Neo4j has
+  drifted from the signed events); and `summaries` does **not** expose `word.slug`, which Decision 2
+  needs. A convenience endpoint isn't worth contradicting the epic's strfry-canonical precedent.
+
+### Decision 2 — How a picked concept becomes graph `nodes` + `imports`
+
+**Option A (chosen) — author the header node with its *descriptive* slug + a convention import; no
+per-concept graph read.** For each selected concept:
+- `nodes += { slug: descriptiveSlug (word.slug), uuid: handle, name }`
+- `imports += { slug: 'concept-graph-for-' + shortSlug (cosmetic), uuid: '39999:<TA>:'+shortSlug+'-concept-graph' }`
+- `relationshipTypes: []`, `relationships: []` (no cross-concept edges in v1).
+
+Because the authored node's `slug` is the concept-header's `word.slug` — the **same** slug the derived
+`*-concept-graph` uses for its header node — `composeGraph` dedups them at read time: each member
+renders **exactly once**, and when the import resolves it contributes the superset + `IS_THE_CONCEPT_FOR`
+spine (seed-shaped). When an import can't resolve (empty local graph / a concept with no derived graph),
+the authored node still lists the member. Zero author-time graph reads.
+- Pros: deterministic; robust to absent imports; no extra reads; produces seed-identical structure;
+  fully unit-testable from the picker data alone.
+- Cons: assumes a concept-graph's header-node slug equals its concept-header `word.slug` (a firmware-
+  level invariant — both derive from the same concept-header). **Live-verification item** (below), since
+  the local graph can't confirm it. If it ever diverged, that member would render twice.
+
+**Option B (rejected) — read each concept's `*-concept-graph` at author time and copy its header +
+superset nodes verbatim.** Immune to any slug divergence (copies the real slug).
+- Rejected for v1: N author-time strfry reads for a benefit (immunity to a firmware-level invariant
+  holding) that Option A already gets for free; locally every read falls back anyway (empty graph), so
+  it buys nothing we can test. Keep as the fallback design if the invariant is ever shown to break.
+
+**Option C (rejected) — nodes only, no imports.** No dedup risk at all.
+- Rejected: contradicts AC "one `*-concept-graph` import per selected concept" and yields no spine.
+
+### Decision 3 — Publish + signing selector
+
+Only real path: reuse `POST /api/strfry/publish` (no new endpoint).
+- **"My own key"** — build the unsigned event with `pubkey = user.pubkey`, `window.nostr.signEvent`,
+  then `publishOrThrow(signed)` (local strfry + external co-publish, per the story). Guard the active
+  signer with `getActiveSignerOrThrow(user.pubkey)` (issue #335 pattern).
+- **"Tapestry Assistant"** (default) — build the unsigned **template** (`{kind,created_at,tags,content}`,
+  no pubkey/sig) and `POST /api/strfry/publish {event, signAs:'assistant'}`. The server signs as TA and
+  publishes to local strfry; the owner gate is enforced there (403 for non-owner). External co-publish
+  for TA-signed events is **out of scope v1** (the directory reads local strfry).
+
+### Decision 4 — Owner gating
+
+- **UI (affordance):** gate the directory's "+ Create New Tapestry" button (`Index.jsx:90-92`) and the
+  `/new` form behind `hasAdminAccess(user)` from `useAuth()`. Non-owners see an owner-only notice on
+  `/new`, no working form.
+- **Server (TA-sign):** already 403-gated in `publishEvent.js` — covered, not re-implemented.
+- **Honest note:** client-signed publishing is **permissionless by design** (decentralized-first);
+  there is no server "create-tapestry" write to gate for the own-key path. v1 gates the *curator
+  affordance* in the UI; whether the *directory view* should be POV/WoT-filtered is a separate,
+  already-deferred concern (epic `tapestries.md`). This is intentional, not a gap.
+
+## Decision
+
+Build the page on **Decision 1-A** (picker = strfry kind-39998 scan), **Decision 2-A** (author header
+node with its descriptive slug + a convention import, no per-concept read), **Decision 3** (reuse
+`/api/strfry/publish`, `signAs` selector, TA default), **Decision 4** (`hasAdminAccess` UI gate; server
+TA-gate already present). No new backend, no new dependency, no firmware change, no change to the
+shipped read-path model (`tapestryGraphModel.js` / `useTapestryGraph.js`).
+
+## Consequences
+
+- **Enables** the full create → publish → directory → explore loop, owner-curated, signable as the
+  owner or the TA — producing tapestries structurally identical to the seed.
+- **Constrains:** correctness of clean member rendering rests on the concept-header `word.slug` ==
+  derived concept-graph header slug invariant (Decision 2-A). **Live-verification item for staging:**
+  create a tapestry from real concepts and confirm each member appears once (no duplicate node) on the
+  Exploration page. If it ever duplicates, switch that member to Option 2-B (read-and-copy) — a
+  contained change to one builder function.
+- **Debt / follow-ups (out of scope, noted):** cross-concept integration authoring; edit/delete;
+  external co-publish for TA-signed tapestries; POV/WoT directory filtering; a uuid-based node identity
+  in `composeGraph` (would make Decision 2 slug-agnostic) — only if the invariant proves insufficient.
+- **Firmware reinstall required?** **No** — no concept definitions change.
+
+## Implementation notes
+
+Concrete module map (the Implementer builds these; **no test files** — those are Phase 3):
+
+- **NEW `ui/src/pages/tapestries/tapestryDraft.mjs`** — pure, React-free (`.mjs` so the stack-free Node
+  runner can `await import()` it and `vite` still bundles it):
+  - `slugifyTitle(title)` → kebab slug (lowercase, non-alnum→`-`, trim).
+  - `buildTapestryDraft({ title, description = '', members, taPubkey, dTagSuffix })` where
+    `members = [{ handle, shortSlug, descriptiveSlug, name }]` → returns
+    `{ dTag, uuid, tapestry, graph, unsignedEvent }`:
+    - `dTag = 'tapestry-' + slugifyTitle(title) + '-' + dTagSuffix` (suffix injected for determinism in
+      tests; the hook supplies a short random hex).
+    - `uuid = '39999:' + taPubkey + ':' + dTag`.
+    - `tapestry = { slug: slugifyTitle(title), title, description }`.
+    - `graph = { graphType:'tapestry', nodes: members.map(m => ({ slug:m.descriptiveSlug, uuid:m.handle, name:m.name })), relationshipTypes:[], relationships:[], imports: members.map(m => ({ slug:'concept-graph-for-'+m.shortSlug, uuid:'39999:'+taPubkey+':'+m.shortSlug+'-concept-graph' })) }`.
+    - `unsignedEvent = { kind:39999, created_at:<now>, content:'', tags:[['d',dTag],['name',title],['z','39998:'+taPubkey+':tapestry'],['json', JSON.stringify({ tapestry, graph })]] }` (created_at injectable for tests).
+    - Throws on empty title or empty members (guards the wire shape independent of the UI).
+- **NEW `ui/src/pages/tapestries/useCreateTapestry.js`** — React hook:
+  - Loads picker options: `queryRelay({ kinds:[39998], authors:[taPubkey] })`, parse each event's
+    `json` tag → `{ handle, shortSlug, descriptiveSlug: word.slug, name: conceptHeader.oNames.singular }`
+    (fall back name→shortSlug, descriptiveSlug→'concept-header-for-'+shortSlug if a field is missing).
+    Sort by name. Returns `{ concepts, conceptsLoading, conceptsError }`.
+  - `create({ title, description, selectedHandles, signAs })`: map selected handles → member objects
+    (from the loaded concepts), `buildTapestryDraft(...)`. If `signAs==='client'`: set
+    `unsignedEvent.pubkey = user.pubkey`, `getActiveSignerOrThrow(user.pubkey)`,
+    `signed = await window.nostr.signEvent(unsignedEvent)`, `await publishOrThrow(signed)`. If
+    `signAs==='assistant'`: `POST /api/strfry/publish { event: unsignedEvent, signAs:'assistant' }`,
+    throw on `!ok || !json.success` (surfacing the 403). Return `{ uuid }`.
+- **REWRITE `ui/src/pages/tapestries/NewTapestry.jsx`** — container:
+  - `const { user } = useAuth();` → if `!hasAdminAccess(user)`, render `<Breadcrumbs/>` + a clear
+    owner-only notice (no form). Else the form: Title (required), Description (optional textarea), a
+    **searchable multi-select** of `concepts` (text filter + checkbox list; selected chips), and a
+    **signing selector** (radio: "Tapestry Assistant" [default] | "My own key"). Reuse `useConfig()`
+    `taPubkey`, `useCreateTapestry`, `useNavigate`.
+  - Submit: block if no title or zero selected (inline messages; nothing published). On success
+    (`{ uuid }`) `navigate('/tapestry/tapestries/' + encodeURIComponent(uuid))`. On throw, show the
+    error string; no navigation. Disable submit while creating.
+  - The concept list is client-side filtered; empty `concepts` → an empty-state ("No concepts found on
+    this instance") so the page never looks broken on an empty graph.
+- **EDIT `ui/src/pages/tapestries/Index.jsx`** — wrap the "+ Create New Tapestry" button (`:90-92`) in
+  `hasAdminAccess(user)` (add `useAuth`); non-owners simply don't see it.
+- **Reuse, no new deps:** `Breadcrumbs`, `queryRelay`, `publishOrThrow`/`publishEverywhere`,
+  `getActiveSignerOrThrow`, `hasAdminAccess`, `useAuth`, `useConfig`, `react-router` `useNavigate`.
+  No vis-network/new packages; the picker is plain React.
+
+**Testability guidance for Phase 3 (Tester decides mechanics).** The binding CI gate is the stack-free
+`node test/test.js` runner (Playwright specs are `BRAINSTORM_SERVER_ACCESSIBLE`-gated and skipped in
+stack-free CI). Recommended coverage:
+- **Node unit suite** `test/create-tapestry.test.js` (registered in `test/test.js`, `async run()`): a
+  dynamic `await import('../ui/src/pages/tapestries/tapestryDraft.mjs')`, asserting for both signing
+  modes — kind 39999; z-tag `39998:<TA>:tapestry`; `d`-tag pattern `tapestry-<slug>-<suffix>`;
+  `json.tapestry.{title,description}`; **one node and one import per member**; each node's `uuid` is the
+  concept handle and `slug` is the descriptive slug (dedup-clean); `relationshipTypes`/`relationships`
+  empty; empty-title / empty-members throw. Plus source-assertions on `NewTapestry.jsx` (owner gate via
+  `hasAdminAccess`, both `signAs` branches, validation) and `Index.jsx` (gated button) — mirroring
+  `test/admin-tools-dashboard-panel.test.js`.
+- **Playwright** `tests/brainstorm/tapestry-create.spec.js` (mock `/api/strfry/scan`, `/api/strfry/
+  publish`, `/api/assistant/pubkey`, `/api/auth/*`, `window.nostr`): owner sees the form / non-owner
+  doesn't; validation blocks; submit posts the expected `signAs` + event; success navigates to the new
+  uuid; a non-owner TA-sign attempt surfaces the 403 — mirroring `tapestry-exploration.spec.js`.
+
+## Out of scope
+- Cross-concept integration authoring (subsets/elements/enumerations between members); auto-derivation.
+- Editing / deleting a tapestry; external co-publish for TA-signed tapestries.
+- POV/WoT filtering of the directory; letting non-owners publish; transitive import expansion.
+- Changing `composeGraph` to uuid-based node identity (future, only if Decision 2-A's invariant breaks).

--- a/engineering-team/reviews/tapestries/3-create-tapestry.md
+++ b/engineering-team/reviews/tapestries/3-create-tapestry.md
@@ -1,0 +1,113 @@
+# Review: Story 3 — Create a Tapestry (members-only authoring)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-07-24
+**Diff:** `git diff origin/staging..HEAD` (commits 8f588562 tests, 9a0998e5 impl)
+**Method:** reviewer-run gates + 4 independent, fresh-context adversarial reviewers (each tasked to
+*refute* a claim), each permitted to probe the live graph at `localhost:7778`.
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `node test/create-tapestry.test.js` (create-tapestry suite) — **18/18 pass** (P1–P9, S1–S6, R1–R3).
+- [~] `npm test` (full runner) — not run to completion: hangs environmentally on live-stack suites
+  (known; the stack-free differential is the binding CI gate). The create-tapestry suite is registered
+  in the **live** `overallOk` chain (`test/test.js:1024`, before the severed terminator — OPEN.md #43),
+  verified by the scope/arch reviewer.
+- [~] `npm run test:playwright` — spec authored (`tests/brainstorm/tapestry-create.spec.js`), server-gated
+  (runs in the cycle-staging smoke). **Gap:** E6 (own-key) asserts the publish payload but NOT the
+  post-create navigation, so it does not catch the blocking bug below.
+- [x] `vite build` — compiles; bundle provably contains the worktree source.
+- [x] Read-path integrity — `tapestryGraphModel.js` / `useTapestryGraph.js` / `TapestryDetail.jsx` /
+  `TapestryIntegrationGraph.jsx` absent from the diff; directory query unchanged.
+- _Lint / typecheck — not configured; skipped per house rules._
+
+## Spec adherence
+- [x] Owner-gated (AC) — **stands.** Form is truly absent for non-owners (`NewTapestry.jsx:36-46`
+  early-returns before any form JSX); directory button gated (`Index.jsx:94-98`); server refuses
+  non-owner TA-signing (`publishEvent.js:36-38`, 403).
+- [x] Compose / Publish shape (AC) — kind-39999, z-tag `39998:<TA>:tapestry`, one node + one import per
+  member, members-only (`relationshipTypes`/`relationships` empty). Pinned by P1–P6.
+- [x] Signing selector, owner-enforced (AC) — TA default + own-key; server 403 is the real TA gate;
+  client-sign is permissionless (honest, decentralized-first).
+- [ ] **Round-trips (AC) — FAILS for the own-key path** (blocking finding 1): a successful own-key
+  publish navigates to a non-existent coordinate → "Tapestry not found."
+- [x] Validation & failure visible (AC) — empty title / zero concepts block before any publish
+  (`NewTapestry.jsx:57-58`, `buildTapestryDraft` throws); signer-absent / signer-mismatch / 403 all
+  surface via the catch. (One edge: retry-after-false-error — non-blocking finding 3.)
+
+## ADR adherence
+- [x] Files, layering, and module boundaries match ADR 0003 §Implementation (pure `.mjs` builder, hook,
+  page rewrite, gated button). No new dependencies. No firmware change (correct — no concept defs
+  changed). Picker sourced from strfry kind-39998 (Decision 1-A), not Neo4j.
+- [x] Decision 2-A dedup **mechanism** verified live: for all 41 TA concept headers, `word.slug` equals
+  the concept-graph header-node slug (0 mismatches) — no member renders as a slug-duplicate. *But* the
+  import-uuid derivation has a naming bug (non-blocking finding 2).
+
+## Concept-graph integrity
+- [x] Handles are `kind:pubkey:slug`; TA pubkey runtime-resolved (`useConfig().taPubkey`), never hardcoded.
+- [x] No concept definitions changed → no firmware reinstall needed. New code reads via strfry
+  (`queryRelay`), consistent with ADR tapestries/0002.
+
+## Things tests can't catch
+- [x] No secrets, no `console.log`/debug, no commented-out code, no TODOs in the impl files.
+- [x] No XSS — title/description render only through React text interpolation (`TapestryDetail.jsx:124-125`,
+  `JsonView`, `DataTable`); no `dangerouslySetInnerHTML`.
+- [x] POV-first / decentralized-first honored — no global trusted-set precompute; publication ungated
+  (only TA-impersonation is gated).
+
+## Findings
+
+### Blocking
+1. **`ui/src/pages/tapestries/useCreateTapestry.js:97` + `tapestryDraft.mjs:39`** — the own-key
+   (`signAs === 'client'`) path returns a **TA-namespaced** uuid for an event actually authored by the
+   **owner's** key, so the post-create redirect 404s. The event is signed with `pubkey: authorPk`
+   (`useCreateTapestry.js:82`) → real coordinate `39999:<ownerKey>:<dTag>`, but `create()` returns
+   `draft.uuid` = `39999:<taPubkey>:<dTag>` (`tapestryDraft.mjs:39`); `NewTapestry.jsx:62` navigates
+   there; `useTapestryGraph.js:19-24` queries `authors:[taPubkey]` and finds nothing →
+   `TapestryDetail.jsx:105-107` "Tapestry not found." (The TA path works only because there author ==
+   taPubkey. The tapestry *is* reachable via the directory, which recomputes the uuid from `ev.pubkey`
+   — so this is a broken *redirect*, not a lost tapestry.) Found independently by the publish-paths and
+   owner-gating reviewers; confirmed by trace. **Fails the Round-trips AC for the own-key option.**
+   **Asked change:** return the uuid keyed to the *actual signer* — client → `39999:<authorPk>:<dTag>`,
+   assistant → `39999:<taPubkey>:<dTag>`. Keep the z-tag `39998:<taPubkey>:tapestry` (concept handle,
+   always TA). Add coverage: a unit assertion that the returned uuid's author segment matches the
+   signing identity per `signAs`, and/or extend Playwright E6 to assert navigation to the owner-keyed
+   coordinate (closes the test gap that let this through).
+
+### Non-blocking (please address in the same fix pass where cheap)
+1. **`ui/src/pages/tapestries/tapestryDraft.mjs:55` + `useCreateTapestry.js:30`** — the `*-concept-graph`
+   import uuid is built from the header's **d-tag** (`shortSlug`), but derived concept-graphs are named
+   from `conceptHeader.oSlugs.singular`. These match for 40/41 live concepts but **diverge for
+   `nostr-event-tag`** (d-tag `nostr-event-tag`, `oSlugs.singular` `nostr-event-tagging`): the built
+   import `39999:<TA>:nostr-event-tag-concept-graph` does not exist (actual:
+   `nostr-event-tagging-concept-graph`), so that member's import never resolves and it renders isolated
+   (no superset/spine). Degrades gracefully (renders once, no crash), but is a latent correctness bug.
+   **Suggested:** capture `conceptHeader.oSlugs.singular` in `toConcept` and build the import uuid from
+   it (the header *handle* stays d-tag-based).
+2. **`ui/src/pages/tapestries/NewTapestry.jsx:52-68`** — `onSubmit` has no `if (submitting) return`
+   re-entry guard (only the button's `disabled`), and each `create()` mints a fresh random d-tag, so a
+   false-negative publish error (e.g. `strfry import` timeout that actually landed, `publishEvent.js:70`)
+   followed by a retry yields a *second* distinct tapestry. Low-likelihood; **suggested:** add the
+   re-entry guard. (True idempotency across retries is out of scope for v1 — note it.)
+3. **`test/create-tapestry.test.js` P5** — asserts the dedup invariant but is tautological w.r.t. it: it
+   only re-echoes the fixture inputs `buildTapestryDraft` copies, never cross-checking a real
+   concept-graph header slug or import resolvability; its `dog`/`golden-retriever` fixtures
+   (`shortSlug == oSlugs.singular`) structurally cannot exercise the divergence in non-blocking #1.
+   **Suggested (Tester):** add a fixture where `shortSlug != oSlugs.singular` and assert the import uuid
+   is built from `oSlugs.singular`.
+4. **`useCreateTapestry.js` / `Index.jsx` comments** — "owner-only" wording, but `hasAdminAccess` admits
+   `owner || admin` (client and server agree, so no bypass — wording nit only).
+
+### Harness friction (→ OPEN.md, type `meta`)
+1. A worktree's `ui/node_modules` symlinked to main's causes a worktree `vite dev` server to serve the
+   **main** checkout (my new files 404 → blank app), making a dev-server browser smoke useless from a
+   worktree. Verify worktree UI via the Node suite + `vite build` + code reading instead. (Confirmed
+   this session; matches the "shared-checkout" caution in session notes.)
+
+## Verdict
+**CHANGES_REQUESTED** — one blocking defect (own-key redirect 404, a Round-trips AC failure). The
+architecture, security, scope, and read-path integrity are all sound; the fix is small and localized to
+the uuid the hook returns, plus the two cheap non-blocking correctness items and a test to close the gap.
+
+## On PASS (same commit)
+- [ ] *(Not applicable — CHANGES_REQUESTED. Story stays Draft; kick back to `/implement-feature`.)*

--- a/engineering-team/reviews/tapestries/3-create-tapestry.md
+++ b/engineering-team/reviews/tapestries/3-create-tapestry.md
@@ -104,10 +104,36 @@
    worktree. Verify worktree UI via the Node suite + `vite build` + code reading instead. (Confirmed
    this session; matches the "shared-checkout" caution in session notes.)
 
+## Re-review — fix cycle (commit 1314e543, 2026-07-24)
+
+The Implementer addressed all three findings; I re-ran the gates and got **independent, fresh-context
+adversarial re-verification** (one verifier, code trace + whole-graph live probe) — verdict FIX-VERIFIED.
+
+- **Blocking #1 (own-key redirect) — RESOLVED.** `buildTapestryDraft` gained `authorPubkey`
+  (default `taPubkey`); `uuid = 39999:${authorPubkey}:${dTag}` (`tapestryDraft.mjs:46`). The hook's
+  client branch resolves the signer first and passes `authorPubkey: authorPk`
+  (`useCreateTapestry.js:84-88`), so the returned uuid's author segment == the published pubkey for
+  both paths; z-tag + imports stay TA-namespaced. Locked by P10, S7, Playwright E6.
+- **Non-blocking #1 (import naming) — RESOLVED.** Import uuid now built from
+  `conceptGraphSlug = conceptHeader.oSlugs.singular` (`useCreateTapestry.js:33`, `tapestryDraft.mjs:63-64`).
+  Live sweep of all 41 headers: the single divergence (`nostr-event-tag` → `nostr-event-tagging`) is the
+  only one, and the fix is necessary **and** sufficient (no header left unresolvable). Locked by P11 + updated P5.
+- **Non-blocking #2 (re-entry guard) — RESOLVED** (`NewTapestry.jsx:54`).
+- **Non-blocking #3 (P5 tautology) — ADDRESSED**: P11 now exercises the divergence with a real
+  `oSlugs.singular != d-tag` fixture.
+- Gates: create-tapestry suite **21/21**; `vite build` compiles; read-path & `publishEvent.js` still
+  untouched. Two residual **non-blocking** observations, both accepted (not fixing): a pre-existing
+  NIP-07 TOCTOU account-switch edge (already mitigated by the signer guard), and an unreachable
+  signer-prompt-before-empty-members-throw ordering nit (the page pre-validates zero-concepts).
+
 ## Verdict
-**CHANGES_REQUESTED** — one blocking defect (own-key redirect 404, a Round-trips AC failure). The
-architecture, security, scope, and read-path integrity are all sound; the fix is small and localized to
-the uuid the hook returns, plus the two cheap non-blocking correctness items and a test to close the gap.
+**PASS** — the one blocking defect is fixed and independently re-verified; all non-blocking items are
+resolved or accepted. Architecture, security, scope, POV-first/decentralized-first, and read-path
+integrity were clean throughout. (Original verdict this story: CHANGES_REQUESTED → fixed → PASS.)
 
 ## On PASS (same commit)
-- [ ] *(Not applicable — CHANGES_REQUESTED. Story stays Draft; kick back to `/implement-feature`.)*
+- [x] Story `**Status:**` flipped to `Done` in place.
+- [x] Completion detection run: the members-only create ask is delivered; the broader Create/Edit
+  Tapestry phase (edit, cross-concept integration authoring, real-deployment seeding) remains deferred
+  per the story's Out-of-scope + `audits/tapestries/prd-seed.md` §6–§7, and the `tapestries` epic is
+  still in flight — so **no `/close-book` offered**. Next step is the deploy chain (`cycle-staging`).

--- a/engineering-team/stories/tapestries/3-create-tapestry.md
+++ b/engineering-team/stories/tapestries/3-create-tapestry.md
@@ -1,0 +1,88 @@
+# Story 3: Create a Tapestry (members-only authoring)
+
+**Status:** Draft
+**Created:** 2026-07-24
+**Type:** Feature
+
+## Background
+The `tapestries` epic shipped the **read-only** surface — a directory (`View Tapestries`) and a
+per-tapestry Exploration page — and explicitly deferred authoring to "a future story." The
+`/tapestry/tapestries/new` page (`NewTapestry.jsx`) is an inert placeholder: it previews the planned
+fields but has no working submit. The build audit's `prd-seed.md` names this exact page as the next
+phase and flags its authoring UX as the biggest open question.
+
+This story delivers the **first working authoring capability**: the instance owner creates a Tapestry
+by naming it and choosing which existing concepts it groups, and publishes it as a real, explorable
+tapestry element — no hand-editing of nostr events. It is deliberately a **members-only** slice:
+authoring the cross-concept integrations *between* members (subsets / elements / enumerations) is left
+to a fast-follow. v1's job is to establish the complete **create → publish → appears in directory →
+explorable** loop and the authoring conventions later stories build on.
+
+**Who is affected:** the instance **owner** (the "curator" persona). Explorers (any visitor) benefit
+indirectly — newly created tapestries appear in the public directory and render on the existing
+Exploration page.
+
+## User-facing description
+As the **instance owner**, I want to create a new Tapestry by giving it a title and description and
+selecting which existing concepts it groups — and publish it either under **my own key** or as my
+**Tapestry Assistant** — so that the Tapestry appears in the directory and is explorable just like the
+seeded ones, without me having to hand-craft a nostr event.
+
+## Acceptance criteria
+Testable from the outside (members-only v1).
+
+- [ ] **Owner-gated.** Given a visitor who is not the owner/admin (unauthenticated, guest, or a regular
+  signed-in user), when they view the Tapestries directory or navigate to `/tapestry/tapestries/new`,
+  then no working create affordance is offered to them and the page explains that creating a Tapestry
+  is owner-only. Given the owner/admin, the create affordance and a working form are available.
+- [ ] **Compose.** Given the owner on the Create page, when the form loads, then they can enter a
+  **Title** (required) and a **Description** (optional) and select **one or more** existing member
+  concepts by name (searching/choosing from the concepts that exist on this instance).
+- [ ] **Publish shape.** Given a title and ≥1 selected concept, when the owner submits, then a
+  **kind-39999** tapestry element is published to the relay that (a) is **z-tagged** to the tapestry
+  concept handle (`39998:<TA>:tapestry`) so it appears in the directory, and (b) carries a `json` tag
+  whose `tapestry` block holds the title + description and whose `graph` block contains **one
+  concept-header node and one `*-concept-graph` import per selected concept**.
+- [ ] **Signing selector, owner-enforced.** Given the owner has chosen "**my own key**", when they
+  submit, then the event is signed via their NIP-07 signer (author = owner's pubkey). Given they chose
+  "**Tapestry Assistant**", then the event is server-signed as the TA (author = TA pubkey). A request
+  to mint a **TA-signed** event from a non-owner session is refused by the server.
+- [ ] **Round-trips.** Given a successful publish, when it completes, then the owner is taken to (or
+  given a direct link to) the new Tapestry, the new Tapestry is retrievable in the **directory**, and
+  it renders on the **Exploration page** with its selected member concepts listed.
+- [ ] **Validation & failure are visible.** Given a submit with no title or zero selected concepts, the
+  form blocks submission and states what's required (nothing is published). Given a signer/relay
+  failure during publish, the owner sees a clear error and no partial or duplicate tapestry is silently
+  created.
+
+## Concepts touched
+Handles use the instance's runtime-resolved TA pubkey (`<TA>`) — **never hardcode it** (CLAUDE.md).
+
+- `39998:<TA>:tapestry` — **Tapestry** concept. Its *elements* are individual tapestries; a created
+  tapestry is a kind-39999 element **z-tagged** to this handle (this is what the directory reads).
+- Per selected member concept: `39998:<TA>:<slug>` — the concept **header** (becomes a `graph.nodes`
+  entry), and `39999:<TA>:<slug>-concept-graph` — the concept's importable graph (becomes a
+  `graph.imports` entry, resolved at read time by the Exploration page). *The Architect resolves the
+  data source for the concept picker and the exact node/import shape at runtime.*
+
+## Out of scope
+- **Cross-concept integration authoring** — asserting subsets / elements / enumerations *between*
+  selected members. v1 publishes membership only; those relationships surface via import resolution on
+  the Exploration page. Explicit authoring (and auto-derivation from the live graph) is a fast-follow.
+- **Editing or deleting** an existing Tapestry.
+- Letting **non-owners** publish tapestries; POV/WoT filtering of the directory.
+- Transitive import expansion (property-tree / core-nodes graphs).
+
+## Open questions
+- **Default signing identity** — should the selector default to **Tapestry Assistant** (consistent with
+  the TA-signed seed tapestries; a uniform curated gallery) or the **owner's own key** (provenance /
+  decentralized-first)? *PO proposal: default to Tapestry Assistant, owner can switch per-create.*
+- **Concept-picker data source under an empty/absent local graph** — the local Docker stack is down and
+  its graph is empty, so the picker can't be smoke-tested against live concepts locally; v1 must be
+  verifiable via unit tests + `vite build` + mocked UI, and must degrade gracefully when no concepts are
+  available. *Flagged for the Architect (data source + empty-state); not a blocker for approval.*
+
+## Linked artifacts
+- ADR: (filled in after Architecture phase)
+- Test plan: (filled in after Test Design phase)
+- Review: (filled in after Review phase)

--- a/engineering-team/stories/tapestries/3-create-tapestry.md
+++ b/engineering-team/stories/tapestries/3-create-tapestry.md
@@ -82,6 +82,22 @@ Handles use the instance's runtime-resolved TA pubkey (`<TA>`) — **never hardc
   verifiable via unit tests + `vite build` + mocked UI, and must degrade gracefully when no concepts are
   available. *Flagged for the Architect (data source + empty-state); not a blocker for approval.*
 
+## Deviations
+Logged per `roles/implementer.md` §9. Review-fix cycle (review verdict CHANGES_REQUESTED → fixes):
+- **[blocking fix]** The own-key (`signAs:'client'`) path returned a TA-namespaced uuid, so the
+  post-create redirect 404'd. `buildTapestryDraft` gained an `authorPubkey` param (default = `taPubkey`)
+  and now namespaces the returned `uuid` to the signer; the hook resolves the owner's signer first and
+  passes `authorPubkey: authorPk`. The z-tag and concept-graph imports stay TA-namespaced.
+- **[non-blocking fix]** Concept-graph imports were built from the header d-tag, but derived
+  concept-graphs are named from `conceptHeader.oSlugs.singular` (diverges for `nostr-event-tag` →
+  `nostr-event-tagging-concept-graph`, verified live). The picker now captures `conceptGraphSlug =
+  oSlugs.singular` and the import uuid is built from it.
+- **[non-blocking fix]** Added an `if (submitting) return;` re-entry guard to `NewTapestry.onSubmit`.
+- **[judgment call]** The Implementer authored the regression tests for these fixes in the fix cycle
+  (unit P10 = uuid-per-signer, P11 = import-from-`conceptGraphSlug`, source S7; updated the P5 fixture;
+  strengthened Playwright E6 to assert own-key navigation) rather than round-tripping to the Tester —
+  proportionate for a localized review-fix; the tests lock the exact review findings. Suite: 21/21.
+
 ## Linked artifacts
 - ADR: `engineering-team/decisions/tapestries/0003-create-tapestry-authoring.md`
 - Test plan: `engineering-team/stories/tapestries/3-create-tapestry.test-plan.md`

--- a/engineering-team/stories/tapestries/3-create-tapestry.md
+++ b/engineering-team/stories/tapestries/3-create-tapestry.md
@@ -1,6 +1,6 @@
 # Story 3: Create a Tapestry (members-only authoring)
 
-**Status:** Draft
+**Status:** Done
 **Created:** 2026-07-24
 **Type:** Feature
 
@@ -101,4 +101,4 @@ Logged per `roles/implementer.md` §9. Review-fix cycle (review verdict CHANGES_
 ## Linked artifacts
 - ADR: `engineering-team/decisions/tapestries/0003-create-tapestry-authoring.md`
 - Test plan: `engineering-team/stories/tapestries/3-create-tapestry.test-plan.md`
-- Review: `engineering-team/reviews/tapestries/3-create-tapestry.md` — **CHANGES_REQUESTED** (own-key redirect 404; 2026-07-24)
+- Review: `engineering-team/reviews/tapestries/3-create-tapestry.md` — **PASS** (CHANGES_REQUESTED → fixed → re-verified; 2026-07-24)

--- a/engineering-team/stories/tapestries/3-create-tapestry.md
+++ b/engineering-team/stories/tapestries/3-create-tapestry.md
@@ -85,4 +85,4 @@ Handles use the instance's runtime-resolved TA pubkey (`<TA>`) — **never hardc
 ## Linked artifacts
 - ADR: `engineering-team/decisions/tapestries/0003-create-tapestry-authoring.md`
 - Test plan: `engineering-team/stories/tapestries/3-create-tapestry.test-plan.md`
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/tapestries/3-create-tapestry.md` — **CHANGES_REQUESTED** (own-key redirect 404; 2026-07-24)

--- a/engineering-team/stories/tapestries/3-create-tapestry.md
+++ b/engineering-team/stories/tapestries/3-create-tapestry.md
@@ -83,6 +83,6 @@ Handles use the instance's runtime-resolved TA pubkey (`<TA>`) — **never hardc
   available. *Flagged for the Architect (data source + empty-state); not a blocker for approval.*
 
 ## Linked artifacts
-- ADR: (filled in after Architecture phase)
+- ADR: `engineering-team/decisions/tapestries/0003-create-tapestry-authoring.md`
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/tapestries/3-create-tapestry.md
+++ b/engineering-team/stories/tapestries/3-create-tapestry.md
@@ -84,5 +84,5 @@ Handles use the instance's runtime-resolved TA pubkey (`<TA>`) — **never hardc
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/tapestries/0003-create-tapestry-authoring.md`
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/tapestries/3-create-tapestry.test-plan.md`
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/tapestries/3-create-tapestry.test-plan.md
+++ b/engineering-team/stories/tapestries/3-create-tapestry.test-plan.md
@@ -1,0 +1,87 @@
+# Test Plan: Story 3 — Create a Tapestry (members-only authoring)
+
+**Story:** `engineering-team/stories/tapestries/3-create-tapestry.md`
+**ADR:** `engineering-team/decisions/tapestries/0003-create-tapestry-authoring.md`
+**Date:** 2026-07-24
+
+## Strategy
+
+Two levels, matching the ADR's testability guidance and the exploration-page precedent:
+
+- **`test/create-tapestry.test.js`** — the **binding, stack-free** Node suite (`node test/test.js`). It
+  unit-tests the pure wire-shape builder `tapestryDraft.mjs` via dynamic `import()` (the highest-value
+  coverage — the exact kind-39999 element the directory + Exploration page must render), plus source
+  sentinels on the page/hook/index (the shape a browser exercises fully), plus regression guards.
+  Fixtures are grounded in **live** concept-header data (TA `e00ed090…df36`), and ADR Decision 2-A's
+  dedup invariant was confirmed live (concept `dog` `word.slug` == its `dog-concept-graph` header-node
+  slug), so `test P5` pins real behavior.
+- **`tests/brainstorm/tapestry-create.spec.js`** — the Playwright round-trip (network-mocked),
+  `BRAINSTORM_SERVER_ACCESSIBLE`-gated → skipped in stack-free CI, run in the cycle-staging smoke
+  (same pattern as `tapestry-exploration.spec.js` / `admin-tools-dashboard-panel`).
+
+## Coverage map
+
+| Acceptance criterion | Test(s) | File | Level |
+|---|---|---|---|
+| **Owner-gated** (owner sees form; non-owner blocked) | `S1`, `S5` / `S6`; `E1`, `E2` | `test/create-tapestry.test.js`; `tests/brainstorm/tapestry-create.spec.js` | source + e2e |
+| **Compose** (title req., desc opt., pick ≥1 concept by name) | `P3`; `S3`; `E1`, `E4` | both | unit + source + e2e |
+| **Publish shape** (kind-39999, z-tag, one node+import/member) | `P1`,`P2`,`P4`,`P5`,`P6`; `E4` | both | unit + e2e |
+| **Signing selector, owner-enforced** (own-key → client; TA → assistant; non-owner TA refused) | `S2`,`S4`; `R3` (server 403 half); `E4`,`E6` | both | source + e2e |
+| **Round-trips** (navigate to new tapestry; appears + explorable) | `P2` (uuid); `E5` | both | unit + e2e |
+| **Validation & failure visible** (no title / no concept blocks; nothing published) | `P7`,`P8`; `E3` | both | unit + e2e |
+
+Regression guards (PASS pre and post): `R1` (shipped read-path model `composeGraph`/`inferNodeType`
+untouched), `R2` (directory query intact), `R3` (server's TA-sign 403 gate preserved — the server half
+of the signing AC).
+
+## Edge cases
+
+- [x] Empty title → `buildTapestryDraft` throws (`P7`) and the form blocks (`E3`).
+- [x] Zero selected concepts → throws (`P8`) / blocked (`E3`).
+- [x] **Clean dedup** — member node uses the descriptive `word.slug` so it merges with its resolved
+  import instead of rendering twice (`P5`; ADR Decision 2-A, verified live).
+- [x] Non-owner cannot mint a TA-signed event (`R3` server 403 + `E2` no affordance).
+- [ ] Empty concept graph (picker returns `[]`) → empty-state, not a crash. *(Behavioral; covered by the
+  hook's empty-state + manual/cycle-staging check — the Node suite pins the source path in `S3`.)*
+- [ ] Relay/publish failure surfaces an error, no partial tapestry. *(AC covered by `E3`-style handling;
+  full failure-injection deferred to the cycle-staging smoke — mock returns success here.)*
+
+## Test infrastructure
+
+- **Framework:** Node built-in runner (`node test/test.js`) + Playwright (`npm run test:playwright`). No
+  new frameworks.
+- **Registration:** `test/create-tapestry.test.js` is required and run in `test/test.js`, wired into the
+  **live** `overallOk` chain (before the severed terminator — OPEN.md #43) so its failures gate.
+- **Live-API dependency:** none required to run the tests. Fixtures were *grounded* against the live
+  graph at `localhost:7778` (TA `e00ed090…`), but the committed tests are self-contained (no live calls).
+- **Playwright mocks:** `/api/strfry/scan` (kind-39998 → concept headers), `/api/strfry/publish`
+  (captures body), `/api/assistant|owner/pubkey`, `/api/relays`, `/api/status`, `/api/auth/*`,
+  `/api/profiles`, and an injected `window.nostr` for the own-key path.
+- **Fixtures:** two real concepts — `dog` and `golden-retriever` — with their live `word.slug` /
+  `oNames.singular` shapes.
+
+## How to run
+
+```
+npm test
+```
+
+Browser round-trip (operator smoke; needs a running server):
+```
+BRAINSTORM_SERVER_ACCESSIBLE=true npm run test:playwright -- tapestry-create
+```
+
+## Verification
+
+New tests fail with the current code (feature unimplemented). Confirmed 2026-07-24 by running the suite
+in isolation — **15 fail for the right reason, 3 regression guards pass**:
+
+```
+✗ P1..P9  Cannot import ui/src/pages/tapestries/tapestryDraft.mjs — the Implementer must create this … module
+✗ S1,S2   NewTapestry.jsx does not reference hasAdminAccess / the signing selector (still the inert placeholder)
+✗ S3,S4   ui/src/pages/tapestries/useCreateTapestry.js missing
+✗ S5      Index.jsx does not gate the create button with hasAdminAccess
+✗ S6      NewTapestry.jsx still carries the placeholder markers ("Coming soon" / aria-disabled)
+✓ R1,R2,R3  regression guards pass (read-path model, directory query, server TA-sign 403 gate intact)
+RESULT: {"pass":3,"fail":15}
+```

--- a/test/create-tapestry.test.js
+++ b/test/create-tapestry.test.js
@@ -42,8 +42,8 @@ const PUBLISH_EVENT   = path.join(ROOT, 'src/api/strfry/commands/publishEvent.js
 // Grounded in the live graph (TA e00ed090…df36). Descriptive slugs are the real word.slug values.
 const TA = 'e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36';
 const MEMBERS = [
-  { handle: `39998:${TA}:dog`,              shortSlug: 'dog',              descriptiveSlug: 'concept-header-for-the-concept-of-dogs',              name: 'dog' },
-  { handle: `39998:${TA}:golden-retriever`, shortSlug: 'golden-retriever', descriptiveSlug: 'concept-header-for-the-concept-of-golden-retrievers', name: 'golden retriever' },
+  { handle: `39998:${TA}:dog`,              shortSlug: 'dog',              conceptGraphSlug: 'dog',              descriptiveSlug: 'concept-header-for-the-concept-of-dogs',              name: 'dog' },
+  { handle: `39998:${TA}:golden-retriever`, shortSlug: 'golden-retriever', conceptGraphSlug: 'golden-retriever', descriptiveSlug: 'concept-header-for-the-concept-of-golden-retrievers', name: 'golden retriever' },
 ];
 
 const tests = [];
@@ -117,8 +117,8 @@ test('P5: each member node uses uuid=handle and slug=descriptiveSlug so it DEDUP
       `composeGraph dedups by slug; matching the derived concept-graph's header-node slug is what makes each member render ` +
       `EXACTLY ONCE on the Exploration page (ADR Decision 2-A, verified live). Got slug="${node.slug}".`);
     assert(node.name === m.name, `node for ${m.shortSlug} must carry the display name "${m.name}", got ${JSON.stringify(node.name)}.`);
-    const imp = g.imports.find((i) => i.uuid === `39999:${TA}:${m.shortSlug}-concept-graph`);
-    assert(imp, `no import with uuid 39999:${TA}:${m.shortSlug}-concept-graph — the Exploration page resolves this to add the superset + spine.`);
+    const imp = g.imports.find((i) => i.uuid === `39999:${TA}:${m.conceptGraphSlug}-concept-graph`);
+    assert(imp, `no import with uuid 39999:${TA}:${m.conceptGraphSlug}-concept-graph — the Exploration page resolves this to add the superset + spine.`);
   }
 });
 
@@ -150,6 +150,33 @@ test('P9: slugifyTitle lowercases, collapses non-alphanumerics to single dashes,
   const messy = slugifyTitle('  My Dogs & Cats!! ');
   assert(/^[a-z0-9]+(-[a-z0-9]+)*$/.test(messy), `slugifyTitle must yield a clean kebab slug (no leading/trailing/double dashes, lowercase), got ${JSON.stringify(messy)}.`);
   assert(messy.includes('dogs') && messy.includes('cats'), `slug must preserve the words, got ${JSON.stringify(messy)}.`);
+});
+
+test('P10: the returned uuid is namespaced to the AUTHOR (signer), not always the TA (AC Round-trips — own-key redirect fix)', async () => {
+  const { buildTapestryDraft } = await loadDraft();
+  const OWNER = '1'.repeat(64);
+  const own = buildTapestryDraft({ title: 'My Dogs', members: MEMBERS, taPubkey: TA, authorPubkey: OWNER, dTagSuffix: 'abcd1234' });
+  assert(own.uuid === `39999:${OWNER}:tapestry-my-dogs-abcd1234`,
+    `own-key uuid must be namespaced to the SIGNER — the own-key event is authored by the owner, so a TA-keyed uuid ` +
+    `makes the post-create redirect 404 (readByUuid queries authors:[<TA>]). Got ${own.uuid}.`);
+  // The z-tag and concept-graph imports stay TA-namespaced (concept handles are always TA), regardless of author.
+  assert(tagVal(own.unsignedEvent, 'z') === `39998:${TA}:tapestry`, 'z-tag must remain TA-namespaced regardless of signer.');
+  assert(jsonTag(own.unsignedEvent).graph.imports.every((i) => i.uuid.startsWith(`39999:${TA}:`)),
+    'concept-graph imports must remain TA-namespaced regardless of signer.');
+  // Default author is the TA (assistant path).
+  const ta = buildTapestryDraft({ title: 'My Dogs', members: MEMBERS, taPubkey: TA, dTagSuffix: 'abcd1234' });
+  assert(ta.uuid === `39999:${TA}:tapestry-my-dogs-abcd1234`, 'default authorPubkey must be the TA (assistant path).');
+});
+
+test('P11: the *-concept-graph import uuid is built from conceptGraphSlug (oSlugs.singular), not the header d-tag (dedup fix — nostr-event-tag)', async () => {
+  const { buildTapestryDraft } = await loadDraft();
+  // A real concept (verified live) whose concept-graph name diverges from its header d-tag:
+  // d-tag 'nostr-event-tag' but oSlugs.singular 'nostr-event-tagging'.
+  const divergent = { handle: `39998:${TA}:nostr-event-tag`, shortSlug: 'nostr-event-tag', conceptGraphSlug: 'nostr-event-tagging', descriptiveSlug: 'concept-header-for-the-concept-of-nostr-event-taggings', name: 'nostr event tag' };
+  const g = jsonTag(buildTapestryDraft({ title: 'Tags', members: [divergent], taPubkey: TA, dTagSuffix: 'x9' }).unsignedEvent).graph;
+  assert(g.imports.length === 1 && g.imports[0].uuid === `39999:${TA}:nostr-event-tagging-concept-graph`,
+    `import must be built from conceptGraphSlug (nostr-event-tagging) so it resolves — the d-tag-based ` +
+    `'39999:${TA}:nostr-event-tag-concept-graph' does not exist and would render the member isolated. Got ${g.imports[0]?.uuid}.`);
 });
 
 // ───────────────────────── Source sentinels — pinned by the spec, exercised by Playwright ─────────────────────────
@@ -198,6 +225,15 @@ test('S4: useCreateTapestry.js implements BOTH publish paths — NIP-07 own-key 
   assert(/\/api\/strfry\/publish/.test(src) && /assistant/.test(src),
     'useCreateTapestry.js does not POST /api/strfry/publish with signAs:"assistant" for the TA path (AC Signing selector). ' +
     'The server signs as the TA (and 403s non-owners).');
+});
+
+test('S7: useCreateTapestry keys the own-key uuid to the SIGNER (passes authorPubkey: authorPk) so the redirect matches (AC Round-trips)', () => {
+  const src = readSafe(USE_CREATE_HOOK);
+  assert(src !== null, 'useCreateTapestry.js missing — S3 must pass first.');
+  assert(/authorPubkey\s*:\s*authorPk/.test(src),
+    'useCreateTapestry.js client (own-key) path does not pass `authorPubkey: authorPk` to buildTapestryDraft (review ' +
+    'blocking fix). The own-key event is authored by the owner, so the returned uuid must be 39999:<ownerKey>:<dTag> — ' +
+    'otherwise the post-create redirect 404s (useTapestryGraph.readByUuid queries authors:[<TA>]).');
 });
 
 test('S5: Index.jsx gates the "+ Create New Tapestry" affordance behind hasAdminAccess (AC Owner-gated)', () => {

--- a/test/create-tapestry.test.js
+++ b/test/create-tapestry.test.js
@@ -1,0 +1,257 @@
+/**
+ * tapestries #3 — Create a Tapestry (members-only authoring).
+ * Story: engineering-team/stories/tapestries/3-create-tapestry.md
+ * ADR:   engineering-team/decisions/tapestries/0003-create-tapestry-authoring.md
+ *
+ * This suite is the BINDING (stack-free) gate — the Node runner. It has two halves:
+ *
+ *   P1..P9  — behavioral unit tests of the PURE wire-shape builder
+ *             ui/src/pages/tapestries/tapestryDraft.mjs, loaded via dynamic import().
+ *             These pin the exact kind-39999 element the Exploration page must be able
+ *             to render (grounded against LIVE concept-header data probed 2026-07-24:
+ *             concept `dog` → word.slug `concept-header-for-the-concept-of-dogs`, and its
+ *             `dog-concept-graph` uses that SAME slug for its header node — ADR Decision
+ *             2-A's dedup invariant, confirmed).
+ *   S1..S6  — source sentinels on the page/hook/index that the spec pins but that only a
+ *             browser can fully exercise (mirrors test/admin-tools-dashboard-panel.test.js).
+ *   R1..R3  — regression guards (PASS pre AND post): the shipped read-path model and the
+ *             directory query stay intact, and the server's TA-sign 403 gate (the
+ *             "non-owner TA-sign is server-refused" AC's server half) is preserved.
+ *
+ * P1..P9, S1..S6 FAIL now (tapestryDraft.mjs + useCreateTapestry.js don't exist; NewTapestry.jsx
+ * is still the inert placeholder; Index.jsx's create button isn't gated). R1..R3 PASS now and after.
+ *
+ * The full browser round-trip (owner sees form / non-owner blocked / validation blocks / submit
+ * posts the right signAs+event / success navigates) is tests/brainstorm/tapestry-create.spec.js
+ * (Playwright; BRAINSTORM_SERVER_ACCESSIBLE-gated, run in the cycle-staging smoke).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const DRAFT_MJS       = path.join(ROOT, 'ui/src/pages/tapestries/tapestryDraft.mjs');
+const NEW_TAPESTRY    = path.join(ROOT, 'ui/src/pages/tapestries/NewTapestry.jsx');
+const USE_CREATE_HOOK = path.join(ROOT, 'ui/src/pages/tapestries/useCreateTapestry.js');
+const INDEX_JSX       = path.join(ROOT, 'ui/src/pages/tapestries/Index.jsx');
+const GRAPH_MODEL     = path.join(ROOT, 'ui/src/pages/tapestries/tapestryGraphModel.js');
+const PUBLISH_EVENT   = path.join(ROOT, 'src/api/strfry/commands/publishEvent.js');
+
+// Grounded in the live graph (TA e00ed090…df36). Descriptive slugs are the real word.slug values.
+const TA = 'e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36';
+const MEMBERS = [
+  { handle: `39998:${TA}:dog`,              shortSlug: 'dog',              descriptiveSlug: 'concept-header-for-the-concept-of-dogs',              name: 'dog' },
+  { handle: `39998:${TA}:golden-retriever`, shortSlug: 'golden-retriever', descriptiveSlug: 'concept-header-for-the-concept-of-golden-retrievers', name: 'golden retriever' },
+];
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function readSafe(p) { try { return fs.readFileSync(p, 'utf8'); } catch (_e) { return null; } }
+
+// Memoized dynamic import of the pure ESM builder. A missing module is the expected
+// pre-implementation failure — reported with a message that names what to build.
+let _mod;
+async function loadDraft() {
+  if (_mod) return _mod;
+  try { _mod = await import(pathToFileURL(DRAFT_MJS).href); return _mod; }
+  catch (e) {
+    throw new Error(
+      'Cannot import ui/src/pages/tapestries/tapestryDraft.mjs — the Implementer must create this pure, ' +
+      'React-free ESM module (ADR 0003 §Implementation): export `slugifyTitle(title)` and ' +
+      '`buildTapestryDraft({title, description, members, taPubkey, dTagSuffix})`. Import error: ' + e.message
+    );
+  }
+}
+
+function tagVal(ev, name) { const t = (ev.tags || []).find((x) => x[0] === name); return t ? t[1] : undefined; }
+function jsonTag(ev) { return JSON.parse(tagVal(ev, 'json')); }
+function buildOK() { // the canonical happy-path draft used by several tests
+  return loadDraft().then(({ buildTapestryDraft }) =>
+    buildTapestryDraft({ title: 'My Dogs', description: 'good dogs', members: MEMBERS, taPubkey: TA, dTagSuffix: 'abcd1234' }));
+}
+
+// ───────────────────────── Pure builder — wire shape (AC "Publish shape") ─────────────────────────
+
+test('P1: buildTapestryDraft emits a kind-39999 element z-tagged 39998:<TA>:tapestry with content "" (AC Publish shape)', async () => {
+  const draft = await buildOK();
+  const ev = draft.unsignedEvent;
+  assert(ev && ev.kind === 39999, `unsignedEvent.kind must be 39999, got ${ev && ev.kind}. This is the tapestry element kind the directory + Exploration page read.`);
+  assert(ev.content === '', `unsignedEvent.content must be "" (the payload lives in the json tag), got ${JSON.stringify(ev.content)}.`);
+  assert(ev.sig === undefined, 'buildTapestryDraft must return an UNSIGNED template (no sig) — signing happens in the hook (own-key NIP-07) or server (TA).');
+  assert(tagVal(ev, 'z') === `39998:${TA}:tapestry`, `missing/incorrect z tag — must be "39998:${TA}:tapestry" so the directory (queryRelay #z) lists it; got ${tagVal(ev, 'z')}.`);
+});
+
+test('P2: the d tag follows tapestry-<slug>-<suffix> and the returned uuid is its a-tag coordinate (AC Publish shape / Round-trips)', async () => {
+  const draft = await buildOK();
+  const dTag = tagVal(draft.unsignedEvent, 'd');
+  assert(dTag === 'tapestry-my-dogs-abcd1234', `d tag must be "tapestry-my-dogs-abcd1234" (tapestry-<slugifyTitle>-<dTagSuffix>), got ${dTag}.`);
+  assert(draft.dTag === dTag, `returned draft.dTag (${draft.dTag}) must equal the event's d tag (${dTag}).`);
+  assert(draft.uuid === `39999:${TA}:${dTag}`, `returned uuid must be the a-tag coordinate 39999:<TA>:<dTag> (this is what the owner is navigated to), got ${draft.uuid}.`);
+});
+
+test('P3: the json tag carries tapestry {slug,title,description} (AC Compose / Publish shape)', async () => {
+  const j = jsonTag((await buildOK()).unsignedEvent);
+  assert(j && j.tapestry, 'json tag must contain a `tapestry` block.');
+  assert(j.tapestry.title === 'My Dogs', `tapestry.title must be the entered title "My Dogs", got ${JSON.stringify(j.tapestry.title)}.`);
+  assert(j.tapestry.description === 'good dogs', `tapestry.description must be the entered description, got ${JSON.stringify(j.tapestry.description)}.`);
+  assert(j.tapestry.slug === 'my-dogs', `tapestry.slug must be the slugified title "my-dogs", got ${JSON.stringify(j.tapestry.slug)}.`);
+});
+
+test('P4: the graph block has exactly one node and one import PER selected member (AC Publish shape)', async () => {
+  const g = jsonTag((await buildOK()).unsignedEvent).graph;
+  assert(g && g.graphType === 'tapestry', `graph.graphType must be "tapestry", got ${g && g.graphType}.`);
+  assert(Array.isArray(g.nodes) && g.nodes.length === MEMBERS.length, `graph.nodes must have one entry per selected concept (${MEMBERS.length}), got ${g.nodes && g.nodes.length}.`);
+  assert(Array.isArray(g.imports) && g.imports.length === MEMBERS.length, `graph.imports must have one *-concept-graph import per selected concept (${MEMBERS.length}), got ${g.imports && g.imports.length}.`);
+});
+
+test('P5: each member node uses uuid=handle and slug=descriptiveSlug so it DEDUPS with its resolved import (AC Publish shape / ADR Decision 2-A)', async () => {
+  const g = jsonTag((await buildOK()).unsignedEvent).graph;
+  for (const m of MEMBERS) {
+    const node = g.nodes.find((n) => n.uuid === m.handle);
+    assert(node, `no graph node with uuid ${m.handle} (the concept header coordinate).`);
+    assert(node.slug === m.descriptiveSlug,
+      `node for ${m.shortSlug} must use slug="${m.descriptiveSlug}" (the concept-header word.slug) — NOT the short slug. ` +
+      `composeGraph dedups by slug; matching the derived concept-graph's header-node slug is what makes each member render ` +
+      `EXACTLY ONCE on the Exploration page (ADR Decision 2-A, verified live). Got slug="${node.slug}".`);
+    assert(node.name === m.name, `node for ${m.shortSlug} must carry the display name "${m.name}", got ${JSON.stringify(node.name)}.`);
+    const imp = g.imports.find((i) => i.uuid === `39999:${TA}:${m.shortSlug}-concept-graph`);
+    assert(imp, `no import with uuid 39999:${TA}:${m.shortSlug}-concept-graph — the Exploration page resolves this to add the superset + spine.`);
+  }
+});
+
+test('P6: members-only — relationshipTypes and relationships are empty (AC / Out-of-scope: no cross-concept integrations in v1)', async () => {
+  const g = jsonTag((await buildOK()).unsignedEvent).graph;
+  assert(Array.isArray(g.relationshipTypes) && g.relationshipTypes.length === 0, `graph.relationshipTypes must be [] in members-only v1, got ${JSON.stringify(g.relationshipTypes)}.`);
+  assert(Array.isArray(g.relationships) && g.relationships.length === 0, `graph.relationships must be [] in members-only v1 (cross-concept integrations are a fast-follow), got ${JSON.stringify(g.relationships)}.`);
+});
+
+test('P7: buildTapestryDraft THROWS on an empty title (AC Validation & failure)', async () => {
+  const { buildTapestryDraft } = await loadDraft();
+  let threw = false;
+  try { buildTapestryDraft({ title: '   ', description: '', members: MEMBERS, taPubkey: TA, dTagSuffix: 'x1' }); }
+  catch (_e) { threw = true; }
+  assert(threw, 'buildTapestryDraft must throw when the title is empty/whitespace — the wire shape must be guarded independent of the UI (nothing publishable without a title).');
+});
+
+test('P8: buildTapestryDraft THROWS on zero members (AC Validation & failure)', async () => {
+  const { buildTapestryDraft } = await loadDraft();
+  let threw = false;
+  try { buildTapestryDraft({ title: 'Empty', description: '', members: [], taPubkey: TA, dTagSuffix: 'x2' }); }
+  catch (_e) { threw = true; }
+  assert(threw, 'buildTapestryDraft must throw when no concepts are selected — a tapestry with no members must never be published.');
+});
+
+test('P9: slugifyTitle lowercases, collapses non-alphanumerics to single dashes, trims (d-tag/slug contract)', async () => {
+  const { slugifyTitle } = await loadDraft();
+  assert(slugifyTitle('My Dogs') === 'my-dogs', `slugifyTitle("My Dogs") must be "my-dogs", got ${JSON.stringify(slugifyTitle('My Dogs'))}.`);
+  const messy = slugifyTitle('  My Dogs & Cats!! ');
+  assert(/^[a-z0-9]+(-[a-z0-9]+)*$/.test(messy), `slugifyTitle must yield a clean kebab slug (no leading/trailing/double dashes, lowercase), got ${JSON.stringify(messy)}.`);
+  assert(messy.includes('dogs') && messy.includes('cats'), `slug must preserve the words, got ${JSON.stringify(messy)}.`);
+});
+
+// ───────────────────────── Source sentinels — pinned by the spec, exercised by Playwright ─────────────────────────
+
+test('S1: NewTapestry.jsx is owner-gated (hasAdminAccess) and wired to the create hook (AC Owner-gated)', () => {
+  const src = readSafe(NEW_TAPESTRY);
+  assert(src !== null, 'ui/src/pages/tapestries/NewTapestry.jsx missing — re-baseline.');
+  assert(/hasAdminAccess/.test(src),
+    'NewTapestry.jsx does not reference hasAdminAccess (AC Owner-gated). The page must read useAuth() and, for a ' +
+    'non-owner/admin, render an owner-only notice instead of the form — same idiom as Layout.jsx / Dashboard.jsx ' +
+    '(hasAdminAccess from ui/src/utils/auth.js).');
+  assert(/useCreateTapestry/.test(src),
+    'NewTapestry.jsx does not use the useCreateTapestry hook (ADR 0003 §Implementation). The form must drive ' +
+    'concept loading + publish through the hook, not remain the inert placeholder.');
+});
+
+test('S2: NewTapestry.jsx offers the owner-enforced signing selector (Tapestry Assistant | my own key) (AC Signing selector)', () => {
+  const src = readSafe(NEW_TAPESTRY);
+  assert(src !== null, 'NewTapestry.jsx missing — S1 must pass first.');
+  assert(/Tapestry Assistant/.test(src) && /own key/i.test(src),
+    'NewTapestry.jsx does not present BOTH signing options ("Tapestry Assistant" and "my own key") (AC Signing selector). ' +
+    'The owner picks the author identity per-create; per the ADR the selector defaults to Tapestry Assistant.');
+  assert(/signAs/.test(src),
+    'NewTapestry.jsx does not reference `signAs` (AC Signing selector). The chosen identity must flow to the publish ' +
+    'call as signAs "assistant" | "client".');
+});
+
+test('S3: useCreateTapestry.js loads the picker from strfry concept headers and builds via the pure model (AC Compose / Publish shape)', () => {
+  const src = readSafe(USE_CREATE_HOOK);
+  assert(src !== null,
+    'ui/src/pages/tapestries/useCreateTapestry.js missing — the Implementer must create the hook (ADR 0003 §Implementation): ' +
+    'load concepts via queryRelay({kinds:[39998], authors:[taPubkey]}), and publish via buildTapestryDraft + the two signing paths.');
+  assert(/queryRelay/.test(src) && /39998/.test(src),
+    'useCreateTapestry.js does not scan kind-39998 concept headers via queryRelay (ADR Decision 1-A — strfry is the ' +
+    'canonical picker source, not Neo4j /summaries).');
+  assert(/buildTapestryDraft/.test(src),
+    'useCreateTapestry.js does not call buildTapestryDraft (ADR 0003) — the wire shape must come from the pure model, not be re-inlined.');
+});
+
+test('S4: useCreateTapestry.js implements BOTH publish paths — NIP-07 own-key and TA via /api/strfry/publish (AC Signing selector)', () => {
+  const src = readSafe(USE_CREATE_HOOK);
+  assert(src !== null, 'useCreateTapestry.js missing — S3 must pass first.');
+  assert(/signEvent|window\.nostr/.test(src),
+    'useCreateTapestry.js does not sign via NIP-07 for the own-key path (AC Signing selector — author = owner). ' +
+    'Build the unsigned event with pubkey=owner, then window.nostr.signEvent before publishing signAs:"client".');
+  assert(/\/api\/strfry\/publish/.test(src) && /assistant/.test(src),
+    'useCreateTapestry.js does not POST /api/strfry/publish with signAs:"assistant" for the TA path (AC Signing selector). ' +
+    'The server signs as the TA (and 403s non-owners).');
+});
+
+test('S5: Index.jsx gates the "+ Create New Tapestry" affordance behind hasAdminAccess (AC Owner-gated)', () => {
+  const src = readSafe(INDEX_JSX);
+  assert(src !== null, 'ui/src/pages/tapestries/Index.jsx missing — re-baseline.');
+  assert(/hasAdminAccess/.test(src),
+    'Index.jsx does not gate the create button with hasAdminAccess (AC Owner-gated). Non-owner/admin visitors must not ' +
+    'see a "+ Create New Tapestry" affordance in the directory. Wrap the button in a useAuth()+hasAdminAccess check.');
+});
+
+test('S6: NewTapestry.jsx no longer advertises the inert placeholder (AC — the page now functions)', () => {
+  const src = readSafe(NEW_TAPESTRY);
+  assert(src !== null, 'NewTapestry.jsx missing — re-baseline.');
+  assert(!/Coming soon/i.test(src) && !/aria-disabled=["']true["']/.test(src),
+    'NewTapestry.jsx still carries the placeholder markers ("Coming soon" / aria-disabled="true"). The story replaces the ' +
+    'inert preview with a working, owner-gated authoring form.');
+});
+
+// ───────────────────────── Regression guards — PASS pre AND post ─────────────────────────
+
+test('R1: the shipped Exploration read-path model is untouched (composeGraph + inferNodeType still exported)', () => {
+  const src = readSafe(GRAPH_MODEL);
+  assert(src !== null, 'tapestryGraphModel.js missing — re-baseline.');
+  assert(/export function composeGraph/.test(src) && /export function inferNodeType/.test(src),
+    'R1: ui/src/pages/tapestries/tapestryGraphModel.js no longer exports composeGraph/inferNodeType. ADR 0003 makes NO ' +
+    'change to the shipped read path — the create page produces data these already render. Do not refactor them here.');
+});
+
+test('R2: the directory query is intact (Index.jsx still reads kind-39999 elements by #z tapestry handle)', () => {
+  const src = readSafe(INDEX_JSX);
+  assert(src !== null, 'Index.jsx missing — re-baseline.');
+  assert(/39999/.test(src) && /#z/.test(src) && /:tapestry/.test(src),
+    'R2: Index.jsx no longer queries kind-39999 elements z-tagged to the tapestry concept. The owner-gate change to the ' +
+    'create button must be ADDITIVE — the directory read (queryRelay kinds:[39999], #z 39998:<TA>:tapestry) must remain.');
+});
+
+test('R3: the server still refuses TA-signing from a non-owner session (AC Signing selector — server half; pre-existing gate preserved)', () => {
+  const src = readSafe(PUBLISH_EVENT);
+  assert(src !== null, 'src/api/strfry/commands/publishEvent.js missing — re-baseline.');
+  const region = src.slice(src.indexOf("signAs === 'assistant'"), src.indexOf("signAs === 'assistant'") + 600);
+  assert(region.length > 0, 'publishEvent.js no longer branches on signAs === "assistant".');
+  assert(/isOwner\(req\)/.test(region) && /localTrusted/.test(region) && /403/.test(region),
+    'R3: publishEvent.js no longer 403-gates assistant-signing to owner/localTrusted (AC "a TA-sign request from a ' +
+    'non-owner session is refused by the server"). This gate (ADR security-auth-exposure/0002) is the server half of the ' +
+    'signing AC — the create feature must NOT weaken it.');
+});
+
+async function run() {
+  let pass = 0, fail = 0;
+  for (const t of tests) {
+    try { await t.fn(); console.log(`  ✓ ${t.name}`); pass++; }
+    catch (err) { console.log(`  ✗ ${t.name}`); console.log(`      ${err.message}`); fail++; }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,7 @@ const taskQueueNeo4jResourceClass = require('./task-queue-neo4j-resource-class.t
 const entrypointTemplateRendering = require('./entrypoint-template-rendering.test.js');
 const bullboardAdminAccess = require('./bullboard-admin-access.test.js');
 const adminToolsDashboardPanel = require('./admin-tools-dashboard-panel.test.js');
+const createTapestry = require('./create-tapestry.test.js');
 const reconciliationIncrementalMode = require('./reconciliation-incremental-mode.test.js');
 const generalizedTaskScheduler = require('./generalized-task-scheduler.test.js');
 const reconciliationRearchitecture = require('./reconciliation-rearchitecture.test.js');
@@ -268,6 +269,9 @@ async function main() {
 
   console.log('\nadmin-tools-dashboard-panel suite:');
   const adminToolsDashboardPanelResult = await adminToolsDashboardPanel.run();
+
+  console.log('\ncreate-tapestry suite:');
+  const createTapestryResult = await createTapestry.run();
 
   console.log('\nreconciliation-incremental-mode suite:');
   const reconciliationIncrementalModeResult = await reconciliationIncrementalMode.run();
@@ -628,6 +632,9 @@ async function main() {
   );
   console.log(
     `admin-tools-dashboard-panel suite:               ${adminToolsDashboardPanelResult.fail === 0 ? 'PASS' : 'FAIL'} (${adminToolsDashboardPanelResult.pass} passed, ${adminToolsDashboardPanelResult.fail} failed)`
+  );
+  console.log(
+    `create-tapestry suite:                           ${createTapestryResult.fail === 0 ? 'PASS' : 'FAIL'} (${createTapestryResult.pass} passed, ${createTapestryResult.fail} failed)`
   );
   console.log(
     `reconciliation-incremental-mode suite:           ${reconciliationIncrementalModeResult.fail === 0 ? 'PASS' : 'FAIL'} (${reconciliationIncrementalModeResult.pass} passed, ${reconciliationIncrementalModeResult.fail} failed)`
@@ -1011,7 +1018,10 @@ async function main() {
     attachTheWorldResult.fail === 0 &&
     // second-brain #5 — sessions read the brain (work records + bounded orient)
     // (LIVE chain — before the severed terminator; OPEN.md #43).
-    sessionsReadTheBrainResult.fail === 0;
+    sessionsReadTheBrainResult.fail === 0 &&
+    // tapestries #3 — create a tapestry (members-only authoring)
+    // (LIVE chain — before the severed terminator; OPEN.md #43).
+    createTapestryResult.fail === 0;
     harnessLintResult.fail === 0 &&
     harnessStatsResult.fail === 0 &&
     sessionStartResult.fail === 0 &&
@@ -1034,7 +1044,7 @@ async function main() {
     nip51ListExportPublishResult, pinDetailIntoTagTabResult, collapseIntoExportResult, loginFailureAndTagCollapseResult,
     headerConceptGraphTagResult, communityReferenceSupersetLinkResult, graperankSharedCsvRaceResult, communityClassThreadPullResult,
     taskQueueBullmqResult, taskQueueNeo4jResourceClassResult, entrypointTemplateRenderingResult, bullboardAdminAccessResult,
-    adminToolsDashboardPanelResult, reconciliationIncrementalModeResult, generalizedTaskSchedulerResult, reconciliationRearchitectureResult,
+    adminToolsDashboardPanelResult, createTapestryResult, reconciliationIncrementalModeResult, generalizedTaskSchedulerResult, reconciliationRearchitectureResult,
     scheduledTasksWithArgumentsResult, manualTaskRetriggerAfterFinishResult, scheduledTaskTimeoutPropagationResult, killTimeoutOrphansByDefaultResult,
     taskQueueSemaphoreProtectionAuditResult, profileFollowsListResult, profileWebsiteLinkResult, profileVerifiedFollowersCountResult,
     profileFollowersListResult, profileVerifiedReportersCountResult, verifiedReportersMembershipDataResult, verifiedReportersListPageResult,

--- a/tests/brainstorm/tapestry-create.spec.js
+++ b/tests/brainstorm/tapestry-create.spec.js
@@ -196,5 +196,8 @@ test.describe('Create a Tapestry (tapestries #3)', () => {
     expect(body.signAs, 'own-key path publishes a client-signed event').toBe('client');
     expect(body.event.pubkey, 'client-signed event is authored by the owner').toBe(OWNER);
     expect(body.event.sig, 'client-signed event must carry a signature').toBeTruthy();
+    // Round-trip: the redirect must land on the OWNER-keyed coordinate (39999:<OWNER>:…), not the
+    // TA's — the own-key event is authored by the owner, so a TA-keyed redirect would 404.
+    await page.waitForURL(new RegExp(`/tapestry/tapestries/39999(%3A|:)${OWNER}`), { timeout: 10000 });
   });
 });

--- a/tests/brainstorm/tapestry-create.spec.js
+++ b/tests/brainstorm/tapestry-create.spec.js
@@ -1,0 +1,200 @@
+const { test, expect } = require('@playwright/test');
+
+/**
+ * tapestries #3: Create a Tapestry (members-only authoring) — ui/src/pages/tapestries/NewTapestry.jsx
+ * at /tapestry/tapestries/new.
+ * Story: engineering-team/stories/tapestries/3-create-tapestry.md
+ * ADR:   engineering-team/decisions/tapestries/0003-create-tapestry-authoring.md
+ *
+ * Network-mocked browser round-trip (the binding wire-shape unit tests live in
+ * test/create-tapestry.test.js). Verifies:
+ *   E1 — the OWNER sees a working form (title, concept picker, signing selector, Create).   [AC Owner-gated +]
+ *   E2 — a signed-in NON-owner sees an owner-only notice, no working create form.           [AC Owner-gated −]
+ *   E3 — submit with no title / no concept is blocked; nothing is published.                [AC Validation]
+ *   E4 — a valid submit as Tapestry Assistant POSTs signAs:"assistant" + a kind-39999        [AC Publish shape +
+ *        element z-tagged 39998:<TA>:tapestry with one node/import for the picked concept.    AC Signing selector]
+ *   E5 — on success the owner is navigated to the new tapestry's /tapestry/tapestries/:uuid.  [AC Round-trips]
+ *   E6 — choosing "my own key" NIP-07-signs and POSTs signAs:"client" (author = owner).       [AC Signing selector]
+ *
+ * These FAIL against the current build: NewTapestry.jsx is still the inert placeholder.
+ * (The "non-owner TA-sign is server-refused" server half is guarded by test/create-tapestry.test.js R3.)
+ */
+
+test.describe('Create a Tapestry (tapestries #3)', () => {
+  test.beforeEach(async ({ page }) => {
+    if (process.env.BRAINSTORM_SERVER_ACCESSIBLE !== 'true') {
+      test.skip('Brainstorm server not accessible (set BRAINSTORM_SERVER_ACCESSIBLE=true)');
+    }
+  });
+
+  const TA    = 'e00ed09087b831ecf40442c82768b2114b707008916ac801dabbfbe76ae9df36';
+  const OWNER = '1111111111111111111111111111111111111111111111111111111111111111';
+  const GUEST = '2222222222222222222222222222222222222222222222222222222222222222';
+  const URL = '/tapestry/tapestries/new';
+
+  // Concept-header fixtures for the picker (kind-39998 scan), shaped like the live events:
+  // d-tag = short slug, json.word.slug = descriptive slug, json.conceptHeader.oNames.singular = name.
+  function headerEv(shortSlug, descriptiveSlug, name) {
+    return {
+      id: 'a'.repeat(64), pubkey: TA, kind: 39998, created_at: 1784821324,
+      tags: [['d', shortSlug], ['json', JSON.stringify({
+        word: { slug: descriptiveSlug, name },
+        conceptHeader: { oNames: { singular: name } },
+      })]],
+      content: '', sig: '0'.repeat(128),
+    };
+  }
+  const CONCEPTS = [
+    headerEv('dog', 'concept-header-for-the-concept-of-dogs', 'dog'),
+    headerEv('golden-retriever', 'concept-header-for-the-concept-of-golden-retrievers', 'golden retriever'),
+  ];
+
+  /**
+   * Install the common route mocks. `classification` drives the owner gate;
+   * captured publish bodies are pushed into `published`.
+   */
+  async function mock(page, { classification = 'owner', published = [] } = {}) {
+    const pubkey = classification === 'owner' || classification === 'admin' ? OWNER
+      : classification === 'unauthenticated' ? null : GUEST;
+
+    // Config plumbing (ConfigContext fetches these; unmocked ones would hang the load).
+    await page.route('**/api/assistant/pubkey', (r) => r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, pubkey: TA }) }));
+    await page.route('**/api/owner/pubkey', (r) => r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, pubkey: OWNER }) }));
+    await page.route('**/api/relays', (r) => r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, relays: [] }) }));
+    await page.route('**/api/status', (r) => r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true }) }));
+
+    // Auth: status → (maybe) classification → profile.
+    await page.route('**/api/auth/status', (r) => r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ authenticated: !!pubkey, pubkey }) }));
+    await page.route('**/api/auth/user-classification', (r) => r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ classification, pubkey, assistantPubkey: TA }) }));
+    await page.route('**/api/profiles**', (r) => r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, profiles: {} }) }));
+
+    // Concept picker: kind-39998 scan → concept headers. Other scans → empty.
+    await page.route('**/api/strfry/scan**', (r) => {
+      const raw = r.request().url();
+      const is39998 = /%2239998%22|kinds%22%3A%5B39998|39998/.test(raw);
+      r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, events: is39998 ? CONCEPTS : [] }) });
+    });
+
+    // Publish sink — capture the body, echo a signed-looking event back.
+    await page.route('**/api/strfry/publish', (r) => {
+      const body = r.request().postDataJSON();
+      published.push(body);
+      const ev = { ...(body.event || {}), id: 'e'.repeat(64), sig: '0'.repeat(128), pubkey: body.signAs === 'assistant' ? TA : (body.event && body.event.pubkey) || OWNER };
+      r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, event: ev }) });
+    });
+  }
+
+  /** Inject a NIP-07 signer (window.nostr) for the own-key path. */
+  async function injectSigner(page, pubkey) {
+    await page.addInitScript((pk) => {
+      window.nostr = {
+        getPublicKey: async () => pk,
+        getRelays: async () => ({}),
+        signEvent: async (ev) => ({ ...ev, pubkey: pk, id: 'f'.repeat(64), sig: '0'.repeat(128) }),
+      };
+    }, pubkey);
+  }
+
+  async function pickConcept(page, name) {
+    // Tolerate checkbox/label/button/option affordances for selecting a concept.
+    const opt = page.getByRole('checkbox', { name }).or(page.getByRole('option', { name })).or(page.getByText(name, { exact: false })).first();
+    await opt.click();
+  }
+
+  /* ───────── E1 — owner sees the working form ───────── */
+  test('E1: the owner sees a working create form (title, concept picker, signing selector, Create)', async ({ page }) => {
+    await mock(page, { classification: 'owner' });
+    await page.goto(URL);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByLabel(/title/i).or(page.getByPlaceholder(/tapestry for dog/i)).first()).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/dog/i).first()).toBeVisible();               // picker populated from the scan
+    await expect(page.getByText(/Tapestry Assistant/i).first()).toBeVisible(); // signing selector
+    await expect(page.getByText(/own key/i).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /create tapestry/i })).toBeVisible();
+  });
+
+  /* ───────── E2 — non-owner is blocked ───────── */
+  test('E2: a signed-in non-owner sees an owner-only notice and no working form', async ({ page }) => {
+    await mock(page, { classification: 'guest' });
+    await page.goto(URL);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText(/owner/i).first()).toBeVisible({ timeout: 10000 });
+    // The editable title control must not be present for a non-owner.
+    await expect(page.getByLabel(/title/i)).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /create tapestry/i })).toHaveCount(0);
+  });
+
+  /* ───────── E3 — validation blocks; nothing published ───────── */
+  test('E3: submitting with no title / no concept is blocked and publishes nothing', async ({ page }) => {
+    const published = [];
+    await mock(page, { classification: 'owner', published });
+    await page.goto(URL);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: /create tapestry/i }).click().catch(() => {});
+    await page.waitForTimeout(500);
+    expect(published, 'no publish should fire when the form is invalid (no title, no concept)').toHaveLength(0);
+    await expect(page.getByText(/required|enter a title|select .* concept/i).first()).toBeVisible();
+  });
+
+  /* ───────── E4 — TA publish shape ───────── */
+  test('E4: a valid submit as Tapestry Assistant POSTs signAs:"assistant" + a well-formed kind-39999 element', async ({ page }) => {
+    const published = [];
+    await mock(page, { classification: 'owner', published });
+    await page.goto(URL);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByLabel(/title/i).or(page.getByPlaceholder(/tapestry for dog/i)).first().fill('My Dogs');
+    await pickConcept(page, 'dog');
+    await page.getByRole('button', { name: /create tapestry/i }).click();
+
+    await expect.poll(() => published.length, { timeout: 10000 }).toBeGreaterThan(0);
+    const body = published[0];
+    expect(body.signAs, 'default signing identity is the Tapestry Assistant').toBe('assistant');
+    expect(body.event.kind).toBe(39999);
+    const zTag = body.event.tags.find((t) => t[0] === 'z');
+    expect(zTag && zTag[1]).toBe(`39998:${TA}:tapestry`);
+    const jsonTag = JSON.parse(body.event.tags.find((t) => t[0] === 'json')[1]);
+    expect(jsonTag.tapestry.title).toBe('My Dogs');
+    expect(jsonTag.graph.nodes.length).toBe(1);
+    expect(jsonTag.graph.imports.length).toBe(1);
+    expect(jsonTag.graph.nodes[0].uuid).toBe(`39998:${TA}:dog`);
+  });
+
+  /* ───────── E5 — round-trip navigation ───────── */
+  test('E5: on success the owner is navigated to the new tapestry page', async ({ page }) => {
+    await mock(page, { classification: 'owner' });
+    await page.goto(URL);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByLabel(/title/i).or(page.getByPlaceholder(/tapestry for dog/i)).first().fill('My Dogs');
+    await pickConcept(page, 'dog');
+    await page.getByRole('button', { name: /create tapestry/i }).click();
+
+    // Lands on /tapestry/tapestries/<encoded 39999:TA:tapestry-...>
+    await page.waitForURL(new RegExp(`/tapestry/tapestries/39999(%3A|:)${TA}`), { timeout: 10000 });
+    expect(page.url()).toContain('tapestry-my-dogs');
+  });
+
+  /* ───────── E6 — own-key signing path ───────── */
+  test('E6: choosing "my own key" NIP-07-signs and POSTs signAs:"client" (author = owner)', async ({ page }) => {
+    const published = [];
+    await mock(page, { classification: 'owner', published });
+    await injectSigner(page, OWNER);
+    await page.goto(URL);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByLabel(/title/i).or(page.getByPlaceholder(/tapestry for dog/i)).first().fill('My Dogs');
+    await pickConcept(page, 'dog');
+    await page.getByText(/own key/i).first().click(); // switch signing identity
+    await page.getByRole('button', { name: /create tapestry/i }).click();
+
+    await expect.poll(() => published.length, { timeout: 10000 }).toBeGreaterThan(0);
+    const body = published[0];
+    expect(body.signAs, 'own-key path publishes a client-signed event').toBe('client');
+    expect(body.event.pubkey, 'client-signed event is authored by the owner').toBe(OWNER);
+    expect(body.event.sig, 'client-signed event must carry a signature').toBeTruthy();
+  });
+});

--- a/ui/src/pages/tapestries/Index.jsx
+++ b/ui/src/pages/tapestries/Index.jsx
@@ -5,6 +5,8 @@ import Breadcrumbs from '../../components/Breadcrumbs';
 import AuthorCell from '../../components/AuthorCell';
 import useProfiles from '../../hooks/useProfiles';
 import { useConfig } from '../../context/ConfigContext';
+import { useAuth } from '../../context/AuthContext';
+import { hasAdminAccess } from '../../utils/auth';
 import { queryRelay } from '../../api/relay';
 
 // A tapestry is an element of the `tapestry` concept: a kind-39999 addressable
@@ -36,6 +38,8 @@ function toRow(ev) {
 export default function TapestriesIndex() {
   const navigate = useNavigate();
   const { taPubkey } = useConfig();
+  const { user } = useAuth();
+  const isOwner = hasAdminAccess(user); // creating a tapestry is owner-only (tapestries #3)
   const [rows, setRows] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -87,9 +91,11 @@ export default function TapestriesIndex() {
       <Breadcrumbs />
       <div className="page-header-row">
         <h1>🧵 View Tapestries</h1>
-        <button className="btn btn-primary" onClick={() => navigate('/tapestry/tapestries/new')}>
-          + Create New Tapestry
-        </button>
+        {isOwner && (
+          <button className="btn btn-primary" onClick={() => navigate('/tapestry/tapestries/new')}>
+            + Create New Tapestry
+          </button>
+        )}
       </div>
 
       {loading && <p>Loading tapestries…</p>}

--- a/ui/src/pages/tapestries/NewTapestry.jsx
+++ b/ui/src/pages/tapestries/NewTapestry.jsx
@@ -51,6 +51,7 @@ export default function NewTapestry() {
 
   async function onSubmit(e) {
     e.preventDefault();
+    if (submitting) return; // re-entry guard — defense beyond the disabled button
     setValidation(null);
     setError(null);
     if (!title.trim()) { setValidation('Please enter a title.'); return; }

--- a/ui/src/pages/tapestries/NewTapestry.jsx
+++ b/ui/src/pages/tapestries/NewTapestry.jsx
@@ -1,35 +1,164 @@
+import { useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Breadcrumbs from '../../components/Breadcrumbs';
+import { useAuth } from '../../context/AuthContext';
+import { hasAdminAccess } from '../../utils/auth';
+import useCreateTapestry from './useCreateTapestry';
 
 /**
- * Placeholder for tapestry authoring. Inert by design: it previews the planned
- * fields (title / description / member concepts) but has no working submit.
- * Creating a tapestry is a future story (tapestries epic).
+ * Create a Tapestry (members-only authoring) — tapestries #3 / ADR tapestries/0003.
+ * Owner-gated. The owner titles the tapestry, picks existing member concepts, chooses a
+ * signing identity (Tapestry Assistant | their own key), and publishes a real, explorable
+ * kind-39999 element. Cross-concept integration authoring is a deferred fast-follow.
  */
 export default function NewTapestry() {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const isOwner = hasAdminAccess(user);
+  const { concepts, conceptsLoading, conceptsError, create } = useCreateTapestry();
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [selected, setSelected] = useState([]);          // selected concept handles
+  const [filter, setFilter] = useState('');
+  const [signAs, setSignAs] = useState('assistant');     // default: Tapestry Assistant (ADR)
+  const [submitting, setSubmitting] = useState(false);
+  const [validation, setValidation] = useState(null);
+  const [error, setError] = useState(null);
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return concepts;
+    return concepts.filter((c) => c.name.toLowerCase().includes(q) || c.shortSlug.includes(q));
+  }, [concepts, filter]);
+
+  // Owner gate: non-owner/admin visitors get an explanation, never a working form.
+  if (!isOwner) {
+    return (
+      <div className="page">
+        <Breadcrumbs />
+        <h1>🧵 Create New Tapestry</h1>
+        <p className="placeholder">
+          Creating a Tapestry is owner-only. Sign in as the instance owner to author one.
+        </p>
+      </div>
+    );
+  }
+
+  function toggle(handle) {
+    setSelected((prev) => (prev.includes(handle) ? prev.filter((h) => h !== handle) : [...prev, handle]));
+  }
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    setValidation(null);
+    setError(null);
+    if (!title.trim()) { setValidation('Please enter a title.'); return; }
+    if (selected.length === 0) { setValidation('Please select at least one member concept.'); return; }
+
+    setSubmitting(true);
+    try {
+      const { uuid } = await create({ title, description, selectedHandles: selected, signAs });
+      navigate(`/tapestry/tapestries/${encodeURIComponent(uuid)}`);
+    } catch (err) {
+      setError(err.message || 'Failed to create the tapestry.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   return (
     <div className="page">
       <Breadcrumbs />
       <h1>🧵 Create New Tapestry</h1>
-      <p className="placeholder">
-        Coming soon — authoring a tapestry isn&apos;t available yet. Below is a preview of the
-        planned form.
-      </p>
+      <p className="subtitle">Group existing concepts into a curated, explorable Tapestry.</p>
 
-      <form className="tapestry-new-preview" onSubmit={(e) => e.preventDefault()} aria-disabled="true">
+      <form className="tapestry-new-form" onSubmit={onSubmit}>
         <label className="form-field">
           <span>Title</span>
-          <input type="text" placeholder="e.g. Tapestry for Dog" disabled />
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="e.g. Tapestry for Dog"
+          />
         </label>
+
         <label className="form-field">
           <span>Description</span>
-          <textarea placeholder="What this tapestry groups together…" disabled />
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="What this tapestry groups together…"
+          />
         </label>
-        <label className="form-field">
+
+        <div className="form-field">
           <span>Member concepts</span>
-          <input type="text" placeholder="Concepts to include (e.g. dog, dog breed)…" disabled />
-        </label>
-        <button type="submit" className="btn btn-primary" disabled>
-          Create Tapestry
+          {conceptsLoading && <p className="placeholder">Loading concepts…</p>}
+          {conceptsError && <p className="error">Could not load concepts: {conceptsError}</p>}
+          {!conceptsLoading && !conceptsError && concepts.length === 0 && (
+            <p className="placeholder">No concepts found on this instance.</p>
+          )}
+          {!conceptsLoading && !conceptsError && concepts.length > 0 && (
+            <>
+              <input
+                type="text"
+                className="tapestry-concept-filter"
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                placeholder="Filter concepts…"
+                aria-label="Filter concepts"
+              />
+              <div className="tapestry-concept-picker" role="group" aria-label="Member concepts">
+                {filtered.map((c) => (
+                  <label key={c.handle} className="tapestry-concept-option">
+                    <input
+                      type="checkbox"
+                      checked={selected.includes(c.handle)}
+                      onChange={() => toggle(c.handle)}
+                    />
+                    <span>{c.name}</span>
+                  </label>
+                ))}
+                {filtered.length === 0 && (
+                  <p className="placeholder" style={{ margin: '0.25rem' }}>No concepts match “{filter}”.</p>
+                )}
+              </div>
+              <p className="tapestry-selected-count">{selected.length} selected</p>
+            </>
+          )}
+        </div>
+
+        <fieldset className="form-field tapestry-signing">
+          <legend>Sign as</legend>
+          <label className="tapestry-radio">
+            <input
+              type="radio"
+              name="signAs"
+              value="assistant"
+              checked={signAs === 'assistant'}
+              onChange={() => setSignAs('assistant')}
+            />
+            <span>Tapestry Assistant</span>
+          </label>
+          <label className="tapestry-radio">
+            <input
+              type="radio"
+              name="signAs"
+              value="client"
+              checked={signAs === 'client'}
+              onChange={() => setSignAs('client')}
+            />
+            <span>My own key</span>
+          </label>
+        </fieldset>
+
+        {validation && <p className="error tapestry-validation">{validation}</p>}
+        {error && <p className="error">{error}</p>}
+
+        <button type="submit" className="btn btn-primary" disabled={submitting}>
+          {submitting ? 'Creating…' : 'Create Tapestry'}
         </button>
       </form>
     </div>

--- a/ui/src/pages/tapestries/tapestryDraft.mjs
+++ b/ui/src/pages/tapestries/tapestryDraft.mjs
@@ -1,0 +1,73 @@
+/**
+ * Pure, React-free builder for a "Create a Tapestry" draft (members-only v1).
+ * See ADR tapestries/0003. No React/DOM imports so it is unit-testable in the
+ * stack-free Node runner via dynamic import().
+ */
+
+/** kebab-case slug: lowercase, runs of non-alphanumerics → a single dash, trimmed. */
+export function slugifyTitle(title) {
+  return String(title || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Build an unsigned kind-39999 tapestry element from a title + description + members.
+ *
+ * @param {object} args
+ * @param {string} args.title                 required; a whitespace-only title throws.
+ * @param {string} [args.description='']
+ * @param {Array<{handle,shortSlug,descriptiveSlug,name}>} args.members  ≥1 required; empty throws.
+ *        handle          = the concept-header coordinate `39998:<TA>:<shortSlug>`.
+ *        descriptiveSlug = the concept-header `word.slug` — used as the node slug so it dedups
+ *                          with the resolved `*-concept-graph` import at read time (ADR Decision 2-A).
+ * @param {string} args.taPubkey              runtime-resolved TA pubkey (never hardcode).
+ * @param {string} args.dTagSuffix            short unique suffix for the parameterized-replaceable d-tag.
+ * @returns {{dTag, uuid, tapestry, graph, unsignedEvent}}
+ */
+export function buildTapestryDraft({ title, description = '', members, taPubkey, dTagSuffix }) {
+  const cleanTitle = String(title || '').trim();
+  if (!cleanTitle) throw new Error('A tapestry needs a title.');
+  if (!Array.isArray(members) || members.length === 0) {
+    throw new Error('A tapestry needs at least one member concept.');
+  }
+  if (!taPubkey) throw new Error('A tapestry needs the instance TA pubkey.');
+
+  const slug = slugifyTitle(cleanTitle);
+  const dTag = `tapestry-${slug}-${dTagSuffix || ''}`;
+  const uuid = `39999:${taPubkey}:${dTag}`;
+
+  const tapestry = { slug, title: cleanTitle, description: String(description || '') };
+
+  const graph = {
+    graphType: 'tapestry',
+    // Node slug = the concept-header's descriptive word.slug (NOT the short slug): this is the
+    // slug its derived *-concept-graph uses for the same header node, so composeGraph dedups
+    // them and each member renders exactly once on the Exploration page (ADR Decision 2-A).
+    nodes: members.map((m) => ({ slug: m.descriptiveSlug, uuid: m.handle, name: m.name })),
+    // Members-only v1: no cross-concept integrations are authored — those surface via import
+    // resolution, and explicit authoring is a fast-follow.
+    relationshipTypes: [],
+    relationships: [],
+    imports: members.map((m) => ({
+      slug: `concept-graph-for-${m.shortSlug}`,
+      uuid: `39999:${taPubkey}:${m.shortSlug}-concept-graph`,
+    })),
+  };
+
+  const unsignedEvent = {
+    kind: 39999,
+    created_at: Math.floor(Date.now() / 1000),
+    content: '',
+    tags: [
+      ['d', dTag],
+      ['name', cleanTitle],
+      // The z-tag to the tapestry concept handle is what the directory reads (queryRelay #z).
+      ['z', `39998:${taPubkey}:tapestry`],
+      ['json', JSON.stringify({ tapestry, graph })],
+    ],
+  };
+
+  return { dTag, uuid, tapestry, graph, unsignedEvent };
+}

--- a/ui/src/pages/tapestries/tapestryDraft.mjs
+++ b/ui/src/pages/tapestries/tapestryDraft.mjs
@@ -18,15 +18,19 @@ export function slugifyTitle(title) {
  * @param {object} args
  * @param {string} args.title                 required; a whitespace-only title throws.
  * @param {string} [args.description='']
- * @param {Array<{handle,shortSlug,descriptiveSlug,name}>} args.members  ≥1 required; empty throws.
- *        handle          = the concept-header coordinate `39998:<TA>:<shortSlug>`.
+ * @param {Array<{handle,shortSlug,conceptGraphSlug,descriptiveSlug,name}>} args.members  ≥1 required; empty throws.
+ *        handle          = the concept-header coordinate `39998:<TA>:<shortSlug>` (short slug = its d-tag).
+ *        conceptGraphSlug= the header's `oSlugs.singular` — the name its derived `*-concept-graph` uses
+ *                          (diverges from the d-tag for some concepts, e.g. nostr-event-tag).
  *        descriptiveSlug = the concept-header `word.slug` — used as the node slug so it dedups
  *                          with the resolved `*-concept-graph` import at read time (ADR Decision 2-A).
  * @param {string} args.taPubkey              runtime-resolved TA pubkey (never hardcode).
+ * @param {string} [args.authorPubkey=taPubkey] who SIGNS the element — the owner's key for own-key
+ *        publishing, the TA for assistant publishing. Namespaces the tapestry's own coordinate (uuid).
  * @param {string} args.dTagSuffix            short unique suffix for the parameterized-replaceable d-tag.
  * @returns {{dTag, uuid, tapestry, graph, unsignedEvent}}
  */
-export function buildTapestryDraft({ title, description = '', members, taPubkey, dTagSuffix }) {
+export function buildTapestryDraft({ title, description = '', members, taPubkey, authorPubkey = taPubkey, dTagSuffix }) {
   const cleanTitle = String(title || '').trim();
   if (!cleanTitle) throw new Error('A tapestry needs a title.');
   if (!Array.isArray(members) || members.length === 0) {
@@ -36,7 +40,10 @@ export function buildTapestryDraft({ title, description = '', members, taPubkey,
 
   const slug = slugifyTitle(cleanTitle);
   const dTag = `tapestry-${slug}-${dTagSuffix || ''}`;
-  const uuid = `39999:${taPubkey}:${dTag}`;
+  // The tapestry's own coordinate is namespaced to whoever SIGNS it (owner key for own-key
+  // publishing, the TA for assistant publishing) — the directory + Exploration page resolve it by
+  // author. The z-tag below stays TA-namespaced (it is the concept handle, always TA).
+  const uuid = `39999:${authorPubkey}:${dTag}`;
 
   const tapestry = { slug, title: cleanTitle, description: String(description || '') };
 
@@ -50,10 +57,12 @@ export function buildTapestryDraft({ title, description = '', members, taPubkey,
     // resolution, and explicit authoring is a fast-follow.
     relationshipTypes: [],
     relationships: [],
-    imports: members.map((m) => ({
-      slug: `concept-graph-for-${m.shortSlug}`,
-      uuid: `39999:${taPubkey}:${m.shortSlug}-concept-graph`,
-    })),
+    imports: members.map((m) => {
+      // Concept-graphs are named from the header's oSlugs.singular, which diverges from the
+      // header d-tag for some concepts (e.g. nostr-event-tag → nostr-event-tagging-concept-graph).
+      const cg = m.conceptGraphSlug || m.shortSlug;
+      return { slug: `concept-graph-for-${cg}`, uuid: `39999:${taPubkey}:${cg}-concept-graph` };
+    }),
   };
 
   const unsignedEvent = {

--- a/ui/src/pages/tapestries/useCreateTapestry.js
+++ b/ui/src/pages/tapestries/useCreateTapestry.js
@@ -26,8 +26,11 @@ function toConcept(ev) {
     if (raw) { const j = JSON.parse(raw); word = j.word || {}; conceptHeader = j.conceptHeader || {}; }
   } catch { /* malformed json → fall back to the d-tag below */ }
   return {
-    handle: `39998:${ev.pubkey}:${dTag}`,        // the concept-header coordinate
-    shortSlug: dTag,                              // the d-tag = short slug (→ *-concept-graph import)
+    handle: `39998:${ev.pubkey}:${dTag}`,        // the concept-header coordinate (d-tag = short slug)
+    shortSlug: dTag,
+    // oSlugs.singular is what the derived *-concept-graph is named after (diverges from the d-tag
+    // for some concepts, e.g. nostr-event-tag) — used to build a resolvable import uuid.
+    conceptGraphSlug: conceptHeader.oSlugs?.singular || dTag,
     descriptiveSlug: word.slug || `concept-header-for-${dTag}`, // word.slug → clean dedup at read time
     name: conceptHeader.oNames?.singular || word.name || dTag,  // friendly display name
   };
@@ -74,26 +77,29 @@ export default function useCreateTapestry() {
     const members = (selectedHandles || [])
       .map((h) => concepts.find((c) => c.handle === h))
       .filter(Boolean);
-    const draft = buildTapestryDraft({ title, description, members, taPubkey, dTagSuffix: randomSuffix() });
 
     if (signAs === 'client') {
-      // Own-key path: NIP-07 sign under the owner's key, then publish (local + external).
+      // Own-key path: resolve the signer FIRST so the tapestry's coordinate (uuid) is keyed to the
+      // owner's own key — the event is published under that key, so the redirect must match it.
       const authorPk = await getActiveSignerOrThrow(user?.pubkey || undefined);
+      const draft = buildTapestryDraft({ title, description, members, taPubkey, authorPubkey: authorPk, dTagSuffix: randomSuffix() });
       const signed = await window.nostr.signEvent({ ...draft.unsignedEvent, pubkey: authorPk });
-      await publishOrThrow(signed);
-    } else {
-      // Tapestry Assistant path: the server signs as the TA and publishes (owner-gated → 403 otherwise).
-      const resp = await fetch('/api/strfry/publish', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ event: draft.unsignedEvent, signAs: 'assistant' }),
-      });
-      const data = await resp.json().catch(() => null);
-      if (!resp.ok || !data?.success) {
-        throw new Error(data?.error || `Publish failed: status ${resp.status}`);
-      }
+      await publishOrThrow(signed); // local + external
+      return { uuid: draft.uuid };
     }
 
+    // Tapestry Assistant path: the server signs as the TA (author == taPubkey) and publishes
+    // (owner-gated → 403 otherwise). authorPubkey defaults to taPubkey.
+    const draft = buildTapestryDraft({ title, description, members, taPubkey, dTagSuffix: randomSuffix() });
+    const resp = await fetch('/api/strfry/publish', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event: draft.unsignedEvent, signAs: 'assistant' }),
+    });
+    const data = await resp.json().catch(() => null);
+    if (!resp.ok || !data?.success) {
+      throw new Error(data?.error || `Publish failed: status ${resp.status}`);
+    }
     return { uuid: draft.uuid };
   }, [concepts, taPubkey, user?.pubkey]);
 

--- a/ui/src/pages/tapestries/useCreateTapestry.js
+++ b/ui/src/pages/tapestries/useCreateTapestry.js
@@ -1,0 +1,101 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useConfig } from '../../context/ConfigContext';
+import { useAuth } from '../../context/AuthContext';
+import { queryRelay } from '../../api/relay';
+import { publishOrThrow } from '../../utils/publishProfileTag';
+import { getActiveSignerOrThrow } from '../../utils/signerGuard';
+import { buildTapestryDraft } from './tapestryDraft.mjs';
+
+/**
+ * Authoring hook for "Create a Tapestry" (members-only v1). See ADR tapestries/0003.
+ *
+ * - Loads the concept picker from strfry concept headers (the canonical source per ADR
+ *   tapestries/0002 — not Neo4j /summaries).
+ * - create() builds the wire shape via the pure tapestryDraft model and publishes it either
+ *   under the owner's own key (NIP-07 → signAs "client") or as the Tapestry Assistant
+ *   (server-signed → signAs "assistant", owner-gated by the server).
+ */
+
+/** Parse a kind-39998 concept-header event into a picker option (or null to skip). */
+function toConcept(ev) {
+  const dTag = ev.tags?.find((t) => t[0] === 'd')?.[1];
+  if (!dTag) return null; // an addressable event with no d-tag has no stable identity
+  let word = {}, conceptHeader = {};
+  try {
+    const raw = ev.tags?.find((t) => t[0] === 'json')?.[1];
+    if (raw) { const j = JSON.parse(raw); word = j.word || {}; conceptHeader = j.conceptHeader || {}; }
+  } catch { /* malformed json → fall back to the d-tag below */ }
+  return {
+    handle: `39998:${ev.pubkey}:${dTag}`,        // the concept-header coordinate
+    shortSlug: dTag,                              // the d-tag = short slug (→ *-concept-graph import)
+    descriptiveSlug: word.slug || `concept-header-for-${dTag}`, // word.slug → clean dedup at read time
+    name: conceptHeader.oNames?.singular || word.name || dTag,  // friendly display name
+  };
+}
+
+/** Short random hex for the parameterized-replaceable d-tag suffix. */
+function randomSuffix() {
+  const bytes = new Uint8Array(4);
+  (window.crypto || crypto).getRandomValues(bytes);
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export default function useCreateTapestry() {
+  const { taPubkey } = useConfig();
+  const { user } = useAuth();
+  const [concepts, setConcepts] = useState([]);
+  const [conceptsLoading, setConceptsLoading] = useState(true);
+  const [conceptsError, setConceptsError] = useState(null);
+
+  useEffect(() => {
+    if (!taPubkey) return; // wait for the runtime-resolved TA pubkey (never hardcode)
+    let cancelled = false;
+
+    (async () => {
+      try {
+        setConceptsLoading(true);
+        setConceptsError(null);
+        const events = await queryRelay({ kinds: [39998], authors: [taPubkey] });
+        if (cancelled) return;
+        const list = (events || []).map(toConcept).filter(Boolean)
+          .sort((a, b) => a.name.localeCompare(b.name));
+        setConcepts(list);
+      } catch (err) {
+        if (!cancelled) setConceptsError(err.message);
+      } finally {
+        if (!cancelled) setConceptsLoading(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [taPubkey]);
+
+  const create = useCallback(async ({ title, description, selectedHandles, signAs }) => {
+    const members = (selectedHandles || [])
+      .map((h) => concepts.find((c) => c.handle === h))
+      .filter(Boolean);
+    const draft = buildTapestryDraft({ title, description, members, taPubkey, dTagSuffix: randomSuffix() });
+
+    if (signAs === 'client') {
+      // Own-key path: NIP-07 sign under the owner's key, then publish (local + external).
+      const authorPk = await getActiveSignerOrThrow(user?.pubkey || undefined);
+      const signed = await window.nostr.signEvent({ ...draft.unsignedEvent, pubkey: authorPk });
+      await publishOrThrow(signed);
+    } else {
+      // Tapestry Assistant path: the server signs as the TA and publishes (owner-gated → 403 otherwise).
+      const resp = await fetch('/api/strfry/publish', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ event: draft.unsignedEvent, signAs: 'assistant' }),
+      });
+      const data = await resp.json().catch(() => null);
+      if (!resp.ok || !data?.success) {
+        throw new Error(data?.error || `Publish failed: status ${resp.status}`);
+      }
+    }
+
+    return { uuid: draft.uuid };
+  }, [concepts, taPubkey, user?.pubkey]);
+
+  return { concepts, conceptsLoading, conceptsError, create };
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -8231,3 +8231,31 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
 .brain-record-produced { margin-top: 4px; }
 .brain-record-questions { list-style: none; margin: 4px 0 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
 .brain-record-question { font-size: 0.85rem; color: var(--text-muted); }
+
+/* Create-a-Tapestry authoring form (tapestries #3). Token-driven; no new tokens. */
+.tapestry-new-form { max-width: 640px; }
+.tapestry-concept-filter { margin-bottom: 0.5rem; }
+.tapestry-concept-picker {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  max-height: 260px;
+  overflow-y: auto;
+  padding: 0.25rem;
+}
+.tapestry-concept-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.4rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.tapestry-concept-option:hover { background: var(--bg-tertiary); }
+.tapestry-concept-option input { margin: 0; }
+.tapestry-selected-count { color: var(--text-muted); font-size: 0.85rem; margin: 0.4rem 0 0; }
+.tapestry-signing { border: 1px solid var(--border); border-radius: 6px; padding: 0.6rem 0.9rem; }
+.tapestry-signing legend { padding: 0 0.4rem; color: var(--text-muted); font-size: 0.85rem; }
+.tapestry-radio { display: flex; align-items: center; gap: 0.5rem; padding: 0.2rem 0; cursor: pointer; }
+.tapestry-radio input { margin: 0; }
+.tapestry-validation { margin-top: 0.5rem; }


### PR DESCRIPTION
## Summary

Turns the inert `/tapestry/tapestries/new` placeholder into a working, **owner-gated** authoring page (tapestries epic, story #3). The owner titles a tapestry, picks existing member concepts by name, chooses a signing identity (**Tapestry Assistant** default, or **their own key**), and publishes a real kind-39999 element that appears in the directory and renders on the Exploration page. Deliberately **members-only** — cross-concept integration authoring is a deferred fast-follow. Full harness cycle (story → ADR 0003 → tests → impl → review); a blocking own-key-redirect bug was caught in review, fixed, and independently re-verified before PASS.

## Changes

- **NEW** `ui/src/pages/tapestries/tapestryDraft.mjs` — pure kind-39999 wire-shape builder (nodes use the concept-header `word.slug` for clean read-time dedup; `*-concept-graph` imports built from `oSlugs.singular`; uuid namespaced to the signer; z-tag + imports stay TA-namespaced).
- **NEW** `ui/src/pages/tapestries/useCreateTapestry.js` — strfry kind-39998 concept picker + both publish paths (own-key NIP-07 → `signAs:client`; TA → `/api/strfry/publish signAs:assistant`).
- **REWRITE** `ui/src/pages/tapestries/NewTapestry.jsx` — owner-gated form (title/description/searchable concept multi-select/signing selector), validation, success navigation.
- **EDIT** `ui/src/pages/tapestries/Index.jsx` — "+ Create New Tapestry" gated behind `hasAdminAccess`.
- `ui/src/styles.css` — token-driven styles for the form.
- Tests: `test/create-tapestry.test.js` (21 tests: pure builder + source sentinels + regression guards, registered in the live `overallOk` chain) and Playwright `tests/brainstorm/tapestry-create.spec.js`.
- Engineering-team artifacts: story, ADR 0003, test plan, review (CHANGES_REQUESTED → PASS).

## Test plan

- [ ] After merge: `deploy-staging.yml` runs; stack-free CI `npm test` passes (create-tapestry suite 21/21).
- [ ] Smoke on staging.brainstorm.world: `/tapestry/tapestries` loads.
- [ ] `/tapestry/tapestries/new` shows the **owner-only notice** when unauthenticated (owner-gated); no console errors.
- [ ] Read-path (`tapestryGraphModel.js` / `useTapestryGraph.js`) and directory query unchanged — existing tapestry still explores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)