### PR TITLE
ui(tapestries): broaden Create-Tapestry concept search to all fields + description

### DIFF
--- a/engineering-team/stories/tapestries/3-create-tapestry.md
+++ b/engineering-team/stories/tapestries/3-create-tapestry.md
@@ -102,6 +102,10 @@ Logged per `roles/implementer.md` §9. Review-fix cycle (review verdict CHANGES_
   has text (hidden when empty), clicking a match adds it to a compact always-visible removable-chip list
   (added concepts drop out of results). Input-UX only — published wire shape unchanged. Verified by
   executing the Playwright spec (E1/E7 + updated pickConcept) against the built UI: **7/7 in chromium**.
+- **[post-staging UX polish, operator request]** Broadened the concept **keyword search** beyond the
+  display name to a `searchText` blob spanning all concept-header naming fields
+  (oNames/oSlugs/oKeys/oTitles/oLabels + word.name/slug + d-tag) **and the description** — all already
+  present on the strfry kind-39998 event (no new data source). Node S8 + Playwright E8 (8/8 chromium).
 - **[judgment call]** The Implementer authored the regression tests for these fixes in the fix cycle
   (unit P10 = uuid-per-signer, P11 = import-from-`conceptGraphSlug`, source S7; updated the P5 fixture;
   strengthened Playwright E6 to assert own-key navigation) rather than round-tripping to the Tester —

--- a/test/create-tapestry.test.js
+++ b/test/create-tapestry.test.js
@@ -252,6 +252,21 @@ test('S6: NewTapestry.jsx no longer advertises the inert placeholder (AC — the
     'inert preview with a working, owner-gated authoring form.');
 });
 
+test('S8: concept keyword search covers the o* naming fields + the description, not just the name (operator request 2026-07-24)', () => {
+  const hook = readSafe(USE_CREATE_HOOK);
+  const page = readSafe(NEW_TAPESTRY);
+  assert(hook !== null && page !== null, 'useCreateTapestry.js / NewTapestry.jsx missing — re-baseline.');
+  // The picker parse builds a searchable blob spanning the header's naming forms + free-text description…
+  assert(/searchText/.test(hook),
+    'useCreateTapestry.js builds no searchText blob — the keyword search would still match only the display name.');
+  assert(/description/.test(hook) && /oSlugs/.test(hook) && /oKeys/.test(hook),
+    'searchText omits the concept-header description and/or the o* fields (oSlugs/oKeys/…). The operator asked to search ' +
+    'the description (most important) plus the other naming fields, not just oNames.singular.');
+  // …and the typeahead filters against that blob rather than name/shortSlug alone.
+  assert(/searchText/.test(page),
+    'NewTapestry.jsx results filter does not reference searchText — the expanded keyword search is not wired into the typeahead.');
+});
+
 // ───────────────────────── Regression guards — PASS pre AND post ─────────────────────────
 
 test('R1: the shipped Exploration read-path model is untouched (composeGraph + inferNodeType still exported)', () => {

--- a/tests/brainstorm/tapestry-create.spec.js
+++ b/tests/brainstorm/tapestry-create.spec.js
@@ -34,12 +34,12 @@ test.describe('Create a Tapestry (tapestries #3)', () => {
 
   // Concept-header fixtures for the picker (kind-39998 scan), shaped like the live events:
   // d-tag = short slug, json.word.slug = descriptive slug, json.conceptHeader.oNames.singular = name.
-  function headerEv(shortSlug, descriptiveSlug, name) {
+  function headerEv(shortSlug, descriptiveSlug, name, description = '') {
     return {
       id: 'a'.repeat(64), pubkey: TA, kind: 39998, created_at: 1784821324,
       tags: [['d', shortSlug], ['json', JSON.stringify({
         word: { slug: descriptiveSlug, name },
-        conceptHeader: { oNames: { singular: name } },
+        conceptHeader: { oNames: { singular: name }, description },
       })]],
       content: '', sig: '0'.repeat(128),
     };
@@ -47,6 +47,9 @@ test.describe('Create a Tapestry (tapestries #3)', () => {
   const CONCEPTS = [
     headerEv('dog', 'concept-header-for-the-concept-of-dogs', 'dog'),
     headerEv('golden-retriever', 'concept-header-for-the-concept-of-golden-retrievers', 'golden retriever'),
+    // A concept whose name shares no keyword with its description — proves description-based search (E8).
+    headerEv('graperank', 'concept-header-for-the-concept-of-graperanks', 'graperank',
+      'A contextual Web of Trust scoring algorithm for Nostr.'),
   ];
 
   /**
@@ -229,5 +232,18 @@ test.describe('Create a Tapestry (tapestries #3)', () => {
     // Removing the chip empties the selection.
     await page.getByRole('button', { name: 'Remove dog', exact: true }).click();
     await expect(page.getByRole('button', { name: 'Remove dog', exact: true })).toHaveCount(0);
+  });
+
+  /* ───────── E8 — keyword search matches the description, not just the name ───────── */
+  test('E8: searching a keyword that appears only in a concept\'s description surfaces that concept', async ({ page }) => {
+    await mock(page, { classification: 'owner' });
+    await page.goto(URL);
+    await page.waitForLoadState('networkidle');
+
+    // "algorithm" appears only in graperank's description ("…scoring algorithm…"), never in its name.
+    await page.getByRole('textbox', { name: /search concepts/i }).fill('algorithm');
+    await expect(page.getByRole('button', { name: 'Add graperank', exact: true })).toBeVisible();
+    // And it must NOT surface unrelated concepts (dog has no such description keyword).
+    await expect(page.getByRole('button', { name: 'Add dog', exact: true })).toHaveCount(0);
   });
 });

--- a/ui/src/pages/tapestries/NewTapestry.jsx
+++ b/ui/src/pages/tapestries/NewTapestry.jsx
@@ -37,9 +37,9 @@ export default function NewTapestry() {
   const results = useMemo(() => {
     const q = filter.trim().toLowerCase();
     if (!q) return [];
+    // Match the full searchText blob (names/slugs/keys/titles/labels + description), not just the name.
     return concepts.filter(
-      (c) => !selected.includes(c.handle)
-        && (c.name.toLowerCase().includes(q) || c.shortSlug.includes(q)),
+      (c) => !selected.includes(c.handle) && (c.searchText || '').includes(q),
     );
   }, [concepts, filter, selected]);
 

--- a/ui/src/pages/tapestries/useCreateTapestry.js
+++ b/ui/src/pages/tapestries/useCreateTapestry.js
@@ -25,6 +25,15 @@ function toConcept(ev) {
     const raw = ev.tags?.find((t) => t[0] === 'json')?.[1];
     if (raw) { const j = JSON.parse(raw); word = j.word || {}; conceptHeader = j.conceptHeader || {}; }
   } catch { /* malformed json → fall back to the d-tag below */ }
+  // Keyword search matches this blob (not just the display name): every naming form the
+  // concept-header carries — oNames/oSlugs/oKeys/oTitles/oLabels (singular+plural), word.name/slug,
+  // the d-tag — plus the free-text description. Built once here; the typeahead filters on it.
+  const both = (o) => (o ? [o.singular, o.plural] : []);
+  const searchText = [
+    ...both(conceptHeader.oNames), ...both(conceptHeader.oSlugs), ...both(conceptHeader.oKeys),
+    ...both(conceptHeader.oTitles), ...both(conceptHeader.oLabels),
+    word.name, word.slug, dTag, conceptHeader.description,
+  ].filter(Boolean).join(' ').toLowerCase();
   return {
     handle: `39998:${ev.pubkey}:${dTag}`,        // the concept-header coordinate (d-tag = short slug)
     shortSlug: dTag,
@@ -33,6 +42,7 @@ function toConcept(ev) {
     conceptGraphSlug: conceptHeader.oSlugs?.singular || dTag,
     descriptiveSlug: word.slug || `concept-header-for-${dTag}`, // word.slug → clean dedup at read time
     name: conceptHeader.oNames?.singular || word.name || dTag,  // friendly display name
+    searchText,
   };
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the concept typeahead (story #3): the keyword search matched only the display name (`conceptHeader.oNames.singular`) + the d-tag. Per operator request, broaden it to match **all of the concept-header's naming fields plus its free-text description**.

Each concept now carries a lowercased `searchText` blob built from: `oNames`/`oSlugs`/`oKeys`/`oTitles`/`oLabels` (singular+plural), `word.name`/`word.slug`, the d-tag, **and `conceptHeader.description`**. The typeahead filters against that blob. Every field already rides on the strfry kind-39998 event the picker reads — **no new data source** (ADR Decision 1-A intact, no Neo4j/`/summaries` dependency).

## Changes

- `ui/src/pages/tapestries/useCreateTapestry.js` — `toConcept` builds the `searchText` blob.
- `ui/src/pages/tapestries/NewTapestry.jsx` — `results` filters on `searchText` instead of name/shortSlug.
- Tests: Node **S8** guards the wiring (searchText spans o* fields + description); Playwright mock gains descriptions + **E8** proves a description-only keyword (`algorithm` → `graperank`) surfaces the concept.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs; `stack-free` CI passes (create-tapestry suite **22/22**).
- [x] Playwright executed against the built UI: **8/8 chromium** (incl. E8 description-search).
- [ ] Smoke (owner, staging): searching a word from a concept's description surfaces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)