### PR TITLE
Shared Concepts area: directory, detail, create form, b-tag surfaces

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -50,6 +50,13 @@ import UserDetail from './pages/users/UserDetail';
 import TapestriesIndex from './pages/tapestries/Index';
 import NewTapestry from './pages/tapestries/NewTapestry';
 import TapestryDetail from './pages/tapestries/TapestryDetail';
+import SharedConceptsIndex from './pages/shared-concepts/Index';
+import SharedConceptDetail from './pages/shared-concepts/Detail';
+import NewSharedConcept from './pages/shared-concepts/New';
+import ActiveBTags from './pages/shared-concepts/ActiveBTags';
+import BTagDetail from './pages/shared-concepts/BTagDetail';
+import SelfDeclaredSharedConcepts from './pages/shared-concepts/SelfDeclaredSharedConcepts';
+import SelfDeclaredDetail from './pages/shared-concepts/SelfDeclaredDetail';
 import AboutIndex from './pages/about/Index';
 import SettingsIndex from './pages/settings/Index';
 
@@ -357,6 +364,19 @@ const router = createBrowserRouter([
           { index: true, element: <TapestriesIndex />, handle: { crumb: 'View Tapestries' } },
           { path: 'new', element: <NewTapestry />, handle: { crumb: 'New Tapestry' } },
           { path: ':uuid', element: <TapestryDetail />, handle: { crumb: 'Detail' } },
+        ],
+      },
+      {
+        path: 'shared-concepts',
+        handle: { crumb: 'Shared Concepts' },
+        children: [
+          { index: true, element: <SharedConceptsIndex />, handle: { crumb: 'View Shared Concepts' } },
+          { path: 'new', element: <NewSharedConcept />, handle: { crumb: 'New Shared Concept' } },
+          { path: 'b-tags', element: <ActiveBTags />, handle: { crumb: 'Active b-tags' } },
+          { path: 'b-tags/:uuid', element: <BTagDetail />, handle: { crumb: 'b-tag Detail' } },
+          { path: 'self-declared', element: <SelfDeclaredSharedConcepts />, handle: { crumb: 'Self-declared Shared Concepts' } },
+          { path: 'self-declared/:uuid', element: <SelfDeclaredDetail />, handle: { crumb: 'Detail' } },
+          { path: ':uuid', element: <SharedConceptDetail />, handle: { crumb: 'Detail' } },
         ],
       },
       { path: 'relationships', element: <RelationshipsIndex />, handle: { crumb: 'Relationships' } },

--- a/ui/src/components/Layout.jsx
+++ b/ui/src/components/Layout.jsx
@@ -70,6 +70,16 @@ const mainNavItems = [
       { to: '/tapestry/tapestries/new', label: 'Create New Tapestry' },
     ],
   },
+  {
+    label: '🤝 Shared Concepts',
+    prefix: '/tapestry/shared-concepts',
+    children: [
+      { to: '/tapestry/shared-concepts', label: 'View Shared Concepts', end: true },
+      { to: '/tapestry/shared-concepts/new', label: 'Create New Shared Concept' },
+      { to: '/tapestry/shared-concepts/b-tags', label: 'Active b-tags' },
+      { to: '/tapestry/shared-concepts/self-declared', label: 'Self-declared Shared Concepts' },
+    ],
+  },
 ];
 
 const managementNavItems = [

--- a/ui/src/pages/shared-concepts/ActiveBTags.jsx
+++ b/ui/src/pages/shared-concepts/ActiveBTags.jsx
@@ -1,0 +1,206 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import DataTable from '../../components/DataTable';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import AuthorCell from '../../components/AuthorCell';
+import useProfiles from '../../hooks/useProfiles';
+import { useConfig } from '../../context/ConfigContext';
+import { queryRelay } from '../../api/relay';
+import { fetchFromRelays } from '../../utils/nostrPublish';
+
+// Where b-tag targets are looked up. Hardcoded for now — the future source is
+// the appropriate subset of the nostr-relays concept.
+const COMMUNITY_RELAYS = ['wss://dcosl.brainstorm.world'];
+
+// Nostr filters cannot express "has a b tag", so the scan is bounded by kind
+// and filtered client-side. Concept headers (39998) are the only b-tag
+// carriers today (~150 events); widen this—or move the has-b filter into a
+// server endpoint—if b-tags start appearing on other kinds.
+const B_CARRIER_KINDS = [39998];
+
+const A_TAG_RE = /^(\d+):([0-9a-f]{64}):(.+)$/;
+const EVENT_ID_RE = /^[0-9a-f]{64}$/;
+
+/** The singular name: `names` tag = ["names", singular, plural, …]. */
+function singularName(ev) {
+  const t = ev?.tags?.find((x) => x[0] === 'names');
+  return t && typeof t[1] === 'string' && t[1].trim() !== '' ? t[1] : null;
+}
+
+/**
+ * Active b-tags — every local-TA-authored event carrying a `b` tag, one row
+ * per b tag: the local event's singular name, the b-tag itself, and the name
+ * + author of the event the b-tag points to, fetched from the community
+ * relay. A b-tag is an a-tag or an event id; anything else is unresolvable
+ * ("cannot locate event"). A located event without a `names` tag reads
+ * "cannot locate name".
+ */
+export default function ActiveBTags() {
+  const navigate = useNavigate();
+  const { taPubkey } = useConfig();
+
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // b-tag value → located event (null = searched, not found). `done` flips
+  // when the community lookup for the current row set has completed.
+  const [shared, setShared] = useState({ map: {}, done: false });
+
+  useEffect(() => {
+    if (!taPubkey) return undefined; // wait for the runtime-resolved TA pubkey
+    let cancelled = false;
+
+    async function load() {
+      try {
+        setLoading(true);
+        setError(null);
+        const events = await queryRelay({ authors: [taPubkey], kinds: B_CARRIER_KINDS });
+        if (cancelled) return;
+        const out = [];
+        for (const ev of events || []) {
+          const d = ev.tags?.find((t) => t[0] === 'd')?.[1];
+          for (const t of ev.tags || []) {
+            if (t[0] === 'b' && typeof t[1] === 'string' && t[1].trim() !== '') {
+              out.push({
+                uuid: `${ev.id}:${t[1]}`,
+                localName: singularName(ev),
+                bTag: t[1].trim(),
+                // Detail-page coordinate of the local event; rows without a
+                // d-tag (non-addressable carriers) have no detail route.
+                coord: d != null ? `${ev.kind}:${ev.pubkey}:${d}` : null,
+              });
+            }
+          }
+        }
+        setRows(out);
+      } catch (err) {
+        if (!cancelled) setError(err.message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => { cancelled = true; };
+  }, [taPubkey]);
+
+  // Look the b-tag targets up on the community relay — two merged filters
+  // (one for all a-tag coordinates, one for all event ids) instead of a
+  // relay dial per row. The merged a-tag filter over-fetches across the
+  // cross-product; rows re-match precisely below, newest per coordinate.
+  useEffect(() => {
+    setShared({ map: {}, done: false });
+    if (rows.length === 0) return undefined;
+    let cancelled = false;
+
+    (async () => {
+      const targets = [...new Set(rows.map((r) => r.bTag))];
+      const aTags = targets.filter((v) => A_TAG_RE.test(v));
+      const ids = targets.filter((v) => EVENT_ID_RE.test(v));
+      const filters = [];
+      if (aTags.length > 0) {
+        filters.push({
+          kinds: [...new Set(aTags.map((v) => Number(v.match(A_TAG_RE)[1])))],
+          authors: [...new Set(aTags.map((v) => v.match(A_TAG_RE)[2]))],
+          '#d': [...new Set(aTags.map((v) => v.match(A_TAG_RE)[3]))],
+        });
+      }
+      if (ids.length > 0) filters.push({ ids });
+
+      const results = (await Promise.all(
+        filters.map((f) => fetchFromRelays(f, COMMUNITY_RELAYS)),
+      )).flat();
+      if (cancelled) return;
+
+      const byId = new Map();
+      const byCoord = new Map();
+      for (const ev of results) {
+        byId.set(ev.id, ev);
+        const d = ev.tags?.find((t) => t[0] === 'd')?.[1];
+        if (d != null) {
+          const coord = `${ev.kind}:${ev.pubkey}:${d}`;
+          const prev = byCoord.get(coord);
+          if (!prev || ev.created_at > prev.created_at) byCoord.set(coord, ev);
+        }
+      }
+
+      const map = {};
+      for (const v of targets) {
+        if (A_TAG_RE.test(v)) map[v] = byCoord.get(v) || null;
+        else if (EVENT_ID_RE.test(v)) map[v] = byId.get(v) || null;
+        else map[v] = null; // neither an a-tag nor an event id — unresolvable
+      }
+      setShared({ map, done: true });
+    })();
+
+    return () => { cancelled = true; };
+  }, [rows]);
+
+  const sharedAuthors = useMemo(
+    () => [...new Set(Object.values(shared.map).filter(Boolean).map((ev) => ev.pubkey))],
+    [shared],
+  );
+  const profiles = useProfiles(sharedAuthors);
+
+  const columns = [
+    {
+      key: 'localName',
+      label: 'name (local)',
+      render: (val) => val || <span className="text-muted">—</span>,
+    },
+    {
+      key: 'bTag',
+      label: 'b-tag',
+      render: (val) => <code style={{ overflowWrap: 'anywhere' }}>{val}</code>,
+    },
+    {
+      // Virtual column: no `sharedName` field exists on the row — the cell
+      // resolves through the async lookup map via the row's bTag.
+      key: 'sharedName',
+      label: 'name (shared)',
+      render: (_val, row) => {
+        if (!shared.done) return <span className="text-muted">…</span>;
+        const ev = shared.map[row.bTag];
+        if (!ev) return <span className="text-muted">cannot locate event</span>;
+        return singularName(ev) || <span className="text-muted">cannot locate name</span>;
+      },
+    },
+    {
+      key: 'sharedAuthor',
+      label: 'author (shared)',
+      render: (_val, row) => {
+        const ev = shared.done ? shared.map[row.bTag] : null;
+        if (!ev) return <span className="text-muted">—</span>;
+        return <AuthorCell pubkey={ev.pubkey} profiles={profiles} />;
+      },
+    },
+  ];
+
+  return (
+    <div className="page">
+      <Breadcrumbs />
+      <h1>🤝 Active b-tags</h1>
+      <p className="subtitle">
+        A list of locally-authored nostr events that use the b-tag to point to shared nostr events.
+      </p>
+
+      {loading && <p>Loading active b-tags…</p>}
+      {error && <p className="error">Error: {error}</p>}
+      {!loading && !error && (
+        <>
+          <p className="subtitle">{rows.length} active b-tags</p>
+          <DataTable
+            columns={columns}
+            data={rows}
+            onRowClick={(row) => {
+              if (!row.coord) return;
+              navigate(`/tapestry/shared-concepts/b-tags/${encodeURIComponent(row.coord)}?b=${encodeURIComponent(row.bTag)}`);
+            }}
+            emptyMessage="No active b-tags."
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/shared-concepts/BTagDetail.jsx
+++ b/ui/src/pages/shared-concepts/BTagDetail.jsx
@@ -1,0 +1,219 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import AuthorCell from '../../components/AuthorCell';
+import useProfiles from '../../hooks/useProfiles';
+import { queryRelay } from '../../api/relay';
+import { fetchFromRelays } from '../../utils/nostrPublish';
+
+// Where the b-tag target is looked up (same constant as the table page) —
+// hardcoded for now; future source is the nostr-relays concept subset.
+const COMMUNITY_RELAYS = ['wss://dcosl.brainstorm.world'];
+
+const A_TAG_RE = /^(\d+):([0-9a-f]{64}):(.+)$/;
+const EVENT_ID_RE = /^[0-9a-f]{64}$/;
+
+/** The singular name: `names` tag = ["names", singular, plural, …]. */
+function singularName(ev) {
+  const t = ev?.tags?.find((x) => x[0] === 'names');
+  return t && typeof t[1] === 'string' && t[1].trim() !== '' ? t[1] : null;
+}
+
+/** The event's description tag value, if any. */
+function descriptionOf(ev) {
+  const t = ev?.tags?.find((x) => x[0] === 'description');
+  return t && typeof t[1] === 'string' && t[1].trim() !== '' ? t[1] : null;
+}
+
+const columnStyle = {
+  flex: '1 1 320px',
+  minWidth: 0,
+  border: '1px solid var(--border)',
+  borderRadius: '8px',
+  padding: '1rem',
+};
+
+/**
+ * One side of the pair: name (singular), description, author, and the raw
+ * event json — hidden by default behind this column's own toggle.
+ * `state`: 'loading' | 'missing' | 'ok'; `missingText` is what the column
+ * says when its event could not be located.
+ */
+function EventColumn({ title, ev, state, missingText, profiles }) {
+  const [showRaw, setShowRaw] = useState(false);
+  return (
+    <div style={columnStyle}>
+      <div className="firmware-sidebar-header" style={{ padding: '0 0 0.5rem', borderBottom: 'none' }}>
+        {title}
+      </div>
+      {state === 'loading' ? (
+        <p className="text-muted" style={{ margin: 0 }}>Looking for the event…</p>
+      ) : state === 'missing' ? (
+        <p className="text-muted" style={{ margin: 0 }}>{missingText}</p>
+      ) : (
+        <>
+          <h2 style={{ fontSize: '1.05rem', margin: '0 0 0.5rem' }}>
+            {singularName(ev) || <span className="text-muted">cannot locate name</span>}
+          </h2>
+          <p style={{ margin: '0 0 0.75rem' }}>
+            {descriptionOf(ev) || <span className="text-muted">No description.</span>}
+          </p>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.75rem' }}>
+            <span className="text-muted">Author</span>
+            <AuthorCell pubkey={ev.pubkey} profiles={profiles} />
+          </div>
+          <button className="btn" onClick={() => setShowRaw((v) => !v)}>
+            {showRaw ? 'Hide raw event' : 'Show raw event'}
+          </button>
+          {showRaw && (
+            <pre className="firmware-json-pre" style={{ marginTop: '0.5rem' }}>
+              {JSON.stringify(ev, null, 2)}
+            </pre>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * b-tag pair view: the locally-authored event that carries the b-tag (left)
+ * and the shared event the b-tag points to (right). Local side is read from
+ * the local strfry by coordinate; shared side from the community relay by
+ * the b-tag (a-tag or event id). ?b=<value> selects which of the local
+ * event's b-tags to follow (default: its first).
+ */
+export default function BTagDetail() {
+  const { uuid } = useParams();
+  const [searchParams] = useSearchParams();
+
+  const [kind, pubkey, dTag] = useMemo(() => {
+    const parts = (uuid || '').split(':');
+    return [Number(parts[0]) || 0, parts[1] || '', parts.slice(2).join(':')];
+  }, [uuid]);
+
+  const [localEvent, setLocalEvent] = useState(null);
+  const [localLoading, setLocalLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!kind || !pubkey || !dTag) { setLocalLoading(false); setError('Malformed event coordinate'); return undefined; }
+    let cancelled = false;
+
+    (async () => {
+      try {
+        setLocalLoading(true);
+        setError(null);
+        const events = await queryRelay({ kinds: [kind], authors: [pubkey], '#d': [dTag] });
+        if (cancelled) return;
+        const newest = (events || []).reduce((a, b) => (!a || b.created_at > a.created_at ? b : a), null);
+        setLocalEvent(newest);
+      } catch (err) {
+        if (!cancelled) setError(err.message);
+      } finally {
+        if (!cancelled) setLocalLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [kind, pubkey, dTag]);
+
+  // Which b-tag to follow: ?b= when given, else the local event's first.
+  const bTag = useMemo(() => {
+    const fromQuery = (searchParams.get('b') || '').trim();
+    if (fromQuery) return fromQuery;
+    const t = localEvent?.tags?.find((x) => x[0] === 'b' && typeof x[1] === 'string' && x[1].trim() !== '');
+    return t ? t[1].trim() : '';
+  }, [searchParams, localEvent]);
+
+  const [sharedEvent, setSharedEvent] = useState(null);
+  const [sharedLoading, setSharedLoading] = useState(false);
+  const [sharedSearched, setSharedSearched] = useState(false);
+
+  useEffect(() => {
+    setSharedEvent(null);
+    setSharedSearched(false);
+    if (!bTag) return undefined;
+
+    let filter = null;
+    const m = bTag.match(A_TAG_RE);
+    if (m) filter = { kinds: [Number(m[1])], authors: [m[2]], '#d': [m[3]] };
+    else if (EVENT_ID_RE.test(bTag)) filter = { ids: [bTag] };
+    if (!filter) { setSharedSearched(true); return undefined; } // unresolvable value
+
+    let cancelled = false;
+    (async () => {
+      setSharedLoading(true);
+      try {
+        const events = await fetchFromRelays(filter, COMMUNITY_RELAYS);
+        if (cancelled) return;
+        const newest = (events || []).reduce((a, b) => (!a || b.created_at > a.created_at ? b : a), null);
+        setSharedEvent(newest);
+      } finally {
+        if (!cancelled) {
+          setSharedLoading(false);
+          setSharedSearched(true);
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [bTag]);
+
+  const profilePubkeys = useMemo(
+    () => [localEvent?.pubkey, sharedEvent?.pubkey].filter(Boolean),
+    [localEvent, sharedEvent],
+  );
+  const profiles = useProfiles(profilePubkeys);
+
+  if (localLoading) {
+    return (
+      <div className="page">
+        <Breadcrumbs />
+        <p>Loading b-tag detail…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="page">
+        <Breadcrumbs />
+        <h1>🤝 b-tag</h1>
+        <p className="error">Error: {error}</p>
+      </div>
+    );
+  }
+
+  const sharedState = !localEvent || !bTag
+    ? 'missing'
+    : (sharedLoading || !sharedSearched) ? 'loading'
+      : sharedEvent ? 'ok' : 'missing';
+
+  return (
+    <div className="page">
+      <Breadcrumbs />
+      <h1>🤝 {localEvent ? (singularName(localEvent) || dTag) : 'b-tag'}</h1>
+      {bTag && (
+        <p className="subtitle" style={{ overflowWrap: 'anywhere' }}>
+          b-tag: <code>{bTag}</code>
+        </p>
+      )}
+
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', alignItems: 'flex-start', maxWidth: '1100px' }}>
+        <EventColumn
+          title="Local event"
+          ev={localEvent}
+          state={localEvent ? 'ok' : 'missing'}
+          missingText="Local event not found."
+          profiles={profiles}
+        />
+        <EventColumn
+          title="Shared event"
+          ev={sharedEvent}
+          state={sharedState}
+          missingText={!localEvent ? '—' : !bTag ? 'The local event carries no b-tag.' : 'cannot locate event'}
+          profiles={profiles}
+        />
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/shared-concepts/Detail.jsx
+++ b/ui/src/pages/shared-concepts/Detail.jsx
@@ -1,0 +1,229 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import AuthorCell from '../../components/AuthorCell';
+import useProfiles from '../../hooks/useProfiles';
+import { queryRelay } from '../../api/relay';
+import { fetchFromRelays } from '../../utils/nostrPublish';
+
+const SHARED_CONCEPT_KIND = 39999;
+
+// Where to look for the referenced event besides the local strfry. Hardcoded
+// for now — the future source is the appropriate subset of the nostr-relays
+// concept (same relay the concept-publish flow already targets).
+const COMMUNITY_RELAYS = ['wss://dcosl.brainstorm.world'];
+
+/**
+ * Shared Concept detail: name, description, author, the element's
+ * identifiers, and the REFERENCED nostr event those identifiers point at.
+ *
+ * Identifier rules (per spec): show the a-tag when present; show the
+ * event-id when it's the only one present; when BOTH are present the a-tag
+ * shows and the event-id hides behind a visibility toggle. "Present" means a
+ * non-empty string — the authoring flow stores '' for an unset identifier.
+ *
+ * Referenced event: fetched by a-tag when available, else by event-id, from
+ * the local strfry AND the community relay(s); newest wins (a-tags are
+ * replaceable coordinates). Shown as author (standard avatar+name cell) plus
+ * a raw-event view that is hidden by default behind a toggle — nothing else.
+ */
+export default function SharedConceptDetail() {
+  const { uuid } = useParams();
+
+  // uuid is the a-tag coordinate kind:pubkey:d-tag; the d-tag keeps any
+  // further colons it might contain.
+  const [kind, pubkey, dTag] = useMemo(() => {
+    const parts = (uuid || '').split(':');
+    return [Number(parts[0]) || SHARED_CONCEPT_KIND, parts[1] || '', parts.slice(2).join(':')];
+  }, [uuid]);
+
+  const [event, setEvent] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [showEventId, setShowEventId] = useState(false);
+
+  useEffect(() => {
+    if (!pubkey || !dTag) { setLoading(false); setError('Malformed shared-concept id'); return undefined; }
+    let cancelled = false;
+
+    async function load() {
+      try {
+        setLoading(true);
+        setError(null);
+        const events = await queryRelay({ kinds: [kind], authors: [pubkey], '#d': [dTag] });
+        if (cancelled) return;
+        // Addressable events replace by coordinate — the newest is the live one.
+        const newest = (events || []).reduce((a, b) => (!a || b.created_at > a.created_at ? b : a), null);
+        setEvent(newest);
+      } catch (err) {
+        if (!cancelled) setError(err.message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => { cancelled = true; };
+  }, [kind, pubkey, dTag]);
+
+  // The element's sharedConcept section and its identifiers, derived once per
+  // fetched event (the referenced-event effect keys on these).
+  const { section, aTag, eventId } = useMemo(() => {
+    let sec = {};
+    try {
+      const raw = event?.tags?.find((t) => t[0] === 'json')?.[1];
+      if (raw) sec = JSON.parse(raw).sharedConcept || {};
+    } catch {
+      sec = {};
+    }
+    const ids = sec.identifiers || {};
+    return {
+      section: sec,
+      aTag: typeof ids['a-tag'] === 'string' ? ids['a-tag'].trim() : '',
+      eventId: typeof ids['event-id'] === 'string' ? ids['event-id'].trim() : '',
+    };
+  }, [event]);
+
+  // ── Referenced event (by a-tag, else event-id; local strfry + community) ──
+  const [refEvent, setRefEvent] = useState(null);
+  const [refLoading, setRefLoading] = useState(false);
+  const [refSearched, setRefSearched] = useState(false);
+  const [showRaw, setShowRaw] = useState(false);
+
+  useEffect(() => {
+    setRefEvent(null);
+    setShowRaw(false);
+    setRefSearched(false);
+    if (!aTag && !eventId) return undefined;
+
+    // Prefer the a-tag; fall back to the event-id when the a-tag is absent
+    // (or too malformed to build a filter from).
+    let filter = null;
+    if (aTag) {
+      const parts = aTag.split(':');
+      const k = Number(parts[0]);
+      if (parts.length >= 3 && Number.isFinite(k) && parts[1]) {
+        filter = { kinds: [k], authors: [parts[1]], '#d': [parts.slice(2).join(':')] };
+      }
+    }
+    if (!filter && eventId) filter = { ids: [eventId] };
+    if (!filter) return undefined;
+
+    let cancelled = false;
+    (async () => {
+      setRefLoading(true);
+      try {
+        const [localEvents, remoteEvents] = await Promise.all([
+          queryRelay(filter).catch(() => []),
+          fetchFromRelays(filter, COMMUNITY_RELAYS),
+        ]);
+        if (cancelled) return;
+        const all = [...(localEvents || []), ...(remoteEvents || [])];
+        const newest = all.reduce((a, b) => (!a || b.created_at > a.created_at ? b : a), null);
+        setRefEvent(newest);
+      } finally {
+        if (!cancelled) {
+          setRefLoading(false);
+          setRefSearched(true);
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [aTag, eventId]);
+
+  const profilePubkeys = useMemo(
+    () => [event?.pubkey, refEvent?.pubkey].filter(Boolean),
+    [event, refEvent],
+  );
+  const profiles = useProfiles(profilePubkeys);
+
+  if (loading) {
+    return (
+      <div className="page">
+        <Breadcrumbs />
+        <p>Loading shared concept…</p>
+      </div>
+    );
+  }
+
+  if (error || !event) {
+    return (
+      <div className="page">
+        <Breadcrumbs />
+        <h1>Shared Concept</h1>
+        {error
+          ? <p className="error">Error: {error}</p>
+          : <p className="text-muted">Shared concept not found.</p>}
+      </div>
+    );
+  }
+
+  const name = section.name || dTag;
+  const description = section.description || '';
+
+  const idRow = (label, value) => (
+    <div style={{ marginBottom: '0.5rem' }}>
+      <span className="text-muted" style={{ marginRight: '0.5rem' }}>{label}</span>
+      <code style={{ overflowWrap: 'anywhere' }}>{value}</code>
+    </div>
+  );
+
+  return (
+    <div className="page">
+      <Breadcrumbs />
+      <h1>🤝 {name}</h1>
+
+      <section style={{ maxWidth: '760px' }}>
+        <p style={{ margin: '0 0 1rem' }}>
+          {description || <span className="text-muted">No description.</span>}
+        </p>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '1rem' }}>
+          <span className="text-muted">Author</span>
+          <AuthorCell pubkey={event.pubkey} profiles={profiles} />
+        </div>
+
+        <h2 style={{ fontSize: '1rem', margin: '0 0 0.5rem' }}>Identifiers</h2>
+        {aTag && idRow('a-tag', aTag)}
+        {eventId && !aTag && idRow('event-id', eventId)}
+        {eventId && aTag && (
+          <div style={{ marginBottom: '0.5rem' }}>
+            <button className="btn" onClick={() => setShowEventId((v) => !v)}>
+              {showEventId ? 'Hide event id' : 'Show event id'}
+            </button>
+            {showEventId && <div style={{ marginTop: '0.5rem' }}>{idRow('event-id', eventId)}</div>}
+          </div>
+        )}
+        {!aTag && !eventId && <p className="text-muted" style={{ margin: 0 }}>No identifiers.</p>}
+
+        {(aTag || eventId) && (
+          <>
+            <h2 style={{ fontSize: '1rem', margin: '1.5rem 0 0.5rem' }}>Referenced event</h2>
+            {refLoading ? (
+              <p className="text-muted" style={{ margin: 0 }}>Looking for the referenced event…</p>
+            ) : refEvent ? (
+              <>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.5rem' }}>
+                  <span className="text-muted">Author</span>
+                  <AuthorCell pubkey={refEvent.pubkey} profiles={profiles} />
+                </div>
+                <button className="btn" onClick={() => setShowRaw((v) => !v)}>
+                  {showRaw ? 'Hide raw event' : 'Show raw event'}
+                </button>
+                {showRaw && (
+                  <pre className="firmware-json-pre" style={{ marginTop: '0.5rem' }}>
+                    {JSON.stringify(refEvent, null, 2)}
+                  </pre>
+                )}
+              </>
+            ) : refSearched ? (
+              <p className="text-muted" style={{ margin: 0 }}>
+                Referenced event not found on the local relay or the community relay.
+              </p>
+            ) : null}
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/ui/src/pages/shared-concepts/Index.jsx
+++ b/ui/src/pages/shared-concepts/Index.jsx
@@ -1,0 +1,121 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import DataTable from '../../components/DataTable';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import AuthorCell from '../../components/AuthorCell';
+import useProfiles from '../../hooks/useProfiles';
+import { useConfig } from '../../context/ConfigContext';
+import { useAuth } from '../../context/AuthContext';
+import { hasAdminAccess } from '../../utils/auth';
+import { queryRelay } from '../../api/relay';
+
+// A shared concept is an element of the `shared-concept` concept: a kind-39999
+// addressable event z-tagged to `39998:<TA>:shared-concept`. Read from strfry
+// like the tapestries directory (the durable source of truth for elements —
+// ADR tapestries/0001 pattern).
+const SHARED_CONCEPT_KIND = 39999;
+
+/** Parse a strfry shared-concept element event into a directory row (or null to skip). */
+function toRow(ev) {
+  const dTag = ev.tags?.find((t) => t[0] === 'd')?.[1];
+  if (!dTag) return null; // an addressable event with no d-tag has no stable identity
+  let json = {};
+  try {
+    const raw = ev.tags?.find((t) => t[0] === 'json')?.[1];
+    if (raw) json = JSON.parse(raw);
+  } catch {
+    json = {}; // malformed json → fall back to the d-tag below
+  }
+  const sc = json.sharedConcept || {};
+  return {
+    uuid: `${SHARED_CONCEPT_KIND}:${ev.pubkey}:${dTag}`,
+    name: sc.name || dTag,
+    description: sc.description || '',
+    author: ev.pubkey,
+  };
+}
+
+export default function SharedConceptsIndex() {
+  const navigate = useNavigate();
+  const { taPubkey } = useConfig();
+  const { user } = useAuth();
+  const isOwner = hasAdminAccess(user);
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!taPubkey) return; // wait for the runtime-resolved TA pubkey (never hardcode)
+    let cancelled = false;
+
+    async function load() {
+      try {
+        setLoading(true);
+        setError(null);
+        const events = await queryRelay({
+          kinds: [SHARED_CONCEPT_KIND],
+          '#z': [`39998:${taPubkey}:shared-concept`],
+        });
+        if (cancelled) return;
+        setRows((events || []).map(toRow).filter(Boolean));
+      } catch (err) {
+        if (!cancelled) setError(err.message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => { cancelled = true; };
+  }, [taPubkey]);
+
+  const authors = useMemo(() => rows.map((r) => r.author), [rows]);
+  const profiles = useProfiles(authors);
+
+  const columns = [
+    { key: 'name', label: 'Name' },
+    {
+      key: 'description',
+      label: 'Description',
+      render: (val) => val || <span className="text-muted">—</span>,
+    },
+    {
+      key: 'author',
+      label: 'Author',
+      render: (val) => <AuthorCell pubkey={val} profiles={profiles} />,
+    },
+  ];
+
+  return (
+    <div className="page">
+      <Breadcrumbs />
+      <div className="page-header-row">
+        <h1>🤝 View Shared Concepts</h1>
+        {isOwner && (
+          <button className="btn btn-primary" onClick={() => navigate('/tapestry/shared-concepts/new')}>
+            + Create New Shared Concept
+          </button>
+        )}
+      </div>
+      <p className="subtitle">
+        These are concepts recognized by the local tapestry (me) as being authoritative. They
+        typically will not be authored by me (the Tapestry owner) or my Tapestry Assistant,
+        although they could be.
+      </p>
+
+      {loading && <p>Loading shared concepts…</p>}
+      {error && <p className="error">Error: {error}</p>}
+      {!loading && !error && (
+        <>
+          <p className="subtitle">{rows.length} shared concepts</p>
+          <DataTable
+            columns={columns}
+            data={rows}
+            onRowClick={(row) => navigate(`/tapestry/shared-concepts/${encodeURIComponent(row.uuid)}`)}
+            emptyMessage="No shared concepts yet."
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/shared-concepts/New.jsx
+++ b/ui/src/pages/shared-concepts/New.jsx
@@ -1,0 +1,195 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import { useAuth } from '../../context/AuthContext';
+import { hasAdminAccess } from '../../utils/auth';
+
+/**
+ * Create a Shared Concept — an element of the `shared concept` concept,
+ * authored through the standard element machinery (create-element signs as
+ * the TA, publishes to local strfry, imports, wires HAS_ELEMENT).
+ *
+ * Required: name, slug (auto-derived from the name until hand-edited),
+ * description, and at least one identifier (a-tag and/or event-id). The
+ * stored identifiers object always carries both keys — '' means unset, the
+ * shape the directory/detail pages already read.
+ */
+
+/** Kebab-case a name the same way the server derives element slugs. */
+function kebab(s) {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+}
+
+const A_TAG_RE = /^\d+:[0-9a-f]{64}:.+$/;
+const EVENT_ID_RE = /^[0-9a-f]{64}$/;
+const SLUG_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+export default function NewSharedConcept() {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const isOwner = hasAdminAccess(user);
+
+  const [name, setName] = useState('');
+  const [slug, setSlug] = useState('');
+  const [slugTouched, setSlugTouched] = useState(false);
+  const [description, setDescription] = useState('');
+  const [aTag, setATag] = useState('');
+  const [eventId, setEventId] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [validation, setValidation] = useState(null);
+  const [error, setError] = useState(null);
+
+  // Owner gate: non-owner visitors get an explanation, never a working form.
+  if (!isOwner) {
+    return (
+      <div className="page">
+        <Breadcrumbs />
+        <h1>🤝 Create New Shared Concept</h1>
+        <p className="placeholder">
+          Creating a Shared Concept is owner-only. Sign in as the instance owner to author one.
+        </p>
+      </div>
+    );
+  }
+
+  function onNameChange(value) {
+    setName(value);
+    if (!slugTouched) setSlug(kebab(value));
+  }
+
+  function onSlugChange(value) {
+    setSlugTouched(true);
+    setSlug(value);
+  }
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    if (submitting) return; // re-entry guard — defense beyond the disabled button
+    setValidation(null);
+    setError(null);
+
+    const trimmedName = name.trim();
+    const trimmedSlug = slug.trim();
+    const trimmedDescription = description.trim();
+    const trimmedATag = aTag.trim();
+    const trimmedEventId = eventId.trim();
+
+    if (!trimmedName) { setValidation('Please enter a name.'); return; }
+    if (!trimmedSlug) { setValidation('Please enter a slug.'); return; }
+    if (!SLUG_RE.test(trimmedSlug)) {
+      setValidation('The slug may only contain lowercase letters, digits, and single hyphens.');
+      return;
+    }
+    if (!trimmedDescription) { setValidation('Please enter a description.'); return; }
+    if (!trimmedATag && !trimmedEventId) {
+      setValidation('Please provide at least one identifier — an a-tag, an event-id, or both.');
+      return;
+    }
+    if (trimmedATag && !A_TAG_RE.test(trimmedATag)) {
+      setValidation('The a-tag must look like kind:pubkey:d-tag (e.g. 39998:<64-hex>:some-slug).');
+      return;
+    }
+    if (trimmedEventId && !EVENT_ID_RE.test(trimmedEventId)) {
+      setValidation('The event-id must be a 64-character lowercase hex string.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const resp = await fetch('/api/normalize/create-element', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          concept: 'shared concept',
+          name: trimmedName,
+          json: {
+            sharedConcept: {
+              name: trimmedName,
+              slug: trimmedSlug,
+              description: trimmedDescription,
+              identifiers: {
+                'a-tag': trimmedATag,
+                'event-id': trimmedEventId,
+              },
+            },
+          },
+        }),
+      });
+      const data = await resp.json().catch(() => null);
+      if (!resp.ok || !data?.success) {
+        throw new Error(data?.error || `Create failed: status ${resp.status}`);
+      }
+      navigate(`/tapestry/shared-concepts/${encodeURIComponent(data.element.uuid)}`);
+    } catch (err) {
+      setError(err.message || 'Failed to create the shared concept.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="page">
+      <Breadcrumbs />
+      <h1>🤝 Create New Shared Concept</h1>
+      <p className="subtitle">Register a concept shared by another instance, by its identifiers.</p>
+
+      <form className="tapestry-new-form" onSubmit={onSubmit}>
+        <label className="form-field">
+          <span>Name</span>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+            placeholder="e.g. nostr event tag"
+          />
+        </label>
+
+        <label className="form-field">
+          <span>Slug</span>
+          <input
+            type="text"
+            value={slug}
+            onChange={(e) => onSlugChange(e.target.value)}
+            placeholder="auto-derived from the name"
+          />
+        </label>
+
+        <label className="form-field">
+          <span>Description</span>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="What this shared concept is…"
+          />
+        </label>
+
+        <label className="form-field">
+          <span>a-tag</span>
+          <input
+            type="text"
+            value={aTag}
+            onChange={(e) => setATag(e.target.value)}
+            placeholder="kind:pubkey:d-tag of the shared concept's header (optional if event-id given)"
+          />
+        </label>
+
+        <label className="form-field">
+          <span>event-id</span>
+          <input
+            type="text"
+            value={eventId}
+            onChange={(e) => setEventId(e.target.value)}
+            placeholder="64-hex event id (optional if a-tag given)"
+          />
+        </label>
+
+        {validation && <p className="error">{validation}</p>}
+        {error && <p className="error">Error: {error}</p>}
+
+        <button className="btn btn-primary" type="submit" disabled={submitting}>
+          {submitting ? 'Creating…' : 'Create Shared Concept'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/ui/src/pages/shared-concepts/SelfDeclaredDetail.jsx
+++ b/ui/src/pages/shared-concepts/SelfDeclaredDetail.jsx
@@ -1,0 +1,112 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import AuthorCell from '../../components/AuthorCell';
+import useProfiles from '../../hooks/useProfiles';
+import { fetchFromRelays } from '../../utils/nostrPublish';
+
+// The public relay the self-declared listing searches — its detail reads
+// from the same place. Hardcoded for now (future: nostr-relays concept).
+const COMMUNITY_RELAYS = ['wss://dcosl.brainstorm.world'];
+
+/** The singular name: `names` tag = ["names", singular, plural, …]. */
+function singularName(ev) {
+  const t = ev?.tags?.find((x) => x[0] === 'names');
+  return t && typeof t[1] === 'string' && t[1].trim() !== '' ? t[1] : null;
+}
+
+/** The event's description tag value, if any. */
+function descriptionOf(ev) {
+  const t = ev?.tags?.find((x) => x[0] === 'description');
+  return t && typeof t[1] === 'string' && t[1].trim() !== '' ? t[1] : null;
+}
+
+/**
+ * Self-declared Shared Concept detail: the event behind one row of the
+ * self-declared listing, fetched from the community relay by its own
+ * coordinate (the same value its self-pointing b-tag carries). Shows name,
+ * description, author, and the raw event — hidden by default behind a
+ * toggle.
+ */
+export default function SelfDeclaredDetail() {
+  const { uuid } = useParams();
+
+  const [kind, pubkey, dTag] = useMemo(() => {
+    const parts = (uuid || '').split(':');
+    return [Number(parts[0]) || 0, parts[1] || '', parts.slice(2).join(':')];
+  }, [uuid]);
+
+  const [event, setEvent] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [showRaw, setShowRaw] = useState(false);
+
+  useEffect(() => {
+    if (!kind || !pubkey || !dTag) { setLoading(false); setError('Malformed event coordinate'); return undefined; }
+    let cancelled = false;
+
+    (async () => {
+      setLoading(true);
+      setError(null);
+      const events = await fetchFromRelays(
+        { kinds: [kind], authors: [pubkey], '#d': [dTag] },
+        COMMUNITY_RELAYS,
+      );
+      if (cancelled) return;
+      const newest = (events || []).reduce((a, b) => (!a || b.created_at > a.created_at ? b : a), null);
+      setEvent(newest);
+      setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [kind, pubkey, dTag]);
+
+  const profiles = useProfiles(useMemo(() => (event ? [event.pubkey] : []), [event]));
+
+  if (loading) {
+    return (
+      <div className="page">
+        <Breadcrumbs />
+        <p>Loading self-declared shared concept…</p>
+      </div>
+    );
+  }
+
+  if (error || !event) {
+    return (
+      <div className="page">
+        <Breadcrumbs />
+        <h1>🤝 Self-declared Shared Concept</h1>
+        {error
+          ? <p className="error">Error: {error}</p>
+          : <p className="text-muted">Cannot locate the event on the community relay.</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="page">
+      <Breadcrumbs />
+      <h1>🤝 {singularName(event) || dTag}</h1>
+
+      <section style={{ maxWidth: '760px' }}>
+        <p style={{ margin: '0 0 1rem' }}>
+          {descriptionOf(event) || <span className="text-muted">No description.</span>}
+        </p>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '1rem' }}>
+          <span className="text-muted">Author</span>
+          <AuthorCell pubkey={event.pubkey} profiles={profiles} />
+        </div>
+
+        <button className="btn" onClick={() => setShowRaw((v) => !v)}>
+          {showRaw ? 'Hide raw event' : 'Show raw event'}
+        </button>
+        {showRaw && (
+          <pre className="firmware-json-pre" style={{ marginTop: '0.5rem' }}>
+            {JSON.stringify(event, null, 2)}
+          </pre>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/ui/src/pages/shared-concepts/SelfDeclaredSharedConcepts.jsx
+++ b/ui/src/pages/shared-concepts/SelfDeclaredSharedConcepts.jsx
@@ -1,0 +1,150 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import DataTable from '../../components/DataTable';
+import Breadcrumbs from '../../components/Breadcrumbs';
+import AuthorCell from '../../components/AuthorCell';
+import useProfiles from '../../hooks/useProfiles';
+import { fetchFromRelays } from '../../utils/nostrPublish';
+
+// The public relay searched for self-declarations. Hardcoded for now — the
+// future source is the appropriate subset of the nostr-relays concept.
+const COMMUNITY_RELAYS = ['wss://dcosl.brainstorm.world'];
+
+// Relay filters cannot express "has a b tag", so the search is bounded by
+// kind and filtered client-side. Concept headers (39998) are where the
+// self-declaration pattern lives; widen if it appears on other kinds.
+const SELF_DECLARED_KINDS = [39998];
+
+/** The singular name: `names` tag = ["names", singular, plural, …]. */
+function singularName(ev) {
+  const t = ev?.tags?.find((x) => x[0] === 'names');
+  return t && typeof t[1] === 'string' && t[1].trim() !== '' ? t[1] : null;
+}
+
+/** The event's description tag value, if any. */
+function descriptionOf(ev) {
+  const t = ev?.tags?.find((x) => x[0] === 'description');
+  return t && typeof t[1] === 'string' && t[1].trim() !== '' ? t[1] : null;
+}
+
+/** Age as trimmed "Ny Nd Nh Nm Ns" (leading zero units dropped). */
+function formatAge(totalSeconds) {
+  let s = Math.max(0, Math.floor(totalSeconds));
+  const y = Math.floor(s / 31536000); s -= y * 31536000;
+  const d = Math.floor(s / 86400); s -= d * 86400;
+  const h = Math.floor(s / 3600); s -= h * 3600;
+  const m = Math.floor(s / 60); s -= m * 60;
+  const parts = [];
+  if (y) parts.push(`${y}y`);
+  if (y || d) parts.push(`${d}d`);
+  if (y || d || h) parts.push(`${h}h`);
+  if (y || d || h || m) parts.push(`${m}m`);
+  parts.push(`${s}s`);
+  return parts.join(' ');
+}
+
+/**
+ * Self-declared Shared Concepts — events on the community relay whose author
+ * offers them as shared concepts, evidenced by a b-tag pointing at the
+ * event's OWN a-tag coordinate (kind:pubkey:d-tag). Self-declaration by
+ * event id is impossible (an event cannot know its id before signing), so
+ * only a-tag-form b-tags are considered — the self-coordinate equality
+ * enforces that by construction. Replaceable events dedupe newest-first per
+ * coordinate before the match.
+ */
+export default function SelfDeclaredSharedConcepts() {
+  const navigate = useNavigate();
+  const [rows, setRows] = useState(null); // null = loading
+  const [loadedAt, setLoadedAt] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      const events = await fetchFromRelays({ kinds: SELF_DECLARED_KINDS }, COMMUNITY_RELAYS);
+      if (cancelled) return;
+
+      // Newest per coordinate (addressable events replace by coordinate).
+      const byCoord = new Map();
+      for (const ev of events || []) {
+        const d = ev.tags?.find((t) => t[0] === 'd')?.[1];
+        if (d == null) continue;
+        const coord = `${ev.kind}:${ev.pubkey}:${d}`;
+        const prev = byCoord.get(coord);
+        if (!prev || ev.created_at > prev.created_at) byCoord.set(coord, ev);
+      }
+
+      const out = [];
+      for (const [coord, ev] of byCoord) {
+        const selfDeclared = (ev.tags || []).some(
+          (t) => t[0] === 'b' && typeof t[1] === 'string' && t[1].trim() === coord,
+        );
+        if (!selfDeclared) continue;
+        out.push({
+          uuid: coord,
+          name: singularName(ev),
+          description: descriptionOf(ev),
+          author: ev.pubkey,
+          createdAt: ev.created_at,
+        });
+      }
+      out.sort((a, b) => b.createdAt - a.createdAt);
+      setRows(out);
+      setLoadedAt(Math.floor(Date.now() / 1000));
+    })();
+
+    return () => { cancelled = true; };
+  }, []);
+
+  const authors = useMemo(() => (rows || []).map((r) => r.author), [rows]);
+  const profiles = useProfiles(authors);
+
+  const columns = [
+    {
+      key: 'name',
+      label: 'Name',
+      render: (val) => val || <span className="text-muted">—</span>,
+    },
+    {
+      key: 'description',
+      label: 'Description',
+      render: (val) => val || <span className="text-muted">—</span>,
+    },
+    {
+      key: 'author',
+      label: 'Author',
+      render: (val) => <AuthorCell pubkey={val} profiles={profiles} />,
+    },
+    {
+      key: 'createdAt',
+      label: 'Age',
+      render: (val) => <span style={{ whiteSpace: 'nowrap' }}>{formatAge((loadedAt || 0) - val)}</span>,
+    },
+  ];
+
+  return (
+    <div className="page">
+      <Breadcrumbs />
+      <h1>🤝 Self-declared Shared Concepts</h1>
+      <p className="subtitle">
+        Events published to a public relay whose author offers them as shared concepts, as
+        evidenced by a b-tag that points to the event itself. To make use of one, point to it
+        with the same b-tag it uses to point to itself.
+      </p>
+
+      {rows === null ? (
+        <p>Searching the community relay…</p>
+      ) : (
+        <>
+          <p className="subtitle">{rows.length} self-declared shared concepts</p>
+          <DataTable
+            columns={columns}
+            data={rows}
+            onRowClick={(row) => navigate(`/tapestry/shared-concepts/self-declared/${encodeURIComponent(row.uuid)}`)}
+            emptyMessage="No self-declared shared concepts found."
+          />
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the 🤝 Shared Concepts sidebar group (under Tapestries) — the surfaces for recognizing, registering, and discovering concepts shared across tapestry instances via b-tags. Built slice-by-slice against the local stack with in-browser verification of every slice, including a disposable end-to-end fixture for the create form (created, verified, fully cleaned).

## Changes

- `ui/src/pages/shared-concepts/Index.jsx` — View Shared Concepts: elements of the local `shared concept` concept from strfry (z-tag scan, tapestries-directory pattern); name/description/author; explainer.
- `ui/src/pages/shared-concepts/Detail.jsx` — per-concept detail: identifiers per the a-tag/event-id rules (event-id behind a toggle when both present) + the referenced event fetched from local strfry and wss://dcosl.brainstorm.world, raw view toggleable.
- `ui/src/pages/shared-concepts/New.jsx` — owner-gated create form: auto-derived slug, at-least-one-identifier + format validation, submits via create-element (TA-signed).
- `ui/src/pages/shared-concepts/ActiveBTags.jsx` — local-TA events carrying b-tags (bounded kind-39998 scan), targets resolved from the community relay via merged filters; "cannot locate event"/"cannot locate name" states.
- `ui/src/pages/shared-concepts/BTagDetail.jsx` — local event and b-tag target side by side, independent raw toggles.
- `ui/src/pages/shared-concepts/SelfDeclaredSharedConcepts.jsx` — community-relay events whose b-tag points at their own coordinate; name/description/author/age (y d h m s).
- `ui/src/pages/shared-concepts/SelfDeclaredDetail.jsx` — detail behind a self-declared row.
- `ui/src/App.jsx`, `ui/src/components/Layout.jsx` — routes + menu group.

## Test plan

- [x] Local: every page verified in-browser against real data (5 registry elements, 6 active b-tags, 3 self-declared concepts on dcosl); create form exercised end-to-end with a fixture, then fixture removed (strfry + Neo4j verified clean).
- [ ] After merge: deploy-staging.yml runs.
- [ ] Smoke test on staging.brainstorm.world.
- [ ] Staging-specific: routes serve the SPA; View Shared Concepts and Active b-tags show empty states (staging has no shared-concept concept and no TA b-tags — expected data-state); Self-declared Shared Concepts should list the same 3 relay-global entries as local; create form shows the owner gate to anonymous visitors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)