### PR TITLE
fix: await tapestry-store LMDB write + document the store (BIBLE §29)

### DIFF
--- a/BIBLE.md
+++ b/BIBLE.md
@@ -5,7 +5,7 @@
 >
 > Specifics of the reference deployment at `tapestry.brainstorm.world` (deploy targets, droplet specs, CI/CD workflows, branch protection ruleset, active team, tracking issues, operational gotchas we've hit) live in a sibling document: [OPERATIONS.md](./OPERATIONS.md). If you're forking this repo to run your own instance, BIBLE is the doc you want — OPERATIONS describes someone else's running instance.
 
-**Last updated:** 2026-07-24 (content: §6 graph-embedding convention + §13 Tapestries area + §16 changelog — tapestries book; prior: §11 relationship primitives + probe, §13 set-detail route + owner placement affordances — graph-curation-ui / relationship-primitives)
+**Last updated:** 2026-07-24 (content: §29 Derived-JSON Store — documents the standalone tapestry-store LMDB layer (`tapestryKey` + `lmdb:` pointers), alongside a `handlePut` await fix; prior: §6 graph-embedding convention + §13 Tapestries area + §16 changelog — tapestries book; §11 relationship primitives + probe, §13 set-detail route + owner placement affordances — graph-curation-ui / relationship-primitives)
 
 ---
 
@@ -38,6 +38,8 @@
 25. [The Inherit-From Tag (`b`)](#25-the-inherit-from-tag-b)
 26. [Resolved Definition](#26-resolved-definition)
 27. [Point of View (PoV) Resolution](#27-point-of-view-pov-resolution)
+28. [Open Ranking (ORE) Provider](#28-open-ranking-ore-provider)
+29. [Derived-JSON Store: tapestryKey and the tapestry-store LMDB](#29-derived-json-store-tapestrykey-and-the-tapestry-store-lmdb)
 
 ---
 
@@ -159,6 +161,8 @@ For the specific branches and deploy targets configured in the reference deploym
 | `tapestry-data` | `/var/lib/brainstorm` | App data + user settings |
 | `tapestry-logs` | `/var/log/brainstorm` | Logs |
 | `nostr-search-meili` | `/meili_data` | Meilisearch index data |
+
+**Not a Docker volume — the derived-JSON store.** Separate from strfry's LMDB above, the control panel keeps its own application-level LMDB (the `lmdb` npm package) at `~/.tapestry/lmdb` inside the container, holding derived per-node JSON keyed by each node's `tapestryKey`. It is **not** mapped to a named volume — a rebuildable cache, not a source of truth — so don't confuse it with strfry's event store. See §29.
 
 ### Data Flow
 
@@ -357,6 +361,8 @@ Triggered via the Dashboard "Install Tapestry firmware" button or `POST /api/fir
 ## 8. Word-Wrapper JSON Format
 
 **The format is specified in [protocols/drafts/tapestry-concepts.md](protocols/drafts/tapestry-concepts.md) → "The word-wrapper format" — normative** (structure, the `word` block, type-specific keys, worked examples). In this codebase, all core nodes and firmware concepts carry word-wrapper JSON in their `json` tag; firmware schemas validate it at install time (§7).
+
+A node's `json`-tag value may be held **inline** (as above) or **offloaded** to the derived-JSON LMDB store as an `lmdb:<tapestryKey>` pointer, resolved transparently on read (§29). That is a local storage detail; the wire format is unchanged.
 
 ---
 
@@ -1731,6 +1737,26 @@ The `graperank-personalized` **stats** path is an **unauthenticated provisioning
 ### Deployment
 
 Live on **`staging.brainstorm.world`**: ORE-01 + ORE-02 via [apps#318](https://github.com/nous-clawds4/tapestry/pull/318) (2026-06-18); ORE-05 via [apps#322](https://github.com/nous-clawds4/tapestry/pull/322) (2026-06-19). **Not on production** (the personalized-stats gate above must be resolved first). Sources: ADRs `engineering-team/decisions/open-ranking/0001`–`0002`; book `engineering-team/audits/open-ranking/`; worksheet W12/W13.
+
+---
+
+## 29. Derived-JSON Store: tapestryKey and the tapestry-store LMDB
+
+> **Status: in progress.** This layer is scaffolded and wired, but the migration into it is **not** complete — most node JSON is still stored inline in the `json` tag (§8). Read this section as describing an in-flight subsystem, not a settled state.
+
+Separate from strfry's internal LMDB event store (§4), the control panel keeps its **own** application-level LMDB key-value store — the [`lmdb`](https://www.npmjs.com/package/lmdb) npm package — for **serialized / derived per-node representations**. This is the "tapestry-store". It is unrelated to strfry's LMDB beyond both happening to use the LMDB library.
+
+**Where it lives.** `src/lib/tapestry-store.js` opens a singleton LMDB at `process.env.TAPESTRY_LMDB_PATH || ~/.tapestry/lmdb` (compression on, 256 MB map). Inside the container that resolves under `/root/.tapestry/`, which is **not** mapped to a named Docker volume (§4) — so it is a **rebuildable cache**: lost on container *recreation* and repopulated by the derive engine, never a source of truth.
+
+**Keying — the `tapestryKey` node property.** Each Neo4j node carries a `tapestryKey` (a v4 UUID, assigned once and never changed) that **is** the LMDB key. `POST /api/tapestry-key/initialize` stamps `SET n.tapestryKey` on every node lacking one, and the firmware install does the same (`src/firmware/install.js`, "assign tapestryKeys to all nodes"). Stored values are envelopes: `{ updatedAt, rebuiltFrom?, data }`. A companion `tapestryJsonUpdatedAt` timestamp is written back onto the node whenever the LMDB entry is (re)written.
+
+**The `lmdb:` pointer convention.** Any string property value may hold either the inline value **or** a pointer of the form `lmdb:<tapestryKey>`. `src/lib/tapestry-resolve.js` (`isLmdbRef` / `toLmdbRef` / `resolveValue` / `resolveDeep`) resolves these transparently server-side; the client does the same via `ui/src/utils/lmdb.js`, which fetches `/api/tapestry-key/:key`. A reader gets the data whether it is inline or offloaded — so **resolve through this layer rather than reading a raw property**, since you cannot assume which form a given node uses.
+
+**Write / derive path.** `src/lib/tapestry-derive.js` computes derived JSON per node and calls `store.put(node.tapestryKey, data, …)`, then stamps `tapestryJsonUpdatedAt`. The "offload" endpoints (`POST /api/tapestry-key/offload`, `/offload-all`) take an inline `json`-tag value, write it into LMDB under the parent event's `tapestryKey`, and replace the tag value with the `lmdb:` pointer. The full API surface (`status` / `initialize` / `get` / `put` / `offload` / `resolve` / `derive`) lives in `src/api/tapestry-key/index.js`. All async `store.put` writes must be awaited before the node timestamp is written or the response is sent (regression-guarded by `test/tapestry-key-put-await.test.js`).
+
+**Relationship to the protocol (§5, §8).** Node content is still *specified* in the event's `json` tag (word-wrapper format); the tapestry-store is a **local storage optimization** over that content, not a wire-format change. a-tag addressing and the `json`-tag spec are unaffected.
+
+**Migration status (as of 2026-07).** Per the post-install dashboard (`README.md`), a minority of nodes still need a `tapestryKey` and most `json` tags remain inline in Neo4j — reported there as "harmless and expected for now". The offload is incremental and ongoing.
 
 ---
 

--- a/src/api/tapestry-key/index.js
+++ b/src/api/tapestry-key/index.js
@@ -175,7 +175,7 @@ async function handlePut(req, res) {
 
     // Write to LMDB
     const meta = rebuiltFrom ? { rebuiltFrom } : {};
-    const envelope = store.put(key, data, meta);
+    const envelope = await store.put(key, data, meta);
 
     // Update Neo4j timestamp
     await writeCypher(`

--- a/test/tapestry-key-put-await.test.js
+++ b/test/tapestry-key-put-await.test.js
@@ -1,0 +1,173 @@
+/**
+ * Regression guard: POST /api/tapestry-key/:key (handlePut) must AWAIT the
+ * async LMDB write before it reads the envelope and responds.
+ *
+ * The bug: handlePut called `const envelope = store.put(key, data, meta)` with
+ * no `await`. Because tapestry-store.put is async, `envelope` was a *pending
+ * Promise*, so:
+ *   - `envelope.updatedAt` was `undefined` → Neo4j's `tapestryJsonUpdatedAt`
+ *     was written as undefined/null, and
+ *   - `res.json({ data: envelope })` serialized the Promise to `{}`, and
+ *   - the LMDB write was not guaranteed durable before the response.
+ * Every other call site (handleOffload, handleOffloadAll, tapestry-derive)
+ * awaits store.put correctly — handlePut was the lone outlier.
+ *
+ * Stack-free: this suite needs neither LMDB nor Neo4j. It injects fake
+ * tapestry-store and neo4j-driver modules into the require cache (the seam used
+ * by close-unauth-write-surface.test.js), loads handlePut fresh, and asserts
+ * the resolved envelope — not a Promise — reaches both the Cypher write and the
+ * response body. Originals are restored in run()'s finally so later suites in
+ * the shared runner are not contaminated.
+ *
+ * TI1, TI2 : FAIL against the un-awaited code, PASS once the `await` lands.
+ * RI1      : PASS pre AND post — a source sentinel mirroring the sibling-audit
+ *            grep; flips to FAIL if any un-awaited store.put/store.remove is
+ *            (re)introduced anywhere in tapestry-key/index.js.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const INDEX_FILE = path.join(ROOT, 'src/api/tapestry-key/index.js');
+const INDEX_PATH = require.resolve(INDEX_FILE);
+const STORE_PATH = require.resolve(path.join(ROOT, 'src/lib/tapestry-store'));
+const DRIVER_PATH = require.resolve(path.join(ROOT, 'src/lib/neo4j-driver'));
+const DERIVE_PATH = require.resolve(path.join(ROOT, 'src/lib/tapestry-derive'));
+
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+
+function mkRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(c) { this.statusCode = c; return this; },
+    json(o) { this.body = o; return this; },
+  };
+}
+
+// A fixed, non-Date epoch the fake store stamps onto every envelope. If
+// handlePut forgets to await, the handler reads `.updatedAt` off the pending
+// Promise (undefined) instead of this number — the discriminating signal.
+const FAKE_TS = 1234567890;
+
+/**
+ * Load a fresh handlePut with tapestry-store + neo4j-driver stubbed, returning
+ * the handler plus the call logs the stubs record.
+ */
+function loadHandlerWithStubs() {
+  // Force fresh loads of the handler and anything that closes over the store.
+  delete require.cache[INDEX_PATH];
+  delete require.cache[DERIVE_PATH];
+
+  const storeCalls = [];
+  const cypherCalls = [];
+
+  require.cache[STORE_PATH] = {
+    id: STORE_PATH, filename: STORE_PATH, loaded: true,
+    exports: {
+      put: async (key, data, meta = {}) => {
+        storeCalls.push({ key, data, meta });
+        return { updatedAt: FAKE_TS, ...meta, data };
+      },
+      get() { return null; },
+      remove: async () => {},
+      stats() { return { count: 0, path: '(stub)' }; },
+      listKeys() { return []; },
+      close() {},
+    },
+  };
+
+  require.cache[DRIVER_PATH] = {
+    id: DRIVER_PATH, filename: DRIVER_PATH, loaded: true,
+    exports: {
+      runCypher: async (cypher, params) => { cypherCalls.push({ fn: 'runCypher', cypher, params }); return []; },
+      writeCypher: async (cypher, params) => { cypherCalls.push({ fn: 'writeCypher', cypher, params }); return []; },
+      getDriver() { return null; },
+      closeDriver() {},
+      toJS(x) { return x; },
+    },
+  };
+
+  const mod = require(INDEX_PATH);
+  return { handlePut: mod.handlePut, storeCalls, cypherCalls };
+}
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+
+test('TI1: handlePut awaits store.put — the Neo4j timestamp write gets the resolved numeric updatedAt (not undefined)', async () => {
+  const { handlePut, storeCalls, cypherCalls } = loadHandlerWithStubs();
+  const res = mkRes();
+  await handlePut({ params: { key: 'k1' }, body: { data: { hello: 'world' } } }, res);
+
+  assert(storeCalls.length === 1, `expected store.put to be called once, got ${storeCalls.length}`);
+  const write = cypherCalls.find((c) => c.fn === 'writeCypher');
+  assert(write, 'expected a writeCypher call to set tapestryJsonUpdatedAt');
+  assert(
+    write.params && write.params.ts === FAKE_TS,
+    `tapestryJsonUpdatedAt must be the resolved numeric updatedAt (${FAKE_TS}); got ${write.params && write.params.ts} — store.put was not awaited.`
+  );
+});
+
+test('TI2: handlePut response body carries the resolved envelope, not a pending Promise', async () => {
+  const { handlePut } = loadHandlerWithStubs();
+  const res = mkRes();
+  await handlePut({ params: { key: 'k2' }, body: { data: { a: 1 } } }, res);
+
+  assert(res.body && res.body.success === true, `expected { success: true }, got ${JSON.stringify(res.body)}`);
+  const env = res.body.data;
+  assert(
+    env && typeof env.updatedAt === 'number',
+    `response data must be the resolved envelope with a numeric updatedAt; got ${JSON.stringify(env)} — an un-awaited Promise serializes to {}.`
+  );
+  assert(env.data && env.data.a === 1, 'the response envelope must carry the written data.');
+});
+
+test('RI1: no un-awaited store.put(/store.remove( remains in tapestry-key/index.js (sibling-audit sentinel)', () => {
+  const src = fs.readFileSync(INDEX_FILE, 'utf8');
+  const offenders = [];
+  src.split('\n').forEach((line, i) => {
+    if (/\bstore\.(put|remove)\s*\(/.test(line) && !/\bawait\s+store\.(put|remove)\s*\(/.test(line)) {
+      offenders.push(i + 1);
+    }
+  });
+  assert(
+    offenders.length === 0,
+    `un-awaited store.put/store.remove at src/api/tapestry-key/index.js line(s) ${offenders.join(', ')} — async LMDB writes must be awaited.`
+  );
+});
+
+async function run() {
+  // Snapshot the cache entries we mutate so later suites in the shared runner
+  // (node test/test.js) see the real modules again.
+  const snapshot = {
+    [INDEX_PATH]: require.cache[INDEX_PATH],
+    [STORE_PATH]: require.cache[STORE_PATH],
+    [DRIVER_PATH]: require.cache[DRIVER_PATH],
+    [DERIVE_PATH]: require.cache[DERIVE_PATH],
+  };
+  let pass = 0;
+  let fail = 0;
+  try {
+    for (const t of tests) {
+      try {
+        await t.fn();
+        console.log(`  ✓ ${t.name}`);
+        pass++;
+      } catch (err) {
+        console.log(`  ✗ ${t.name}`);
+        console.log(`      ${err.message}`);
+        fail++;
+      }
+    }
+  } finally {
+    for (const [p, entry] of Object.entries(snapshot)) {
+      if (entry === undefined) delete require.cache[p];
+      else require.cache[p] = entry;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -185,6 +185,8 @@ const attachTheWorld = require('./attach-the-world.test.js');
 // epic: second-brain — Story 5 (sessions read the brain — work records + orient).
 const sessionsReadTheBrain = require('./sessions-read-the-brain.test.js');
 const theProposalLoop = require('./the-proposal-loop.test.js');
+// bug — tapestry-key handlePut must await the async LMDB write (regression guard).
+const tapestryKeyPutAwait = require('./tapestry-key-put-await.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...');
@@ -488,6 +490,9 @@ async function main() {
   const sessionsReadTheBrainResult = await sessionsReadTheBrain.run();
   const theProposalLoopResult = await theProposalLoop.run();
 
+  console.log('\ntapestry-key-put-await suite:');
+  const tapestryKeyPutAwaitResult = await tapestryKeyPutAwait.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -637,6 +642,9 @@ async function main() {
   );
   console.log(
     `create-tapestry suite:                           ${createTapestryResult.fail === 0 ? 'PASS' : 'FAIL'} (${createTapestryResult.pass} passed, ${createTapestryResult.fail} failed)`
+  );
+  console.log(
+    `tapestry-key-put-await suite:                    ${tapestryKeyPutAwaitResult.fail === 0 ? 'PASS' : 'FAIL'} (${tapestryKeyPutAwaitResult.pass} passed, ${tapestryKeyPutAwaitResult.fail} failed)`
   );
   console.log(
     `reconciliation-incremental-mode suite:           ${reconciliationIncrementalModeResult.fail === 0 ? 'PASS' : 'FAIL'} (${reconciliationIncrementalModeResult.pass} passed, ${reconciliationIncrementalModeResult.fail} failed)`
@@ -1032,7 +1040,10 @@ async function main() {
     theProposalLoopResult.fail === 0 &&
     // tapestries #3 — create a tapestry (members-only authoring)
     // (LIVE chain — before the severed terminator; OPEN.md #43).
-    createTapestryResult.fail === 0;
+    createTapestryResult.fail === 0 &&
+    // bug — tapestry-key handlePut must await the async LMDB write.
+    // (LIVE chain — before the severed terminator; OPEN.md #43.)
+    tapestryKeyPutAwaitResult.fail === 0;
     harnessLintResult.fail === 0 &&
     harnessStatsResult.fail === 0 &&
     sessionStartResult.fail === 0 &&


### PR DESCRIPTION
## Summary

`POST /api/tapestry-key/:key` (`handlePut`) called the async `store.put(...)` **without `await`**, so the resolved envelope never reached the Neo4j timestamp write or the HTTP response — `tapestryJsonUpdatedAt` was written as `undefined`, the response body serialized a pending Promise to `{}`, and the LMDB write wasn't guaranteed durable before responding. Every other call site already awaits. This adds the `await`, a stack-free regression guard, and documents the (previously undocumented) standalone tapestry-store LMDB layer in a new BIBLE §29.

## Changes

- `src/api/tapestry-key/index.js` — add `await` to the `store.put` call in `handlePut` (the lone un-awaited call site).
- `test/tapestry-key-put-await.test.js` — new **stack-free** regression suite; stubs the store + Bolt driver via the require-cache seam and asserts the resolved envelope reaches both the Cypher timestamp write and the response body, plus a source sentinel mirroring the sibling-audit grep. Verified red→green.
- `test/test.js` — wire the suite into the **live** `overallOk` chain (before the pre-existing severed terminator, OPEN.md #43), so it actually gates.
- `BIBLE.md` — new **§29** documenting the standalone `tapestry-store` LMDB (`tapestryKey` node property + `lmdb:<tapestryKey>` pointer convention + transparent resolution), distinct from strfry's LMDB; cross-refs from §4 (not a named volume) and §8 (json-tag storage); ToC + "Last updated" bump; adds the missing §28 ToC entry. Flagged explicitly as an in-progress subsystem. AGENTS.md untouched (at its 102-line cap).

## Test plan

- [ ] After merge: deploy-staging.yml runs.
- [ ] Smoke test on staging.brainstorm.world.
- [ ] `tapestry-key-put-await` suite passes in CI (stack-free, gates overallOk).
- [ ] BIBLE §29 renders; ToC anchor resolves; harness-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)