### PR TITLE
Add configure-prod workflow for magic-carpet droplet remote config

### DIFF
--- a/.github/workflows/configure-prod.yml
+++ b/.github/workflows/configure-prod.yml
@@ -1,0 +1,76 @@
+name: Configure Prod (auto-pay)
+
+on:
+  workflow_dispatch:
+    inputs:
+      enable_auto_pay:
+        description: "Set AUTO_PAY_ENABLED"
+        type: boolean
+        default: true
+      max_sats:
+        description: "AUTO_PAY_MAX_SATS"
+        type: string
+        default: "100"
+      set_mnemonic:
+        description: "Write MDK_WALLET_MNEMONIC from secret MDK_DEMO_WALLET_MNEMONIC"
+        type: boolean
+        default: false
+      issuer_pubkey:
+        description: "If set (64-char hex), provision the auto-pay delegate for this issuer"
+        type: string
+        default: ""
+
+jobs:
+  configure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Guard mnemonic secret
+        if: ${{ inputs.set_mnemonic }}
+        env:
+          MNEMONIC: ${{ secrets.MDK_DEMO_WALLET_MNEMONIC }}
+        run: |
+          if [ -z "$MNEMONIC" ]; then
+            echo "::error::set_mnemonic=true but secret MDK_DEMO_WALLET_MNEMONIC is empty"; exit 1
+          fi
+      - name: Configure via SSH
+        uses: appleboy/ssh-action@v1
+        timeout-minutes: 15
+        with:
+          host: ${{ secrets.DEPLOY_HOST_MAGIC_CARPET }}
+          username: ${{ secrets.DEPLOY_USER_MAGIC_CARPET }}
+          key: ${{ secrets.DEPLOY_SSH_KEY_MAGIC_CARPET }}
+          command_timeout: 12m
+          envs: AUTO_PAY_ENABLED_IN,MAX_SATS_IN,SET_MNEMONIC_IN,MNEMONIC_IN,ISSUER_IN
+          script: |
+            set -eu
+            cd /opt/tapestry
+            touch .env
+            set_kv() { # idempotent key replace/append; never prints values
+              key="$1"; val="$2"
+              grep -v "^${key}=" .env > .env.tmp || true
+              printf '%s=%s\n' "$key" "$val" >> .env.tmp
+              mv .env.tmp .env
+            }
+            set_kv AUTO_PAY_ENABLED "$AUTO_PAY_ENABLED_IN"
+            set_kv AUTO_PAY_MAX_SATS "$MAX_SATS_IN"
+            if [ "$SET_MNEMONIC_IN" = "true" ]; then
+              set_kv MDK_WALLET_MNEMONIC "$MNEMONIC_IN"
+              echo "mnemonic: written"
+            fi
+            chmod 600 .env
+            echo "env keys now present:"
+            cut -d= -f1 .env
+            docker compose up -d
+            if [ -n "$ISSUER_IN" ]; then
+              echo "$ISSUER_IN" | grep -Eq '^[0-9a-f]{64}$' || { echo "::error::issuer_pubkey must be 64-char lowercase hex"; exit 1; }
+              sleep 5
+              docker compose exec -T tapestry node bin/agent.js provision-delegate --issuer "$ISSUER_IN"
+            fi
+            echo "done"
+        env:
+          AUTO_PAY_ENABLED_IN: ${{ inputs.enable_auto_pay }}
+          MAX_SATS_IN: ${{ inputs.max_sats }}
+          SET_MNEMONIC_IN: ${{ inputs.set_mnemonic }}
+          MNEMONIC_IN: ${{ secrets.MDK_DEMO_WALLET_MNEMONIC }}
+          ISSUER_IN: ${{ inputs.issuer_pubkey }}


### PR DESCRIPTION
Adds a workflow_dispatch workflow that reuses the existing DEPLOY_*_MAGIC_CARPET SSH secrets to idempotently update /opt/tapestry/.env (AUTO_PAY_ENABLED, AUTO_PAY_MAX_SATS, optionally MDK_WALLET_MNEMONIC from a repo secret), restart compose, and optionally provision the auto-pay delegate — for the Phase 1 hands-off payout demo. No secrets are ever echoed; .env is chmod 600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013io1JFHUae62KRhfLFDgr7