### PR TITLE
Promote staging → main: self-ontology handoff + second-brain #8 + smoke-test gotcha (#457, #456)

### DIFF
--- a/docs/SECOND_BRAIN_STORY7_HANDOFF.md
+++ b/docs/SECOND_BRAIN_STORY7_HANDOFF.md
@@ -1,6 +1,6 @@
 # Second Brain — Story 7 Session Handoff (2026-07-24)
 
-**Status:** 🔴 OPEN
+**Status:** ✅ ADDRESSED — story 7 (teach-it-what-matters) shipped to production 2026-07-24: staging PR #454, prod promotion PR #455, independent review PASS (`engineering-team/reviews/second-brain/7-teach-it-what-matters.md`). Pickup for story 8: `docs/SECOND_BRAIN_STORY8_HANDOFF.md`.
 
 > Written at the close of the story-6 session (the-proposal-loop: review PASS,
 > shipped to production 2026-07-24, staging PR #449, prod promotion PR #450). This

--- a/docs/SECOND_BRAIN_STORY8_HANDOFF.md
+++ b/docs/SECOND_BRAIN_STORY8_HANDOFF.md
@@ -1,0 +1,179 @@
+# Second Brain — Story 8 Session Handoff (2026-07-24)
+
+**Status:** 🔴 OPEN
+
+> Written at the close of the story-7 session (teach-it-what-matters: review PASS,
+> shipped to production 2026-07-24, staging PR #454, prod promotion PR #455). This
+> is the pickup prompt for the next session, with the load-bearing discoveries
+> from story 7 baked in. When story 8 ships, flip this Status to ✅ ADDRESSED.
+
+## Pickup prompt
+
+Pick up story 8 of the second-brain book — **"The brain survives — export and
+restore"** (the owner exports the brain's owner-authored content and proves,
+once, that a restore reproduces it — PRD §5.7, §7.4). Stories 1–7 are Done and
+in production. **This is the book's LAST story** — after it PASSes, run
+completion detection and offer `/close-book` (the operator's "yes" triggers it;
+see "Then" below for the close-out bundle). The book, epic, and stories folder
+exist — do **not** re-open the book. Branch fresh off updated staging
+(`git checkout staging && git pull`, then re-create `feat/second-brain` — the
+remote branch auto-deletes at each PR merge).
+
+Read, in order:
+
+1. `product-team/stories-queue.md` — Second Brain block, Story 8. The 4 ACs:
+   a dated export artifact carrying **goals (with decomposition positions),
+   resources, signals, proposals and decisions, and work records**; a restore
+   drill against a **scratch target** that reproduces goals/pointers/records,
+   **journaled**; **no egress** (§7.4 — the export completes without touching
+   or publishing anything outward); running export twice with no changes →
+   **equivalent content**. "Notes for engineering": scope is the owner-authored
+   second-brain content, **not a whole-database backup**; "scratch target" =
+   any environment that is not the live brain — **the drill must not risk the
+   thing it protects**. Dependency: story 1 only (satisfied). Until the
+   separate firmware clobber-protection epic lands, **this export IS the
+   protection** (referenced, never re-specified — PRD §7.9).
+2. `product-team/prd/second-brain.md` — §5.7 (safeguards: export + one verified
+   restore drill), §7.4 (privacy: local by convention, no outbound sync), §7.2
+   (append-only), §5.9 (second-operator guard — the export is also the
+   portability seed; no reference-instance identities baked in).
+3. `product-team/guides/second-brain-style-guide.md` — **story 8 has LESS of a
+   copy gap than 6/7 did:** the button label **"Export brain."** (line 24) and
+   the confirmation *"Restore drill complete — your brain matches the export."*
+   (line 27) are **already pinned verbatim**. What's NOT pinned: where the
+   export affordance lives (the design guide's three-view inventory has no
+   export surface — §5.8 names three views only) and any export confirmation
+   sentence. Surface placement + any new string at a gate (the d16/d5
+   precedent). Note the design guide's do-not-design list still binds.
+4. `engineering-team/epics/second-brain.md` + `audits/second-brain/book.md` —
+   roster (stories 1–7 all marked Done), guardrails, the two recorded coverage
+   gaps (rename/abandon; category instances/filter) — both land in the
+   book-close addendum, not story 8.
+5. `engineering-team/decisions/second-brain/0007-teach-it-what-matters.md` —
+   the freshest ADR (the fourth runtime-created append-only concept; the
+   two-goal read-time fan-out; server-stamped framing). ADRs 0001–0006 remain
+   binding. **For story 8 the load-bearing prior art is the full concept set:**
+   the export must carry five content families whose live producers now all
+   exist — `tapestry-owner-goal`, `tapestry-external-resource`,
+   `tapestry-work-record`, `tapestry-proposal`, `tapestry-priority-signal`.
+6. `engineering-team/reviews/second-brain/7-teach-it-what-matters.md` — PASS;
+   zero blocking; the fetchSignals omission adjudicated defensible (dead-code
+   avoidance beats notes-listing); non-blocking items all dispositioned.
+
+## Load-bearing context from story 7
+
+- **All five owner-authored content families have live read paths in
+  `src/api/brain/index.js`:** `readResolvedGoals`, `readResourceRecords`,
+  `readWorkRecords`, `readProposals`, `readSignals` — each the same
+  EXPLICIT ∪ IMPLICIT ConceptElements union, absence-tolerant. These are the
+  natural export read set; whether export rides them (a brain read?) or a
+  normalize lane is the Architect's call — but remember the brain module is
+  **pinned read-only** (no mutation/strfry tokens) and RESTORE writes, so
+  restore cannot live in `src/api/brain/`.
+- **The brain import surface is NINE, septuple-pinned.** The identical
+  allowlist array now sits in SEVEN suites (capture 333, structures 454, break
+  540, attach 560, sessions-read 573, the-proposal-loop 580, and
+  teach-it-what-matters — grep `lib\\/brain\\/signals` for the exact lines). A
+  tenth require (e.g. `lib/brain/export`) amends **all seven in the same
+  diff** — the recurring lesson, now the eighth occurrence. If story 8 adds NO
+  brain require (plausible — export may live entirely in normalize or a new
+  module), the pins stay untouched; decide in Phase 3 either way.
+- **Restore must respect the self-bootstrap pattern.** Every non-goal concept
+  is runtime-created (`ensureResourceConcept` / `ensureWorkRecordConcept` /
+  `ensureProposalConcept` / `ensureSignalConcept` in
+  `src/api/normalize/index.js`) — a scratch target starts WITHOUT them. A
+  restore path that writes elements must ensure the concept first (the
+  ensure-then-mint idiom), and the goal concept itself
+  (`tapestry-owner-goal`) exists on the reference instance via firmware — a
+  TRULY fresh scratch target may lack it; the second-operator guard (§5.9)
+  says nothing may assume it pre-exists. Surface this at Architecture.
+- **Append-only survives export/restore by construction if you carry the
+  record fields, not the element identities.** Records link by SLUG fields
+  (`goal`, `proposalId`, `prefers`/`over`) — record-based linkage means an
+  export of json sections round-trips the graph structure with zero edge
+  reconstruction. But element d-tags are random (work records / proposals /
+  signals) and goal d-tags are name-derived — the Architect must decide
+  whether restore re-mints (new d-tags, same content — simplest honest;
+  "equivalent content" not byte-identical events) or replays raw events
+  (byte-true; heavier). The queue's AC4 says "equivalent content" — that
+  word choice is load-bearing.
+- **§7.4 is a structural test target:** the story-7 S-suite's no-egress scan
+  (`publishEverywhere`/outbound `fetch`/etc.) extends naturally over the
+  export path; export writes a LOCAL artifact only. Local-only publish
+  (`publishToStrfry` + `importEventDirect`) applies to restore writes.
+- **Copy:** "Export brain." + the restore-drill confirmation are already
+  canonical (style guide lines 24/27). No numeric anywhere owner-facing. Any
+  NEW strings (export confirmation, drill-journal wording if owner-facing) are
+  authored to register and ratified at a gate.
+- **The drill's journal is an artifact question** — where does "the drill's
+  result is journaled" live? (A work record on a goal? A file? The book's
+  audit?) The PO should pin the intent at Planning; story 5's work-record
+  spine is available as the append-only journal surface (a `worked`/`noted`
+  entry about the drill) — but that's mechanism; decide at the gates.
+
+## Practicalities
+
+- TA pubkey runtime-resolved (`/api/assistant/pubkey`); never hand-transcribe.
+- Full `npm test` ≈ **25 min** (the reviewer's measured number; includes the
+  story-7 suite). Background it AS the backgrounded call (no inner `nohup…&`).
+  **Quiesce `strfry-router` first** (`docker exec tapestry supervisorctl stop
+  strfry-router`, restart after) — OPEN.md row 75: it drifts the
+  relationship-primitives scan-count brackets under load.
+- **OPEN.md row 94 (new this session): the brain H-suites' fixture pre-clean
+  cannot recover from a crashed teardown** — deletions derive from
+  process-local state, so a mid-gate teardown crash strands element nodes
+  whose json tags the next pre-clean sweeps away, leaving "already exists" +
+  hygiene `unreadable-record` cascades (the-proposal-loop went 23/10 twice).
+  Recovery: query Neo4j for `uuid CONTAINS 'harness-proposal'` (or
+  `'harness-signal'`), delete strfry events by the uuid's d-tag part, DETACH
+  DELETE nodes+tags, verify count-0. **If the Tester writes story-8 H
+  fixtures, consider the row-94 fix in-suite** (pre-seed known fixture names;
+  name-based sweep) — that closes the row for the new suite at least.
+- The `tl-publication-from-pins-publish` suite still flakes under heavy local
+  churn (row from story 6) — unrelated to brain code; CI clean-env is
+  authoritative.
+- **Parallel-session collisions remain live.** Story 7 hit both flavors AGAIN:
+  (a) tapestry-key #452 merged to staging mid-session → pre-PR re-sync merge;
+  conflicts only in `test/test.js` (BOTH sides added runner registrations —
+  additive keep-both; their suite is module-only/4-touch, which is fine); (b)
+  a concurrent promotion #453 carried #452 to prod before ours, so our
+  promote (#455) was exclusively second-brain — **always re-check
+  `origin/main..origin/staging` before the prod merge.** Also: **main now has
+  a required `stack-free` CI check** — the promotion PR merge is BLOCKED until
+  it completes (~1 min); poll `gh pr view --json statusCheckRollup`, then
+  merge (seen on #455).
+- New suite registers in `test/test.js`'s live `overallOk` chain — the current
+  live terminator is `teachItWhatMattersResult.fail === 0;` (flip its `;` to
+  ` &&`, add your term ending `;`, leave the dead block — OPEN.md #43) + the
+  `totalSkipped` array + a summary line.
+- Host shell quirks: bare `curl`/`python3` "command not found" in compound
+  scripts (use `/usr/bin/curl`, `/opt/homebrew/bin/python3`); foreground
+  `sleep N && cmd` chains are blocked — use bounded `until` loops.
+- Local dev loop: server routes need `docker exec tapestry supervisorctl
+  restart brainstorm`; UI changes need the in-container `npx vite build`
+  (story 7 had zero UI diff; story 8 likely adds an export affordance — plan
+  the build).
+- The independent reviewer subagent is required-by-practice (OPEN.md row 80b)
+  when the main session implements — it re-runs every gate itself.
+- Known environmental: `GET /api/get-user-data` for large-graph pubkeys
+  (Jack, and since 2026-07-24 also Odell) 504s in ~16s on staging AND prod —
+  the documented per-query-timeout class with its own planned fix; never a
+  second-brain defect (SMOKE_TEST.md updated this session).
+
+## Then
+
+Act as the engineering Product Owner: promote Story 8 — "The brain survives —
+export and restore" — via `/plan-feature` into
+`engineering-team/stories/second-brain/` (next story number: 8, slug
+`the-brain-survives` per the epic roster). ADR number: 0008.
+
+Run human-gated: the operator answers every phase gate. One story per session.
+**After story 8 PASSes, the book is complete — offer `/close-book`.** The
+close-out bundle waiting at book-close: back-fill into the product-team guides
+(the return edge) the ratified strings — ADR 0006 d16's approve confirmation
+(*"Approved — launch it when you're ready."*), ADR 0007 d5's signal wording
+(type words `preferred` / `passed over`, both side templates, the capture
+confirmation *"Noted — "{prefers}" over "{over}"."*), and the canonical
+pairwise prompt — plus the epic's story-8 Done marker, the two recorded
+coverage gaps (rename/abandon; category instances) into the PRD addendum, and
+the book's audit + addendum artifacts under `audits/second-brain/`.

--- a/docs/SELF_ONTOLOGY_DESIGN_HANDOFF.md
+++ b/docs/SELF_ONTOLOGY_DESIGN_HANDOFF.md
@@ -1,0 +1,128 @@
+# The Self and Its Stores — Ontology, Provenance, and Backup — Design Handoff
+
+**Status:** 🔴 OPEN
+**Created:** 2026-07-24
+**Provenance:** Scoped in direct owner conversation (2026-07-24, the session that shipped the tapestry-key await fix + BIBLE §29), not via a `/discuss` subagent — the scoping *was* the conversation. This is the **Capture** step of the Protocol-Spec Workflow (`engineering-team/workflows/protocol-spec-workflow.md`): settled decisions + open questions, recorded so nothing lives only in the transcript. Ratify settled pieces into `BIBLE.md` + ADRs in docs-mode; flip this to ✅ SUPERSEDED once they land.
+
+---
+
+## 1. Why this exists — the unresolved tension
+
+The codebase embodies two models at once:
+
+- **Protocol-first** (CLAUDE.md architecture invariants): signed events are the substrate; neo4j is a per-POV computed *view*; import / normalization / firmware reinstall / reconciliation treat the graph as freely re-derivable from strfry.
+- **Brain-first** (second-brain, graph-curation, relationship-primitives): neo4j accumulates **locally-authored state with no event behind it** — the relationship-primitives epic is literally "strfry-free relationship add/delete."
+
+Both are live today, which means rebuild flows built under the first model can silently destroy state that only exists under the second. The owner resolved the tension explicitly on 2026-07-24. This doc records the resolution and its consequences.
+
+## 2. The ontology (SETTLED — owner decision, 2026-07-24)
+
+**Tapestry is, first and foremost, a local-first personal knowledge graph.** The decentralized-protocol layer is real and first-class, but it is not the identity layer.
+
+| Store | Ontological role |
+|---|---|
+| **neo4j** | **The definitive "me."** Complete, mortal, restorable in full from a neo4j backup. The seat of self. |
+| **tapestry LMDB** (`src/lib/tapestry-store.js`, BIBLE §29) | Also "me," but **not a co-equal seat of self** — the brain's cache / working memory, derivable from neo4j. |
+| **strfry / nostr events** | **"Letters"** — artifacts *authored by* me (or received from peers). The proof + communication + durability **axis**, not the identity substrate. |
+
+Corollaries, all settled:
+
+- **Derivability ≠ identity.** Events largely sit at the bottom of the *derivation* stack (events → graph → cache), but the derivation axis and the identity axis are different axes. A letter is derivable from me; it isn't me. My brain isn't derivable from my letters.
+- **Publishing is optional to selfhood.** A neo4j write without a published event = a private thought. Signing + publishing = writing and mailing a letter. In principle a full Tapestry instance could operate without ever signing a single nostr event.
+- **Unpublished brain-state is mortal and box-bound.** That's accepted, not a bug — with the discipline that durability is provided deliberately (backups, §7), not assumed.
+- **Events are not demoted.** They remain first-class on their own axis: the only *verifiable, trust-weightable, peer-shareable* form of an assertion. The brain can think privately, but it cannot be trusted by others until it speaks. WoT runs on signatures; nothing here licenses gating peers' events at write time (§9).
+
+## 3. The asserted core — "me minus everything recomputable" (SETTLED framing)
+
+The owner's conjecture: neo4j is (roughly) the most *compact* full representation of the self. Sharpened during scoping: neo4j-as-stored also holds **recomputable** material, so the true minimum — the **asserted core** — is neo4j minus everything recomputable:
+
+Recomputable inventory (grows over time; non-exhaustive):
+- **Derived / implicit relationships** — re-materializable from event structure + normalization rules (BIBLE §5–§6, §10).
+- **WoT scores** — GrapeRank / influence / verified counts, recomputable from the follow/mute/report graph.
+- **JSON Schema documents** — the schema stored for a JSONSchema node is recomputable from a full property tree.
+- **All tapestry-LMDB derived JSON** — by definition (§29 cache).
+
+The asserted core is then: locally-authored graph state (published or not), plus received-and-kept assertions, plus non-derivable local bookkeeping. **The compact me is small — and that's a feature**: it is what backups must preserve losslessly (§7) and what rebuilds must never touch (§5). Defining its boundary *is* the provenance model (§4) — same question, two hats.
+
+## 4. The provenance primitive (SETTLED as requirement; OPEN as design)
+
+Every node and edge must be classifiable as exactly one of:
+
+| Class | Meaning | Rebuild policy |
+|---|---|---|
+| **(a) asserted / locally-authored** | authored here; may or may not ever have been published | **Precious.** Survives every rebuild, reimport, reinstall, reconcile. |
+| **(b) event-projection** | materialized from event structure (import, normalization, derive) | **Disposable.** Re-derivable from the local event archive. |
+| **(c) peer-received** | a peer's signed assertion, recorded and trust-weighted | Re-derivable from events if the events are retained; trust filtering stays read-time, per POV. |
+
+Without this flag, neither safe rebuilds (§5) nor minimal backups (§7) are possible.
+
+**Open design questions:**
+- Representation: property on every node/edge? labels? a separate provenance ledger? (Must survive dumps/restores; must be cheap on the millions-of-edges social graph — probably *default-(b/c) with explicit (a) marking*, since (a) is the small set.)
+- Migration: classifying the *existing* graph (heuristics: strfry-free-primitive writes → (a); import/derive writers → (b)/(c); ambiguous residue → owner review?).
+- Writer discipline: every write path declares its class (relationship-primitives → (a); stream-consumer/import → (b)/(c); normalization/derive → (b)).
+
+## 5. Rebuild & reconciliation guarantee (SETTLED as requirement)
+
+**Invariant: no pipeline may destroy class-(a) state.** Risk surfaces to audit and harden:
+
+- strfry→neo4j **import** and the stream-consumer ETL
+- **Normalization** passes that rebuild derived structure
+- **Firmware reinstall** (including `tapestryKey` re-initialization — fresh UUIDs orphan existing LMDB entries)
+- **Reconciliation** (`reconciliation-rearchitecture` / `reconciliation-incremental-mode` is the beachhead — its non-destructive posture becomes the *rule*, not an option)
+- Dev tooling (`scripts/dev-refresh.sh`, wipes)
+
+Until provenance (§4) exists, the interim rule of thumb: treat any state a rebuild cannot reproduce as precious by default.
+
+## 6. LMDB dual role (SETTLED)
+
+One tool, two non-overlapping purposes, explicitly separated:
+
+1. **Primary, ongoing: low-latency compact cache.** Lossy and partial *by right* — a denormalized read model (single-document reads instead of multi-hop path queries). This is §29's existing role.
+2. **Secondary, intermittent: full lossless serialization** — the staging format for backups (§7). Coverage-complete (§8), verifiable, produced on demand; not maintained continuously.
+
+The two can coexist in one LMDB (full serialization + low-latency cache, at the price of compactness), but a given entry/run must be **distinguishable as to which mode produced it** — a cache entry must never be mistaken for backup-grade data. **Open:** mode marking (separate keyspace? envelope flag?) and a **serialization-run manifest** (key set + content hashes + timestamp + graph snapshot identity) so a backup is a verifiable artifact, not a hope.
+
+## 7. Backup routes (SETTLED intent; OPEN design)
+
+| Route | Properties |
+|---|---|
+| **neo4j dump** | Definitive and complete by decision; opaque; tied to neo4j tooling/versions. |
+| **LMDB covering serialization** | Lossless **iff** coverage (§8) holds; doubles as the export/packaging surface. |
+| **Encrypted nostr stash** (chosen pipeline) | (1) produce the full lossless serialization into LMDB (§6 mode 2); (2) **chunk + encrypt** it into nostr events; (3) stash on a safe relay (e.g. a mirror relay). Encrypted → privacy preserved; lossless → the self reconstitutable in full at the time and place of our choosing. |
+
+Honest asymmetry (settled): nostr is a full backup **only** via the encrypted-blob pipeline. Publishing the graph as constituent *semantic* events is nostr-native and verifiable but **necessarily lossy for the definitive-me** (class-(a) state has no event form) — by the ontology itself, "I can always reconstruct myself from my published events" is false.
+
+**Open:** encryption scheme (NIP-44-to-self? age?) and **key custody** — the backup of the self is protected by a key that must survive *outside* the self; chunk size vs relay event-size limits; manifest/reassembly event design; which relay(s); retention/rotation; whether the event archive (for (b)/(c) re-derivation) rides along or is assumed from relays.
+
+## 8. Coverage — a first-class concept (SETTLED concept; OPEN property)
+
+**Definition:** a set of derived documents **covers** the graph iff every node and edge is represented losslessly in at least one document and the set reassembles to the graph exactly.
+
+- **Coverage ≠ normalization** (settled). Normalization rules (§10) guarantee the graph's *internal consistency*; they say nothing about whether the *deriver set* captures everything losslessly. Owner's conjecture — error-free normalization makes a concept-graph covering *feasible* — is plausible and **deferred to a future discussion**; it is not assumed.
+- **Current gap:** registered derivers cover only concept-graph labels (Set, Superset, ListItem, ListHeader, ConceptHeader, JSONSchema, Property) — not the NostrUser/FOLLOWS/MUTES/REPORTS social graph, which is the bulk of a real instance.
+- **Scope-shrinking insight (settled):** with provenance, a full-self backup = **asserted-core serialization + event archive** — classes (b)/(c) re-derive from events, so the covering obligation may bind only on the (small) asserted core, not on millions of social edges. This makes §7 tractable.
+- **Second use (forward-looking):** coverage is also the right frame for Alice→Bob *communication* — packaging a covered subgraph for a peer.
+
+## 9. What stays protocol-first (SETTLED)
+
+The architecture invariants are **not repealed** — they govern the event/social axis: accept all signed events (no write-time gating of peers), POV-namespaced trust, filter at view time. A trusted peer's incoming event still often outranks the local graph's current belief — that's what learning from peers *is*; it updates the brain, it doesn't replace it as the seat of self. The multi-tenant caveat stands: on a shared instance, "me" = the **owner-POV slice**; the ontology as written targets the single-owner personal deployment. Ratification should reconcile the CLAUDE.md invariants' framing with this doc via ADR (add the identity axis; change no read/write-time behavior toward peers).
+
+## 10. Consequence map — candidate work (NOT yet stories)
+
+1. **Provenance primitive** (§4) — the gating piece; everything else leans on it.
+2. **Non-destructive rebuild/reconcile hardening** (§5) — audit the risk surfaces; make incremental/non-destructive the rule.
+3. **Deriver audit + lossless serialization mode + run manifest** (§6, §8).
+4. **Backup pipeline** (§7) — serialize → encrypt → chunk → stash → verified restore drill.
+5. **Health monitoring** (pre-dates this doc; folds in): orphan nodes; nodes lacking LMDB docs; LMDB docs failing schema validation; staleness (`tapestryJsonUpdatedAt`); coverage drift; provenance integrity once (1) lands. Existing signals to assemble: Health Audit (§9 BIBLE), normalization rules, `/api/tapestry-key/status`, BullMQ scheduler.
+
+Sequencing intuition: (1) → (2) → (3) → (4), with (5) attachable at any point after (1).
+
+## 11. Where we paused / open questions ledger
+
+- Provenance representation, migration, and writer discipline (§4).
+- Serialization-mode marking + manifest design (§6).
+- Encryption scheme, key custody, chunking, relay choice, retention (§7).
+- The normalization⇒covering conjecture for the concept graph (§8) — owner is fairly confident; deliberately deferred.
+- Whether the event archive is part of the backup artifact or assumed recoverable from relays (§7/§8).
+- Multi-tenant "whose brain" implications beyond the owner-POV answer (§9).
+- Ratification order: likely one umbrella ADR for the ontology (§2–§3, §9) first, then per-piece ADRs following the consequence map.

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -4,7 +4,7 @@
 >
 > **Purpose:** A single canonical definition of "smoke-tested clean" so the four `/cycle-*` slash commands don't each carry their own variant. When a new gotcha is discovered, update this file and every cycle inherits.
 
-**Last updated:** 2026-05-04
+**Last updated:** 2026-07-24
 
 ---
 
@@ -47,7 +47,7 @@ Confirm the basic surface area is up. All should HTTP 200:
 
 A "known-active" pubkey for the parameter-bearing tests: `04c915daefee38317fa734444acee390a8269fe5810b2241e5e6dd343dfbecc9` (Odell).
 
-**Known gotcha (until story #6 lands):** `/api/get-user-data?pubkey=<jack>` is expected to return **HTTP 504 with `{"success":false, "message":"Neo4j query timeout…"}`** within ~15s, not 200. Jack's follow graph is large enough that the current unbounded Cypher in `src/api/export/users/queries/userdata.js` exceeds the per-query `NEO4J_QUERY_TIMEOUT_MS` deadline (story #5 added the deadline; story #6 will rewrite the Cypher to use bounded `size(...)` pattern expressions). For this pubkey on this endpoint, a 504 with a JSON body is the **expected** smoke-test outcome — a hang or a 502 is the real regression to flag. Other pubkeys (and other endpoints for Jack, like `/api/get-user-counts`) should still 200 normally.
+**Known gotcha (until story #6 lands):** `/api/get-user-data?pubkey=<large-graph-pk>` is expected to return **HTTP 504 with `{"success":false, "message":"Neo4j query timeout…"}`** in ~16s, not 200. A large-enough follow graph makes the current unbounded Cypher in `src/api/export/users/queries/userdata.js` exceed the per-query `NEO4J_QUERY_TIMEOUT_MS` deadline (story #5 added the deadline; story #6 will rewrite the Cypher to use bounded `size(...)` pattern expressions). This started with Jack; **as of 2026-07-24 the Odell pubkey above is in the same class on both staging and prod** (identical 504-in-~16s, self-describing JSON body) — so a Tier-5 sweep using Odell should expect 504 here, not 200. For these pubkeys on this endpoint, a 504 with a JSON body is the **expected** smoke-test outcome — a hang, a 502, or a bare `000` at a client timeout ≥45s is the real regression to flag (a `000` at a short client timeout like `-m 15` just means you raced the server's ~16s answer — retry with `-m 45`). Other endpoints for these pubkeys (like `/api/get-user-counts`) should still 200 normally.
 
 ### Tier 3 — PR-specific (depends on what changed)
 


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`. **This bundle is 100% docs-only** — every changed file is a `.md`. No source, no config, no workflow, no behavior change.

## Bundled

- **#457** — `docs`: **self-ontology design handoff** (`docs/SELF_ONTOLOGY_DESIGN_HANDOFF.md`, Status 🔴 OPEN). The Protocol-Spec **Capture** artifact recording the owner's ontology decision: Tapestry is first and foremost a local-first personal knowledge graph; neo4j is the definitive "me"; the tapestry LMDB is a subordinate cache; signed nostr events are "letters."
- **#456** — `docs`: second-brain **story-8 handoff** (+ story-7 status tweak), and a correction to `docs/SMOKE_TEST.md` documenting that the Odell pubkey is now in the same `/api/get-user-data` 504-timeout class as Jack (with `-m 45` retry guidance).

## Net production impact

**None.** Documentation only. No forced sign-out, no migration, no schema/API/UI change. The `SMOKE_TEST.md` correction improves future smoke-test accuracy but changes no runtime behavior.

## Verification trail

- **#457**: staging deploy run [30140869620](https://github.com/nous-clawds4/tapestry/actions/runs/30140869620) (1m25s); staging smoke clean — Tier 1 3/3 200s, all pages + public APIs 200, search `q=jack` 200 with hits.
- Tier-5 regression on `/api/tapestry-key/status` initially returned a Neo4j connection error, recovered on first retry with identical data (`2929/339/3268`) — the documented "HTTP readiness ≠ Neo4j readiness" warm-up window, not a regression.
- **#456**: shipped to staging earlier (deploy `4b287c5a`); docs-only.

## Test plan

- [ ] After merge: deploy-tapestry.yml runs to completion.
- [ ] Smoke test on tapestry.brainstorm.world (tiers 1/2/5 — docs-only, so no Tier 3/4 surface).
- [ ] Confirm no runtime regression from a docs-only deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)