### PR TITLE
ui(tapestries): compact 'Sign as' dropdown on Create Tapestry

### DIFF
--- a/engineering-team/stories/tapestries/3-create-tapestry.md
+++ b/engineering-team/stories/tapestries/3-create-tapestry.md
@@ -93,6 +93,10 @@ Logged per `roles/implementer.md` §9. Review-fix cycle (review verdict CHANGES_
   `nostr-event-tagging-concept-graph`, verified live). The picker now captures `conceptGraphSlug =
   oSlugs.singular` and the import uuid is built from it.
 - **[non-blocking fix]** Added an `if (submitting) return;` re-entry guard to `NewTapestry.onSubmit`.
+- **[post-staging UX polish, operator request]** The "Sign as" signing selector was changed from a
+  full-width `<fieldset>` with two stacked radios to a compact `<select>` dropdown (same two `signAs`
+  values, zero behavior change — presentation only). Treated as a trivial mechanical edit; suite stays
+  21/21 (S2 unaffected), Playwright E1/E6 updated for the `<select>` (combobox + `selectOption`).
 - **[judgment call]** The Implementer authored the regression tests for these fixes in the fix cycle
   (unit P10 = uuid-per-signer, P11 = import-from-`conceptGraphSlug`, source S7; updated the P5 fixture;
   strengthened Playwright E6 to assert own-key navigation) rather than round-tripping to the Tester —

--- a/tests/brainstorm/tapestry-create.spec.js
+++ b/tests/brainstorm/tapestry-create.spec.js
@@ -109,8 +109,10 @@ test.describe('Create a Tapestry (tapestries #3)', () => {
 
     await expect(page.getByLabel(/title/i).or(page.getByPlaceholder(/tapestry for dog/i)).first()).toBeVisible({ timeout: 10000 });
     await expect(page.getByText(/dog/i).first()).toBeVisible();               // picker populated from the scan
-    await expect(page.getByText(/Tapestry Assistant/i).first()).toBeVisible(); // signing selector
-    await expect(page.getByText(/own key/i).first()).toBeVisible();
+    const signAs = page.getByRole('combobox'); // the "Sign as" dropdown (the only select on the page)
+    await expect(signAs).toBeVisible();
+    await expect(signAs.locator('option', { hasText: /Tapestry Assistant/i })).toHaveCount(1);
+    await expect(signAs.locator('option', { hasText: /own key/i })).toHaveCount(1);
     await expect(page.getByRole('button', { name: /create tapestry/i })).toBeVisible();
   });
 
@@ -188,7 +190,7 @@ test.describe('Create a Tapestry (tapestries #3)', () => {
 
     await page.getByLabel(/title/i).or(page.getByPlaceholder(/tapestry for dog/i)).first().fill('My Dogs');
     await pickConcept(page, 'dog');
-    await page.getByText(/own key/i).first().click(); // switch signing identity
+    await page.getByRole('combobox').selectOption('client'); // switch signing identity to own key
     await page.getByRole('button', { name: /create tapestry/i }).click();
 
     await expect.poll(() => published.length, { timeout: 10000 }).toBeGreaterThan(0);

--- a/ui/src/pages/tapestries/NewTapestry.jsx
+++ b/ui/src/pages/tapestries/NewTapestry.jsx
@@ -131,29 +131,13 @@ export default function NewTapestry() {
           )}
         </div>
 
-        <fieldset className="form-field tapestry-signing">
-          <legend>Sign as</legend>
-          <label className="tapestry-radio">
-            <input
-              type="radio"
-              name="signAs"
-              value="assistant"
-              checked={signAs === 'assistant'}
-              onChange={() => setSignAs('assistant')}
-            />
-            <span>Tapestry Assistant</span>
-          </label>
-          <label className="tapestry-radio">
-            <input
-              type="radio"
-              name="signAs"
-              value="client"
-              checked={signAs === 'client'}
-              onChange={() => setSignAs('client')}
-            />
-            <span>My own key</span>
-          </label>
-        </fieldset>
+        <label className="form-field tapestry-signing">
+          <span>Sign as</span>
+          <select value={signAs} onChange={(e) => setSignAs(e.target.value)}>
+            <option value="assistant">Tapestry Assistant</option>
+            <option value="client">My own key</option>
+          </select>
+        </label>
 
         {validation && <p className="error tapestry-validation">{validation}</p>}
         {error && <p className="error">{error}</p>}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -8254,8 +8254,16 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
 .tapestry-concept-option:hover { background: var(--bg-tertiary); }
 .tapestry-concept-option input { margin: 0; }
 .tapestry-selected-count { color: var(--text-muted); font-size: 0.85rem; margin: 0.4rem 0 0; }
-.tapestry-signing { border: 1px solid var(--border); border-radius: 6px; padding: 0.6rem 0.9rem; }
-.tapestry-signing legend { padding: 0 0.4rem; color: var(--text-muted); font-size: 0.85rem; }
-.tapestry-radio { display: flex; align-items: center; gap: 0.5rem; padding: 0.2rem 0; cursor: pointer; }
-.tapestry-radio input { margin: 0; }
+.tapestry-signing { max-width: 500px; }
+.form-field select {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 12px;
+  color: var(--text);
+  font-size: 0.95em;
+  width: 100%;
+  max-width: 500px;
+  cursor: pointer;
+}
 .tapestry-validation { margin-top: 0.5rem; }


### PR DESCRIPTION
## Summary

Post-staging UX polish for the Create Tapestry page (story #3, follow-up to #443): the **Sign as** signing selector was a full-width `<fieldset>` with two stacked radios, which took up a disproportionate amount of vertical space for a secondary binary choice. Replaced with a compact `<select>` dropdown. **Presentation-only** — same two `signAs` values (`assistant` default, `client`), zero behavior change.

## Changes

- `ui/src/pages/tapestries/NewTapestry.jsx` — signing selector `<fieldset>`+radios → `<label>`+`<select>`.
- `ui/src/styles.css` — dropped the `.tapestry-radio`/fieldset styles; added a `.form-field select` rule matching the text-input styling.
- `tests/brainstorm/tapestry-create.spec.js` — E1 asserts the combobox + its two options; E6 switches via `selectOption('client')`.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs; `stack-free` CI passes (create-tapestry suite 21/21).
- [ ] Smoke: `/tapestry/tapestries/new` shows a compact "Sign as" dropdown (owner view); no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)