### PR TITLE
Promote staging → main: tapestry-store await fix + docs (#452, #451)

### DIFF
--- a/BIBLE.md
+++ b/BIBLE.md
@@ -5,7 +5,7 @@
 >
 > Specifics of the reference deployment at `tapestry.brainstorm.world` (deploy targets, droplet specs, CI/CD workflows, branch protection ruleset, active team, tracking issues, operational gotchas we've hit) live in a sibling document: [OPERATIONS.md](./OPERATIONS.md). If you're forking this repo to run your own instance, BIBLE is the doc you want — OPERATIONS describes someone else's running instance.
 
-**Last updated:** 2026-07-24 (content: §6 graph-embedding convention + §13 Tapestries area + §16 changelog — tapestries book; prior: §11 relationship primitives + probe, §13 set-detail route + owner placement affordances — graph-curation-ui / relationship-primitives)
+**Last updated:** 2026-07-24 (content: §29 Derived-JSON Store — documents the standalone tapestry-store LMDB layer (`tapestryKey` + `lmdb:` pointers), alongside a `handlePut` await fix; prior: §6 graph-embedding convention + §13 Tapestries area + §16 changelog — tapestries book; §11 relationship primitives + probe, §13 set-detail route + owner placement affordances — graph-curation-ui / relationship-primitives)
 
 ---
 
@@ -38,6 +38,8 @@
 25. [The Inherit-From Tag (`b`)](#25-the-inherit-from-tag-b)
 26. [Resolved Definition](#26-resolved-definition)
 27. [Point of View (PoV) Resolution](#27-point-of-view-pov-resolution)
+28. [Open Ranking (ORE) Provider](#28-open-ranking-ore-provider)
+29. [Derived-JSON Store: tapestryKey and the tapestry-store LMDB](#29-derived-json-store-tapestrykey-and-the-tapestry-store-lmdb)
 
 ---
 
@@ -159,6 +161,8 @@ For the specific branches and deploy targets configured in the reference deploym
 | `tapestry-data` | `/var/lib/brainstorm` | App data + user settings |
 | `tapestry-logs` | `/var/log/brainstorm` | Logs |
 | `nostr-search-meili` | `/meili_data` | Meilisearch index data |
+
+**Not a Docker volume — the derived-JSON store.** Separate from strfry's LMDB above, the control panel keeps its own application-level LMDB (the `lmdb` npm package) at `~/.tapestry/lmdb` inside the container, holding derived per-node JSON keyed by each node's `tapestryKey`. It is **not** mapped to a named volume — a rebuildable cache, not a source of truth — so don't confuse it with strfry's event store. See §29.
 
 ### Data Flow
 
@@ -357,6 +361,8 @@ Triggered via the Dashboard "Install Tapestry firmware" button or `POST /api/fir
 ## 8. Word-Wrapper JSON Format
 
 **The format is specified in [protocols/drafts/tapestry-concepts.md](protocols/drafts/tapestry-concepts.md) → "The word-wrapper format" — normative** (structure, the `word` block, type-specific keys, worked examples). In this codebase, all core nodes and firmware concepts carry word-wrapper JSON in their `json` tag; firmware schemas validate it at install time (§7).
+
+A node's `json`-tag value may be held **inline** (as above) or **offloaded** to the derived-JSON LMDB store as an `lmdb:<tapestryKey>` pointer, resolved transparently on read (§29). That is a local storage detail; the wire format is unchanged.
 
 ---
 
@@ -1731,6 +1737,26 @@ The `graperank-personalized` **stats** path is an **unauthenticated provisioning
 ### Deployment
 
 Live on **`staging.brainstorm.world`**: ORE-01 + ORE-02 via [apps#318](https://github.com/nous-clawds4/tapestry/pull/318) (2026-06-18); ORE-05 via [apps#322](https://github.com/nous-clawds4/tapestry/pull/322) (2026-06-19). **Not on production** (the personalized-stats gate above must be resolved first). Sources: ADRs `engineering-team/decisions/open-ranking/0001`–`0002`; book `engineering-team/audits/open-ranking/`; worksheet W12/W13.
+
+---
+
+## 29. Derived-JSON Store: tapestryKey and the tapestry-store LMDB
+
+> **Status: in progress.** This layer is scaffolded and wired, but the migration into it is **not** complete — most node JSON is still stored inline in the `json` tag (§8). Read this section as describing an in-flight subsystem, not a settled state.
+
+Separate from strfry's internal LMDB event store (§4), the control panel keeps its **own** application-level LMDB key-value store — the [`lmdb`](https://www.npmjs.com/package/lmdb) npm package — for **serialized / derived per-node representations**. This is the "tapestry-store". It is unrelated to strfry's LMDB beyond both happening to use the LMDB library.
+
+**Where it lives.** `src/lib/tapestry-store.js` opens a singleton LMDB at `process.env.TAPESTRY_LMDB_PATH || ~/.tapestry/lmdb` (compression on, 256 MB map). Inside the container that resolves under `/root/.tapestry/`, which is **not** mapped to a named Docker volume (§4) — so it is a **rebuildable cache**: lost on container *recreation* and repopulated by the derive engine, never a source of truth.
+
+**Keying — the `tapestryKey` node property.** Each Neo4j node carries a `tapestryKey` (a v4 UUID, assigned once and never changed) that **is** the LMDB key. `POST /api/tapestry-key/initialize` stamps `SET n.tapestryKey` on every node lacking one, and the firmware install does the same (`src/firmware/install.js`, "assign tapestryKeys to all nodes"). Stored values are envelopes: `{ updatedAt, rebuiltFrom?, data }`. A companion `tapestryJsonUpdatedAt` timestamp is written back onto the node whenever the LMDB entry is (re)written.
+
+**The `lmdb:` pointer convention.** Any string property value may hold either the inline value **or** a pointer of the form `lmdb:<tapestryKey>`. `src/lib/tapestry-resolve.js` (`isLmdbRef` / `toLmdbRef` / `resolveValue` / `resolveDeep`) resolves these transparently server-side; the client does the same via `ui/src/utils/lmdb.js`, which fetches `/api/tapestry-key/:key`. A reader gets the data whether it is inline or offloaded — so **resolve through this layer rather than reading a raw property**, since you cannot assume which form a given node uses.
+
+**Write / derive path.** `src/lib/tapestry-derive.js` computes derived JSON per node and calls `store.put(node.tapestryKey, data, …)`, then stamps `tapestryJsonUpdatedAt`. The "offload" endpoints (`POST /api/tapestry-key/offload`, `/offload-all`) take an inline `json`-tag value, write it into LMDB under the parent event's `tapestryKey`, and replace the tag value with the `lmdb:` pointer. The full API surface (`status` / `initialize` / `get` / `put` / `offload` / `resolve` / `derive`) lives in `src/api/tapestry-key/index.js`. All async `store.put` writes must be awaited before the node timestamp is written or the response is sent (regression-guarded by `test/tapestry-key-put-await.test.js`).
+
+**Relationship to the protocol (§5, §8).** Node content is still *specified* in the event's `json` tag (word-wrapper format); the tapestry-store is a **local storage optimization** over that content, not a wire-format change. a-tag addressing and the `json`-tag spec are unaffected.
+
+**Migration status (as of 2026-07).** Per the post-install dashboard (`README.md`), a minority of nodes still need a `tapestryKey` and most `json` tags remain inline in Neo4j — reported there as "harmless and expected for now". The offload is incremental and ongoing.
 
 ---
 

--- a/docs/SECOND_BRAIN_STORY6_HANDOFF.md
+++ b/docs/SECOND_BRAIN_STORY6_HANDOFF.md
@@ -1,7 +1,25 @@
 # Second Brain — Story 6 Session Handoff (2026-07-24)
 
-**Status:** 🔴 OPEN
+**Status:** ✅ ADDRESSED
 
+> **ADDRESSED 2026-07-24** — story 6 "the-proposal-loop" shipped to production
+> (staging PR #449, prod promotion PR #450). Full human-gated cycle: story →
+> ADR 0006 → tests (33/0) → impl → independent review PASS → local → staging →
+> prod. **The load-bearing (a)/(b) design question resolved to append-only
+> shape (b):** a decision is a separate appended fact referencing the proposal by
+> `proposalId` — the proposal element is never mutated, nothing on the path
+> `regenerateJson`s, and open-ness is derived at read from a decision's absence
+> (`openProposals`). Decided on the §6 durable-intent-vs-append-only distinction
+> (Proposal is append-only, unlike External Resource). New `tapestry-proposal`
+> concept (type-discriminated `proposed/approved/skipped`), three gated producers
+> (`make-proposal` validates a viable-leaf nominee against the live graph +
+> `approve/skip-proposal`), the "What next?" queue view, the goal-detail
+> `records[]` merge (8th brain require), and the ratified approve string
+> *"Approved — launch it when you're ready."* The story-7 pickup is
+> `docs/SECOND_BRAIN_STORY7_HANDOFF.md`.
+>
+> _Original pickup prompt retained below for history._
+>
 > Written at the close of the story-5 session (sessions-read-the-brain: review
 > PASS, shipped to production 2026-07-24, staging PR #439, carried to prod by the
 > concurrent promotion PR #440). This is the pickup prompt for the next session,

--- a/docs/SECOND_BRAIN_STORY7_HANDOFF.md
+++ b/docs/SECOND_BRAIN_STORY7_HANDOFF.md
@@ -1,0 +1,182 @@
+# Second Brain — Story 7 Session Handoff (2026-07-24)
+
+**Status:** 🔴 OPEN
+
+> Written at the close of the story-6 session (the-proposal-loop: review PASS,
+> shipped to production 2026-07-24, staging PR #449, prod promotion PR #450). This
+> is the pickup prompt for the next session, with the load-bearing discoveries
+> from story 6 baked in. When story 7 ships, flip this Status to ✅ ADDRESSED.
+
+## Pickup prompt
+
+Pick up story 7 of the second-brain book — **"Teach it what matters — priority
+signals"** (the owner records pairwise choices between goals — dated, attributed,
+framing-tagged — which proposals *may* cite but which never launch anything —
+PRD §5.6, §6, §7.6). Stories 1–6 are Done and in production. The book, epic, and
+stories folder exist — do **not** re-open the book. Branch fresh off updated
+staging (`git checkout staging && git pull`, then re-create `feat/second-brain` —
+note: the remote `feat/second-brain` is auto-deleted when each story's PR merges,
+so the re-create is a fresh branch each time).
+
+Read, in order:
+
+1. `product-team/stories-queue.md` — Second Brain block, Story 7. Dependency line:
+   **only Story 1 is strictly required** (goals must exist); it "pairs naturally
+   after Story 6 but does not require it." Note the 5 ACs and the "Notes for
+   engineering": **the framing is a replaceable slot by design** (PRD §7.6; the
+   operator's stated epistemology — "99 wrong framings, find the right one by
+   iterating"); **V1 ships pairwise only — no score aggregation, no ranking
+   display**; the signals are *data for the future*, not a feature surface now.
+2. `product-team/prd/second-brain.md` — §5.6 (priority signals: the owner records
+   pairwise choices "solve one today: which?" with an optional one-line reason;
+   each signal is dated, attributed, and **tagged with the framing that produced
+   it**, so a replaced framing's history stays interpretable; **recorded, never
+   acted on autonomously in v1** — proposals may cite them as rationale, nothing
+   launches from them), §6 (**Priority Signal** is a *new append-only* concept —
+   *prefers goal / over goal, reason, judged-by, judged-on, framing tag*), §7.6
+   (the prioritization framing is a **replaceable slot**: replacements are
+   proposed with evidence and ratified by the owner — the constitution binds this).
+3. `product-team/guides/second-brain-design-guide.md` + `second-brain-style-guide.md`
+   — **note the gap:** the guides do **not** define a signal-specific component or
+   a spine record-type word for signals (the design-guide record types are
+   `proposed / approved / skipped / worked / noted` — no signal word). The AC
+   requires signals be "**visible on the goals they touch**," so the Architect
+   must decide the spine representation (a new record type word? a distinct
+   panel?) and any owner-facing copy — flag it as a ratification gate the way
+   story 6's **approve-confirmation copy** was (that gap was surfaced at planning
+   and ratified at the Architecture gate to *"Approved — launch it when you're
+   ready."* — the same move applies here). **Comparisons, not decimals** still
+   binds: a signal is a *choice between two goals*, never a number.
+4. `engineering-team/epics/second-brain.md` + `audits/second-brain/book.md` —
+   roster, guardrails. After story 7, the book has only **story 8** (export/restore)
+   left, then it closes. (Epic hygiene note: the per-story "Done" markers in the
+   epic lag — stories 3/4/5 still read "Queued" though they shipped; story 6 is
+   marked Done. Reconcile 3–6 to Done at book-close, or when convenient.)
+5. `engineering-team/decisions/second-brain/0006-the-proposal-loop.md` — **the one
+   to internalize.** Story 6 is the **third** self-bootstrapping append-only
+   concept (after External Resource / Work Record) and it settled the
+   **append-only-by-construction** idiom you'll reuse wholesale: `ensureXConcept`
+   (idempotent create-concept + save-schema via `invokeNormalizeHandler`),
+   `mintXElement` (nonce/`randomDTag`, **never `regenerateJson`**), record-based
+   linkage (the `goal` slug field, dereferenced at read by grouping — no edge, no
+   whitelist change), and the pure-core + read-time-derivation pattern
+   (`src/lib/brain/proposals.js`). ADRs 0001–0005 remain binding context.
+6. `engineering-team/reviews/second-brain/6-the-proposal-loop.md` — PASS; 2
+   non-blocking findings, both dispositioned (the error-state Retry button was
+   fixed post-review; the `ensureProposalConcept`/`already-open` ordering is
+   benign).
+
+## Load-bearing context from story 6
+
+- **Priority Signal is a NEW append-only concept — self-bootstrap it like Work
+  Record / Proposal (the fourth such concept).** `ensureProposalConcept` /
+  `mintProposalElement` in `src/api/normalize/index.js` are the exact template
+  (idempotent bootstrap; append-only random-d-tag mint; never `regenerateJson`;
+  gated + validated + serialized through the **existing `serializeGoalWrite`** —
+  do **not** rename it). **Never firmware-seeded** (PRD §7.8); self-provisions
+  per-instance on the first live write. Unlike Proposal (type-discriminated
+  proposed/approved/skipped), a Signal likely has **one shape**
+  (`prefers`/`over`/`reason`/`judgedBy`/`judgedOn`/`framing`) — simpler; no `type`
+  enum needed unless the Architect finds a reason.
+- **THE new wrinkle: a signal touches TWO goals (`prefers` + `over`), so it must
+  surface on BOTH goals' spines.** Work records and proposals each attach to
+  **one** goal (`workRecord.goal` / `proposal.goal`); a Priority Signal is about a
+  **pair**. The goal-detail `records[]` projection (`handleGetGoalDetail`,
+  `src/api/brain/index.js`) currently groups by a single `goal` slug — story 7
+  must project a signal onto **both** the prefers-goal and the over-goal (each
+  reading "chose this over X" / "X chosen over this", in plain comparative
+  language). Decide this at Architecture — it is the story's spine, the way the
+  (a)/(b) transition was story 6's and bounded-orientation was story 5's. The
+  pure core is `src/lib/brain/proposals.js` (parse / group-by-goal / project) —
+  mirror it as `src/lib/brain/signals.js`, but the grouping fans out to two goals.
+- **The framing tag is a replaceable slot (PRD §7.6).** Each signal records the
+  framing that produced it, so a later framing swap leaves earlier signals
+  interpretable. V1 just records the framing string on the signal; **no framing
+  registry, no swap mechanism, no ranking/aggregation** (all deferred — the
+  signals are raw data for the future). Don't build a framing-management surface.
+- **Signals are recorded, never acted on (§7.6/§5.6).** A signal **never** causes
+  a launch or a decision. Story 6's `make-proposal` does **not** consume signals
+  (its rationale is caller-supplied); AC4's "a proposal's why-now *may* cite
+  recorded signals in plain words" is a soft affordance — the conversational agent
+  can read signals and mention them; **no hard wiring of signals into
+  make-proposal is required** (and per the queue note, story 6 doesn't depend on
+  signals). If the Architect adds a signals **read** surface, it stays read-only
+  and in the brain module.
+- **Writes ride the settled pattern; a signal validates BOTH goals exist + are
+  distinct.** Gate-first (`isOwner(req) || req.localTrusted → 403`), validate
+  before any write (both goal slugs resolve to real goals; refuse if either is
+  unknown/ambiguous, or if `prefers === over`), serialize through
+  `serializeGoalWrite`, local-only (`publishToStrfry` + `importEventDirect`,
+  never `publishEverywhere`). Mirror `make-proposal`'s live-graph validation.
+  Unlike make-proposal, a signal does **not** require the goals to be *viable* —
+  the owner can prefer any goal over any other (confirm at the gate).
+- **The brain read import surface is now EIGHT, sextuple-pinned.**
+  `src/api/brain/index.js` is pinned to eight requires by story-1 S2, story-2 S3,
+  story-3 S1, story-4 S11, story-5 S8, **and** story-6 S8 (the six cores +
+  `lib/brain/work-records` + `lib/brain/proposals`). If story 7 adds
+  `lib/brain/signals`, that require addition must amend **all six** sibling
+  allowlists in the same diff — the recurring sibling-re-pin lesson, now the
+  **sixth** time. Plan it in Phase 3. The brain module stays read-only (signal
+  **writes** live in normalize).
+- **Copy is comparisons, never decimals.** A signal is "chose A over B" (+ an
+  optional one-line reason), never a score. The pairwise prompt is "solve one
+  today: which?" (PRD §5.6). Any new owner-facing string passes the banned-jargon
+  scan (*element, kind, schema, event, pubkey, superset, concept header, persona,
+  acceptance criteria, lease, payload, endpoint*), no exclamation marks. **No
+  numeric score anywhere.** The signal's spine wording + any capture confirmation
+  are a **style-guide gap** — ratify the exact copy at a gate (see Read #3).
+
+## Practicalities
+
+- TA pubkey is runtime-resolved; never hand-transcribe — fetch into a variable
+  (`/api/assistant/pubkey`).
+- Full `npm test` ≈ 24+ min (now includes the story-6 `the-proposal-loop` suite).
+  Background it from the start via the bounded `until grep -q "^Overall:" <log>;
+  do sleep 15; done` waiter (OPEN.md rows 74/83). **Run the long command *as* the
+  backgrounded call — no inner `nohup … &`** — or the launcher exits immediately
+  and the real process detaches untracked (story-6 lesson: this idled a spawned
+  reviewer subagent; it had to be resumed with SendMessage).
+- **The `tl-publication-from-pins-publish` suite flakes under heavy local-session
+  churn** — it goes non-deterministically red (`status 0` / empty-TL /
+  missing-cutoff-tag) as the local Meili/WoT index degrades from many fixture
+  create/teardown cycles; it is **unrelated to any brain code** (zero overlap with
+  the second-brain diff) and was green in the clean pre-merge run. Don't chase it;
+  CI in a clean environment is the authoritative gate. (Row-75 strfry-router
+  scan-count drift is a separate known environmental flake on
+  `relationship-primitives`.)
+- New suite registers in `test/test.js`'s **live** `overallOk` chain before the
+  severed terminator (OPEN.md #43 — flip the current terminator's `;` to ` &&`,
+  add your term ending `;`, leave the dead block) plus the `totalSkipped` array
+  and a per-suite summary line. Story 6's `theProposalLoopResult` is now the live
+  terminator.
+- **Parallel-session collisions are live.** The tapestries book has been shipping
+  concurrently (story 6 hit it: tapestries #3 merged to staging mid-session,
+  forcing a re-sync merge — conflicts only in `test/test.js` runner-registration +
+  `ui/src/styles.css`, both **additive → keep both** — and a concurrent
+  `staging→main` promotion (#448) carried tapestries #3 to prod, which happened to
+  make story 6's prod promote clean). **Re-sync (merge origin/staging) before the
+  staging PR; re-check `origin/main..origin/staging` before any prod promote** — it
+  may bundle another team's work your authorization doesn't cover.
+- If you implement in the main session, spawning the independent reviewer subagent
+  is required-by-practice (OPEN.md row 80b) — re-run every gate itself, trust
+  nothing the implementer reported.
+- Host shell quirk: bare `curl` / `python3` / `docker` / `head` intermittently
+  resolve as "command not found" inside compound scripts; use explicit paths
+  (`/usr/bin/curl`, `/opt/homebrew/bin/python3`).
+- Local dev loop: the repo bind-mounts into the container; new/changed server
+  routes need `docker exec tapestry supervisorctl restart brainstorm`; UI changes
+  need the in-container `npx vite build`.
+
+## Then
+
+Act as the engineering Product Owner: promote Story 7 — "Teach it what matters —
+priority signals" — via `/plan-feature` into `engineering-team/stories/second-brain/`
+(next story number: 7).
+
+Run human-gated: the operator answers every phase gate. Any owner-facing copy
+comes verbatim from `product-team/guides/second-brain-style-guide.md` (and any
+gap — the signal spine wording — is ratified at a gate, per story 6's
+approve-string precedent). One story per session. After story 7, only story 8
+(export/restore) remains before the book closes; at book-close, back-fill the
+ratified approve string *"Approved — launch it when you're ready."* into the
+style guide's confirmations list (ADR 0006 d16 / the product-team return edge).

--- a/src/api/tapestry-key/index.js
+++ b/src/api/tapestry-key/index.js
@@ -175,7 +175,7 @@ async function handlePut(req, res) {
 
     // Write to LMDB
     const meta = rebuiltFrom ? { rebuiltFrom } : {};
-    const envelope = store.put(key, data, meta);
+    const envelope = await store.put(key, data, meta);
 
     // Update Neo4j timestamp
     await writeCypher(`

--- a/test/tapestry-key-put-await.test.js
+++ b/test/tapestry-key-put-await.test.js
@@ -1,0 +1,173 @@
+/**
+ * Regression guard: POST /api/tapestry-key/:key (handlePut) must AWAIT the
+ * async LMDB write before it reads the envelope and responds.
+ *
+ * The bug: handlePut called `const envelope = store.put(key, data, meta)` with
+ * no `await`. Because tapestry-store.put is async, `envelope` was a *pending
+ * Promise*, so:
+ *   - `envelope.updatedAt` was `undefined` → Neo4j's `tapestryJsonUpdatedAt`
+ *     was written as undefined/null, and
+ *   - `res.json({ data: envelope })` serialized the Promise to `{}`, and
+ *   - the LMDB write was not guaranteed durable before the response.
+ * Every other call site (handleOffload, handleOffloadAll, tapestry-derive)
+ * awaits store.put correctly — handlePut was the lone outlier.
+ *
+ * Stack-free: this suite needs neither LMDB nor Neo4j. It injects fake
+ * tapestry-store and neo4j-driver modules into the require cache (the seam used
+ * by close-unauth-write-surface.test.js), loads handlePut fresh, and asserts
+ * the resolved envelope — not a Promise — reaches both the Cypher write and the
+ * response body. Originals are restored in run()'s finally so later suites in
+ * the shared runner are not contaminated.
+ *
+ * TI1, TI2 : FAIL against the un-awaited code, PASS once the `await` lands.
+ * RI1      : PASS pre AND post — a source sentinel mirroring the sibling-audit
+ *            grep; flips to FAIL if any un-awaited store.put/store.remove is
+ *            (re)introduced anywhere in tapestry-key/index.js.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const INDEX_FILE = path.join(ROOT, 'src/api/tapestry-key/index.js');
+const INDEX_PATH = require.resolve(INDEX_FILE);
+const STORE_PATH = require.resolve(path.join(ROOT, 'src/lib/tapestry-store'));
+const DRIVER_PATH = require.resolve(path.join(ROOT, 'src/lib/neo4j-driver'));
+const DERIVE_PATH = require.resolve(path.join(ROOT, 'src/lib/tapestry-derive'));
+
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+
+function mkRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(c) { this.statusCode = c; return this; },
+    json(o) { this.body = o; return this; },
+  };
+}
+
+// A fixed, non-Date epoch the fake store stamps onto every envelope. If
+// handlePut forgets to await, the handler reads `.updatedAt` off the pending
+// Promise (undefined) instead of this number — the discriminating signal.
+const FAKE_TS = 1234567890;
+
+/**
+ * Load a fresh handlePut with tapestry-store + neo4j-driver stubbed, returning
+ * the handler plus the call logs the stubs record.
+ */
+function loadHandlerWithStubs() {
+  // Force fresh loads of the handler and anything that closes over the store.
+  delete require.cache[INDEX_PATH];
+  delete require.cache[DERIVE_PATH];
+
+  const storeCalls = [];
+  const cypherCalls = [];
+
+  require.cache[STORE_PATH] = {
+    id: STORE_PATH, filename: STORE_PATH, loaded: true,
+    exports: {
+      put: async (key, data, meta = {}) => {
+        storeCalls.push({ key, data, meta });
+        return { updatedAt: FAKE_TS, ...meta, data };
+      },
+      get() { return null; },
+      remove: async () => {},
+      stats() { return { count: 0, path: '(stub)' }; },
+      listKeys() { return []; },
+      close() {},
+    },
+  };
+
+  require.cache[DRIVER_PATH] = {
+    id: DRIVER_PATH, filename: DRIVER_PATH, loaded: true,
+    exports: {
+      runCypher: async (cypher, params) => { cypherCalls.push({ fn: 'runCypher', cypher, params }); return []; },
+      writeCypher: async (cypher, params) => { cypherCalls.push({ fn: 'writeCypher', cypher, params }); return []; },
+      getDriver() { return null; },
+      closeDriver() {},
+      toJS(x) { return x; },
+    },
+  };
+
+  const mod = require(INDEX_PATH);
+  return { handlePut: mod.handlePut, storeCalls, cypherCalls };
+}
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+
+test('TI1: handlePut awaits store.put — the Neo4j timestamp write gets the resolved numeric updatedAt (not undefined)', async () => {
+  const { handlePut, storeCalls, cypherCalls } = loadHandlerWithStubs();
+  const res = mkRes();
+  await handlePut({ params: { key: 'k1' }, body: { data: { hello: 'world' } } }, res);
+
+  assert(storeCalls.length === 1, `expected store.put to be called once, got ${storeCalls.length}`);
+  const write = cypherCalls.find((c) => c.fn === 'writeCypher');
+  assert(write, 'expected a writeCypher call to set tapestryJsonUpdatedAt');
+  assert(
+    write.params && write.params.ts === FAKE_TS,
+    `tapestryJsonUpdatedAt must be the resolved numeric updatedAt (${FAKE_TS}); got ${write.params && write.params.ts} — store.put was not awaited.`
+  );
+});
+
+test('TI2: handlePut response body carries the resolved envelope, not a pending Promise', async () => {
+  const { handlePut } = loadHandlerWithStubs();
+  const res = mkRes();
+  await handlePut({ params: { key: 'k2' }, body: { data: { a: 1 } } }, res);
+
+  assert(res.body && res.body.success === true, `expected { success: true }, got ${JSON.stringify(res.body)}`);
+  const env = res.body.data;
+  assert(
+    env && typeof env.updatedAt === 'number',
+    `response data must be the resolved envelope with a numeric updatedAt; got ${JSON.stringify(env)} — an un-awaited Promise serializes to {}.`
+  );
+  assert(env.data && env.data.a === 1, 'the response envelope must carry the written data.');
+});
+
+test('RI1: no un-awaited store.put(/store.remove( remains in tapestry-key/index.js (sibling-audit sentinel)', () => {
+  const src = fs.readFileSync(INDEX_FILE, 'utf8');
+  const offenders = [];
+  src.split('\n').forEach((line, i) => {
+    if (/\bstore\.(put|remove)\s*\(/.test(line) && !/\bawait\s+store\.(put|remove)\s*\(/.test(line)) {
+      offenders.push(i + 1);
+    }
+  });
+  assert(
+    offenders.length === 0,
+    `un-awaited store.put/store.remove at src/api/tapestry-key/index.js line(s) ${offenders.join(', ')} — async LMDB writes must be awaited.`
+  );
+});
+
+async function run() {
+  // Snapshot the cache entries we mutate so later suites in the shared runner
+  // (node test/test.js) see the real modules again.
+  const snapshot = {
+    [INDEX_PATH]: require.cache[INDEX_PATH],
+    [STORE_PATH]: require.cache[STORE_PATH],
+    [DRIVER_PATH]: require.cache[DRIVER_PATH],
+    [DERIVE_PATH]: require.cache[DERIVE_PATH],
+  };
+  let pass = 0;
+  let fail = 0;
+  try {
+    for (const t of tests) {
+      try {
+        await t.fn();
+        console.log(`  ✓ ${t.name}`);
+        pass++;
+      } catch (err) {
+        console.log(`  ✗ ${t.name}`);
+        console.log(`      ${err.message}`);
+        fail++;
+      }
+    }
+  } finally {
+    for (const [p, entry] of Object.entries(snapshot)) {
+      if (entry === undefined) delete require.cache[p];
+      else require.cache[p] = entry;
+    }
+  }
+  return { pass, fail };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -185,6 +185,8 @@ const attachTheWorld = require('./attach-the-world.test.js');
 // epic: second-brain — Story 5 (sessions read the brain — work records + orient).
 const sessionsReadTheBrain = require('./sessions-read-the-brain.test.js');
 const theProposalLoop = require('./the-proposal-loop.test.js');
+// bug — tapestry-key handlePut must await the async LMDB write (regression guard).
+const tapestryKeyPutAwait = require('./tapestry-key-put-await.test.js');
 
 async function main() {
   console.log('Running Brainstorm tests...');
@@ -488,6 +490,9 @@ async function main() {
   const sessionsReadTheBrainResult = await sessionsReadTheBrain.run();
   const theProposalLoopResult = await theProposalLoop.run();
 
+  console.log('\ntapestry-key-put-await suite:');
+  const tapestryKeyPutAwaitResult = await tapestryKeyPutAwait.run();
+
   console.log('\nTest Results');
   console.log('-------------');
   console.log(`Configuration Loading:                           ${configOk ? 'PASS' : 'FAIL'}`);
@@ -637,6 +642,9 @@ async function main() {
   );
   console.log(
     `create-tapestry suite:                           ${createTapestryResult.fail === 0 ? 'PASS' : 'FAIL'} (${createTapestryResult.pass} passed, ${createTapestryResult.fail} failed)`
+  );
+  console.log(
+    `tapestry-key-put-await suite:                    ${tapestryKeyPutAwaitResult.fail === 0 ? 'PASS' : 'FAIL'} (${tapestryKeyPutAwaitResult.pass} passed, ${tapestryKeyPutAwaitResult.fail} failed)`
   );
   console.log(
     `reconciliation-incremental-mode suite:           ${reconciliationIncrementalModeResult.fail === 0 ? 'PASS' : 'FAIL'} (${reconciliationIncrementalModeResult.pass} passed, ${reconciliationIncrementalModeResult.fail} failed)`
@@ -1032,7 +1040,10 @@ async function main() {
     theProposalLoopResult.fail === 0 &&
     // tapestries #3 — create a tapestry (members-only authoring)
     // (LIVE chain — before the severed terminator; OPEN.md #43).
-    createTapestryResult.fail === 0;
+    createTapestryResult.fail === 0 &&
+    // bug — tapestry-key handlePut must await the async LMDB write.
+    // (LIVE chain — before the severed terminator; OPEN.md #43.)
+    tapestryKeyPutAwaitResult.fail === 0;
     harnessLintResult.fail === 0 &&
     harnessStatsResult.fail === 0 &&
     sessionStartResult.fail === 0 &&


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`.

## Bundled

- **#452** — `fix(tapestry-key)`: await the async LMDB write in `handlePut` (`POST /api/tapestry-key/:key`) so the resolved envelope reaches the Neo4j timestamp write and the response; adds BIBLE **§29** documenting the standalone tapestry-store LMDB layer + a stack-free regression test.
- **#451** — `docs`: second-brain story-6 handoff marked ADDRESSED + story-7 handoff. **Docs-only.**

## Net production impact

Effectively none for end users. #452 fixes a latent bug in an **owner-gated write** endpoint (`tapestryJsonUpdatedAt` was written undefined / response body serialized `{}` / write durability) — no schema, UI, or public-API change. #451 is documentation only. **No forced sign-out, no data migration.**

## Verification trail

- #452: staging deploy run [30132036774](https://github.com/nous-clawds4/tapestry/actions/runs/30132036774) (1m27s); stack-free CI (`test.yml`) success; staging smoke clean (`/api/tapestry-key/status` → 200, all pages 200, search 200 w/ hits).
- #451: shipped to staging earlier (deploy `b0314669`); docs-only.
- **Diff note:** the raw two-dot `main..staging` diff appears to "delete" `.github/workflows/configure-prod.yml`, but that is a tip-comparison artifact — the file is **main-only** (added via #446 directly to main); the three-way merge **preserves** it. The actual merge introduces only 6 files (+414/-4): the two above.

## Test plan

- [ ] After merge: deploy-tapestry.yml runs to completion.
- [ ] Smoke test on tapestry.brainstorm.world (tiers 1/2/3/5).
- [ ] `/api/tapestry-key/status` → 200; BIBLE §29 present; no workflow/config regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)