### PR TITLE
fix: adoption-queue — stream corpus scans (staging maxBuffer failure)

### DIFF
--- a/src/api/adoption/index.js
+++ b/src/api/adoption/index.js
@@ -5,21 +5,23 @@
  *   → { success, nominations: [{coord, name, author, eventCount, authorCount,
  *      usedByMe}], declined: [{target, name, author, decidedOn}] }
  *
- * Assembly: five direct strfry scans (no chunking — the CLI has no URI limit,
- * unlike the browser's GET-query path that ActiveZTags works around), piped
- * through the pure arithmetic core (src/lib/adoptionQueue.js). The endpoint
- * never writes; actions live on the F5 primitive (b-append), the registry's
- * create-element, and the adoption-disposition producer.
+ * Assembly: five STREAMING strfry scans (fix/adoption-queue-stream-scan: a
+ * deployed corpus can exceed any fixed exec buffer — staging's did at 16MB —
+ * so each scan streams line-by-line and keeps only a slim projection; memory
+ * follows the projected result, never the corpus), piped through the pure
+ * arithmetic core (src/lib/adoptionQueue.js). The endpoint never writes.
  */
 
 'use strict';
 
 const { getOwnerAssistantPubkey } = require('../../utils/assistantKeys');
-const { strfryScan } = require('../concept/bDisposition');
+const { strfryScanStream } = require('../concept/bDisposition');
 const { computeQueue } = require('../../lib/adoptionQueue');
 
 const REGISTRY_SLUG = 'shared-concept';
 const LEDGER_SLUG = 'adoption-disposition';
+
+const keepTags = (ev, names) => (ev.tags || []).filter((t) => t && names.includes(t[0]));
 
 async function handleAdoptionQueue(req, res) {
   try {
@@ -28,29 +30,40 @@ async function handleAdoptionQueue(req, res) {
       return res.status(500).json({ success: false, error: 'TA pubkey unavailable' });
     }
 
-    // 1. All local kind-39998 headers; foreign = author ≠ TA.
-    const allHeaders = await strfryScan({ kinds: [39998] });
-    const foreignHeaders = allHeaders.filter((ev) => ev.pubkey !== taPubkey);
+    // 1. All local kind-39998 headers, projected slim; foreign = author ≠ TA.
+    const foreignHeaders = await strfryScanStream({ kinds: [39998] }, (ev) => (
+      ev.pubkey === taPubkey ? null : {
+        kind: ev.kind, pubkey: ev.pubkey, created_at: ev.created_at, id: ev.id,
+        tags: keepTags(ev, ['d', 'names', 'name']),
+      }
+    ));
     const coords = [];
     for (const ev of foreignHeaders) {
-      const d = (ev.tags || []).find((t) => t[0] === 'd')?.[1];
+      const d = ev.tags.find((t) => t[0] === 'd')?.[1];
       if (d != null) coords.push(`${ev.kind}:${ev.pubkey}:${d}`);
     }
 
-    // 2–5. Carriers for those coords; my b-carriers (S2a); registry; ledger.
-    const [zCarriers, myEvents, registryRecords, dispositionRecords] = await Promise.all([
-      coords.length ? strfryScan({ '#z': coords }) : Promise.resolve([]),
-      strfryScan({ authors: [taPubkey], kinds: [39998, 39999] }),
-      strfryScan({ kinds: [39999], '#z': [`39998:${taPubkey}:${REGISTRY_SLUG}`] }),
-      strfryScan({ kinds: [39999], '#z': [`39998:${taPubkey}:${LEDGER_SLUG}`] }),
+    // 2–5. Carriers for those coords; my b-values (S2a); registry; ledger.
+    const [zCarriers, myBTargetArrays, registryRecords, dispositionRecords] = await Promise.all([
+      coords.length
+        ? strfryScanStream({ '#z': coords }, (ev) => {
+          const z = keepTags(ev, ['z']);
+          return z.length ? { pubkey: ev.pubkey, id: ev.id, tags: z } : null;
+        })
+        : Promise.resolve([]),
+      strfryScanStream({ authors: [taPubkey], kinds: [39998, 39999] }, (ev) => {
+        const bs = (ev.tags || []).filter((t) => t && t[0] === 'b' && typeof t[1] === 'string' && t[1]).map((t) => t[1]);
+        return bs.length ? bs : null;
+      }),
+      strfryScanStream({ kinds: [39999], '#z': [`39998:${taPubkey}:${REGISTRY_SLUG}`] }, (ev) => ({
+        pubkey: ev.pubkey, created_at: ev.created_at, tags: keepTags(ev, ['json']),
+      })),
+      strfryScanStream({ kinds: [39999], '#z': [`39998:${taPubkey}:${LEDGER_SLUG}`] }, (ev) => ({
+        pubkey: ev.pubkey, created_at: ev.created_at, tags: keepTags(ev, ['json']),
+      })),
     ]);
 
-    const myBTargets = [];
-    for (const ev of myEvents) {
-      for (const t of ev.tags || []) {
-        if (t && t[0] === 'b' && typeof t[1] === 'string' && t[1]) myBTargets.push(t[1]);
-      }
-    }
+    const myBTargets = myBTargetArrays.flat();
 
     const out = computeQueue({ foreignHeaders, zCarriers, myBTargets, registryRecords, dispositionRecords, taPubkey });
     return res.json({ success: true, ...out });

--- a/src/api/concept/bDisposition.js
+++ b/src/api/concept/bDisposition.js
@@ -60,6 +60,45 @@ function strfryScan(filter) {
 }
 
 /**
+ * Streaming variant for corpus-scale scans (fix/adoption-queue-stream-scan):
+ * exec's stdout buffer caps at maxBuffer and a deployed instance's corpus can
+ * exceed any fixed cap (staging's dcosl read-union did, at 16MB — the
+ * adoption queue's smoke failure). Spawns `strfry scan`, consumes stdout
+ * line-by-line, and keeps only what `project` returns — memory stays
+ * proportional to the PROJECTED result, never the corpus.
+ */
+function strfryScanStream(filter, project) {
+  const { spawn } = require('child_process');
+  return new Promise((resolve, reject) => {
+    const child = spawn('strfry', ['scan', JSON.stringify(filter)], { stdio: ['ignore', 'pipe', 'pipe'] });
+    const out = [];
+    let buf = '';
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      buf += chunk;
+      let nl;
+      while ((nl = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (!line) continue;
+        try {
+          const ev = JSON.parse(line);
+          const kept = project ? project(ev) : ev;
+          if (kept != null) out.push(kept);
+        } catch { /* malformed line — skip */ }
+      }
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code !== 0) return reject(new Error(`strfry scan exited ${code}`));
+      const tail = buf.trim();
+      if (tail) { try { const ev = JSON.parse(tail); const kept = project ? project(ev) : ev; if (kept != null) out.push(kept); } catch {} }
+      resolve(out);
+    });
+  });
+}
+
+/**
  * Resolve the latest version of one of THIS instance's own headers, or answer
  * with the appropriate error. Returns null after responding on failure.
  */
@@ -166,6 +205,6 @@ async function handleBDefer(req, res) {
   }
 }
 
-// strfryScan is exported for the adoption module (ADR shared-concepts-adoption/0002)
-// — shared, never copied (OPEN.md #142).
-module.exports = { handleBAppend, handleBDefer, strfryScan };
+// strfryScan + strfryScanStream are exported for the adoption module (ADR
+// shared-concepts-adoption/0002) — shared, never copied (OPEN.md #142).
+module.exports = { handleBAppend, handleBDefer, strfryScan, strfryScanStream };

--- a/test/adoption-candidates-queue.test.js
+++ b/test/adoption-candidates-queue.test.js
@@ -277,13 +277,15 @@ test('S4: the UI seams exist — page, route by NAME (never a count), nav entry,
   assert(page && page.includes('/api/adoption-queue'), 'the page must fetch the server-assembled queue (never re-derive the arithmetic)');
 });
 
-test('S5: the scan helper is shared, not copied — bDisposition exports strfryScan and the adoption module imports it (OPEN.md #142)', () => {
+test('S5: the scan helper is shared, not copied — bDisposition exports the scan family and the adoption module STREAMS (OPEN.md #142; corpus-scale fix)', () => {
   const bd = safeRead(B_DISPOSITION_API_JS);
   assert(bd && /module\.exports\s*=\s*\{[^}]*strfryScan/.test(bd),
-    'bDisposition.js must export strfryScan for the adoption module');
+    'bDisposition.js must export the scan helpers for the adoption module');
+  assert(bd && /function strfryScanStream/.test(bd),
+    'the streaming variant must live beside strfryScan (a deployed corpus exceeds any fixed exec buffer — the staging smoke failure)');
   const mod = safeRead(ADOPTION_API_JS);
-  assert(mod && /require\([^)]*concept\/bDisposition/.test(mod) && /strfryScan/.test(mod),
-    'the adoption module must import strfryScan from bDisposition — no new divergent copy');
+  assert(mod && /require\([^)]*concept\/bDisposition/.test(mod) && /strfryScanStream/.test(mod),
+    'the adoption module must import the STREAMING scan from bDisposition — no new copy, no buffered corpus reads');
 });
 
 // ═══ H — live integration (SKIP when the stack is down) ════════════════


### PR DESCRIPTION
## Summary

Smoke-test fix-forward for #499: staging's corpus exceeds the 16MB exec buffer on the adoption-queue's scans (`stdout maxBuffer length exceeded`). All five scans now stream line-by-line with slim per-event projections — memory proportional to the projected result at any corpus size.

## Test plan

- [ ] After merge: deploy-staging.yml runs.
- [ ] `GET https://staging.brainstorm.world/api/adoption-queue` → `success: true` with arrays.
- [ ] Local: both story suites green (19/19, 26/26); local queue serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)