### PR TITLE
Fix Active z-tags on deployed instances: chunk the #z scan

### DIFF
--- a/ui/src/pages/shared-concepts/ActiveZTags.jsx
+++ b/ui/src/pages/shared-concepts/ActiveZTags.jsx
@@ -6,6 +6,27 @@ import useProfiles from '../../hooks/useProfiles';
 import { useConfig } from '../../context/ConfigContext';
 import { queryRelay } from '../../api/relay';
 
+/**
+ * Scan for z-carriers in bounded chunks: the filter rides the scan API's GET
+ * query string, and ~100 coordinates in one filter blows past nginx's URI
+ * limit on deployed instances (HTML 414 instead of JSON). Per-chunk failures
+ * degrade to partial results rather than killing the page.
+ */
+async function chunkedZScan(coords, chunkSize = 20) {
+  const out = [];
+  let failures = 0;
+  for (let i = 0; i < coords.length; i += chunkSize) {
+    const chunk = coords.slice(i, i + chunkSize);
+    try {
+      const events = await queryRelay({ '#z': chunk });
+      out.push(...(events || []));
+    } catch {
+      failures += 1;
+    }
+  }
+  return { events: out, failedChunks: failures, totalChunks: Math.ceil(coords.length / chunkSize) };
+}
+
 /** The singular name: `names` tag = ["names", singular, plural, …]; falls
  * back to a `name` tag (elements). */
 function bestName(ev) {
@@ -53,9 +74,13 @@ export default function ActiveZTags() {
         }
         if (targets.size === 0) { setRows([]); return; }
 
-        // 2. One merged scan: every local event z-pointing at any of them.
-        const carriers = await queryRelay({ '#z': [...targets.keys()] });
+        // 2. Chunked scans: every local event z-pointing at any of them.
+        const scan = await chunkedZScan([...targets.keys()]);
         if (cancelled) return;
+        const carriers = scan.events;
+        if (scan.failedChunks > 0 && scan.failedChunks === scan.totalChunks) {
+          throw new Error('the local z-tag scan failed');
+        }
         const usage = new Map(); // coord → { events: Set, authors: Set }
         for (const ev of carriers || []) {
           for (const t of ev.tags || []) {


### PR DESCRIPTION
## Summary

Follow-up to #492, found during its staging smoke test: the Active z-tags page packed ~100 coordinates into one GET filter, blowing past nginx's URI limit on deployed instances — nginx answered an HTML 414 where the client expected JSON ("Unexpected token '<'", empty page). Local dev squeaked under the limit, staging didn't.

## Changes

- `ui/src/pages/shared-concepts/ActiveZTags.jsx` — scan z-carriers in chunks of 20 coordinates with per-chunk failure tolerance (partial results beat a dead page; a page-level error only when every chunk fails).

## Test plan

- [x] Local: result set identical through the chunked scan (43 shared concepts, same ordering and counts).
- [ ] After merge: staging /tapestry/shared-concepts/z-tags renders staging's real z-usage instead of the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)