### PR TITLE
ui(tapestries): concept typeahead + selected chips on Create Tapestry

### DIFF
--- a/engineering-team/stories/tapestries/3-create-tapestry.md
+++ b/engineering-team/stories/tapestries/3-create-tapestry.md
@@ -97,6 +97,11 @@ Logged per `roles/implementer.md` §9. Review-fix cycle (review verdict CHANGES_
   full-width `<fieldset>` with two stacked radios to a compact `<select>` dropdown (same two `signAs`
   values, zero behavior change — presentation only). Treated as a trivial mechanical edit; suite stays
   21/21 (S2 unaffected), Playwright E1/E6 updated for the `<select>` (combobox + `selectOption`).
+- **[post-staging UX polish, operator request]** Concept selection reworked from an always-open
+  checkbox panel to a **typeahead + selected-chips**: the results panel shows only while the search box
+  has text (hidden when empty), clicking a match adds it to a compact always-visible removable-chip list
+  (added concepts drop out of results). Input-UX only — published wire shape unchanged. Verified by
+  executing the Playwright spec (E1/E7 + updated pickConcept) against the built UI: **7/7 in chromium**.
 - **[judgment call]** The Implementer authored the regression tests for these fixes in the fix cycle
   (unit P10 = uuid-per-signer, P11 = import-from-`conceptGraphSlug`, source S7; updated the P5 fixture;
   strengthened Playwright E6 to assert own-key navigation) rather than round-tripping to the Tester —

--- a/tests/brainstorm/tapestry-create.spec.js
+++ b/tests/brainstorm/tapestry-create.spec.js
@@ -96,9 +96,9 @@ test.describe('Create a Tapestry (tapestries #3)', () => {
   }
 
   async function pickConcept(page, name) {
-    // Tolerate checkbox/label/button/option affordances for selecting a concept.
-    const opt = page.getByRole('checkbox', { name }).or(page.getByRole('option', { name })).or(page.getByText(name, { exact: false })).first();
-    await opt.click();
+    // Typeahead: search for the concept, then click its "Add <name>" result row.
+    await page.getByRole('textbox', { name: /search concepts/i }).fill(name);
+    await page.getByRole('button', { name: `Add ${name}`, exact: true }).first().click();
   }
 
   /* ───────── E1 — owner sees the working form ───────── */
@@ -108,7 +108,9 @@ test.describe('Create a Tapestry (tapestries #3)', () => {
     await page.waitForLoadState('networkidle');
 
     await expect(page.getByLabel(/title/i).or(page.getByPlaceholder(/tapestry for dog/i)).first()).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText(/dog/i).first()).toBeVisible();               // picker populated from the scan
+    // Concept typeahead: the search box is present; the results panel stays hidden until you search.
+    await expect(page.getByRole('textbox', { name: /search concepts/i })).toBeVisible();
+    await expect(page.getByRole('listbox')).toHaveCount(0);
     const signAs = page.getByRole('combobox'); // the "Sign as" dropdown (the only select on the page)
     await expect(signAs).toBeVisible();
     await expect(signAs.locator('option', { hasText: /Tapestry Assistant/i })).toHaveCount(1);
@@ -201,5 +203,31 @@ test.describe('Create a Tapestry (tapestries #3)', () => {
     // Round-trip: the redirect must land on the OWNER-keyed coordinate (39999:<OWNER>:…), not the
     // TA's — the own-key event is authored by the owner, so a TA-keyed redirect would 404.
     await page.waitForURL(new RegExp(`/tapestry/tapestries/39999(%3A|:)${OWNER}`), { timeout: 10000 });
+  });
+
+  /* ───────── E7 — concept typeahead: panel only while searching; adds to a chip list ───────── */
+  test('E7: the results panel appears only while searching; adding a concept moves it into the selected list', async ({ page }) => {
+    await mock(page, { classification: 'owner' });
+    await page.goto(URL);
+    await page.waitForLoadState('networkidle');
+
+    const search = page.getByRole('textbox', { name: /search concepts/i });
+    // Empty search → no results panel (the space-saving behavior).
+    await expect(page.getByRole('listbox')).toHaveCount(0);
+    // Typing shows matching concepts.
+    await search.fill('dog');
+    await expect(page.getByRole('listbox')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Add dog', exact: true })).toBeVisible();
+    // Adding it → becomes a removable chip and drops out of the results.
+    await page.getByRole('button', { name: 'Add dog', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'Remove dog', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Add dog', exact: true })).toHaveCount(0);
+    // Clearing the search hides the panel again; the chip persists.
+    await search.fill('');
+    await expect(page.getByRole('listbox')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Remove dog', exact: true })).toBeVisible();
+    // Removing the chip empties the selection.
+    await page.getByRole('button', { name: 'Remove dog', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'Remove dog', exact: true })).toHaveCount(0);
   });
 });

--- a/ui/src/pages/tapestries/NewTapestry.jsx
+++ b/ui/src/pages/tapestries/NewTapestry.jsx
@@ -26,11 +26,22 @@ export default function NewTapestry() {
   const [validation, setValidation] = useState(null);
   const [error, setError] = useState(null);
 
-  const filtered = useMemo(() => {
+  // The compact, always-visible list of concepts the owner has added (chips).
+  const selectedConcepts = useMemo(
+    () => selected.map((h) => concepts.find((c) => c.handle === h)).filter(Boolean),
+    [selected, concepts],
+  );
+
+  // Typeahead results: matches for the current query, excluding already-added concepts.
+  // Empty when the search box is empty — so the panel only appears while searching.
+  const results = useMemo(() => {
     const q = filter.trim().toLowerCase();
-    if (!q) return concepts;
-    return concepts.filter((c) => c.name.toLowerCase().includes(q) || c.shortSlug.includes(q));
-  }, [concepts, filter]);
+    if (!q) return [];
+    return concepts.filter(
+      (c) => !selected.includes(c.handle)
+        && (c.name.toLowerCase().includes(q) || c.shortSlug.includes(q)),
+    );
+  }, [concepts, filter, selected]);
 
   // Owner gate: non-owner/admin visitors get an explanation, never a working form.
   if (!isOwner) {
@@ -45,8 +56,11 @@ export default function NewTapestry() {
     );
   }
 
-  function toggle(handle) {
-    setSelected((prev) => (prev.includes(handle) ? prev.filter((h) => h !== handle) : [...prev, handle]));
+  function add(handle) {
+    setSelected((prev) => (prev.includes(handle) ? prev : [...prev, handle]));
+  }
+  function remove(handle) {
+    setSelected((prev) => prev.filter((h) => h !== handle));
   }
 
   async function onSubmit(e) {
@@ -103,30 +117,56 @@ export default function NewTapestry() {
           )}
           {!conceptsLoading && !conceptsError && concepts.length > 0 && (
             <>
+              {/* The persistent, compact list of what will be included. */}
+              {selectedConcepts.length === 0 ? (
+                <p className="placeholder">No concepts added yet — search below to add some.</p>
+              ) : (
+                <ul className="tapestry-selected-list" aria-label="Selected member concepts">
+                  {selectedConcepts.map((c) => (
+                    <li key={c.handle} className="tapestry-selected-chip">
+                      <span>{c.name}</span>
+                      <button
+                        type="button"
+                        className="tapestry-chip-remove"
+                        aria-label={`Remove ${c.name}`}
+                        onClick={() => remove(c.handle)}
+                      >
+                        ×
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {/* Typeahead: the results panel only appears while the search box has text. */}
               <input
                 type="text"
                 className="tapestry-concept-filter"
                 value={filter}
                 onChange={(e) => setFilter(e.target.value)}
-                placeholder="Filter concepts…"
-                aria-label="Filter concepts"
+                placeholder="Search concepts to add…"
+                aria-label="Search concepts"
               />
-              <div className="tapestry-concept-picker" role="group" aria-label="Member concepts">
-                {filtered.map((c) => (
-                  <label key={c.handle} className="tapestry-concept-option">
-                    <input
-                      type="checkbox"
-                      checked={selected.includes(c.handle)}
-                      onChange={() => toggle(c.handle)}
-                    />
-                    <span>{c.name}</span>
-                  </label>
-                ))}
-                {filtered.length === 0 && (
-                  <p className="placeholder" style={{ margin: '0.25rem' }}>No concepts match “{filter}”.</p>
-                )}
-              </div>
-              <p className="tapestry-selected-count">{selected.length} selected</p>
+              {filter.trim() && (
+                <div className="tapestry-concept-picker" role="listbox" aria-label="Matching concepts">
+                  {results.length === 0 ? (
+                    <p className="placeholder" style={{ margin: '0.25rem' }}>No concepts match “{filter}”.</p>
+                  ) : (
+                    results.map((c) => (
+                      <button
+                        key={c.handle}
+                        type="button"
+                        className="tapestry-concept-option"
+                        aria-label={`Add ${c.name}`}
+                        onClick={() => add(c.handle)}
+                      >
+                        <span>{c.name}</span>
+                        <span className="tapestry-concept-add">+ Add</span>
+                      </button>
+                    ))
+                  )}
+                </div>
+              )}
             </>
           )}
         </div>

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -8243,17 +8243,54 @@ code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; }
   overflow-y: auto;
   padding: 0.25rem;
 }
+/* Typeahead result rows — full-width add buttons. */
 .tapestry-concept-option {
   display: flex;
+  width: 100%;
   align-items: center;
+  justify-content: space-between;
   gap: 0.5rem;
-  padding: 0.3rem 0.4rem;
+  padding: 0.4rem 0.5rem;
+  border: none;
+  background: none;
   border-radius: 4px;
   cursor: pointer;
+  color: var(--text);
+  font-size: 0.9em;
+  text-align: left;
 }
 .tapestry-concept-option:hover { background: var(--bg-tertiary); }
-.tapestry-concept-option input { margin: 0; }
-.tapestry-selected-count { color: var(--text-muted); font-size: 0.85rem; margin: 0.4rem 0 0; }
+.tapestry-concept-add { color: var(--accent); font-size: 0.8em; white-space: nowrap; }
+
+/* Selected concepts — compact removable chips, always visible. */
+.tapestry-selected-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.6rem;
+}
+.tapestry-selected-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.2rem 0.4rem 0.2rem 0.7rem;
+  font-size: 0.85em;
+}
+.tapestry-chip-remove {
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 1.1em;
+  line-height: 1;
+  padding: 0 0.2rem;
+}
+.tapestry-chip-remove:hover { color: var(--text); }
 .tapestry-signing { max-width: 500px; }
 .form-field select {
   background: var(--bg-secondary);


### PR DESCRIPTION
## Summary

Follow-up UX for the Create Tapestry concept picker (story #3, after #443/#444), per operator request. The always-open checkbox panel listed **every** concept and took up a lot of vertical space. Replaced with a **typeahead + selected-chips** pattern:

- The results panel appears **only while the search box has text** (disappears when empty) and still scrolls when long.
- Clicking a match **adds it to a compact, always-visible list of removable chips** — add one or more at a time; added concepts drop out of the results.
- The persistent selected-chip list is what you see before pressing Create, without the big selector panel in the way.

**Input-UX only** — the published kind-39999 wire shape is unchanged (no model/test changes to the builder).

## Changes

- `ui/src/pages/tapestries/NewTapestry.jsx` — typeahead (`results` excludes already-selected + empty when query blank) + `selectedConcepts` chips; `add`/`remove` replace the checkbox `toggle`.
- `ui/src/styles.css` — result rows as full-width add-buttons; selected-chip + remove-button styles.
- `tests/brainstorm/tapestry-create.spec.js` — `pickConcept` now searches + clicks "Add <name>"; E1 asserts the search box + hidden panel; **new E7** covers show/hide + add/remove.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs; `stack-free` CI passes (create-tapestry suite 21/21).
- [x] Playwright spec executed against the built UI: **7/7 in chromium** (incl. E7).
- [ ] Smoke (owner, staging): search shows matches; empty search hides the panel; added concepts appear as chips; Create still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)