### PR TITLE
Promote staging → main: tapestries #4 per-concept detail views

### DIFF
--- a/engineering-team/decisions/done/tapestries/0002-exploration-page-as-authored-rendering.md
+++ b/engineering-team/decisions/done/tapestries/0002-exploration-page-as-authored-rendering.md
@@ -4,6 +4,12 @@
 **Date:** 2026-07-23
 **Story:** `engineering-team/stories/tapestries/2-tapestry-exploration-page.md`
 
+> **Update (2026-07-25):** **Decision 2** (import/data path) is **partially superseded by ADR
+> `tapestries/0004`** for per-concept *detail* data. Under the owner's ratified ontology (neo4j =
+> definitive source of truth; LMDB = its cache), the Exploration page's **per-concept detail views**
+> read core nodes + JSON from neo4j+LMDB. **Membership and the composed integration graph remain
+> strfry-sourced, exactly as decided here** — this update narrows Decision 2, it does not reverse it.
+
 ## Context
 
 Story `tapestries` #2 replaces the Story-1 placeholder `ui/src/pages/tapestries/TapestryDetail.jsx`

--- a/engineering-team/decisions/tapestries/0004-per-concept-detail-views-neo4j-lmdb.md
+++ b/engineering-team/decisions/tapestries/0004-per-concept-detail-views-neo4j-lmdb.md
@@ -1,0 +1,194 @@
+# ADR 0004: Tapestry per-concept detail views — Neo4j + LMDB read path
+
+**Status:** Accepted
+**Date:** 2026-07-25
+**Story:** `engineering-team/stories/tapestries/4-per-concept-detail-views.md`
+**Relationship to prior ADRs:** **Partially supersedes ADR `tapestries/0002` (Decision 2)** — for
+per-concept *detail* data only. ADR 0002's other decisions (fresh view components; membership and the
+tapestry-level integration graph rendered as-authored from strfry) **stand unchanged**.
+
+## Context
+
+Story `tapestries` #4 replaces today's per-concept view on the Exploration page
+(`ui/src/pages/tapestries/TapestryDetail.jsx`) — which shows only a member concept's *concept-graph
+JSON* (a 2-node header+superset skeleton) — with the Firmware Explorer's full per-concept experience:
+**Overview**, the **8 core-node types** (Concept Header, Superset, JSON Schema, Primary Property,
+Properties Set, Property Tree Graph, Core Nodes Graph, Concept Graph), and **Elements** and **Sets**.
+
+Acceptance criteria (quoted):
+1. **View parity** — Overview + 8 core-node types + Elements + Sets, replacing the single JSON view.
+2. **Overview** — name/description + which core nodes exist / have JSON.
+3. **Core-node JSON + source of truth** — Viewer/Raw toggle; the views surface core nodes/JSON **not
+   present in the tapestry's authored strfry block**, proving the data comes from the instance's graph.
+4. **Elements & Sets** — name-sorted list, Direct/Full scope, count, member JSON drill-down;
+   membership from the instance's graph (structural, not POV-scoped).
+5. **Graceful degradation** — concept/core-node absent from the graph → clear notice, no crash.
+6. **No regression** of the tapestry-level Integration views.
+
+### Constraints and findings (verified against the base this session)
+
+- **Owner ontology (`docs/SELF_ONTOLOGY_DESIGN_HANDOFF.md`, Status OPEN).** neo4j = primary source of
+  truth; **Tapestry LMDB = its low-latency cache**; strfry/nostr = secondary. Per-concept **node JSON
+  → Tapestry LMDB**; **relationships → neo4j**. Membership (which concepts belong) stays authored from
+  the tapestry nostr event.
+- **The tension with ADR 0002.** ADR 0002 **Decision 2 rejected the Neo4j concept-graph API** as the
+  data path (finding F2: Neo4j's json had "drifted" from the signed events after a firmware pass;
+  "never depend on Neo4j for tapestry data") and chose strfry. That choice was correct for *membership
+  and the composed integration graph*, and it is why today's per-concept view is thin: **strfry's
+  `*-concept-graph` import carries only the header + superset** (verified: `dog-concept-graph` = 2
+  nodes, `{slug,uuid}` only, no schema / primary-property / properties / JSON). The rich views are
+  **impossible from strfry** — only Neo4j holds schema, primary property, properties, and the graph
+  core nodes. The owner has since **ratified Neo4j as the definitive self**, which resolves the tension
+  in Neo4j's favor and makes the drift a bug to fix (non-destructive reconciliation; a future
+  "recompute JSON from Neo4j" affordance — both out of scope here).
+- **LMDB resolution is server-side and currently a no-op.** `src/lib/tapestry-resolve.js`
+  `resolveValue(v)` is **synchronous**: an `lmdb:<key>` pointer → `store.get(key).data`; any other value
+  passes through unchanged. The store envelope's `data` is an **object** (`src/lib/tapestry-store.js:5`),
+  whereas an inline json tag is a **string**. Empirically, **433 json tags exist and 0 are `lmdb:`
+  pointers** (`/api/neo4j/query`), so today all JSON is inline. Routing reads through `resolveValue`
+  therefore costs nothing now and transparently honors "JSON from LMDB" once offloading is enabled.
+- **The client cannot resolve LMDB.** The LMDB store is embedded server-side. Any path that returns raw
+  json-tag values to the browser (both `/api/concept-graph/node/:handle` and today's client
+  composition) **cannot** satisfy the ontology for offloaded values — resolution must happen on the server.
+- **The existing read paths.** The firmware read `GET /api/firmware/concept/:slug`
+  (`src/api/firmware/index.js:175-277`) already produces the exact shape the UI wants —
+  `{ nodes: { header, superset, schema, primaryProperty, properties, ptGraph, coreGraph, conceptGraph }
+  }`, each `{uuid,name,json}` — via one `OPTIONAL MATCH` **already keyed on the header `uuid`**
+  (`:210`). Only its *header lookup* is firmware-specific (slug → manifest → match by `names` tag,
+  `:181-207`), and it returns `parseJson(rawValue)` **without** LMDB resolution. The concept-graph
+  `GET /node/:handle/neighbors` returns all 8 core-node edges + `HAS_ELEMENT` (verified for
+  `39998:<TA>:dog`) but no JSON. `ConceptMembersView` (`ui/src/pages/settings/ConceptMembersView.jsx`)
+  already takes `{headerUuid, kind, scope}` and reads members' relationships + JSON from neo4j via
+  `/api/neo4j/query` (`src/api/conceptMembers.js`) — **already handle-keyed and reusable**.
+- **Member header handles are already in hand.** `useTapestryGraph` composes the tapestry graph; member
+  nodes with `inferNodeType(n) === 'conceptHeader'` carry `uuid = 39998:<TA>:<slug>` — the handle the
+  new read path needs. `<TA>` is runtime-resolved (never hardcode).
+
+## Options considered
+
+### Decision 1 — Source of truth for per-concept detail data
+
+**Option A — strfry, as-authored (ADR 0002's choice).** *Rejected.* The imports carry only
+header+superset; the schema / primary-property / properties / core-graph nodes and their JSON are not
+in strfry at all. Cannot satisfy AC 1–4.
+
+**Option B — neo4j (relationships + node identity) + Tapestry LMDB (node JSON) — chosen.** Matches the
+owner ontology; it is the *only* source that has the data. **Partially supersedes ADR 0002 Decision 2**
+for per-concept detail; membership + the tapestry-level integration graph remain strfry-sourced (ADR
+0002 unchanged there). Trade-off: the detail views reflect **Neo4j's** state, which may differ from the
+signed event (the F2 drift). Per the ratified ontology that is *correct* (Neo4j is the self);
+reconciliation / recompute-from-Neo4j are the backstops, deferred.
+
+### Decision 2 — How to fetch the 8 core nodes + JSON by header handle
+
+**Option A — client composes from existing concept-graph endpoints** (`/node/:h/neighbors` → then
+`/node/:coreHandle` per core node). *Rejected:* 1 + up-to-8 round-trips per concept, **and it cannot
+LMDB-resolve** (client can't reach the store) — so it violates the ontology the moment JSON is offloaded.
+
+**Option B — a server-side, handle-keyed read that LMDB-resolves — chosen.** Extract the firmware
+endpoint's core-node query (already `uuid`-keyed) into a shared helper that runs the same Cypher, then
+maps each json value through `resolveValue` before returning the `{nodes:{…}}` shape. Expose it at
+`GET /api/concept-graph/node/:handle/core-nodes`. This **generalizes an existing read** (same query,
+keyed by handle, plus the LMDB step the ontology requires) rather than inventing new derivation — the
+warranted-endpoint bar the epic sets ("no new backend *unless* measured"): client-side resolution is
+impossible, so a server path is required. The firmware endpoint is rewired to the same helper
+(behavior-identical today — 0 pointers — and it gains LMDB-correctness for free), keeping one copy of
+the query.
+
+### Decision 3 — UI reuse
+
+**Option A — copy the Firmware Explorer's per-concept idiom into a tapestry component** (ADR 0002's
+"build fresh" precedent). *Alternative;* avoids touching the firmware page but duplicates ~95 lines
+(`FirmwareOverview`, `FirmwareNodeJson`) that would drift.
+
+**Option B — extract the small, already-generic pieces into a shared module + reuse the
+already-standalone `ConceptMembersView` — chosen.** `FirmwareOverview` and `FirmwareNodeJson` already
+consume the generic `{nodes:{…}}` shape (no firmware-manifest coupling, unlike the integration-graph
+components ADR 0002 deliberately avoided), so extracting them is mechanical and low-risk.
+`ConceptMembersView` is already exported and handle-keyed — import it directly. Trade-off: touches the
+shipped Firmware Explorer's imports → it joins the regression-test surface (Tester/Reviewer must confirm
+it renders identically).
+
+## Decision
+
+Adopt **Option B in all three decisions.** Per-concept detail data comes from **neo4j + Tapestry LMDB**
+via a new **server-side, handle-keyed, LMDB-resolving** read (`GET
+/api/concept-graph/node/:handle/core-nodes`) backed by a shared helper that the firmware endpoint is
+rewired onto. The tapestry per-concept view is built from **shared, extracted** presentational pieces
+(`ConceptOverview`, `ConceptNodeJson`, `CORE_NODES`) plus the **existing** `ConceptMembersView`.
+Membership and the tapestry-level Integration views are untouched (still strfry, per ADR 0002).
+
+## Consequences
+
+- **Enables** full Firmware-Explorer parity for each tapestry concept, sourced from the instance's
+  authoritative graph, with JSON read through the LMDB resolver (correct now; future-proof under
+  offloading).
+- **Narrows ADR 0002 Decision 2**: "never depend on Neo4j for tapestry data" now holds only for
+  membership + the composed integration graph; per-concept *detail* depends on Neo4j by design. A
+  forward-pointer note is added to ADR 0002.
+- **Drift caveat (F2).** Detail views reflect Neo4j state, which can diverge from the signed
+  `*-concept-graph` event (e.g. the known `dog-concept-graph` desync). Acceptable under the ratified
+  ontology. **The Tester must assert against Neo4j / the concept-graph API, not strfry.**
+- **Mixed-source page.** One Exploration page now reads membership + integration graph from strfry and
+  per-concept detail from neo4j+LMDB. Intentional and documented; a later story may migrate the rest.
+- **Regression surface.** The firmware endpoint (rewired to the shared server helper) and the Firmware
+  Explorer page (imports the extracted components) must be regression-checked — behavior is meant to be
+  identical.
+- **Deferred debt:** (a) member-JSON in `ConceptMembersView` is still read raw via `/api/neo4j/query`
+  (no LMDB resolution) — a no-op today (0 pointers), to be closed when offloading is enabled, same gap
+  the firmware page already has; (b) the "recompute JSON from Neo4j" button (owner-deferred); (c)
+  POV/WoT filtering (epic-deferred).
+- **Firmware reinstall required?** **No** — no concept definitions change.
+
+## Implementation notes
+
+**Server**
+- **New `src/lib/conceptCoreNodes.js`** — `async getConceptCoreNodes(headerUuid)`. Runs the 8-core-node
+  `OPTIONAL MATCH` Cypher **moved verbatim** from `src/api/firmware/index.js:209-244` (keyed on
+  `{uuid: headerUuid}`). Build `{ header, superset, schema, primaryProperty, properties, ptGraph,
+  coreGraph, conceptGraph }`, each `{ uuid, name, json }`, where
+  `json = coerce(resolveValue(rawValue))` and `coerce(v)` = `null` if falsy, `JSON.parse(v)` if a
+  string, else `v` as-is (LMDB envelopes return objects). Return `{ found: boolean, nodes }`
+  (`found=false` when the header uuid matches no node).
+- **`src/api/concept-graph/index.js`** — register `GET /api/concept-graph/node/:handle/core-nodes` →
+  `getConceptCoreNodes(decodeURIComponent(handle))` → `{ success, handle, found, nodes }`. Place the
+  route **before** the existing `/node/:handle` registration is unaffected (distinct suffix, like
+  `/neighbors` at `:195`).
+- **`src/api/firmware/index.js`** — in `handleConcept`, replace the inline query+shaping block
+  (`:209-262`) with `const { nodes } = await getConceptCoreNodes(headerUuid)`. Header lookup and the
+  `installed:false` branch are unchanged. (Behavior-identical today; adds LMDB-resolution.)
+
+**Client**
+- **New `ui/src/api/conceptCoreNodes.js`** — `fetchConceptCoreNodes(handle)` → GET the new endpoint,
+  throw on `!success`, return `{ found, nodes }`.
+- **New shared module `ui/src/components/concept/CoreNodeViews.jsx`** — export `CORE_NODES` (the 9-entry
+  list incl. `overview`), `ConceptOverview` (extracted from `FirmwareExplorer.jsx:573-618`
+  `FirmwareOverview`), and `ConceptNodeJson` (extracted from `:905-960` `FirmwareNodeJson`). Verbatim
+  move; only the names generalize.
+- **`ui/src/pages/settings/FirmwareExplorer.jsx`** — delete the inline `CORE_NODES`, `FirmwareOverview`,
+  `FirmwareNodeJson`; import `{ CORE_NODES, ConceptOverview as FirmwareOverview, ConceptNodeJson as
+  FirmwareNodeJson }` from the shared module. No other change (the page's `MEMBER_VIEWS`, integration
+  code, and `ConceptMembersView` usage stay).
+- **`ui/src/pages/tapestries/TapestryDetail.jsx`** — replace `ConceptDetail` (the JSON-only view,
+  `:73-90`) with a firmware-style per-concept panel: a `.firmware-node-tabs` bar (Overview → the 8 core
+  nodes → divider → Elements, Sets), fetching `fetchConceptCoreNodes(concept.uuid)` for the selected
+  member (its `uuid` is the `39998:<TA>:<slug>` handle from `composed.nodes`). Route content:
+  `overview` → `<ConceptOverview data={coreData}/>`; a core-node key → `<ConceptNodeJson data={coreData}
+  nodeKey={key}/>`; `elements`/`sets` → `<ConceptMembersView conceptData={coreData} kind={key}/>`
+  (import from `ui/src/pages/settings/ConceptMembersView.jsx`). Show loading / `found:false` /
+  not-in-graph states (reuse the components' own missing-node handling). The sidebar's **Integrations**
+  section and all tapestry-level views are **unchanged**.
+- Reuse directly: `ConceptMembersView`, `JsonView`, existing `.firmware-*` CSS classes. No new deps.
+
+**Docs**
+- Add a one-line forward-pointer to `engineering-team/decisions/done/tapestries/0002-…md` noting Decision
+  2 is partially superseded by this ADR for per-concept detail data.
+
+Test-file changes (fixtures, suite re-aims, authoring a test tapestry to exercise the page) belong to
+Phase 3 (Tester), not here.
+
+## Out of scope
+- Migrating membership or the tapestry-level integration graph off strfry (only per-concept detail moves).
+- LMDB resolution for `ConceptMembersView` member JSON (no-op today; deferred to when offloading lands).
+- "Recompute JSON from Neo4j" button; POV/WoT filtering; editing.
+- Any change to the concept-graph schema or firmware definitions (no reinstall).

--- a/engineering-team/reviews/tapestries/4-per-concept-detail-views.md
+++ b/engineering-team/reviews/tapestries/4-per-concept-detail-views.md
@@ -1,0 +1,66 @@
+# Review: Story 4 — Per-concept detail views (Firmware-Explorer parity)
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-07-25
+**Diff:** `git diff origin/staging...HEAD` (commits 5bdabbc2 story, 3cd62423 adr, aa1b3ed7 tests, 9e2668ec impl)
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] `node test/tapestry-per-concept-detail-views.test.js` — **17 passed, 0 failed, 3 skipped** (re-run independently). U/S executed gate green; H1–H3 SKIP (running :7778 stack serves the shared checkout, not this worktree — expected).
+- [x] `node test/firmware-concept-elements-sets.test.js` — **19 passed, 0 failed** (re-run independently). The firmware regression suite is green after the R2 re-aim; its H1–H4 ran live and passed.
+- [x] `vite build` (author-run, spot-verified) — compiles; only the pre-existing chunk-size warning.
+- [x] `node --check` on all 3 changed server files — clean.
+- [ ] _Lint/typecheck/build gate not configured — skipped per project policy._
+
+## Spec adherence
+- [x] Every acceptance criterion has a passing test. AC1→U4/S4/S6/S7; AC2→U4/S4/S6; AC3→U1/U2/**U5**/U7/S2/S8/H1; AC4→S6 (+ existing firmware-concept-elements-sets covers Direct/Full/scope/sort of the reused ConceptMembersView); AC5→U3/U6/H3; AC6→R2(mine).
+- [x] No criterion silently dropped. The LMDB-resolution crux (AC3) is proven stack-free by U5 (synthesized `lmdb:` pointer) since the instance has 0 live pointers.
+- [x] No behavior added beyond the story. Membership + tapestry-level integration views untouched (R2 mine).
+
+## ADR adherence
+- [x] Files match ADR 0004 Implementation notes exactly: `src/lib/conceptCoreNodes.js` (helper), `GET /api/concept-graph/node/:handle/core-nodes`, firmware rewire, `ui/src/api/conceptCoreNodes.js`, `ui/src/components/concept/CoreNodeViews.jsx`, FirmwareExplorer import, TapestryDetail per-concept panel.
+- [x] Decision 1 (neo4j+LMDB source) honored — `getConceptCoreNodes` reads relationships via Cypher and JSON via `resolveValue`.
+- [x] Decision 2 (server-side, handle-keyed, LMDB-resolving; share & rewire) honored — one copy of the Cypher; firmware endpoint rewired onto it.
+- [x] Decision 3 (extract shared UI + reuse ConceptMembersView) honored.
+- [x] No new dependencies.
+
+## Concept-graph integrity
+- [x] Handles are `kind:pubkey:slug`; the handle travels as the `$uuid` **param**, never interpolated (verified in the helper + U7).
+- [x] **No hardcoded TA pubkey** — swept the entire added diff for 64-hex; none. Handles come from `composed.nodes` (runtime) client-side and from the request path server-side.
+- [x] Firmware reinstall **not required** — no `firmware/*.json`, schema, or concept-definition changes.
+
+## Things tests can't catch (manual audit)
+- [x] **Firmware rewire is behavior-preserving.** The 8-core-node Cypher moved **verbatim** into the helper (`MATCH (h:ListHeader {uuid:$uuid})` + identical OPTIONAL MATCHes; RETURN aliases identical — the base's extra `AS name`/`AS uuid` belong to the untouched header-lookup query). `coerceJson(resolveValue(v))` ≡ old `parseJson(v)` for the actual data domain (string|null; 0 lmdb pointers today: `resolveValue` passes the string through, `coerceJson` `JSON.parse`s it; null→null). The `installed:false` guard (`headers.length === 0`) still precedes the helper call, so `getConceptCoreNodes` is only invoked with a real header uuid.
+- [x] **R2 re-aim is faithful, not a weakening.** `FirmwareOverview`/`FirmwareNodeJson` moved verbatim to `CoreNodeViews.jsx` (7 structural markers intact); FirmwareExplorer imports `ConceptNodeJson`/`ConceptOverview` aliased to the old names. The re-aimed R2 checks *more* than before — FE still uses `FirmwareNodeJson` **and** the shared module carries `firmware-view-toggle` + `JsonView` + `ConceptNodeJson`. Toggle behavior preserved.
+- [x] **Source-of-truth switch (S8).** `match.graph` occurrences in TapestryDetail: **0** — the old strfry import-JSON per-concept view is gone; detail is fetched by the member header handle. `imports` is no longer destructured from `useTapestryGraph` (no dead var).
+- [x] **`CORE_NODE_ROLES` was genuinely dead** on `origin/staging` (1 occurrence = definition only); no test referenced it. Clean removal.
+- [x] No secrets; no stray `console.log` in the feature paths (the endpoint's `console.error` on failure matches the sibling concept-graph handlers); no commented-out code.
+- [x] Error/edge paths: fetch error → error state; `found:false` → "Not in the graph"; missing core node → the component's own "does not exist" state; `useEffect` guards races via a `cancelled` flag and resets to Overview + refetches on handle change; the members view is remounted by `key` on concept/kind switch.
+- [x] Security: read-only GET; `$uuid` param (no injection); no new auth surface (consistent with the public, read-only concept-graph API and the public tapestry page).
+
+## House rules check
+- [x] Concept Graph API authority respected — the feature reads through the concept-graph API / its Neo4j+LMDB read path (the authoritative source), consistent with ADR 0004 and the firmware precedent.
+- [x] No new lint/typecheck/build tooling.
+- [x] Architecture invariants: the per-concept detail is a **structural inspector** (all members regardless of author), not POV-scoped — matching the ADR and the existing firmware `ConceptMembersView` precedent. POV filtering is correctly deferred.
+
+## Findings
+
+### Blocking
+_None._
+
+### Non-blocking
+1. **ui/src/pages/tapestries/TapestryDetail.jsx:114–117** — the Overview `description` is best-effort from the header JSON (`word/set/conceptHeader.description`). The Firmware Explorer sources its richer description from the firmware manifest (`firmware.getConcept(slug).conceptHeader.description`), which a handle-keyed tapestry read cannot reach; for concepts whose header JSON lacks a `description`, the Overview shows an empty description line. The substantive Overview content (the 8-core-node exists/JSON table + the concept name) is fully present, so AC2 is met. Optional follow-up: surface the header's `oNames`/description more robustly, or accept the minor gap.
+2. **H-class + full browser E2E are staging-verified, not local.** By design (the worktree is not served by the local Docker stack, and no tapestry is seeded locally). H1 (schema/primary-property present for `dog`), H2 (firmware `/concept/dog` ≡ core-nodes endpoint), H3 (graceful `found:false`), and the open-a-tapestry walkthrough must be confirmed in the `cycle-staging` smoke. Recorded, not a defect.
+3. **Deferred (per ADR):** `ConceptMembersView` member JSON is still read raw via `/api/neo4j/query` without LMDB resolution — a no-op today (0 pointers), the same latent gap the firmware page already has; to close when JSON offloading is enabled.
+
+### Harness friction
+None.
+
+## Verdict
+**PASS**
+
+The implementation faithfully realizes ADR 0004: per-concept detail reads relationships from Neo4j and node JSON through the Tapestry-LMDB resolver, behind a shared handle-keyed helper that also (behavior-identically) backs the Firmware Explorer. All acceptance criteria are covered by green U/S tests; the firmware regression suite is green after a faithful R2 re-aim; the two author-flagged risks (rewire parity, R2 re-aim) hold up under audit. The three non-blocking items are documented deferrals/staging-verifications, not defects.
+
+## On PASS (same commit)
+- [x] Story `**Status:**` flipped to `Done` in place.
+- [x] Completion detection run (see below).

--- a/engineering-team/stories/tapestries/4-per-concept-detail-views.md
+++ b/engineering-team/stories/tapestries/4-per-concept-detail-views.md
@@ -1,6 +1,6 @@
 # Story 4: Per-concept detail views in the Tapestry exploration page (Firmware-Explorer parity)
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-07-25
 **Type:** Feature
 
@@ -84,4 +84,4 @@ that I understand what each concept *is*, not just its skeletal header.
 ## Linked artifacts
 - ADR: `engineering-team/decisions/tapestries/0004-per-concept-detail-views-neo4j-lmdb.md` (Accepted) — partially supersedes ADR 0002 Decision 2 for per-concept detail data.
 - Test plan: `engineering-team/stories/tapestries/4-per-concept-detail-views.test-plan.md` — suite `test/tapestry-per-concept-detail-views.test.js` (U/S executed gate, H live sentinels, R regression).
-- Review: *(after Review)*
+- Review: `engineering-team/reviews/tapestries/4-per-concept-detail-views.md` — **PASS** (2026-07-25).

--- a/engineering-team/stories/tapestries/4-per-concept-detail-views.md
+++ b/engineering-team/stories/tapestries/4-per-concept-detail-views.md
@@ -83,5 +83,5 @@ that I understand what each concept *is*, not just its skeletal header.
 
 ## Linked artifacts
 - ADR: `engineering-team/decisions/tapestries/0004-per-concept-detail-views-neo4j-lmdb.md` (Accepted) — partially supersedes ADR 0002 Decision 2 for per-concept detail data.
-- Test plan: *(after Test Design)*
+- Test plan: `engineering-team/stories/tapestries/4-per-concept-detail-views.test-plan.md` — suite `test/tapestry-per-concept-detail-views.test.js` (U/S executed gate, H live sentinels, R regression).
 - Review: *(after Review)*

--- a/engineering-team/stories/tapestries/4-per-concept-detail-views.md
+++ b/engineering-team/stories/tapestries/4-per-concept-detail-views.md
@@ -1,0 +1,87 @@
+# Story 4: Per-concept detail views in the Tapestry exploration page (Firmware-Explorer parity)
+
+**Status:** Approved
+**Created:** 2026-07-25
+**Type:** Feature
+
+## Background
+
+Story #2 built the tapestry exploration page. Today, selecting a member concept shows **only its
+concept-graph JSON** — a 2-node header+superset skeleton, rendered as-authored from the tapestry's
+strfry event. That's the thinnest possible view of a concept.
+
+The **Firmware Explorer** (`ui/src/pages/settings/FirmwareExplorer.jsx`) offers a much richer
+per-concept experience: an **Overview**, the **8 core-node types** (Concept Header, Superset, JSON
+Schema, Primary Property, Properties Set, Property Tree Graph, Core Nodes Graph, Concept Graph), and
+**Elements** and **Sets**. Users want that same depth for each concept inside a tapestry.
+
+**Owner data-source constraint (intent, for the Architect to honor).** Per the owner's ontology
+(`docs/SELF_ONTOLOGY_DESIGN_HANDOFF.md`): **neo4j is the primary source of truth; Tapestry LMDB is
+its low-latency cache; strfry/nostr are secondary.** Therefore each concept's **node JSON must come
+from Tapestry LMDB** and its **relationships from neo4j** — *not* re-composed from the tapestry's
+authored strfry graph. Only **membership** (which concepts belong to the tapestry) continues to come
+from the authored tapestry event. This deliberately **evolves ADR tapestries/0002's "render
+as-authored from strfry" stance** for the per-concept drill-down; the new ADR must reconcile the two.
+
+## User-facing description
+
+As a person exploring a tapestry, I want to inspect each member concept with the same depth the
+Firmware Explorer gives me — an overview, each of its core node types, and its elements and sets — so
+that I understand what each concept *is*, not just its skeletal header.
+
+## Acceptance criteria
+*Testable from the outside. Each gets at least one test.*
+
+- [ ] **View parity.** Given a selected member concept on a tapestry's exploration page, when I
+  inspect it, then I can choose among the same per-concept views the Firmware Explorer offers — an
+  **Overview**, the **8 core-node types**, and **Elements** and **Sets** — replacing today's single
+  concept-graph-JSON view.
+- [ ] **Overview.** Given a selected concept, when I open its Overview, then it shows the concept's
+  name/description and which of its core nodes exist / have JSON (the Firmware Explorer's overview
+  behavior).
+- [ ] **Core-node JSON + source of truth.** Given a selected concept and a chosen core-node type,
+  when I view it, then it renders that node's JSON with a **Viewer / Raw JSON** toggle — and the
+  views surface core nodes and JSON that are **not present in the tapestry's authored graph block**
+  (e.g. JSON Schema, Primary Property), demonstrating the data is sourced from the instance's own
+  graph (neo4j + LMDB), not the authored event.
+- [ ] **Elements & Sets.** Given a selected concept and the Elements or Sets view, when I browse it,
+  then I get a name-sorted member list with a **Direct / Full** scope toggle and a count, and
+  selecting a member shows its JSON (Viewer/Raw). Membership reflects the concept's relationships
+  **in the instance's graph** (structural — shown regardless of author, matching the Firmware
+  Explorer; POV filtering is out of scope).
+- [ ] **Graceful degradation.** Given a member concept that is absent or only partially present in
+  the instance's graph, when I view it, then the page clearly indicates the concept/core-node isn't
+  in the graph and does **not** crash or show a raw error.
+- [ ] **No regression of tapestry-level views.** Given the tapestry-level Integration views story #2
+  built (Integration Graph, Enumerations, Elements, Subsets, Tapestry JSON), when this ships, then
+  they remain available (this story enriches the per-concept drill-down; it does not remove the
+  tapestry-level section).
+
+## Concepts touched
+- `39998:<TA>:tapestry` — the Tapestry concept (the page's subject is one of its elements).
+- The **member concepts of the viewed tapestry**, resolved from the authored event, then read in
+  depth from the graph — e.g. for "Tapestry for Dog": `39998:<TA>:dog`, `39998:<TA>:dog-breed`,
+  `39998:<TA>:irish-setter`, `39998:<TA>:golden-retriever`, each with its 8 core nodes. `<TA>` is
+  runtime-resolved (never hardcode).
+
+## Out of scope
+- A button to **recompute** a node's JSON from neo4j (owner explicitly deferred).
+- **POV / WoT filtering** of concepts, elements, or sets (consistent with the epic's deferral).
+- Editing the tapestry or any concept.
+- Migrating the tapestry-level Integration views or the membership read off strfry — only the
+  per-concept data moves to neo4j+LMDB in this story.
+
+## Open questions
+- **For the Architect:** how to obtain the 8 core nodes + JSON + members for an arbitrary member
+  concept identified by its **header handle**. The Firmware Explorer's `/api/firmware/concept/:slug`
+  is keyed on firmware-manifest slug; the concept-graph API is keyed on handle and already returns
+  the core-node edges + `HAS_ELEMENT`. Reconcile reuse vs. a handle-keyed read path — and reconcile
+  with ADR tapestries/0002 in the new ADR.
+- **For the Tester:** local end-to-end needs a tapestry to open. The epic names a seed
+  (`39999:<TA>:tapestry-for-dog-ca3b675e`); none was found under this instance's TA — so testing
+  likely means authoring one via the owner-gated Create page. To confirm in Test Design.
+
+## Linked artifacts
+- ADR: *(after Architecture)*
+- Test plan: *(after Test Design)*
+- Review: *(after Review)*

--- a/engineering-team/stories/tapestries/4-per-concept-detail-views.md
+++ b/engineering-team/stories/tapestries/4-per-concept-detail-views.md
@@ -82,6 +82,6 @@ that I understand what each concept *is*, not just its skeletal header.
   likely means authoring one via the owner-gated Create page. To confirm in Test Design.
 
 ## Linked artifacts
-- ADR: *(after Architecture)*
+- ADR: `engineering-team/decisions/tapestries/0004-per-concept-detail-views-neo4j-lmdb.md` (Accepted) — partially supersedes ADR 0002 Decision 2 for per-concept detail data.
 - Test plan: *(after Test Design)*
 - Review: *(after Review)*

--- a/engineering-team/stories/tapestries/4-per-concept-detail-views.test-plan.md
+++ b/engineering-team/stories/tapestries/4-per-concept-detail-views.test-plan.md
@@ -1,0 +1,82 @@
+# Test Plan: Story 4 — Per-concept detail views (Firmware-Explorer parity)
+
+**Story:** `engineering-team/stories/tapestries/4-per-concept-detail-views.md`
+**ADR:** `engineering-team/decisions/tapestries/0004-per-concept-detail-views-neo4j-lmdb.md`
+**Date:** 2026-07-25
+**Suite:** `test/tapestry-per-concept-detail-views.test.js` (registered in `test/test.js`)
+
+## Test taxonomy (per `test/firmware-concept-elements-sets.test.js`)
+
+- **U-class** — EXECUTED, stack-free, **gates CI**. Requires the CommonJS helper directly
+  (neo4j-driver connects lazily, so the require opens no connection); `runCypher`/`resolveValue`
+  are **injected** so no stack is touched. This is where the ontology crux is proven.
+- **S-class** — source assertions (the harness has no jsdom; React/endpoints are pinned by reading
+  source, exactly as the create-tapestry and firmware-concept suites do).
+- **H-class** — live integration **sentinels**; SKIP when the endpoint/stack is unreachable. The
+  local Docker stack serves the **shared** checkout, not this worktree, so these **SKIP locally** and
+  bind on staging (cycle-staging smoke) once the code ships — the same arrangement as
+  create-tapestry's Playwright spec.
+- **R-class** — regression sentinels; PASS **before and after**.
+
+## Coverage map
+
+| Criterion | Test(s) | Level |
+|---|---|---|
+| **AC1** View parity (Overview + 8 core nodes + Elements + Sets) | `U4` (8-core-node shape), `S4` (shared views exist), `S6` (TD tab bar mounts them), `S7` (client fetch) | unit + source |
+| **AC2** Overview (name/desc + which core nodes exist/have JSON) | `U4` (shape carries every core node incl. missing → null), `S4` (`ConceptOverview` exported), `S6` | unit + source |
+| **AC3** Core-node JSON + **source of truth = neo4j+LMDB** | `U1` (inline string parses), `U2` (LMDB object passthrough), **`U5` (lmdb:<key> resolves via the store — the crux)**, `U7` (header-uuid $param query + resolve), `S2` (helper routes JSON through `resolveValue`), `S8` (TD keys detail on the neo4j handle, drops the strfry import-JSON view), `H1` (live: schema + primary-property present for `dog` — data strfry lacks) | unit + source + live |
+| **AC4** Elements & Sets (Direct/Full, count, JSON drill-down) | `S6` (mounts `ConceptMembersView` with the header uuid) — the Direct/Full/scope/sort behavior itself is already covered by `test/firmware-concept-elements-sets.test.js` (reused component) | source |
+| **AC5** Graceful degradation (absent/partial in graph) | `U3` (missing JSON → null), `U6` (`found:false` for unknown header), `H3` (live: unknown handle → found:false) | unit + live |
+| **AC6** No regression of tapestry-level Integration views | `R2` (TD keeps Integration Graph / Enumerations / Subsets) | source regression |
+| **ADR Decision 2/3** DRY rewire is behavior-preserving | `S3` (firmware endpoint on the shared helper; inline query removed), `S5` (FE imports the extracted views), `H2` (live: firmware `/concept/dog` == core-nodes endpoint for the same nodes), `R1` (firmware page keeps its tabs/Elements-Sets/Integrations) | source + live regression |
+
+## Edge cases covered
+- [x] Node JSON offloaded to LMDB (`lmdb:<key>` pointer) — `U5` (the reason 0-pointers-today doesn't matter).
+- [x] Node JSON stored as an object vs an inline string — `U2` / `U1`.
+- [x] Concept / core node absent from the graph — `U3`, `U6`, `H3`.
+- [x] Handle travels as `$uuid` param, never interpolated — `U7` (mirrors the members write-guard discipline).
+- [x] Firmware page unchanged after extraction/rewire — `R1`, `S3`, `S5`, `H2`.
+
+## Test infrastructure
+- **Runner:** Node built-in (`node test/test.js`). New suite self-registers and is wired into the
+  aggregate pass/fail + skip totals.
+- **Stack-free binding gate:** U-class + S-class (17 tests) run with no Docker/Neo4j/LMDB/live-API —
+  they are the CI gate. `resolveValue`/`runCypher` are injected in U-tests; a synthesized `lmdb:<key>`
+  case proves resolution (the instance has **0** live pointers today, so a real pointer must be faked).
+- **Live sentinels (H-class):** hit `http://127.0.0.1:$TAPESTRY_PORT`. Require the `dog` concept
+  installed in Neo4j (present on this instance). SKIP automatically when the endpoint 404s (not yet
+  deployed to the serving stack) or the stack is down. **Precondition to bind:** the code must be
+  served by the target stack (staging smoke), or `POST /api/firmware/install` for a fresh graph.
+- **Fixtures:** none created (H-class reads the existing `dog` concept read-only — no graph writes,
+  unlike the firmware-concept suite's fixtures).
+
+## Full-page E2E (deferred to verification, not in this suite)
+The full browser round-trip (open a tapestry → select a concept → tab through Overview/core
+nodes/Elements/Sets) is **not** a node-runner test (no jsdom). The epic's `Tapestry for Dog` seed is
+**absent under this instance's TA**, so end-to-end verification during Implementation means authoring
+a test tapestry via the owner-gated Create page, then opening it. A server-gated Playwright spec
+(`tests/brainstorm/…`) mirroring create-tapestry's is a reasonable **follow-up**; it is deliberately
+out of this suite because it cannot run stack-free and needs seeded data.
+
+## How to run
+```
+node test/tapestry-per-concept-detail-views.test.js
+```
+Full gate:
+```
+npm test
+```
+
+## Verification
+The new tests fail with the current code. Confirmed 2026-07-25 (worktree
+`feat/tapestries-per-concept-views`):
+
+```
+tapestry-per-concept-detail-views: 2 passed, 15 failed, 3 skipped
+```
+- **U1–U7, S1–S8 FAIL** — each with a specific "not implemented" message (helper/endpoint/shared
+  UI/TD wiring absent; firmware not yet rewired). Not typos/import errors: the failure messages name
+  the missing artifact.
+- **H1–H3 SKIP** — the running stack serves the shared checkout without the `/core-nodes` endpoint.
+- **R1–R2 PASS** — the Firmware Explorer's and TapestryDetail's existing Integration surfaces are
+  intact (they must stay green after implementation too).

--- a/src/api/concept-graph/index.js
+++ b/src/api/concept-graph/index.js
@@ -21,6 +21,7 @@
  */
 
 const { runCypher } = require('../../lib/neo4j-driver');
+const { getConceptCoreNodes } = require('../../lib/conceptCoreNodes');
 
 // ─── Summaries ────────────────────────────────────────────────────────────────
 
@@ -128,6 +129,22 @@ async function handleNeighbors(req, res) {
   }
 }
 
+// ─── Core nodes ──────────────────────────────────────────────────────────────
+// A concept's 8 core nodes + JSON, keyed by header handle. Relationships from Neo4j;
+// JSON resolved through Tapestry LMDB (ADR tapestries/0004). Powers the tapestry
+// per-concept detail views (and shares the read helper with the Firmware Explorer).
+
+async function handleCoreNodes(req, res) {
+  const handle = decodeURIComponent(req.params.handle);
+  try {
+    const { found, nodes } = await getConceptCoreNodes(handle);
+    res.json({ success: true, handle, found, nodes });
+  } catch (err) {
+    console.error('[concept-graph] core-nodes error:', err);
+    res.status(500).json({ success: false, error: err.message });
+  }
+}
+
 // ─── Subgraph (BFS) ──────────────────────────────────────────────────────────
 
 async function handleSubgraph(req, res) {
@@ -193,6 +210,7 @@ async function handleSubgraph(req, res) {
 function registerConceptGraphRoutes(app) {
   app.get('/api/concept-graph/summaries',             handleSummaries);
   app.get('/api/concept-graph/node/:handle/neighbors', handleNeighbors);
+  app.get('/api/concept-graph/node/:handle/core-nodes', handleCoreNodes);
   app.get('/api/concept-graph/node/:handle',           handleNode);
   app.get('/api/concept-graph/subgraph/:handle',       handleSubgraph);
 }

--- a/src/api/firmware/index.js
+++ b/src/api/firmware/index.js
@@ -12,22 +12,14 @@ const fs = require('fs');
 const path = require('path');
 const firmware = require('../normalize/firmware');
 const { runCypher } = require('../../lib/neo4j-driver');
+const { getConceptCoreNodes } = require('../../lib/conceptCoreNodes');
 const { handleFirmwareInstall } = require('../../firmware/install');
 
 const FIRMWARE_VERSIONS_DIR = path.resolve(__dirname, '../../../firmware/versions');
 const FIRMWARE_ACTIVE_LINK = path.resolve(__dirname, '../../../firmware/active');
 
-// Core node roles and the Neo4j relationship used to find them
-const CORE_NODE_ROLES = [
-  { key: 'header',         label: 'Concept Header',     rel: null },
-  { key: 'superset',       label: 'Superset',           rel: 'IS_THE_CONCEPT_FOR', direction: 'out' },
-  { key: 'schema',         label: 'JSON Schema',        rel: 'IS_THE_JSON_SCHEMA_FOR', direction: 'in' },
-  { key: 'primaryProperty',label: 'Primary Property',   rel: 'IS_THE_PRIMARY_PROPERTY_FOR', direction: 'in' },
-  { key: 'properties',     label: 'Properties',         rel: 'IS_THE_PROPERTIES_SET_FOR', direction: 'in' },
-  { key: 'ptGraph',        label: 'Property Tree Graph', rel: 'IS_THE_PROPERTY_TREE_GRAPH_FOR', direction: 'in' },
-  { key: 'coreGraph',      label: 'Core Nodes Graph',   rel: 'IS_THE_CORE_GRAPH_FOR', direction: 'in' },
-  { key: 'conceptGraph',   label: 'Concept Graph',      rel: 'IS_THE_CONCEPT_GRAPH_FOR', direction: 'in' },
-];
+// The 8 core-node roles + their Neo4j relationships now live in the shared read helper
+// (src/lib/conceptCoreNodes.js) — the single source of that query, per ADR tapestries/0004.
 
 async function handleManifest(req, res) {
   try {
@@ -206,60 +198,10 @@ async function handleConcept(req, res) {
 
     const headerUuid = headers[0].uuid;
 
-    const rows = await runCypher(
-      `MATCH (h:ListHeader {uuid: $uuid})
-       OPTIONAL MATCH (h)-[:HAS_TAG]->(hj:NostrEventTag {type: 'json'})
-
-       OPTIONAL MATCH (h)-[:IS_THE_CONCEPT_FOR]->(sup:Superset)
-       OPTIONAL MATCH (sup)-[:HAS_TAG]->(sj:NostrEventTag {type: 'json'})
-
-       OPTIONAL MATCH (js:JSONSchema)-[:IS_THE_JSON_SCHEMA_FOR]->(h)
-       OPTIONAL MATCH (js)-[:HAS_TAG]->(jsj:NostrEventTag {type: 'json'})
-
-       OPTIONAL MATCH (pp:Property)-[:IS_THE_PRIMARY_PROPERTY_FOR]->(h)
-       OPTIONAL MATCH (pp)-[:HAS_TAG]->(ppj:NostrEventTag {type: 'json'})
-
-       OPTIONAL MATCH (props)-[:IS_THE_PROPERTIES_SET_FOR]->(h)
-       OPTIONAL MATCH (props)-[:HAS_TAG]->(prj:NostrEventTag {type: 'json'})
-
-       OPTIONAL MATCH (ptg)-[:IS_THE_PROPERTY_TREE_GRAPH_FOR]->(h)
-       OPTIONAL MATCH (ptg)-[:HAS_TAG]->(ptj:NostrEventTag {type: 'json'})
-
-       OPTIONAL MATCH (cg)-[:IS_THE_CORE_GRAPH_FOR]->(h)
-       OPTIONAL MATCH (cg)-[:HAS_TAG]->(cgj:NostrEventTag {type: 'json'})
-
-       OPTIONAL MATCH (cog)-[:IS_THE_CONCEPT_GRAPH_FOR]->(h)
-       OPTIONAL MATCH (cog)-[:HAS_TAG]->(cogj:NostrEventTag {type: 'json'})
-
-       RETURN h.uuid AS headerUuid, h.name AS headerName, head(collect(DISTINCT hj.value)) AS headerJson,
-              sup.uuid AS supersetUuid, sup.name AS supersetName, head(collect(DISTINCT sj.value)) AS supersetJson,
-              js.uuid AS schemaUuid, js.name AS schemaName, head(collect(DISTINCT jsj.value)) AS schemaJson,
-              pp.uuid AS ppUuid, pp.name AS ppName, head(collect(DISTINCT ppj.value)) AS ppJson,
-              props.uuid AS propsUuid, props.name AS propsName, head(collect(DISTINCT prj.value)) AS propsJson,
-              ptg.uuid AS ptgUuid, ptg.name AS ptgName, head(collect(DISTINCT ptj.value)) AS ptgJson,
-              cg.uuid AS cgUuid, cg.name AS cgName, head(collect(DISTINCT cgj.value)) AS cgJson,
-              cog.uuid AS cogUuid, cog.name AS cogName, head(collect(DISTINCT cogj.value)) AS cogJson
-       LIMIT 1`,
-      { uuid: headerUuid }
-    );
-
-    const r = rows[0] || {};
-
-    function parseJson(str) {
-      if (!str) return null;
-      try { return JSON.parse(str); } catch { return null; }
-    }
-
-    const nodes = {
-      header:          { uuid: r.headerUuid, name: r.headerName, json: parseJson(r.headerJson) },
-      superset:        { uuid: r.supersetUuid, name: r.supersetName, json: parseJson(r.supersetJson) },
-      schema:          { uuid: r.schemaUuid, name: r.schemaName, json: parseJson(r.schemaJson) },
-      primaryProperty: { uuid: r.ppUuid, name: r.ppName, json: parseJson(r.ppJson) },
-      properties:      { uuid: r.propsUuid, name: r.propsName, json: parseJson(r.propsJson) },
-      ptGraph:         { uuid: r.ptgUuid, name: r.ptgName, json: parseJson(r.ptgJson) },
-      coreGraph:       { uuid: r.cgUuid, name: r.cgName, json: parseJson(r.cgJson) },
-      conceptGraph:    { uuid: r.cogUuid, name: r.cogName, json: parseJson(r.cogJson) },
-    };
+    // Core nodes + JSON via the shared Neo4j+LMDB read helper (ADR tapestries/0004).
+    // The header lookup above stays firmware-specific (slug → manifest → name → uuid);
+    // the core-node traversal + LMDB-resolved JSON is now one shared implementation.
+    const { nodes } = await getConceptCoreNodes(headerUuid);
 
     res.json({
       success: true,

--- a/src/lib/conceptCoreNodes.js
+++ b/src/lib/conceptCoreNodes.js
@@ -1,0 +1,101 @@
+/**
+ * conceptCoreNodes — the shared, handle-keyed read for a concept's 8 core nodes + JSON.
+ *
+ * Per ADR tapestries/0004: node JSON is read from Tapestry LMDB (via resolveValue — an
+ * `lmdb:<key>` value is fetched from the store; an inline value passes through) and the
+ * core-node RELATIONSHIPS come from Neo4j. This is the read path behind both:
+ *   - GET /api/concept-graph/node/:handle/core-nodes   (the tapestry per-concept views)
+ *   - GET /api/firmware/concept/:slug                  (the Firmware Explorer, rewired here)
+ *
+ * The 8-core-node OPTIONAL MATCH is keyed on the header `$uuid` PARAM (never interpolated).
+ * runCypher + resolveValue are lazy-required (or injected via `deps`) so the pure shaping
+ * (shapeCoreNodes / coerceJson) is unit-testable stack-free.
+ */
+
+// Neo4j read: from a ListHeader uuid, collect the header + its 8 core nodes and each one's
+// `json` tag value. Keyed on $uuid — moved verbatim from src/api/firmware/index.js.
+const CORE_NODES_CYPHER = `MATCH (h:ListHeader {uuid: $uuid})
+       OPTIONAL MATCH (h)-[:HAS_TAG]->(hj:NostrEventTag {type: 'json'})
+
+       OPTIONAL MATCH (h)-[:IS_THE_CONCEPT_FOR]->(sup:Superset)
+       OPTIONAL MATCH (sup)-[:HAS_TAG]->(sj:NostrEventTag {type: 'json'})
+
+       OPTIONAL MATCH (js:JSONSchema)-[:IS_THE_JSON_SCHEMA_FOR]->(h)
+       OPTIONAL MATCH (js)-[:HAS_TAG]->(jsj:NostrEventTag {type: 'json'})
+
+       OPTIONAL MATCH (pp:Property)-[:IS_THE_PRIMARY_PROPERTY_FOR]->(h)
+       OPTIONAL MATCH (pp)-[:HAS_TAG]->(ppj:NostrEventTag {type: 'json'})
+
+       OPTIONAL MATCH (props)-[:IS_THE_PROPERTIES_SET_FOR]->(h)
+       OPTIONAL MATCH (props)-[:HAS_TAG]->(prj:NostrEventTag {type: 'json'})
+
+       OPTIONAL MATCH (ptg)-[:IS_THE_PROPERTY_TREE_GRAPH_FOR]->(h)
+       OPTIONAL MATCH (ptg)-[:HAS_TAG]->(ptj:NostrEventTag {type: 'json'})
+
+       OPTIONAL MATCH (cg)-[:IS_THE_CORE_GRAPH_FOR]->(h)
+       OPTIONAL MATCH (cg)-[:HAS_TAG]->(cgj:NostrEventTag {type: 'json'})
+
+       OPTIONAL MATCH (cog)-[:IS_THE_CONCEPT_GRAPH_FOR]->(h)
+       OPTIONAL MATCH (cog)-[:HAS_TAG]->(cogj:NostrEventTag {type: 'json'})
+
+       RETURN h.uuid AS headerUuid, h.name AS headerName, head(collect(DISTINCT hj.value)) AS headerJson,
+              sup.uuid AS supersetUuid, sup.name AS supersetName, head(collect(DISTINCT sj.value)) AS supersetJson,
+              js.uuid AS schemaUuid, js.name AS schemaName, head(collect(DISTINCT jsj.value)) AS schemaJson,
+              pp.uuid AS ppUuid, pp.name AS ppName, head(collect(DISTINCT ppj.value)) AS ppJson,
+              props.uuid AS propsUuid, props.name AS propsName, head(collect(DISTINCT prj.value)) AS propsJson,
+              ptg.uuid AS ptgUuid, ptg.name AS ptgName, head(collect(DISTINCT ptj.value)) AS ptgJson,
+              cg.uuid AS cgUuid, cg.name AS cgName, head(collect(DISTINCT cgj.value)) AS cgJson,
+              cog.uuid AS cogUuid, cog.name AS cogName, head(collect(DISTINCT cogj.value)) AS cogJson
+       LIMIT 1`;
+
+/**
+ * Coerce a (possibly LMDB-resolved) json value into an object.
+ * null/'' → null; a string → JSON.parse (null on failure); an object → as-is
+ * (the LMDB store returns envelope.data already parsed).
+ */
+function coerceJson(raw) {
+  if (raw == null || raw === '') return null;
+  if (typeof raw === 'string') {
+    try { return JSON.parse(raw); } catch { return null; }
+  }
+  return raw;
+}
+
+/**
+ * Map a Cypher row (the RETURN aliases above) into the { header, superset, schema,
+ * primaryProperty, properties, ptGraph, coreGraph, conceptGraph } shape the UI expects,
+ * each `{ uuid, name, json }`. `resolve` (default identity) is applied to each raw json
+ * value before coercion — that is where an `lmdb:<key>` pointer becomes its stored object.
+ */
+function shapeCoreNodes(row, resolve = (v) => v) {
+  const j = (raw) => coerceJson(resolve(raw));
+  return {
+    header:          { uuid: row.headerUuid,   name: row.headerName,   json: j(row.headerJson) },
+    superset:        { uuid: row.supersetUuid, name: row.supersetName, json: j(row.supersetJson) },
+    schema:          { uuid: row.schemaUuid,   name: row.schemaName,   json: j(row.schemaJson) },
+    primaryProperty: { uuid: row.ppUuid,       name: row.ppName,       json: j(row.ppJson) },
+    properties:      { uuid: row.propsUuid,    name: row.propsName,    json: j(row.propsJson) },
+    ptGraph:         { uuid: row.ptgUuid,      name: row.ptgName,      json: j(row.ptgJson) },
+    coreGraph:       { uuid: row.cgUuid,       name: row.cgName,       json: j(row.cgJson) },
+    conceptGraph:    { uuid: row.cogUuid,      name: row.cogName,      json: j(row.cogJson) },
+  };
+}
+
+/**
+ * Read a concept's 8 core nodes + JSON by its header handle (uuid).
+ * Relationships from Neo4j; JSON resolved through Tapestry LMDB (ADR tapestries/0004).
+ * @param {string} headerUuid  the concept header handle, e.g. `39998:<TA>:dog`
+ * @param {{runCypher?:Function, resolveValue?:Function}} [deps]  injectable for stack-free tests
+ * @returns {Promise<{found:boolean, nodes:object}>}
+ */
+async function getConceptCoreNodes(headerUuid, deps = {}) {
+  const runCypher = deps.runCypher || require('./neo4j-driver').runCypher;
+  const resolveValue = deps.resolveValue || require('./tapestry-resolve').resolveValue;
+
+  const rows = await runCypher(CORE_NODES_CYPHER, { uuid: headerUuid });
+  const row = rows && rows[0];
+  if (!row || !row.headerUuid) return { found: false, nodes: {} };
+  return { found: true, nodes: shapeCoreNodes(row, resolveValue) };
+}
+
+module.exports = { CORE_NODES_CYPHER, coerceJson, shapeCoreNodes, getConceptCoreNodes };

--- a/test/firmware-concept-elements-sets.test.js
+++ b/test/firmware-concept-elements-sets.test.js
@@ -366,10 +366,18 @@ test('R1: FirmwareExplorer keeps its core-node tabs (Overview, Concept Header, S
     'the existing per-concept core-node tab row must survive this additive change.');
 });
 
-test('R2: FirmwareExplorer keeps the FirmwareNodeJson Viewer/Raw toggle over JsonView', () => {
+test('R2: the core-node Viewer/Raw JSON toggle survives — extracted to CoreNodeViews, still used by FirmwareExplorer', () => {
+  // Re-aimed for ADR tapestries/0004 Decision 3: the inline FirmwareNodeJson (with the
+  // Viewer/Raw toggle over JsonView) was extracted VERBATIM into the shared CoreNodeViews
+  // module (as ConceptNodeJson), which FirmwareExplorer now imports aliased as FirmwareNodeJson.
+  // The behavior is unchanged; only the source location moved. This sentinel guards that the
+  // toggle is not deleted — now checking its new home plus FirmwareExplorer's continued use.
   const src = safeRead(FE);
-  assert(/FirmwareNodeJson/.test(src) && /firmware-view-toggle/.test(src) && /JsonView/.test(src),
-    'the shipped core-node Viewer/Raw toggle (fea8b0ef) must remain intact.');
+  const shared = safeRead(path.join(ROOT, 'ui/src/components/concept/CoreNodeViews.jsx'));
+  assert(/FirmwareNodeJson/.test(src),
+    'FirmwareExplorer must still render the core-node JSON view (imported/aliased as FirmwareNodeJson).');
+  assert(/firmware-view-toggle/.test(shared) && /JsonView/.test(shared) && /ConceptNodeJson/.test(shared),
+    'the shipped Viewer/Raw toggle over JsonView must remain intact — now in the shared CoreNodeViews module, not deleted.');
 });
 
 test('R3: FirmwareExplorer keeps the Integrations views (manifest-level Elements/Subsets/Graph)', () => {

--- a/test/tapestry-per-concept-detail-views.test.js
+++ b/test/tapestry-per-concept-detail-views.test.js
@@ -1,0 +1,350 @@
+/**
+ * tapestries #4 — Per-concept detail views (Firmware-Explorer parity), Neo4j + LMDB read path.
+ *
+ * Story: engineering-team/stories/tapestries/4-per-concept-detail-views.md
+ * ADR:   engineering-team/decisions/tapestries/0004-per-concept-detail-views-neo4j-lmdb.md
+ *
+ * This suite is the BINDING (stack-free) gate — the Node runner. Test classes
+ * (conventions per test/firmware-concept-elements-sets.test.js):
+ *
+ *   U-class (EXECUTED, stack-free, gates CI) — the CommonJS server helper
+ *     src/lib/conceptCoreNodes.js, required directly (neo4j-driver connects lazily, so
+ *     requiring the helper does not open a connection). Covers the CRUX of the ontology:
+ *     node JSON is read from Tapestry LMDB (an 'lmdb:<key>' value resolves through the
+ *     store) OR inline (a JSON string parses; an object passes through), the {nodes} shape,
+ *     and found:false when the header handle matches no node. runCypher + resolveValue are
+ *     INJECTED (deps arg) so no stack is touched.
+ *
+ *   S-class (source assertions, stack-free) — the endpoint registration, the firmware
+ *     rewire onto the shared helper, the extracted shared UI module, and the TapestryDetail
+ *     per-concept view wiring exist and match the ADR. Source-level because the harness has
+ *     no jsdom (deliberate; mirrors create-tapestry.test.js S-class).
+ *
+ *   H-class (integration SENTINELS — SKIP when the stack/endpoint is unreachable) — against
+ *     the real `dog` concept in Neo4j, the live endpoint returns the schema + primary-property
+ *     core nodes (data that is NOT in the tapestry's authored strfry block — proving Neo4j is
+ *     the source), and the rewired firmware endpoint stays behavior-identical. NOTE: the local
+ *     Docker stack serves the SHARED checkout, not this worktree, so these SKIP locally and
+ *     bind on staging (cycle-staging smoke) once the code is deployed — same as create-tapestry's
+ *     Playwright spec.
+ *
+ *   R-class (regression sentinels, stack-free) — the Firmware Explorer keeps its core-node
+ *     tabs / Elements-Sets / Integrations after the component extraction, and TapestryDetail
+ *     keeps its tapestry-level Integrations section (AC6). PASS before AND after.
+ *
+ * U1-U7 and S1-S8 FAIL until the feature lands. H1-H3 SKIP until a stack serves the code.
+ * R1-R2 PASS throughout. That is the point.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+// Server
+const HELPER   = path.join(ROOT, 'src/lib/conceptCoreNodes.js');       // NEW: the shared read helper
+const CG_INDEX = path.join(ROOT, 'src/api/concept-graph/index.js');    // + GET /node/:handle/core-nodes
+const FW_INDEX = path.join(ROOT, 'src/api/firmware/index.js');         // rewired onto the helper
+// Client / UI
+const CLIENT   = path.join(ROOT, 'ui/src/api/conceptCoreNodes.js');    // NEW: fetchConceptCoreNodes
+const CORE_VIEWS = path.join(ROOT, 'ui/src/components/concept/CoreNodeViews.jsx'); // NEW shared module
+const FE       = path.join(ROOT, 'ui/src/pages/settings/FirmwareExplorer.jsx');
+const TD       = path.join(ROOT, 'ui/src/pages/tapestries/TapestryDetail.jsx');
+
+const PORT = process.env.TAPESTRY_PORT || process.env.TAPESTRY_CONTAINER_PORT || '7778';
+const BASE = `http://127.0.0.1:${PORT}`;
+
+const tests = [];
+function test(name, fn) { tests.push([name, fn]); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+function short(x, n = 240) { const s = typeof x === 'string' ? x : JSON.stringify(x); return s == null ? String(s) : s.slice(0, n); }
+
+const HELPER_MISSING =
+  'src/lib/conceptCoreNodes.js does not exist yet — the shared Neo4j+LMDB core-node read helper ' +
+  '(ADR tapestries/0004, Implementation notes) is not implemented.';
+
+function loadHelper() {
+  assert(fs.existsSync(HELPER), HELPER_MISSING);
+  delete require.cache[require.resolve(HELPER)];
+  try { return require(HELPER); }
+  catch (e) { throw new Error(`src/lib/conceptCoreNodes.js exists but failed to require (must load stack-free — lazy-connect the driver): ${e.message}`); }
+}
+
+// A full Cypher row shaped like the firmware endpoint's RETURN aliases (src/api/firmware/index.js:234-241).
+function fullRow(overrides = {}) {
+  return {
+    headerUuid: '39998:TA:dog', headerName: 'dog', headerJson: '{"word":{"name":"dog"}}',
+    supersetUuid: '39999:TA:dog-superset', supersetName: 'dogs', supersetJson: '{"set":{"name":"dogs"}}',
+    schemaUuid: '39999:TA:dog-schema', schemaName: 'dog schema', schemaJson: '{"$schema":"x"}',
+    ppUuid: '39999:TA:dog-primary-property', ppName: 'dog pp', ppJson: '{"pp":1}',
+    propsUuid: '39999:TA:dog-properties', propsName: 'dog props', propsJson: '{"props":1}',
+    ptgUuid: '39999:TA:dog-property-tree-graph', ptgName: 'dog ptg', ptgJson: '{"ptg":1}',
+    cgUuid: '39999:TA:dog-core-nodes-graph', cgName: 'dog cg', cgJson: '{"cg":1}',
+    cogUuid: '39999:TA:dog-concept-graph', cogName: 'dog cog', cogJson: '{"cog":1}',
+    ...overrides,
+  };
+}
+
+/* ── U-class: the crux — JSON coercion, LMDB resolution, {nodes} shape, found ─── */
+
+test('U1 (AC3: inline JSON): coerceJson parses an inline JSON string into an object', () => {
+  const mod = loadHelper();
+  assert(typeof mod.coerceJson === 'function', 'conceptCoreNodes.js must export coerceJson.');
+  const out = mod.coerceJson('{"a":1,"b":[2]}');
+  assert(out && typeof out === 'object' && out.a === 1 && Array.isArray(out.b),
+    `an inline JSON string must parse to an object (got ${short(out)}).`);
+});
+
+test('U2 (AC3: LMDB object): coerceJson passes an object through unchanged (LMDB envelope.data form)', () => {
+  const mod = loadHelper();
+  const obj = { already: 'parsed' };
+  assert(mod.coerceJson(obj) === obj,
+    'the LMDB store returns envelope.data as an OBJECT; coerceJson must pass objects through, not re-parse them.');
+});
+
+test('U3 (AC5: missing JSON): coerceJson returns null for null / empty', () => {
+  const mod = loadHelper();
+  assert(mod.coerceJson(null) === null && mod.coerceJson('') === null && mod.coerceJson(undefined) === null,
+    'a node with no JSON tag must coerce to null (drives the "no JSON" / degraded states).');
+});
+
+test('U4 (AC1: shape): shapeCoreNodes maps a Cypher row to all 8 core nodes, each {uuid,name,json}', () => {
+  const mod = loadHelper();
+  assert(typeof mod.shapeCoreNodes === 'function', 'conceptCoreNodes.js must export shapeCoreNodes(row, resolve).');
+  const nodes = mod.shapeCoreNodes(fullRow());
+  const keys = ['header', 'superset', 'schema', 'primaryProperty', 'properties', 'ptGraph', 'coreGraph', 'conceptGraph'];
+  for (const k of keys) {
+    assert(nodes[k], `nodes.${k} must be present (the 8 firmware core-node types).`);
+    assert('uuid' in nodes[k] && 'name' in nodes[k] && 'json' in nodes[k],
+      `nodes.${k} must be {uuid,name,json} (got ${short(nodes[k])}).`);
+  }
+  assert(nodes.schema.uuid === '39999:TA:dog-schema' && nodes.schema.json && nodes.schema.json.$schema === 'x',
+    'the schema core node must carry its uuid and its parsed JSON — this is data strfry does NOT have.');
+  assert(nodes.header.json && nodes.header.json.word && nodes.header.json.word.name === 'dog',
+    'header JSON (an inline string) must be parsed to an object.');
+});
+
+test('U5 (AC3 CRUX: JSON from LMDB): an "lmdb:<key>" node value is resolved through the store', () => {
+  const mod = loadHelper();
+  // Simulate an offloaded value: schemaJson is an lmdb pointer; resolve maps it to the stored object.
+  const resolved = { fromLmdb: true, $schema: 'resolved' };
+  const fakeResolve = (v) => (v === 'lmdb:SCHEMA_KEY' ? resolved : v);
+  const nodes = mod.shapeCoreNodes(fullRow({ schemaJson: 'lmdb:SCHEMA_KEY' }), fakeResolve);
+  assert(nodes.schema.json && nodes.schema.json.fromLmdb === true && nodes.schema.json.$schema === 'resolved',
+    'a node whose json tag is an "lmdb:<key>" pointer MUST be resolved from Tapestry LMDB (the ontology requirement), ' +
+    `not returned as the raw pointer string (got ${short(nodes.schema.json)}).`);
+  // A non-pointer sibling still parses normally through the same resolve pass.
+  assert(nodes.header.json && nodes.header.json.word,
+    'inline (non-pointer) siblings must still parse when a resolve function is supplied.');
+});
+
+test('U6 (AC5: not in graph): getConceptCoreNodes returns found:false when the header matches no node', async () => {
+  const mod = loadHelper();
+  assert(typeof mod.getConceptCoreNodes === 'function', 'conceptCoreNodes.js must export getConceptCoreNodes(headerUuid, deps?).');
+  const out = await mod.getConceptCoreNodes('39998:TA:nope-not-here', { runCypher: async () => [] });
+  assert(out && out.found === false, `an unknown header handle must yield {found:false} (got ${short(out)}).`);
+  assert(out.nodes && Object.keys(out.nodes).length === 0, 'found:false must carry an empty nodes map (nothing to render).');
+});
+
+test('U7 (AC3: neo4j-keyed): getConceptCoreNodes runs a header-uuid-PARAM query and shapes+resolves the row', async () => {
+  const mod = loadHelper();
+  const handle = '39998:TA:dog';
+  const calls = [];
+  const runCypher = async (cypher, params) => { calls.push({ cypher, params }); return [fullRow({ schemaJson: 'lmdb:K' })]; };
+  const resolveValue = (v) => (v === 'lmdb:K' ? { viaStore: true } : v);
+  const out = await mod.getConceptCoreNodes(handle, { runCypher, resolveValue });
+  assert(calls.length === 1, `exactly one Cypher read expected (got ${calls.length}).`);
+  assert(calls[0].params && calls[0].params.uuid === handle,
+    `the header handle must ride as the $uuid PARAM (got params ${short(calls[0].params)}).`);
+  assert(!calls[0].cypher.includes(handle),
+    'the handle must NOT be interpolated into the Cypher text — it travels as $uuid.');
+  assert(/IS_THE_JSON_SCHEMA_FOR/.test(calls[0].cypher) && /IS_THE_PRIMARY_PROPERTY_FOR/.test(calls[0].cypher) &&
+         /IS_THE_PROPERTIES_SET_FOR/.test(calls[0].cypher) && /IS_THE_CONCEPT_GRAPH_FOR/.test(calls[0].cypher),
+    'the query must traverse the core-node relationships (relationships come from neo4j directly, per the ontology).');
+  assert(out.found === true && out.nodes.schema.json && out.nodes.schema.json.viaStore === true,
+    'the returned schema JSON must be the LMDB-resolved object (found:true, resolved via the injected store).');
+});
+
+/* ── S-class: source assertions — endpoint, firmware rewire, shared UI, TD wiring ── */
+
+test('S1 (AC1: endpoint): concept-graph API registers GET /node/:handle/core-nodes → getConceptCoreNodes', () => {
+  const src = safeRead(CG_INDEX);
+  assert(src.length > 0, 'src/api/concept-graph/index.js missing — unexpected.');
+  assert(/node\/:handle\/core-nodes/.test(src),
+    'concept-graph API must register the handle-keyed route "/api/concept-graph/node/:handle/core-nodes".');
+  assert(/getConceptCoreNodes/.test(src) && /conceptCoreNodes/.test(src),
+    'the route must delegate to getConceptCoreNodes from the shared helper (no inline core-node query in the router).');
+});
+
+test('S2 (AC3: JSON from LMDB): the helper resolves values through tapestry-resolve', () => {
+  const src = safeRead(HELPER);
+  assert(src.length > 0, HELPER_MISSING);
+  assert(/tapestry-resolve/.test(src) && /resolveValue/.test(src),
+    'conceptCoreNodes.js must route node JSON through resolveValue (src/lib/tapestry-resolve.js) — "JSON from Tapestry LMDB".');
+});
+
+test('S3 (ADR Decision 2: DRY rewire): firmware concept endpoint calls the shared helper, not an inline core-node query', () => {
+  const src = safeRead(FW_INDEX);
+  assert(src.length > 0, 'src/api/firmware/index.js missing — unexpected.');
+  assert(/getConceptCoreNodes/.test(src) && /conceptCoreNodes/.test(src),
+    'the firmware concept endpoint must be rewired onto getConceptCoreNodes (share & rewire — the approved choice).');
+  // The 8-relationship OPTIONAL MATCH must now live in the helper, not inline in the firmware router.
+  const inlineChain = /IS_THE_PROPERTIES_SET_FOR[\s\S]*IS_THE_PROPERTY_TREE_GRAPH_FOR[\s\S]*IS_THE_CORE_GRAPH_FOR/.test(src);
+  assert(!inlineChain,
+    'the inline 8-core-node OPTIONAL MATCH must be MOVED to the shared helper (one copy of the query, per ADR Decision 2).');
+});
+
+test('S4 (AC1: shared UI): CoreNodeViews module exports ConceptOverview, ConceptNodeJson, CORE_NODES', () => {
+  const src = safeRead(CORE_VIEWS);
+  assert(src.length > 0,
+    'ui/src/components/concept/CoreNodeViews.jsx does not exist yet — the extracted per-concept view pieces are not implemented.');
+  assert(/export\s+(function|const)\s+ConceptOverview/.test(src) || /export\s*\{[^}]*ConceptOverview/.test(src),
+    'CoreNodeViews.jsx must export ConceptOverview (extracted from FirmwareExplorer FirmwareOverview).');
+  assert(/export\s+(function|const)\s+ConceptNodeJson/.test(src) || /export\s*\{[^}]*ConceptNodeJson/.test(src),
+    'CoreNodeViews.jsx must export ConceptNodeJson (extracted from FirmwareExplorer FirmwareNodeJson).');
+  assert(/export\s+const\s+CORE_NODES/.test(src) || /export\s*\{[^}]*CORE_NODES/.test(src),
+    'CoreNodeViews.jsx must export the CORE_NODES tab list.');
+  assert(/JsonView/.test(src), 'the extracted core-node JSON view must reuse JsonView (Viewer mode) — not re-implement a tree.');
+});
+
+test('S5 (Decision 3: FE de-duped): FirmwareExplorer imports the shared views instead of defining them inline', () => {
+  const src = safeRead(FE);
+  assert(/from\s+['"][^'"]*components\/concept\/CoreNodeViews['"]/.test(src),
+    'FirmwareExplorer must import ConceptOverview/ConceptNodeJson/CORE_NODES from the shared CoreNodeViews module.');
+  assert(!/function\s+FirmwareOverview\s*\(/.test(src) && !/function\s+FirmwareNodeJson\s*\(/.test(src),
+    'the inline FirmwareOverview / FirmwareNodeJson definitions must be REMOVED from FirmwareExplorer (extracted to the shared module).');
+});
+
+test('S6 (AC1/AC4: TD per-concept view): TapestryDetail mounts the core-node views + ConceptMembersView with a tab bar', () => {
+  const src = safeRead(TD);
+  assert(src.length > 0, 'ui/src/pages/tapestries/TapestryDetail.jsx missing — unexpected.');
+  assert(/fetchConceptCoreNodes/.test(src),
+    'TapestryDetail must fetch per-concept data via fetchConceptCoreNodes (the new Neo4j+LMDB read).');
+  assert(/ConceptOverview/.test(src) && /ConceptNodeJson/.test(src),
+    'the selected concept must render the shared ConceptOverview + ConceptNodeJson core-node views.');
+  assert(/ConceptMembersView/.test(src),
+    'Elements & Sets must reuse the existing ConceptMembersView (imported from settings/ConceptMembersView).');
+  assert(/CORE_NODES/.test(src) && /elements/.test(src) && /sets/.test(src),
+    'the per-concept view must offer the Overview + core-node tabs plus Elements and Sets.');
+});
+
+test('S7 (AC1: client API): fetchConceptCoreNodes GETs the handle-keyed core-nodes endpoint', () => {
+  const src = safeRead(CLIENT);
+  assert(src.length > 0,
+    'ui/src/api/conceptCoreNodes.js does not exist yet — the client fetch for the new endpoint is not implemented.');
+  assert(/export\s+(async\s+)?function\s+fetchConceptCoreNodes|export\s+const\s+fetchConceptCoreNodes/.test(src),
+    'conceptCoreNodes.js (client) must export fetchConceptCoreNodes.');
+  assert(/core-nodes/.test(src) && /concept-graph\/node/.test(src),
+    'fetchConceptCoreNodes must call /api/concept-graph/node/<handle>/core-nodes.');
+});
+
+test('S8 (AC3: source of truth = neo4j, not the authored event): TD keys per-concept detail on the member handle', () => {
+  const src = safeRead(TD);
+  // The old per-concept detail rendered the strfry IMPORT graph JSON (match.graph). The new detail
+  // must instead fetch by the member's neo4j handle (concept uuid), proving the data is from the graph.
+  assert(/fetchConceptCoreNodes\(\s*[^)]*(uuid|handle)/.test(src),
+    'the per-concept detail must be fetched by the member concept HANDLE (its 39998:<TA>:<slug> uuid) — the neo4j read, ' +
+    'not the tapestry event\'s authored import JSON.');
+  assert(!/JsonPanel\s+data=\{\s*match\.graph/.test(src),
+    'the old import-graph-JSON-only per-concept view (match.graph) must be replaced by the Neo4j+LMDB core-node views.');
+});
+
+/* ── H-class: live sentinels (SKIP when the stack/endpoint is unreachable) ─────── */
+
+async function getJson(url) {
+  try {
+    const r = await fetch(url, { signal: AbortSignal.timeout ? AbortSignal.timeout(8000) : undefined });
+    return { status: r.status, json: await r.json().catch(() => null) };
+  } catch { return { status: 0, json: null }; }
+}
+let _ta = undefined;
+async function taPubkey() {
+  if (_ta !== undefined) return _ta;
+  const { json } = await getJson(`${BASE}/api/assistant/pubkey`);
+  _ta = json && json.pubkey ? json.pubkey : null;
+  return _ta;
+}
+async function endpointLive() {
+  // The new endpoint on a reachable stack that has the code. Any transport failure → not live.
+  const ta = await taPubkey();
+  if (!ta) return null;
+  const url = `${BASE}/api/concept-graph/node/${encodeURIComponent(`39998:${ta}:dog`)}/core-nodes`;
+  const { status, json } = await getJson(url);
+  if (status !== 200 || !json || json.success !== true) return null; // core not built / stack absent → SKIP
+  return { ta, dog: json };
+}
+
+test('H1 (AC3 live): the endpoint returns schema + primary-property core nodes for `dog` (data strfry lacks)', async () => {
+  const live = await endpointLive();
+  if (!live) return 'SKIP';
+  const n = live.dog.nodes || {};
+  assert(live.dog.found === true, `dog is a real concept — found must be true (got ${short(live.dog)}).`);
+  assert(n.schema && n.schema.json, 'the schema core node + its JSON must be present — sourced from neo4j+LMDB, not the strfry skeleton.');
+  assert(n.primaryProperty && n.primaryProperty.json, 'the primary-property core node + its JSON must be present.');
+});
+
+test('H2 (regression: rewire behavior-identical): firmware /concept/dog matches the core-nodes endpoint for the same core nodes', async () => {
+  const live = await endpointLive();
+  if (!live) return 'SKIP';
+  const { status, json: fw } = await getJson(`${BASE}/api/firmware/concept/dog`);
+  if (status !== 200 || !fw || fw.success !== true || !fw.installed) return 'SKIP';
+  const a = live.dog.nodes || {}, b = fw.nodes || {};
+  assert(a.schema && b.schema && a.schema.uuid === b.schema.uuid,
+    `the rewired firmware endpoint and the new endpoint must resolve the SAME schema node for dog ` +
+    `(new=${short(a.schema && a.schema.uuid)} firmware=${short(b.schema && b.schema.uuid)}).`);
+  assert(a.header && b.header && a.header.uuid === b.header.uuid, 'both endpoints must resolve the same header node.');
+});
+
+test('H3 (AC5 live): a handle with no matching node yields found:false (graceful)', async () => {
+  const ta = await taPubkey();
+  if (!ta) return 'SKIP';
+  const url = `${BASE}/api/concept-graph/node/${encodeURIComponent(`39998:${ta}:definitely-not-a-concept-zzz`)}/core-nodes`;
+  const { status, json } = await getJson(url);
+  if (status !== 200 || !json || json.success !== true) return 'SKIP'; // endpoint not built → SKIP
+  assert(json.found === false, `an unknown concept handle must return found:false (got ${short(json)}).`);
+});
+
+/* ── R-class: regression sentinels (pass before AND after) ─────────────────────── */
+
+test('R1: FirmwareExplorer keeps its per-concept core-node tabs, Elements/Sets, and Integrations', () => {
+  const src = safeRead(FE);
+  assert(/CORE_NODES/.test(src) && /Concept Header/.test(src) && /Superset/.test(src),
+    'the per-concept core-node tabs must survive the extraction.');
+  assert(/ConceptMembersView/.test(src) && /INTEGRATION_TYPES/.test(src) && /Integration Graph/.test(src),
+    'the Elements/Sets views and the manifest-level Integrations section must remain intact on the firmware page.');
+});
+
+test('R2 (AC6): TapestryDetail keeps its tapestry-level Integrations section', () => {
+  const src = safeRead(TD);
+  assert(/TapestryIntegrationGraph/.test(src) && /Enumerations/.test(src) && /Subsets/.test(src),
+    'the tapestry-level Integration views (graph / enumerations / elements / subsets / JSON) must remain — ' +
+    'this story enriches the per-concept drill-down, it does not remove the integration section.');
+});
+
+/* ─────────────── Run ─────────────── */
+
+async function run() {
+  console.log('\n--- tapestry-per-concept-detail-views tests (epic tapestries, Story 4) ---');
+  let pass = 0, fail = 0, skipped = 0;
+  const failures = [];
+  for (const [name, fn] of tests) {
+    try {
+      const r = await fn();
+      if (r === 'SKIP') { console.log(`  SKIP  ${name}`); skipped++; }
+      else { console.log(`  PASS  ${name}`); pass++; }
+    } catch (err) {
+      console.log(`  FAIL  ${name}\n        ${err.message}`);
+      failures.push({ name, message: err.message });
+      fail++;
+    }
+  }
+  console.log(`\ntapestry-per-concept-detail-views: ${pass} passed, ${fail} failed, ${skipped} skipped`);
+  return { pass, fail, failures, skipped };
+}
+
+if (require.main === module) {
+  run().then(({ fail }) => process.exit(fail === 0 ? 0 : 1)).catch((e) => { console.error(e); process.exit(1); });
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -176,6 +176,8 @@ const moveNodesBetweenSetsUi = require('./move-nodes-between-sets-ui.test.js');
 // epic: second-brain — Story 1 (capture a goal and see it).
 const captureAGoalAndSeeIt = require('./capture-a-goal-and-see-it.test.js');
 const firmwareConceptElementsSets = require('./firmware-concept-elements-sets.test.js');
+// epic: tapestries — Story 4 (per-concept detail views, Neo4j+LMDB read path).
+const tapestryPerConceptDetailViews = require('./tapestry-per-concept-detail-views.test.js');
 // epic: second-brain — Story 2 (hygiene check + primary-property reconcile).
 const structuresTheBrainCanTrust = require('./structures-the-brain-can-trust.test.js');
 // epic: second-brain — Story 3 (break a goal into pieces — decomposition).
@@ -486,6 +488,7 @@ async function main() {
   const moveNodesBetweenSetsUiResult = await moveNodesBetweenSetsUi.run();
   const captureAGoalAndSeeItResult = await captureAGoalAndSeeIt.run();
   const firmwareConceptElementsSetsResult = await firmwareConceptElementsSets.run();
+  const tapestryPerConceptDetailViewsResult = await tapestryPerConceptDetailViews.run();
   const structuresTheBrainCanTrustResult = await structuresTheBrainCanTrust.run();
   const breakAGoalIntoPiecesResult = await breakAGoalIntoPieces.run();
   const attachTheWorldResult = await attachTheWorld.run();
@@ -880,6 +883,12 @@ async function main() {
       ? `SKIP (${firmwareConceptElementsSetsResult.skipped} tests; preconditions not met)`
       : `${firmwareConceptElementsSetsResult.fail === 0 ? 'PASS' : 'FAIL'} (${firmwareConceptElementsSetsResult.pass} passed, ${firmwareConceptElementsSetsResult.fail} failed${firmwareConceptElementsSetsResult.skipped ? `, ${firmwareConceptElementsSetsResult.skipped} skipped` : ''})`;
   console.log(`firmware-concept-elements-sets suite:            ${firmwareConceptElementsSetsLine}`);
+
+  const tapestryPerConceptDetailViewsLine =
+    (tapestryPerConceptDetailViewsResult.pass + tapestryPerConceptDetailViewsResult.fail) === 0 && tapestryPerConceptDetailViewsResult.skipped
+      ? `SKIP (${tapestryPerConceptDetailViewsResult.skipped} tests; preconditions not met)`
+      : `${tapestryPerConceptDetailViewsResult.fail === 0 ? 'PASS' : 'FAIL'} (${tapestryPerConceptDetailViewsResult.pass} passed, ${tapestryPerConceptDetailViewsResult.fail} failed${tapestryPerConceptDetailViewsResult.skipped ? `, ${tapestryPerConceptDetailViewsResult.skipped} skipped` : ''})`;
+  console.log(`tapestry-per-concept-detail-views suite:         ${tapestryPerConceptDetailViewsLine}`);
   // Skip-aware: H-class live tests skip when the local stack is absent (CI's
   // stack-free job); U/S classes always run and gate.
   const breakAGoalIntoPiecesLine =
@@ -1055,6 +1064,8 @@ async function main() {
     captureAGoalAndSeeItResult.fail === 0 &&
     // firmware-explorer #1 — concept Elements & Sets viewer
     firmwareConceptElementsSetsResult.fail === 0 &&
+    // tapestries #4 — per-concept detail views (Neo4j+LMDB read path)
+    tapestryPerConceptDetailViewsResult.fail === 0 &&
     // second-brain #2 — structures the brain can trust (hygiene + reconcile)
     structuresTheBrainCanTrustResult.fail === 0 &&
     // second-brain #3 — break a goal into pieces (decomposition)
@@ -1114,7 +1125,7 @@ async function main() {
     noteTaggingRawEventsInspectorHttpResult, deploySafetyStatusResult, safeToMergeCheckResult, nextTaskCountdownResult,
     closeUnauthWriteSurfaceResult, defaultDenyMutationsResult, usersPageNeo4jEndpointResult, strfryWipeOwnerGateResult,
     relationshipPrimitivesResult, relationshipPrimitivesProbeResult, moveNodesBetweenSetsUiResult,
-    captureAGoalAndSeeItResult, firmwareConceptElementsSetsResult, structuresTheBrainCanTrustResult,
+    captureAGoalAndSeeItResult, firmwareConceptElementsSetsResult, tapestryPerConceptDetailViewsResult, structuresTheBrainCanTrustResult,
     breakAGoalIntoPiecesResult, attachTheWorldResult, sessionsReadTheBrainResult, theProposalLoopResult,
   ].reduce((sum, r) => sum + ((r && r.skipped) || 0), 0);
   console.log(`Total skipped:                                   ${totalSkipped}`);

--- a/ui/src/api/conceptCoreNodes.js
+++ b/ui/src/api/conceptCoreNodes.js
@@ -1,0 +1,18 @@
+/**
+ * Client for the concept-graph core-nodes read (ADR tapestries/0004).
+ * Returns a concept's 8 core nodes + JSON by header handle, sourced from Neo4j + Tapestry
+ * LMDB (relationships from Neo4j, node JSON resolved from LMDB) — the read path behind the
+ * tapestry per-concept detail views.
+ */
+
+/**
+ * Fetch a concept's core nodes by its header handle (uuid), e.g. `39998:<TA>:dog`.
+ * @param {string} handle
+ * @returns {Promise<{found: boolean, nodes: object}>}
+ */
+export async function fetchConceptCoreNodes(handle) {
+  const res = await fetch(`/api/concept-graph/node/${encodeURIComponent(handle)}/core-nodes`);
+  const data = await res.json();
+  if (!data.success) throw new Error(data.error || 'Failed to fetch concept core nodes');
+  return { found: data.found, nodes: data.nodes };
+}

--- a/ui/src/components/concept/CoreNodeViews.jsx
+++ b/ui/src/components/concept/CoreNodeViews.jsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import JsonView from '../JsonView';
+
+/*
+ * CoreNodeViews — the per-concept core-node presentational pieces, shared by the Firmware
+ * Explorer and the Tapestry Exploration page (ADR tapestries/0004, Decision 3). Extracted
+ * verbatim from FirmwareExplorer.jsx (FirmwareOverview → ConceptOverview, FirmwareNodeJson →
+ * ConceptNodeJson) so both pages render an identical concept view from the same `{ name,
+ * nodes: { header, superset, schema, primaryProperty, properties, ptGraph, coreGraph,
+ * conceptGraph } }` shape. Reuses JsonView and the .firmware-* CSS classes.
+ */
+
+export const CORE_NODES = [
+  { key: 'overview',        label: 'Overview' },
+  { key: 'header',          label: 'Concept Header' },
+  { key: 'superset',        label: 'Superset' },
+  { key: 'schema',          label: 'JSON Schema' },
+  { key: 'primaryProperty', label: 'Primary Property' },
+  { key: 'properties',      label: 'Properties Set' },
+  { key: 'ptGraph',         label: 'Property Tree Graph' },
+  { key: 'coreGraph',       label: 'Core Nodes Graph' },
+  { key: 'conceptGraph',    label: 'Concept Graph' },
+];
+
+/* ── Concept Overview ── */
+
+export function ConceptOverview({ data }) {
+  const nodeEntries = Object.entries(data.nodes || {});
+  const existCount = nodeEntries.filter(([, v]) => v.uuid).length;
+  const jsonCount = nodeEntries.filter(([, v]) => v.json).length;
+
+  return (
+    <div className="firmware-overview">
+      <h2>{data.title || data.name}</h2>
+      <p className="firmware-description">{data.description}</p>
+
+      <table className="data-table" style={{ marginTop: '1.5rem' }}>
+        <thead>
+          <tr>
+            <th>Core Node</th>
+            <th>Exists</th>
+            <th>JSON</th>
+            <th>Name</th>
+            <th>UUID</th>
+          </tr>
+        </thead>
+        <tbody>
+          {CORE_NODES.filter(n => n.key !== 'overview').map(n => {
+            const node = data.nodes[n.key];
+            return (
+              <tr key={n.key}>
+                <td><strong>{n.label}</strong></td>
+                <td>{node?.uuid ? '✅' : '❌'}</td>
+                <td>{node?.json ? '✅' : node?.uuid ? '❌' : '—'}</td>
+                <td>{node?.name || '—'}</td>
+                <td>
+                  <code className="uuid-short" title={node?.uuid}>
+                    {node?.uuid?.slice(-12) || '—'}
+                  </code>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+
+      <div className="firmware-overview-stats" style={{ marginTop: '1rem', opacity: 0.7 }}>
+        {existCount}/8 nodes exist · {jsonCount}/8 have JSON
+      </div>
+    </div>
+  );
+}
+
+/* ── Concept Node JSON ── */
+
+export function ConceptNodeJson({ data, nodeKey }) {
+  const nodeInfo = CORE_NODES.find(n => n.key === nodeKey);
+  const node = data.nodes[nodeKey];
+  const [viewMode, setViewMode] = useState('viewer'); // 'viewer' | 'raw'
+
+  if (!node?.uuid) {
+    return (
+      <div className="firmware-missing-node">
+        <h3>{nodeInfo?.label || nodeKey}</h3>
+        <p>This core node does not exist for <strong>{data.name}</strong>.</p>
+      </div>
+    );
+  }
+
+  if (!node.json) {
+    return (
+      <div className="firmware-missing-json">
+        <h3>{nodeInfo?.label || nodeKey}</h3>
+        <p>Node exists but has no JSON tag.</p>
+        <p><code className="uuid-short">{node.uuid}</code></p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="firmware-json-view">
+      <div className="firmware-json-header">
+        <h3>{nodeInfo?.label || nodeKey}</h3>
+        <span className="firmware-json-meta">
+          {node.name} · <code className="uuid-short" title={node.uuid}>{node.uuid?.slice(-16)}</code>
+        </span>
+        <div className="firmware-view-toggle">
+          {[
+            { key: 'viewer', label: 'Viewer' },
+            { key: 'raw', label: 'Raw JSON' },
+          ].map(opt => (
+            <button
+              key={opt.key}
+              className={`firmware-view-btn ${viewMode === opt.key ? 'active' : ''}`}
+              onClick={() => setViewMode(opt.key)}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      {viewMode === 'viewer' ? (
+        <JsonView data={node.json} />
+      ) : (
+        <pre className="firmware-json-pre">
+          {JSON.stringify(node.json, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/settings/FirmwareExplorer.jsx
+++ b/ui/src/pages/settings/FirmwareExplorer.jsx
@@ -3,8 +3,9 @@ import {
   fetchFirmwareManifest, fetchFirmwareConcept,
   fetchFirmwareVersions, fetchInstallStatus, installFirmware,
 } from '../../api/firmware';
-import JsonView from '../../components/JsonView';
 import ConceptMembersView from './ConceptMembersView';
+// Per-concept core-node views, shared with the Tapestry Exploration page (ADR tapestries/0004).
+import { CORE_NODES, ConceptOverview as FirmwareOverview, ConceptNodeJson as FirmwareNodeJson } from '../../components/concept/CoreNodeViews';
 
 // Per-concept membership views — the concept's live elements and sets, rendered
 // as a list → JSON-detail drill-down (distinct from the manifest-level
@@ -14,17 +15,7 @@ const MEMBER_VIEWS = [
   { key: 'sets',     label: 'Sets' },
 ];
 
-const CORE_NODES = [
-  { key: 'overview',        label: 'Overview' },
-  { key: 'header',          label: 'Concept Header' },
-  { key: 'superset',        label: 'Superset' },
-  { key: 'schema',          label: 'JSON Schema' },
-  { key: 'primaryProperty', label: 'Primary Property' },
-  { key: 'properties',      label: 'Properties Set' },
-  { key: 'ptGraph',         label: 'Property Tree Graph' },
-  { key: 'coreGraph',       label: 'Core Nodes Graph' },
-  { key: 'conceptGraph',    label: 'Concept Graph' },
-];
+// CORE_NODES is imported from components/concept/CoreNodeViews (shared with the Tapestry page).
 
 const INTEGRATION_TYPES = [
   { key: 'enumerations', label: 'Enumerations', icon: '🔢' },
@@ -568,54 +559,7 @@ function InstallStatusBanner({ installStatus, versions, activeDir, manifest, ins
   );
 }
 
-/* ── Firmware Overview ── */
-
-function FirmwareOverview({ data }) {
-  const nodeEntries = Object.entries(data.nodes || {});
-  const existCount = nodeEntries.filter(([, v]) => v.uuid).length;
-  const jsonCount = nodeEntries.filter(([, v]) => v.json).length;
-
-  return (
-    <div className="firmware-overview">
-      <h2>{data.title || data.name}</h2>
-      <p className="firmware-description">{data.description}</p>
-
-      <table className="data-table" style={{ marginTop: '1.5rem' }}>
-        <thead>
-          <tr>
-            <th>Core Node</th>
-            <th>Exists</th>
-            <th>JSON</th>
-            <th>Name</th>
-            <th>UUID</th>
-          </tr>
-        </thead>
-        <tbody>
-          {CORE_NODES.filter(n => n.key !== 'overview').map(n => {
-            const node = data.nodes[n.key];
-            return (
-              <tr key={n.key}>
-                <td><strong>{n.label}</strong></td>
-                <td>{node?.uuid ? '✅' : '❌'}</td>
-                <td>{node?.json ? '✅' : node?.uuid ? '❌' : '—'}</td>
-                <td>{node?.name || '—'}</td>
-                <td>
-                  <code className="uuid-short" title={node?.uuid}>
-                    {node?.uuid?.slice(-12) || '—'}
-                  </code>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-
-      <div className="firmware-overview-stats" style={{ marginTop: '1rem', opacity: 0.7 }}>
-        {existCount}/8 nodes exist · {jsonCount}/8 have JSON
-      </div>
-    </div>
-  );
-}
+/* ── Firmware Overview → ConceptOverview, imported from components/concept/CoreNodeViews ── */
 
 /* ── Integration Panel ── */
 
@@ -900,64 +844,7 @@ function IntegrationDetail({ type, item, manifest }) {
   return <div className="empty">Unknown integration type.</div>;
 }
 
-/* ── Firmware Node JSON ── */
-
-function FirmwareNodeJson({ data, nodeKey }) {
-  const nodeInfo = CORE_NODES.find(n => n.key === nodeKey);
-  const node = data.nodes[nodeKey];
-  const [viewMode, setViewMode] = useState('viewer'); // 'viewer' | 'raw'
-
-  if (!node?.uuid) {
-    return (
-      <div className="firmware-missing-node">
-        <h3>{nodeInfo?.label || nodeKey}</h3>
-        <p>This core node does not exist for <strong>{data.name}</strong>.</p>
-      </div>
-    );
-  }
-
-  if (!node.json) {
-    return (
-      <div className="firmware-missing-json">
-        <h3>{nodeInfo?.label || nodeKey}</h3>
-        <p>Node exists but has no JSON tag.</p>
-        <p><code className="uuid-short">{node.uuid}</code></p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="firmware-json-view">
-      <div className="firmware-json-header">
-        <h3>{nodeInfo?.label || nodeKey}</h3>
-        <span className="firmware-json-meta">
-          {node.name} · <code className="uuid-short" title={node.uuid}>{node.uuid?.slice(-16)}</code>
-        </span>
-        <div className="firmware-view-toggle">
-          {[
-            { key: 'viewer', label: 'Viewer' },
-            { key: 'raw', label: 'Raw JSON' },
-          ].map(opt => (
-            <button
-              key={opt.key}
-              className={`firmware-view-btn ${viewMode === opt.key ? 'active' : ''}`}
-              onClick={() => setViewMode(opt.key)}
-            >
-              {opt.label}
-            </button>
-          ))}
-        </div>
-      </div>
-      {viewMode === 'viewer' ? (
-        <JsonView data={node.json} />
-      ) : (
-        <pre className="firmware-json-pre">
-          {JSON.stringify(node.json, null, 2)}
-        </pre>
-      )}
-    </div>
-  );
-}
+/* ── Firmware Node JSON → ConceptNodeJson, imported from components/concept/CoreNodeViews ── */
 
 /* ══════════════════════════════════════════════════════════
    Integration Graph — vis-network visualization of all

--- a/ui/src/pages/tapestries/TapestryDetail.jsx
+++ b/ui/src/pages/tapestries/TapestryDetail.jsx
@@ -1,16 +1,20 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import JsonView from '../../components/JsonView';
 import useTapestryGraph from './useTapestryGraph';
 import TapestryIntegrationGraph from './TapestryIntegrationGraph';
 import { inferNodeType, groupRelationships, nodeName } from './tapestryGraphModel';
+import { fetchConceptCoreNodes } from '../../api/conceptCoreNodes';
+import { CORE_NODES, ConceptOverview, ConceptNodeJson } from '../../components/concept/CoreNodeViews';
+import ConceptMembersView from '../settings/ConceptMembersView';
 
 /**
- * Tapestry Exploration page (ADR tapestries/0002). Renders a tapestry as-authored:
- * the element's graph block + one-level resolved imports, composed into the
- * Firmware-Explorer-style read-only views (integration graph, integration tables,
- * per-concept JSON). Reads everything from strfry via useTapestryGraph.
+ * Tapestry Exploration page (ADR tapestries/0002, extended by 0004). Membership and the
+ * tapestry-level integration views render as-authored from strfry (useTapestryGraph). The
+ * per-concept DETAIL (Overview / 8 core nodes / Elements / Sets) is read from Neo4j + Tapestry
+ * LMDB via the concept-graph core-nodes endpoint, mirroring the Firmware Explorer's per-concept
+ * experience — relationships from Neo4j, node JSON resolved from LMDB (owner ontology).
  */
 
 const INTEGRATION_ITEMS = [
@@ -19,6 +23,12 @@ const INTEGRATION_ITEMS = [
   { key: 'elements', label: 'Elements', icon: '📦' },
   { key: 'subsets', label: 'Subsets', icon: '🔀' },
   { key: 'json', label: 'JSON', icon: '{ }' },
+];
+
+// Per-concept membership tabs (mirror the Firmware Explorer's Elements / Sets views).
+const MEMBER_VIEWS = [
+  { key: 'elements', label: 'Elements' },
+  { key: 'sets', label: 'Sets' },
 ];
 
 /** JsonView with a Viewer / Raw toggle (mirrors the Firmware Explorer's node JSON view). */
@@ -70,28 +80,98 @@ function RelationshipTable({ groupKey, label, rows, composed }) {
   );
 }
 
-function ConceptDetail({ composed, imports, slug }) {
-  const node = (composed?.nodes || []).find((n) => n.slug === slug);
-  const name = node?.name || slug;
-  // The concept's resolved concept-graph is the import whose graph includes this
-  // concept's header node.
-  const match = (imports || []).find((i) => (i.graph?.nodes || []).some((n) => n.uuid && n.uuid === node?.uuid));
+/**
+ * Per-concept detail — the Firmware-Explorer-style views for one member concept, read from
+ * Neo4j + Tapestry LMDB by the concept's header handle (ADR tapestries/0004). Overview + the
+ * 8 core-node types reuse the shared CoreNodeViews; Elements / Sets reuse ConceptMembersView.
+ * The concept's identity/JSON comes from the instance's graph, NOT the tapestry's authored event.
+ */
+function ConceptDetail({ concept }) {
+  const handle = concept?.uuid || null;
+  const name = concept?.name || concept?.slug || 'Concept';
+
+  const [selectedNode, setSelectedNode] = useState('overview');
+  const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!handle) { setResult({ found: false, nodes: {} }); setLoading(false); return; }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setSelectedNode('overview');
+    fetchConceptCoreNodes(handle)
+      .then((res) => { if (!cancelled) setResult(res); })
+      .catch((e) => { if (!cancelled) setError(e.message || String(e)); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [handle]);
+
+  // Adapt the endpoint's { found, nodes } into the shape the shared components expect.
+  const headerJson = result?.nodes?.header?.json || null;
+  const description =
+    headerJson?.word?.description || headerJson?.set?.description || headerJson?.conceptHeader?.description || '';
+  const data = result
+    ? { name, title: name, description, nodes: result.nodes || {}, installed: result.found }
+    : null;
 
   return (
-    <div className="firmware-node-content">
-      <h2>🧩 {name}</h2>
-      {match ? (
-        <JsonPanel data={match.graph} />
-      ) : (
-        <p className="placeholder">No resolved concept graph for this concept.</p>
-      )}
-    </div>
+    <>
+      <div className="firmware-node-tabs">
+        {CORE_NODES.map((n) => (
+          <button
+            key={n.key}
+            className={`firmware-node-tab ${selectedNode === n.key ? 'active' : ''}`}
+            onClick={() => setSelectedNode(n.key)}
+          >
+            {n.label}
+          </button>
+        ))}
+        <span className="firmware-node-tab-divider" aria-hidden="true" />
+        {MEMBER_VIEWS.map((n) => (
+          <button
+            key={n.key}
+            className={`firmware-node-tab ${selectedNode === n.key ? 'active' : ''}`}
+            onClick={() => setSelectedNode(n.key)}
+          >
+            {n.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="firmware-node-content">
+        {loading ? (
+          <div className="loading">Loading…</div>
+        ) : error ? (
+          <p className="error">Error: {error}</p>
+        ) : !data || !data.installed ? (
+          <div className="firmware-not-installed">
+            <h3>⚠️ Not in the graph</h3>
+            <p>
+              <strong>{name}</strong> is a member of this tapestry but was not found in the concept
+              graph, so there is nothing to inspect yet.
+            </p>
+          </div>
+        ) : selectedNode === 'overview' ? (
+          <ConceptOverview data={data} />
+        ) : selectedNode === 'elements' || selectedNode === 'sets' ? (
+          <ConceptMembersView
+            key={`${data.nodes?.header?.uuid}:${selectedNode}`}
+            conceptData={data}
+            kind={selectedNode}
+          />
+        ) : (
+          <ConceptNodeJson data={data} nodeKey={selectedNode} />
+        )}
+      </div>
+    </>
   );
 }
 
 export default function TapestryDetail() {
   const { uuid } = useParams();
-  const { loading, error, tapestry, rawGraph, composed, imports, degraded, notFound } = useTapestryGraph(uuid);
+  const { loading, error, tapestry, rawGraph, composed, degraded, notFound } = useTapestryGraph(uuid);
   const [selected, setSelected] = useState({ kind: 'integration', key: 'graph' });
 
   const title = tapestry?.title || 'Tapestry';
@@ -170,7 +250,7 @@ export default function TapestryDetail() {
             </div>
           )}
           {selected.kind === 'concept' && (
-            <ConceptDetail composed={composed} imports={imports} slug={selected.slug} />
+            <ConceptDetail concept={memberConcepts.find((c) => c.slug === selected.slug)} />
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary

Promotes staging to main after verification on `staging.brainstorm.world`. The bundle is exactly one PR.

## Bundled

- **#467** — Tapestries per-concept detail views (Neo4j+LMDB read path). The Tapestry Exploration page's per-concept view now emulates the Firmware Explorer (Overview + 8 core-node types + Elements + Sets), reading node JSON from Tapestry LMDB and relationships from Neo4j. New `GET /api/concept-graph/node/:handle/core-nodes`; the firmware `/concept/:slug` endpoint rewired onto the same shared helper (behavior-identical); shared UI extracted to `components/concept/CoreNodeViews.jsx`. ADR 0004 partially supersedes ADR 0002 Decision 2 for per-concept detail; membership stays strfry.

## Net production impact

Additive. Exploring a tapestry and selecting a concept now shows the rich per-concept views instead of raw concept-graph JSON. A new read-only endpoint is added; the Firmware Explorer's data path is refactored with identical behavior. **No** session-store change (no forced sign-out), **no** concept-definition/schema change (no firmware reinstall). Prod currently has 0 authored tapestries, so the new views are reachable but show data only once a tapestry is seeded via the owner-gated Create page.

## Verification trail

- #467 staging deploy run `30170460436` ✓ 1m25s; CI `stack-free` ✓ 41s.
- Staging smoke (H-class bound live): `core-nodes/dog` → `found:true` with `schema.json` + `primaryProperty.json` present (data strfry lacks); firmware `/concept/dog` `schema.uuid` == core-nodes `schema.uuid` (rewire byte-identical); bogus handle → `found:false`; regression sweep green; public tapestries directory renders.

## Test plan

- [ ] After merge: `deploy-tapestry.yml` runs to completion.
- [ ] Prod smoke on tapestry.brainstorm.world: core-nodes/dog `found:true` + schema/primaryProperty JSON; firmware/core-nodes schema.uuid parity; bogus → `found:false`; homepage/summaries/manifest green; tapestries directory renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)