### PR TITLE
test: re-pin sentinel inventories for PR #480 (staging gate back to green)

### DIFF
--- a/test/show-the-four-on-the-goal-screens-that-already-exist.test.js
+++ b/test/show-the-four-on-the-goal-screens-that-already-exist.test.js
@@ -168,10 +168,13 @@ const THREE_SCREENS = [
  * Measured 2026-07-27 on this branch, with the regexes used below. A story that
  * legitimately adds a route/nav entry/design token updates these three numbers
  * AND says so in its own artifacts — that is the point of freezing them.
+ * Re-measured 2026-07-29 for PR #480 (goals submenu + Rationale/GoalSets/
+ * GoalPlaceholders): +3 screens, +4 route entries, +4 nav destinations; CSS
+ * custom properties unchanged at 45. Operator-authorized re-pin.
  */
-const BRAIN_PAGE_FILES = ['GoalDetail.jsx', 'Goals.jsx', 'Proposals.jsx'];
-const ROUTE_PATH_ENTRIES = 104;
-const NAV_TO_ENTRIES = 21;
+const BRAIN_PAGE_FILES = ['GoalDetail.jsx', 'GoalPlaceholders.jsx', 'GoalSets.jsx', 'Goals.jsx', 'Proposals.jsx', 'Rationale.jsx'];
+const ROUTE_PATH_ENTRIES = 108;
+const NAV_TO_ENTRIES = 25;
 const CSS_CUSTOM_PROPERTIES = 45;
 
 const tests = [];

--- a/test/the-brain-survives.test.js
+++ b/test/the-brain-survives.test.js
@@ -586,13 +586,14 @@ test('S3 (ADR d3/d6 — the lanes): restore lives in normalize, never in the bra
   assert(!/restore/i.test(brain),
     'the brain module must carry NO restore surface — the brain is pinned read-only; RESTORE writes and lives in normalize (ADR 0008 d6; the story-7 handoff\'s own constraint).');
   const routes = [...brain.matchAll(/app\.get\s*\(\s*['"`]([^'"`]+)['"`]/g)].map((m) => m[1]);
-  // Re-pinned to SEVEN by operational-direction #1 (ADR 0001 d1): the
-  // eligibility read /api/brain/direction/:slug is a deliberate addition and is
-  // read-only like its siblings. The exact-length check is DELIBERATELY kept —
-  // an eighth route still fails here until someone re-pins it on purpose.
-  const want = ['/api/brain/goals', '/api/brain/orient', '/api/brain/proposals', '/api/brain/direction/:slug', '/api/brain/goals/:slug', '/api/brain/hygiene', '/api/brain/export'];
+  // Re-pinned to SEVEN by operational-direction #1 (ADR 0001 d1), then to
+  // EIGHT for PR #480 (goals-rationale: the /api/brain/serves-path read,
+  // operator-authorized re-pin 2026-07-29). The exact-length check is
+  // DELIBERATELY kept — a ninth route still fails here until someone re-pins
+  // it on purpose.
+  const want = ['/api/brain/goals', '/api/brain/orient', '/api/brain/proposals', '/api/brain/direction/:slug', '/api/brain/goals/:slug', '/api/brain/hygiene', '/api/brain/export', '/api/brain/serves-path'];
   assert(routes.length === want.length && want.every((w) => routes.includes(w)),
-    `registerBrainRoutes must carry exactly the seven reads (the six prior + /api/brain/direction/:slug — ADR 0008 d3/d14 + operational-direction/0001 d1); got ${short(routes)}.`);
+    `registerBrainRoutes must carry exactly the eight reads (the seven prior + /api/brain/serves-path — PR #480 goals-rationale, re-pinned 2026-07-29); got ${short(routes)}.`);
 });
 
 test('S4 (ADR d6): restore-brain — route, gate-first, one mutex task, artifact validation, named refusals', () => {


### PR DESCRIPTION
PR #480 merged tonight without extending the two exact-inventory sentinels it trips, leaving the full `npm test` gate red on staging (caught by a preflight baseline at 01:07–01:41: 78/80 suites green, both failures deterministic inventory pins, zero behavioral failures).

- `the-brain-survives` S3 — brain route pin **7 → 8** (`/api/brain/serves-path`)
- `show-the-four…` S5 — screens **3 → 6**; `ROUTE_PATH_ENTRIES` **104 → 108**; `NAV_TO_ENTRIES` **21 → 25**; CSS custom properties verified unchanged at 45 with the suite's own regex

Both suites green in isolation post-fix (31/0/0; 35/0/2, the 2 skips are the known H-class pair). The pins keep their exact-length checks — the next unannounced route or screen still fails loudly, which is their job.

Operator-confirmed: #480 is intended work; this re-pin ratifies its inventory into the sentinels. Unblocks the overnight `take-a-concept-back-out` operational run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)