### PR TITLE
Stamp the owner's own avatar with the brand mark and publish it

### DIFF
--- a/bin/control-panel.js
+++ b/bin/control-panel.js
@@ -148,6 +148,18 @@ app.use('/control', express.static(path.join(__dirname, '../public')));
 // (e.g. ./components/header/header.js, ./css/common.css) resolve correctly.
 app.use('/legacy', express.static(path.join(__dirname, '../public')));
 
+// Serve generated assistant composite avatars (ta-avatar #3, ADR 0003).
+// This is the only directory that is BOTH persisted (the tapestry-data volume at
+// /var/lib/brainstorm, docker-compose.yml) and web-served — a published kind 0
+// names a URL here, so it must survive redeploys and be fetchable without auth.
+// Only the owner-gated upload writes here, under server-generated content-hash
+// filenames, so a caller cannot choose a path. No directory index.
+app.use('/generated', express.static('/var/lib/brainstorm/generated', {
+    index: false,
+    fallthrough: true,
+    maxAge: '7d',
+}));
+
 // Serve Chart.js from node_modules
 app.use('/libs/chart.js', express.static(path.join(__dirname, '../node_modules/chart.js/dist')));
 app.use('/libs/chartjs-adapter-date-fns', express.static(path.join(__dirname, '../node_modules/chartjs-adapter-date-fns/dist')));

--- a/engineering-team/decisions/ta-avatar/0003-owner-composited-avatar-hosted-by-the-instance.md
+++ b/engineering-team/decisions/ta-avatar/0003-owner-composited-avatar-hosted-by-the-instance.md
@@ -1,0 +1,188 @@
+# ADR 0003: The stamped composite — built in the owner's browser, hosted by the instance
+
+**Status:** Proposed
+**Date:** 2026-08-07
+**Story:** `engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md`
+
+## Context
+
+Stories 1 and 2 built the two layers underneath this one: a render-time badge in our own UI
+(ADR 0001), and a branded picture in the assistant's published defaults (ADR 0002). This story is the
+ask's actual end state — **the owner's own avatar with the mark baked into it**, published as the
+assistant's `picture` so that every nostr client shows it.
+
+Six criteria, and two of them are in tension (see D3): a preview before anything is published;
+instance-hosted and publicly fetchable; **surviving redeploy**; **regenerable, with re-publish
+pointing at the new one**; a fallback when the owner has no usable picture; and refused to anyone but
+the owner.
+
+### Concept-graph orientation (AGENTS.md §1–3)
+
+The stack was briefly unreachable and then recovered; orientation ran against the live graph.
+`39998:<TA>:image` exists but resolves to a bare node — no description, and `…:image-schema` returns
+`No node found`. It models images *as knowledge-graph nodes*; a generated brand composite written to
+a volume is not a graph assertion and nobody publishes a competing version of it. Same conclusion as
+ADR 0002: **not applicable, no concept change, no firmware reinstall.** (Handles cited from a live
+read during a window when the stack was up; re-verify if that becomes load-bearing.)
+
+### Verified facts this design rests on
+
+- **`multer` is already a dependency** (`package.json`, `^1.4.5-lts.1`) — used by
+  `src/api/customers/commands/restore-upload.js`, which is also the precedent for writing to
+  `/var/lib/brainstorm` (`:20-30`: `mkdirSync` recursive with a home-dir fallback, plus filename
+  sanitisation at `:44`).
+- **The volume genuinely persists.** `tapestry-data:/var/lib/brainstorm` is a named volume
+  (`docker-compose.yml:23`, declared `:84`), and **no deploy path destroys it** — I grepped the
+  workflows, `docker/`, `setup/`, `bin/` and `scripts/` for `down -v` / `--volumes` / `volume rm` /
+  `volume prune` and found nothing. `deploy-staging.yml:27` runs `docker compose up -d --build`,
+  which recreates the container and keeps the volume. **AC3 rests on this, so it was checked rather
+  than assumed.**
+- **Nothing under `/var/lib/brainstorm` is web-served today.** The static mounts are
+  `bin/control-panel.js:124` (`dist/`), `:132` (`public/`), `:145` (`/control`), `:149` (`/legacy`) —
+  all container-ephemeral. This story creates the repo's first directory that is **both persisted and
+  served**.
+- **Owner gating has an established idiom**: `isOwner(req)` (`src/middleware/auth.js:265`), used as
+  `if (!isOwner(req) && !req.localTrusted) → 403` in `src/api/strfry/commands/publishEvent.js:34-38`.
+- **Assistant routes are flat registrations** at `src/api/index.js:528-532`.
+- **The editor already has the field this story fills.** `picture` is a plain text input
+  (`ui/src/components/AssistantProfileEditor.jsx:11`) and publishing posts to
+  `/api/assistant/publish-profile` (`:104`). Nothing about the signing path needs to change.
+- **Story 1's badge asset is canvas-safe**: `ui/public/ta-badge.svg` carries explicit `width="375"
+  height="375"` alongside its `viewBox`. An SVG without intrinsic dimensions can fail to draw into a
+  canvas; this one won't.
+- **CORS on real avatar hosts is permissive — but only the ones I could test.** With an `Origin:
+  https://staging.brainstorm.world` header, `pbs.twimg.com` and `image.nostr.build` both reflect the
+  origin and `m.primal.net` returns `*`. So a direct `crossOrigin="anonymous"` load would *often*
+  work. It is not guaranteed: a nostr avatar can be hosted anywhere, and the failure mode is a
+  tainted canvas that throws `SecurityError` at `toBlob()` — at the very end of the flow.
+
+## Options considered
+
+### Option A — Composite in the owner's browser; proxy the source image; host the result on the volume
+
+Canvas draws the proxied owner image plus `/ta-badge.svg`, `toBlob()` produces a PNG, an owner-gated
+endpoint stores it under `/var/lib/brainstorm/generated/`, and a new static mount serves it.
+
+- **Pros.** The preview AC1 requires is *the same canvas* that produces the blob — no extra
+  round-trip and no risk of preview and result diverging. No new dependency. The composite is hosted
+  by the instance, so its availability matches the instance's, as the story requires.
+- **Cons.** Adds a server endpoint that fetches a remote URL (bounded — see D2), and creates the
+  first persisted-and-served directory.
+
+### Option B — Composite server-side with an image library (`sharp` / `@resvg/resvg-js`)
+
+- **Rejected.** A native dependency compiled into a hand-rolled Ubuntu image, for arithmetic the
+  browser already does. It also makes AC1's preview a second round-trip against a
+  not-yet-persisted image, which is exactly the kind of seam where preview and published artefact
+  drift apart. ADR 0002 rejected the same dependency for a static asset; the reasoning holds here.
+
+### Option C — Skip the proxy; rely on `crossOrigin="anonymous"`
+
+- **Rejected on the evidence above.** It would work for the hosts I tested and fail, late and
+  confusingly, for others. One deterministic path beats two where the fallback is discovered only
+  when `toBlob()` throws.
+
+### Option D — Host the composite on an external media host (Blossom, nostr.build)
+
+- **Rejected** by the story's own out-of-scope list, and because it makes the assistant's identity
+  depend on a third party the owner did not choose.
+
+## Decision
+
+We chose **Option A**, with four decisions that depart from or sharpen the original sketch.
+
+**D1 — Compositing happens in the browser.** As above: the preview falls out of the same canvas, and
+no native dependency enters the image.
+
+**D2 — The proxy takes no URL parameter.** `GET /api/assistant/owner-avatar` is owner-gated and reads
+the URL from the **owner's own kind-0**, server-side. An endpoint that accepted a URL would be a
+general-purpose arbitrary-fetch primitive; this one's reachable set is "whatever the owner published
+about themselves". Guards, following the shape of `src/api/nip05.js:126-147`: `http(s)` only, 5s
+`AbortController` timeout, `content-type: image/*` allow-list, a ~5 MB cap enforced on both
+`content-length` *and* the streamed body, at most one redirect, and no credentials or cookies
+forwarded. It fails closed — any refusal is AC5's fallback path, not an error the owner has to
+decode.
+
+**D3 — Regenerating does NOT delete the previous composite.** This is where AC3 and AC4 pull against
+each other, and the original sketch got it wrong by deleting older files. Filenames are
+content-hashed (`ta-avatar-<hash8>.png`), so a regenerate yields a *new* URL — which is what makes
+AC4's "re-publishing points at the new one" work without cache staleness. But the previously
+published kind-0 still names the *old* URL, and it stays published until the owner re-publishes.
+Deleting on regenerate would kill the picture of the currently-published profile in the window
+between generating and publishing — precisely AC3's "a published picture never silently dies". So
+**old composites are kept.** They are tens of kilobytes and regeneration is a deliberate manual act;
+a retention policy is a follow-up, not a launch requirement.
+
+**D4 — The publishable URL obeys story 2's routability rule.** The upload response returns the
+absolute URL built from `getInstanceWebsite()` and gated on `isPubliclyReachable()` (ADR 0002), so a
+non-public instance gets no publishable URL — the same rule, in one place, rather than a second
+notion of "is this instance reachable". Generation and local preview still work everywhere; only the
+*publishable* URL is withheld. **Note:** OPEN.md #148 records that `isPubliclyReachable` currently
+admits RFC1918 addresses. This story inherits that gap rather than forking a second predicate —
+fixing it in one place fixes it for both stories.
+
+## Consequences
+
+- **Enables:** the epic's actual goal — a stranger's nostr client shows the owner's face wearing the
+  mark. Story 2's asset becomes the fallback it was designed to be.
+- **Creates the first persisted-and-served directory.** `/generated` is world-readable by design (a
+  published avatar must be fetchable without auth). Only the owner-gated upload writes there, and
+  filenames are server-generated from a content hash, so a caller cannot choose a path.
+- **Stale composites are possible and accepted.** If the owner changes their own avatar, the
+  published composite keeps the old face until they regenerate and re-publish. Automatic
+  regeneration is out of scope by the story's own list.
+- **Old composites accumulate.** By D3, deliberately. Bounded by how often an owner regenerates.
+- **Customer assistants stay out of scope.** The proxy is defined in terms of *the owner's* kind-0;
+  generalising means a different auth model and a per-customer storage path, which is not "zero extra
+  behavior".
+- **Firmware reinstall required?** **No.**
+
+## Implementation notes
+
+**New — `src/api/assistant/avatar.js`** (kept out of `index.js`, which is already ~540 lines):
+
+- `handleOwnerAvatar(req, res)` — `GET /api/assistant/owner-avatar`. Gate with
+  `if (!isOwner(req) && !req.localTrusted) → 403`. Read the owner pubkey via
+  `getConfigFromFile('BRAINSTORM_OWNER_PUBKEY')`, get their kind-0 `picture` (the same strfry scan
+  `getKind0DisplayName` already performs — extract or mirror it rather than re-inventing), apply the
+  D2 guards, stream the bytes back with the upstream `content-type`. **404 with a JSON body when the
+  owner has no picture** — that is AC5's trigger, not an error.
+- `handleUploadAvatar(req, res)` — `POST /api/assistant/avatar`, same gate, `multer` memory storage
+  with a 2 MB limit. Validate **PNG magic bytes** (not the declared mime), hash the buffer, write
+  `ta-avatar-<hash8>.png` into `/var/lib/brainstorm/generated/` via the `ensureDir` +
+  home-dir-fallback pattern from `restore-upload.js:20-30`. Return
+  `{ success, path: '/generated/<file>', url: <absolute or ''> }`, where `url` is empty unless
+  `isPubliclyReachable(getInstanceWebsite())` (D4). **Never delete an existing file** (D3).
+
+**Changed — `src/api/index.js`** (beside `:528-532`): register the two routes.
+
+**Changed — `bin/control-panel.js`** (beside the mounts at `:124-149`): add
+`app.use('/generated', express.static('/var/lib/brainstorm/generated'))`. Mount it *after* the
+existing ones so it cannot shadow app assets, and scope it to that directory only.
+
+**Changed — `ui/src/components/AssistantProfileEditor.jsx`:** a "Generate badged avatar" action next
+to the existing `picture` field (`:11`). It fetches `/api/assistant/owner-avatar` into an `Image`,
+draws it into a 512×512 canvas (cover-fit), draws `/ta-badge.svg` at ~30% of the canvas in the
+bottom-right with a small inset and a ring in the page background colour so it reads against any
+photo — the same geometry ADR 0001 established for the in-app badge — then `toBlob('image/png')`.
+The canvas *is* the preview (AC1). On accept, POST the blob, put the returned `url` into
+`form.picture`, and let the existing publish flow (`:104`) do the rest unchanged. When the proxy
+404s, offer story 2's `/ta-avatar.png` instead (AC5) and say why in one line.
+
+**Not changed:** `handlePublishProfile`, the signing path, the relay fan-out, NIP-05 derivation, and
+`buildDefaultProfileContent`. This story only supplies a different value for a field that already
+exists.
+
+**Testability note for Phase 3 (not a test plan).** The pure, high-value unit is the store-and-name
+step: given a PNG buffer, it writes exactly one content-addressed file, is idempotent for identical
+input, and yields a different name for different input. The routability-gated `url` is the same
+predicate story 2 already tests. The browser half (canvas geometry, preview) is where a Playwright
+class earns its place, as in story 1 — the proxy can be route-mocked so no live avatar host is
+touched.
+
+## Out of scope
+
+Automatic regeneration when the owner's avatar changes; a retention/cleanup policy for old
+composites; customer-assistant composites; external media hosts; fixing OPEN.md #148's RFC1918 gap
+(inherited, one shared predicate); and any change to how the assistant profile is signed or fanned
+out.

--- a/engineering-team/reviews/ta-avatar/3-stamped-composite-avatar-on-nostr.md
+++ b/engineering-team/reviews/ta-avatar/3-stamped-composite-avatar-on-nostr.md
@@ -2,7 +2,8 @@
 
 **Reviewer:** Claude (acting as Reviewer)
 **Date:** 2026-08-07
-**Diff:** `git diff feat/ta-published-profile...HEAD` (commit `00d5e562`, branch `feat/ta-composite-avatar`)
+**Diff:** `git diff feat/ta-published-profile...HEAD` (commits `00d5e562` + fix round `fe613e46`, branch `feat/ta-composite-avatar`)
+**Rounds:** 1 — CHANGES_REQUESTED 2026-08-07 · 2 — **PASS** 2026-08-07 (below)
 **Story:** `engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md`
 **ADR:** `engineering-team/decisions/ta-avatar/0003-owner-composited-avatar-hosted-by-the-instance.md`
 **Test plan:** `engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.test-plan.md`
@@ -118,7 +119,7 @@ Both are in one function and together are a few lines. Nothing else in the diff 
 None this story. The OPEN.md #149 practice (checkout-the-base rather than `git stash`) worked
 cleanly, and the co-tenant stashes were verified intact afterwards.
 
-## Verdict
+## Verdict (round 1)
 
 **CHANGES_REQUESTED**
 
@@ -137,7 +138,81 @@ Finding 1 is blocking mainly because it is an *unlogged* departure from a bound 
 next reader will trust the ADR. Either honour it or record it. Finding 2 is a one-line hardening on
 the same function, so it costs nothing to do in the same pass.
 
-## On CHANGES_REQUESTED
+## On CHANGES_REQUESTED (round 1)
 
-Kick back to `/implement-feature` with the two asks above. The story stays `Approved`; no completion
-detection is run on a non-passing review.
+Kicked back to `/implement-feature` with the two asks above.
+
+---
+
+# Round 2 — re-review of `fe613e46`
+
+**Verdict: PASS.**
+
+## What changed
+
+Exactly the two asks, and nothing else: `src/api/assistant/avatar.js` (+71/-13) and the story's
+Deviations. `git diff --stat` over the fix round confirms no other file moved.
+
+- **Ask 1 — redirects bounded.** `redirect: 'manual'` with an explicit one-hop loop
+  (`MAX_REDIRECTS = 1`), and — the part that matters — each hop is re-validated by the *same*
+  `parseFetchableUrl()` applied to the owner's published URL. Following a redirect can no longer
+  reach a scheme the original check would have refused. This restores what ADR D2 always specified,
+  so it is a fix, not a deviation; the story says so explicitly.
+- **Ask 2 — SVG refused.** The `image/*` prefix test became an explicit raster allow-list
+  (`ALLOWED_SOURCE_TYPES`). Logged as deviation 4, correctly: it is narrower than the ADR's literal
+  `image/*`, in the safer direction, and the composite source is only ever drawn into a canvas.
+
+## Verified against a real server, with cases the fix round did not test
+
+I re-ran the Implementer's six cases and added six more rather than re-running their probe:
+
+| case | result |
+|---|---|
+| baseline PNG | `200 image/png` |
+| **content-type with params + uppercase** (`IMAGE/PNG; charset=binary`) | `200` — normalised correctly |
+| **308 permanent redirect** | `200` — followed |
+| **relative `Location`** | `200` — resolved against the current URL |
+| **redirect loop (A→A)** | `404`, refused in **12 ms** — bounded, no hang |
+| **302 with no `Location`** | `404` — refused |
+| **redirect → slow endpoint** | `404` at **5011 ms** — the single timeout budget spans the whole chain rather than resetting per hop |
+
+The last one is the non-obvious property and it holds: one `AbortController` is created before the
+loop and cleared in `finally`, so a redirect chain cannot extend the deadline.
+
+*Cosmetic only:* a `302` with an empty `Location` resolves to the current URL, burns the hop, and is
+refused with "redirected too many times" rather than "somewhere unfetchable". Still bounded, still
+fast, still refused — the message is just the less precise of the two. Not worth a round trip.
+
+## Gates (round 2, all reviewer-run)
+
+- **Server class** — 13 passed, 0 failed, 2 skipped (H-class, by design).
+- **Browser class** — 5 passed, against a bundle I rebuilt myself.
+- **Differential** (checkout-base method per OPEN.md #149, never `git stash`) — `in-app-badged-ta-avatar`
+  13/0, `recognizable-published-ta-profile` 11/2, `admin-tools-dashboard-panel` 9/0: **identical with
+  and without**. Story 2's pair is its own known-environmental `H1`/`H5`.
+- `harness-lint` clean; working tree clean; **both co-tenant stashes verified intact** afterwards.
+
+## The three round-1 non-blocking findings
+
+1. **Authenticated non-owner reaches `multer` before the 403** — unchanged (`src/api/index.js:538`).
+   Still low: the global default-deny stops anonymous callers, so this needs a valid session.
+2. **`multer` limit breach unhandled** — unchanged (no `MulterError` handling in either file). Cosmetic.
+3. **Old composites accumulate** — unchanged, and intended by ADR D3.
+
+All three were explicitly non-blocking and remain so; none was made worse by the fix round.
+
+## Verdict
+
+**PASS**
+
+Both blocking asks are genuinely fixed, not papered over — and the redirect fix does the harder half
+correctly by re-validating each hop rather than only counting them. The fix stayed inside the scope
+the review set, the ADR and the code now agree, and the one place they intentionally differ is logged.
+
+Everything from round 1 that passed still passes on gates I ran again: all six acceptance criteria,
+both classes, a clean three-suite differential, and D3 proved behaviourally.
+
+## On PASS (same commit)
+
+- [x] Story `**Status:**` flipped to `Done` in place.
+- [x] Completion detection performed; result reported in chat, not here.

--- a/engineering-team/reviews/ta-avatar/3-stamped-composite-avatar-on-nostr.md
+++ b/engineering-team/reviews/ta-avatar/3-stamped-composite-avatar-on-nostr.md
@@ -1,0 +1,143 @@
+# Review: Story 3 — The stamped composite avatar, published to nostr
+
+**Reviewer:** Claude (acting as Reviewer)
+**Date:** 2026-08-07
+**Diff:** `git diff feat/ta-published-profile...HEAD` (commit `00d5e562`, branch `feat/ta-composite-avatar`)
+**Story:** `engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md`
+**ADR:** `engineering-team/decisions/ta-avatar/0003-owner-composited-avatar-hosted-by-the-instance.md`
+**Test plan:** `engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.test-plan.md`
+
+## Quality gates (run by reviewer, not trusted)
+
+- [x] **Server class** — `node -e "require('./test/stamped-composite-avatar.test.js').run()"` → **13 passed, 0 failed, 2 skipped** (H1/H2 skip because the reachable instance does not serve this story — by design, and announced).
+- [x] **Browser class** — rebuilt `ui/` myself and served it at `:4173`: **5 passed**. The pixel assertions genuinely run; I confirmed the composite by eye as well as by test.
+- [x] **Differential regression** — using the safe method from OPEN.md #149 (`git checkout <base> -- <path>`, never `git stash`): `in-app-badged-ta-avatar` **13/0**, `recognizable-published-ta-profile` **11/2**, `admin-tools-dashboard-panel` **9/0** — **identical with and without** this change. Story 2's two failures are its own known-environmental `H1`/`H5`. Co-tenant stashes verified untouched afterwards.
+- [x] `harness-lint` clean; `node --check` clean on all four changed JS files; both new modules load with no circular-require breakage (`avatar.js` → `assistant/index.js` is one-directional).
+- [ ] _Lint / typecheck / build not configured — skipped._
+
+## Spec adherence
+
+| AC | Verified how | Result |
+|---|---|---|
+| **AC1** — preview of their picture, stamped on one corner, before publishing | `B1` pixel-samples three ways (centre is the owner's picture, bottom-right carries the mark, top-left does not); `B2` watches the network and confirms no POST fires on generate | ✓ |
+| **AC2** — published picture is an instance-hosted URL, publicly served | `B3`, `S5`, `S7` | ✓ |
+| **AC3** — survives redeploy; a published picture never dies | `U4` (behavioural) + the mount points at the persisted volume | ✓ |
+| **AC4** — regenerate replaces; re-publish points at the new one | `U2`/`U4`/`U6` — content-addressed naming | ✓ |
+| **AC5** — no owner picture → branded fallback offered, not a failure | `B4` | ✓ |
+| **AC6** — refused to anyone but the owner | `S1`, `H1` (skipped locally); **and** I verified the layered gate independently — see below | ✓ |
+
+**AC6, checked properly rather than by reading the handler.** Both handlers carry
+`if (!isOwner(req) && !req.localTrusted) → 403`. Above them, `src/middleware/auth.js:448-457` denies
+*every* unauthenticated mutation except an exact-match allowlist of `/api/neo4j/query` and
+`/api/strfry/publish`; `app.use(authMiddleware)` is at `bin/control-panel.js:265` and the API routes
+mount at `:289`, so the global gate genuinely runs first. An anonymous `POST /api/assistant/avatar`
+is therefore 401'd before `multer` allocates anything.
+
+## ADR adherence
+
+- [x] Files match the ADR: new `src/api/assistant/avatar.js`, two routes in `src/api/index.js:537-538`,
+      the `/generated` mount in `bin/control-panel.js`, and the editor changes.
+- [x] **D2 (parameterless proxy) — honoured.** `handleOwnerAvatar` reads nothing from
+      `req.query/body/params`; the URL comes from `getOwnerKind0PictureUrl(ownerPubkey)`.
+- [x] **D3 (never delete) — honoured, and proven behaviourally.** `storeCompositeAvatar` writes only
+      when the target is absent, and `U4` stores two different composites and asserts both survive.
+      This was the decision most likely to be got wrong, and it is right.
+- [x] **D4 (one reachability rule) — honoured.** `avatar.js` imports `isPubliclyReachable` from
+      `assistant/index.js` rather than forking a predicate.
+- [x] No new dependencies (`multer` was already present). No lint/typecheck tooling.
+- [x] The three logged deviations are accurate and all three are improvements or neutral.
+- [ ] **D2's redirect bound — NOT honoured, and not logged.** See blocking finding 1.
+
+## Concept-graph integrity
+
+- [x] No handles in the diff; no concept definitions changed → **no firmware reinstall**.
+
+## Things tests can't catch
+
+- [x] **No secrets, no debug logging, no commented-out code, no 64-hex literals.**
+- [x] **Path traversal** — filenames are server-generated from a content hash; the caller never
+      supplies a path. `express.static` resolves within its root. The mount sets `index: false`, so no
+      directory listing.
+- [x] **Cache correctness** — `maxAge: '7d'` is safe *because* the names are content-addressed; a
+      regenerate yields a new URL rather than a stale hit.
+- [x] **The size cap is enforced where it matters.** `readBounded` (`:133-144`) checks
+      `content-length` *and* counts the streamed body, so a chunked response — which declares no
+      length — is still bounded. This is the part most implementations get wrong.
+- [x] **Canvas taint** — the source is fetched same-origin through the proxy, so `toBlob()` cannot
+      throw `SecurityError`. Verified in practice by the browser class passing.
+- [ ] **Two issues on the outbound fetch** — findings 1 and 2.
+
+## House rules check
+
+- [x] Concept Graph authority respected; no new tooling; TA pubkey untouched (resolved at runtime elsewhere).
+
+## Findings
+
+### Blocking
+
+1. **`src/api/assistant/avatar.js:183` — the ADR's redirect bound was dropped, silently.** ADR 0003
+   D2 specifies "**at most one redirect**" among the proxy's guards. The code passes
+   `redirect: 'follow'`, which is Node's default of **up to 20**. This is not a logged deviation —
+   the story logs three others, so this reads as an oversight rather than a considered change.
+   It matters because redirects are the one part of this fetch where **a third party chooses the
+   destination**: the owner publishes a picture URL, but the host at the far end decides where the
+   chain ends, including at `127.0.0.1`, an RFC1918 address, or `169.254.169.254`. The blast radius
+   is genuinely small — the endpoint is owner-only, and the owner already has instance access — which
+   is why this is a small ask rather than a redesign. *Ask:* either set `redirect: 'manual'` and
+   follow at most one hop (validating the hop's destination the same way the initial URL is
+   validated), or keep `follow` and record it in the story's Deviations with the reasoning, so the
+   ADR and the code stop disagreeing. Note a co-tenant session has an SSRF-guard draft parked for the
+   sibling `nip05` fetch (`stash@{1}`), so a shared guard may be the better long-term home.
+
+2. **`src/api/assistant/avatar.js:194` — `image/svg+xml` passes the allow-list and is echoed back
+   from our own origin.** `type.startsWith('image/')` admits SVG, and `:203-205` sets that
+   content-type on the response verbatim. SVG can carry `<script>`, so a picture URL that serves SVG
+   makes `GET /api/assistant/owner-avatar` a same-origin script-execution vector against the control
+   panel for anyone who navigates to it directly. In-app usage is safe (the editor loads it via
+   `new Image()`, where scripts do not run) and the endpoint is owner-gated, so this needs the owner
+   to visit the URL directly with an attacker-influenced picture host — narrow, but it is the classic
+   footgun and the fix is one line. *Ask:* refuse `image/svg+xml` (the composite source only needs
+   raster formats), or send `Content-Disposition: attachment` / a sandbox CSP on this response.
+
+Both are in one function and together are a few lines. Nothing else in the diff is blocked.
+
+### Non-blocking
+
+1. **An authenticated non-owner reaches `multer` before the 403.** The global default-deny stops
+   anonymous callers (verified above), but a signed-in non-owner passes it and buffers up to 2 MB in
+   memory before `handleUploadAvatar:223` refuses them. Bounded and session-gated, so low severity.
+   *Optional:* put the owner check in front of `uploadMiddleware` at `src/api/index.js:538` so the
+   gate precedes the body parse.
+2. **A `multer` limit breach is not handled.** Exceeding `fileSize` rejects into Express's default
+   error handler (an HTML 500) rather than the JSON shape every other branch returns. Cosmetic.
+3. **Old composites accumulate with no cleanup**, exactly as ADR D3 intends — recorded so the
+   book-close sees it as a known, chosen consequence rather than an oversight.
+
+### Harness friction
+
+None this story. The OPEN.md #149 practice (checkout-the-base rather than `git stash`) worked
+cleanly, and the co-tenant stashes were verified intact afterwards.
+
+## Verdict
+
+**CHANGES_REQUESTED**
+
+This is a strong implementation and the verdict is narrow: **two lines in one function**, both on the
+outbound fetch, and I want them fixed rather than inherited because this is the repo's first
+outbound-fetch primitive and its first persisted-and-web-served directory — the precedents set here
+will be copied.
+
+Everything else passes on evidence I gathered myself: all six acceptance criteria, both gates
+(13/0 server, 5/5 browser, run against a build I made), a clean differential against three sibling
+suites, and the layered owner gate confirmed at the middleware level rather than taken from the
+handler. **D3 — the decision this story was most likely to get wrong — is right, and is proven by
+behaviour rather than by a source scan.**
+
+Finding 1 is blocking mainly because it is an *unlogged* departure from a bound the ADR states: the
+next reader will trust the ADR. Either honour it or record it. Finding 2 is a one-line hardening on
+the same function, so it costs nothing to do in the same pass.
+
+## On CHANGES_REQUESTED
+
+Kick back to `/implement-feature` with the two asks above. The story stays `Approved`; no completion
+detection is run on a non-passing review.

--- a/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
+++ b/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
@@ -85,4 +85,5 @@ the original check would have refused.)*
 - ADR: `engineering-team/decisions/ta-avatar/0003-owner-composited-avatar-hosted-by-the-instance.md`
 - Test plan: `engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.test-plan.md`
   (tests: `test/stamped-composite-avatar.test.js` + `tests/brainstorm/ta-composite-avatar.spec.js`)
-- Review: `engineering-team/reviews/ta-avatar/3-stamped-composite-avatar-on-nostr.md` — **PASS** 2026-08-07 (round 1 CHANGES_REQUESTED on two lines of the outbound fetch; round 2 PASS after `fe613e46`)
+- Review: `engineering-team/reviews/ta-avatar/3-stamped-composite-avatar-on-nostr.md` — **PASS** 2026-08-07
+  (two rounds; the first returned two asks on the outbound fetch, both fixed in `fe613e46`)

--- a/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
+++ b/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
@@ -74,4 +74,4 @@ None.
 - ADR: `engineering-team/decisions/ta-avatar/0003-owner-composited-avatar-hosted-by-the-instance.md`
 - Test plan: `engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.test-plan.md`
   (tests: `test/stamped-composite-avatar.test.js` + `tests/brainstorm/ta-composite-avatar.spec.js`)
-- Review: (filled in after Review phase)
+- Review: `engineering-team/reviews/ta-avatar/3-stamped-composite-avatar-on-nostr.md` — **CHANGES_REQUESTED** 2026-08-07 (two lines on the outbound fetch; everything else passed)

--- a/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
+++ b/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
@@ -58,5 +58,6 @@ None.
 ## Linked artifacts
 
 - ADR: `engineering-team/decisions/ta-avatar/0003-owner-composited-avatar-hosted-by-the-instance.md`
-- Test plan: (filled in after Test Design phase)
+- Test plan: `engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.test-plan.md`
+  (tests: `test/stamped-composite-avatar.test.js` + `tests/brainstorm/ta-composite-avatar.spec.js`)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
+++ b/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
@@ -1,6 +1,6 @@
 # Story 3: The stamped composite avatar, published to nostr
 
-**Status:** Approved
+**Status:** Done
 **Created:** 2026-08-06
 **Type:** Feature
 **Epic:** `ta-avatar`
@@ -85,4 +85,4 @@ the original check would have refused.)*
 - ADR: `engineering-team/decisions/ta-avatar/0003-owner-composited-avatar-hosted-by-the-instance.md`
 - Test plan: `engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.test-plan.md`
   (tests: `test/stamped-composite-avatar.test.js` + `tests/brainstorm/ta-composite-avatar.spec.js`)
-- Review: `engineering-team/reviews/ta-avatar/3-stamped-composite-avatar-on-nostr.md` — **CHANGES_REQUESTED** 2026-08-07 (two lines on the outbound fetch; everything else passed)
+- Review: `engineering-team/reviews/ta-avatar/3-stamped-composite-avatar-on-nostr.md` — **PASS** 2026-08-07 (round 1 CHANGES_REQUESTED on two lines of the outbound fetch; round 2 PASS after `fe613e46`)

--- a/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
+++ b/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
@@ -39,7 +39,9 @@ assistant wearing my avatar with the badge.
 
 ## Concepts touched
 
-None known — same note as stories 1–2; the Architect should confirm against the concept graph.
+None. **Confirmed at Architecture** against the live concept graph: `39998:<TA>:image` resolves to a
+bare node (no description, and `…:image-schema` returns `No node found`) and models images as
+knowledge-graph nodes, not files on a volume — see ADR 0003. No firmware reinstall.
 
 ## Out of scope
 
@@ -55,6 +57,6 @@ None.
 
 ## Linked artifacts
 
-- ADR: (filled in after Architecture phase)
+- ADR: `engineering-team/decisions/ta-avatar/0003-owner-composited-avatar-hosted-by-the-instance.md`
 - Test plan: (filled in after Test Design phase)
 - Review: (filled in after Review phase)

--- a/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
+++ b/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
@@ -68,6 +68,17 @@ None.
 3. **The kind-0 helper is named `getOwnerKind0PictureUrl`.** Prompted by the test that checks the
    proxy's URL provenance: the original name (`getOwnerPictureUrl`) left it ambiguous whether the URL
    came from the request or from the owner's own event. The name now says which.
+4. **The composite source allow-list is raster-only, narrower than the ADR's `image/*`.** ADR D2 says
+   "`content-type: image/*` allow-list"; the implementation admits PNG/JPEG/WebP/GIF/AVIF/BMP and
+   refuses `image/svg+xml`. Taken on the review's second ask: SVG can carry script, and this response
+   is served from our own origin, so echoing that content-type back would make the endpoint a
+   same-origin script-execution vector. The composite source is only ever drawn into a canvas, so no
+   raster capability is lost. Narrower than the ADR, in the safer direction.
+
+*(The review's first ask was **not** a deviation — it restored the "at most one redirect" bound ADR D2
+already specified. `redirect: 'manual'` with a one-hop loop, and each hop re-validated by the same
+`parseFetchableUrl` used on the owner's published URL, so a redirect cannot reach a scheme or shape
+the original check would have refused.)*
 
 ## Linked artifacts
 

--- a/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
+++ b/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
@@ -55,6 +55,20 @@ knowledge-graph nodes, not files on a volume — see ADR 0003. No firmware reins
 
 None.
 
+## Deviations
+
+1. **`getInstanceWebsite` and `isPubliclyReachable` are now exported from
+   `src/api/assistant/index.js`.** ADR D4 requires the composite's publishable URL to reuse story 2's
+   reachability rule rather than fork a second one; exporting the two helpers is the mechanism. No
+   behavior change to either — additive exports only.
+2. **The canvas maths lives in `ui/src/utils/compositeAvatar.js`, not inline in the editor.** The ADR
+   said "the editor" draws the composite; the editor is already ~300 lines and the cover-fit +
+   badge-placement geometry is self-contained and worth reading on its own. The editor still owns the
+   flow (fetch → build → preview → accept); only the pixel maths moved one file over.
+3. **The kind-0 helper is named `getOwnerKind0PictureUrl`.** Prompted by the test that checks the
+   proxy's URL provenance: the original name (`getOwnerPictureUrl`) left it ambiguous whether the URL
+   came from the request or from the owner's own event. The name now says which.
+
 ## Linked artifacts
 
 - ADR: `engineering-team/decisions/ta-avatar/0003-owner-composited-avatar-hosted-by-the-instance.md`

--- a/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.test-plan.md
+++ b/engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.test-plan.md
@@ -1,0 +1,125 @@
+# Test Plan: Story 3 — The stamped composite avatar, published to nostr
+
+**Story:** `engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md`
+**ADR:** `engineering-team/decisions/ta-avatar/0003-owner-composited-avatar-hosted-by-the-instance.md`
+**Date:** 2026-08-07
+
+**Test files:**
+- `test/stamped-composite-avatar.test.js` — 15 tests (**U** ×6, **S** ×7, **H** ×2). Registered in
+  `test/test.js` (gates the exit code; own summary line + H-class execution line).
+- `tests/brainstorm/ta-composite-avatar.spec.js` — 5 tests (**B**, Playwright). AC1 and AC5 are
+  settled here.
+
+---
+
+## Why this story needs both classes
+
+Story 2 needed no browser class because its criteria were about what a server *proposes*. This story
+splits cleanly down the middle:
+
+- **The server half** — an owner-gated proxy, a content-addressed store, a static mount — is logic
+  and configuration, and the store step is pure enough to *execute* in a temp directory. That is
+  where ADR **D3** lives, and D3 is the decision this story most needs to get right.
+- **The browser half** — AC1's "a preview of their picture stamped with the brand mark on one
+  corner" — is a claim about pixels. Every load-bearing word (their *picture*; the mark is *on* it;
+  it is in a *corner*) is invisible to a source scan, which sees a canvas and a `drawImage` and
+  cannot distinguish a correct composite from a blank square. Same lesson as `goal-intent-fields` #3.
+
+## The assertion this plan is built around
+
+**`B1` samples the rendered pixels.** The mocked owner avatar is solid **white**; the badge is brand
+purple **#9546ed**. A correct composite therefore has a white middle and a purple bottom-right
+corner. Three separate wrong implementations fail three different assertions:
+
+| what got built | which assertion catches it |
+|---|---|
+| blank / badge-only canvas | the **centre** is not white — "must show the OWNER'S PICTURE" |
+| owner's picture, no mark drawn | the **bottom-right** has no purple — "the mark must be stamped" |
+| mark drawn full-bleed over the face | the **top-left** *is* purple — "the mark sits on one corner" |
+
+The fixture PNG is generated in-spec (`zlib` + `crc32`) so the colours are exact rather than
+whatever a stock asset happens to contain.
+
+## Coverage map
+
+| Criterion | Test | Level |
+|---|---|---|
+| **AC1** — preview of their picture, stamped on one corner, **before** publishing | `B1` (pixel-sampled, three ways) and `B2` (generating issues **no** POST to `/api/assistant/avatar` or `/publish-profile`) | browser |
+| **AC2** — published picture is a URL hosted by the instance, publicly served | `B3` (accepting puts the returned instance URL into the picture field), `S7` (the URL is gated on story 2's `isPubliclyReachable`, not a second predicate), `S5` (the directory is actually mounted), `H2` | browser + source + live |
+| **AC3** — survives redeploy; a published picture never silently dies | **`U4`** (the previous composite is still on disk after a regenerate) and `S5` (the mount points at the **persisted volume**, not a path inside the image) | unit + source |
+| **AC4** — regenerating replaces the old; re-publishing points at the new | `U4` (different content → different name, new file present), `U2`/`U6` (content-addressed naming is what makes the new URL new) | unit |
+| **AC5** — no owner picture → the branded fallback is offered, not a failure | `B4` (the panel says so **and** story 2's `/ta-avatar.png` is what it reaches for; no error state) | browser |
+| **AC6** — refused to anyone who is not the owner | `S1` (two independent `isOwner` gates + 403), `H1` (anonymous gets 401/403 on both endpoints) | source + live |
+| ADR **D2** — the proxy takes no URL from the caller | `S2` (no `req.query/body/params` URL is read; the URL comes from the owner's kind 0) | source |
+| ADR **D2** — the fetch is bounded | `S3` (timeout, `image/*` allow-list, size cap beyond content-length, http(s) only) | source |
+| ADR **D3** — never delete a prior composite | **`U4`** (behavior) + `S4` (a sentinel against a later "tidy-up" delete) | unit + source |
+| Wiring | `S6` (both routes registered), `U5` (non-PNG rejected on **magic bytes**, nothing written) | source + unit |
+
+## Edge cases covered
+
+- [x] **Idempotence** — storing identical bytes twice yields one file with the same name (`U3`).
+- [x] **Collision safety** — the name is the content hash, so different composites never overwrite (`U6`).
+- [x] **Non-PNG input** — rejected on bytes, not on the caller's declared mime, and **nothing is written** (`U5`); everything in that directory is served publicly.
+- [x] **Directory listing** — `H2` guards against an index being exposed on the new public mount.
+- [x] **Preview ≠ publish** — `B2` watches actual network traffic, not UI state.
+- [x] **The mark's position** — asserted as *present bottom-right AND absent top-left*, so a full-bleed mark fails.
+- [x] **Stale-bundle trap** — `B0` fails loudly if the served build predates the edit.
+- [ ] **Not covered — deliberately:** automatic regeneration when the owner's avatar changes; a retention policy for accumulated composites; customer-assistant composites; and OPEN.md #148's RFC1918 gap, which ADR D4 inherits on purpose so one fix serves both stories.
+
+## Test infrastructure
+
+- **Runner:** Node built-in (`npm test`) + existing Playwright. No new frameworks.
+- **One testability ask:** `src/api/assistant/avatar.js` must export **`storeCompositeAvatar(buffer, opts)`** accepting `opts.baseDir`. `/var/lib/brainstorm` does not exist on a dev host or on CI, and without an override D3 could only be checked by scanning for the *absence* of an unlink — which proves nothing about behavior. `U5` also expects it to **throw** on a non-PNG buffer.
+- **One DOM contract:** the preview carries the class **`.ta-composite-preview`** (canvas or img — `B1` handles either, drawing an img into an offscreen canvas before sampling, so the implementation is not constrained).
+- **The H class SKIPs rather than fails when the route is absent.** These describe a *deployed* instance; the reachable one during development is `localhost:7778`, which serves the **shared checkout** and can never reflect this worktree (ta-avatar #2 documented the same constraint). `run()` announces loudly that live coverage did not run, and `TAPESTRY_REQUIRE_LIVE=1` turns that into a failure. Driving is done by U, S and B; **H is the post-deploy instrument.**
+- **Fixtures:** all in-spec. Every API is route-mocked, including the proxy, so **no live avatar host is contacted** and no stack is required.
+
+## How to run
+
+```bash
+npm test
+```
+
+```bash
+cd ui && npm run build && npx vite preview --port 4173 --strictPort
+```
+
+```bash
+BRAINSTORM_SERVER_ACCESSIBLE=true BRAINSTORM_BASE_URL=http://localhost:4173 npx playwright test tests/brainstorm/ta-composite-avatar.spec.js --project=chromium
+```
+
+After deploy, to execute the H class:
+
+```bash
+BRAINSTORM_BASE_URL=https://staging.brainstorm.world node -e "require('./test/stamped-composite-avatar.test.js').run()"
+```
+
+## Verification — confirmed RED on 2026-08-07 at `490e7f95`
+
+**Server half — 0 passed, 13 failed, 2 skipped.** Every failure names the missing artefact:
+
+```
+  FAIL  U1: src/api/assistant/avatar.js does not exist …
+  FAIL  U4: regenerating does NOT delete the previous composite (ADR D3 — AC3 vs AC4)
+  FAIL  S2: the proxy takes no URL from the request (ADR D2)
+  FAIL  S5: the generated directory is served, and only that directory
+  SKIP  H1 / H2
+  stamped-composite-avatar: H-class 0 executed / 2 skipped
+  !! LIVE COVERAGE DID NOT RUN — the reachable instance does not serve this story
+```
+
+**Browser half — 5 failed**, against a freshly built bundle served at `:4173`:
+
+```
+  B0  Error: the served bundle does not contain "ta-composite-preview" …
+  B1  Error: AC1: the editor must offer a way to generate the badged avatar — element(s) not found
+  B2/B3/B4  TimeoutError: locator.click — no such button
+```
+
+**Failing for the right reasons — verified, not assumed.** I probed the mocked page directly: the
+Assistant Profile panel **renders fully** (`.settings-group` present, 6 input fields, buttons
+`["Publish profile","Reset to defaults"]`), with **no** generate control and **no**
+`.ta-composite-preview`. So the fixture — auth, config, and the assistant status mock — is sound, and
+the suite is failing on the absent feature rather than on a page that never loaded. That probe also
+corrected the plan: `about` renders as a *textarea*, so the picture field is not at the input index
+`PROFILE_FIELDS`' order implies; `B3` scans every field's value instead of pinning an index.

--- a/src/api/assistant/avatar.js
+++ b/src/api/assistant/avatar.js
@@ -1,0 +1,245 @@
+/**
+ * Tapestry Assistant composite avatar — proxy, store, serve.
+ *
+ * The owner's browser composites their own avatar with the brand mark and posts
+ * the result here; we store it on the persisted volume and hand back a URL the
+ * instance serves. See ADR ta-avatar/0003.
+ *
+ * Two things about this module are deliberate and easy to "fix" wrongly:
+ *
+ *   - The proxy takes NO url from the caller (D2). It reads the picture URL out
+ *     of the owner's own kind 0, server-side. An endpoint that accepted a URL
+ *     would be a general-purpose arbitrary-fetch primitive wearing an
+ *     assistant-shaped hat.
+ *   - Storing a new composite NEVER deletes an older one (D3). The previously
+ *     stored file is the one named by the currently published kind 0, and it
+ *     stays published until the owner re-publishes. Deleting on regenerate kills
+ *     the live profile's picture in the window between generating and
+ *     publishing. Old composites are tens of kilobytes; keeping them is the
+ *     cheap side of that trade.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+const { exec } = require('child_process');
+const multer = require('multer');
+const { isOwner } = require('../../middleware/auth');
+const { getConfigFromFile } = require('../../utils/config');
+const { getInstanceWebsite, isPubliclyReachable } = require('./index');
+
+// Composites live on the tapestry-data volume (docker-compose.yml), which
+// survives container recreation — a published picture must not die on redeploy.
+const GENERATED_DIR = '/var/lib/brainstorm/generated';
+const PUBLIC_PREFIX = '/generated';
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const MAX_SOURCE_BYTES = 5 * 1024 * 1024;   // what we will pull from a remote host
+const MAX_UPLOAD_BYTES = 2 * 1024 * 1024;   // what we will store
+const FETCH_TIMEOUT_MS = 5000;
+
+function ensureDir(p) {
+  try { fs.mkdirSync(p, { recursive: true }); } catch (_) { /* fall through to the caller's check */ }
+}
+
+/**
+ * Where composites are written. Falls back to the home directory when the volume
+ * path is not available (a dev host, or CI), mirroring
+ * src/api/customers/commands/restore-upload.js.
+ */
+function defaultGeneratedDir() {
+  try {
+    ensureDir(GENERATED_DIR);
+    fs.accessSync(GENERATED_DIR, fs.constants.W_OK);
+    return GENERATED_DIR;
+  } catch (e) {
+    const homeBase = path.join(os.homedir(), 'brainstorm-generated');
+    ensureDir(homeBase);
+    return homeBase;
+  }
+}
+
+/**
+ * Store a composite PNG under a content-addressed name and return where it lives.
+ *
+ * Content addressing does two jobs: regenerating produces a genuinely new URL
+ * (so no client shows a stale cached avatar), and re-storing identical bytes is
+ * a no-op rather than a duplicate.
+ *
+ * @param {Buffer} buffer  the PNG bytes
+ * @param {{ baseDir?: string }} [opts]  directory override, for tests
+ * @returns {{ filename: string, path: string, url: string }}
+ * @throws if the bytes are not a PNG
+ */
+function storeCompositeAvatar(buffer, opts = {}) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < PNG_SIGNATURE.length
+      || !buffer.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)) {
+    // Checked on the bytes, never on a caller-declared mime type: whatever lands
+    // in this directory is served publicly.
+    throw new Error('composite avatar must be a PNG (magic bytes did not match)');
+  }
+  if (buffer.length > MAX_UPLOAD_BYTES) {
+    throw new Error(`composite avatar is ${buffer.length} bytes; the limit is ${MAX_UPLOAD_BYTES}`);
+  }
+
+  const dir = opts.baseDir || defaultGeneratedDir();
+  ensureDir(dir);
+  const hash = crypto.createHash('sha256').update(buffer).digest('hex').slice(0, 8);
+  const filename = `ta-avatar-${hash}.png`;
+  const target = path.join(dir, filename);
+
+  // Identical bytes → identical name, so an existing file is already correct.
+  // Nothing here removes a previously stored composite (D3).
+  if (!fs.existsSync(target)) {
+    fs.writeFileSync(target, buffer);
+  }
+
+  const website = getInstanceWebsite();
+  return {
+    filename,
+    path: `${PUBLIC_PREFIX}/${filename}`,
+    // Only offer a publishable absolute URL when a stranger could actually fetch
+    // it — the same rule story 2 applies to the branded default (ADR 0003 D4).
+    url: isPubliclyReachable(website) ? `${website}${PUBLIC_PREFIX}/${filename}` : '',
+  };
+}
+
+/** The owner's own kind 0 `picture`, read from local strfry. No caller input. */
+function getOwnerKind0PictureUrl(pubkey) {
+  return new Promise((resolve) => {
+    const filter = JSON.stringify({ kinds: [0], authors: [pubkey], limit: 1 });
+    exec(`strfry scan '${filter.replace(/'/g, "'\\''")}' 2>/dev/null`, {
+      encoding: 'utf8',
+      timeout: 10000,
+    }, (error, stdout) => {
+      if (error || !stdout.trim()) { resolve(null); return; }
+      try {
+        const event = JSON.parse(stdout.trim().split('\n')[0]);
+        const content = JSON.parse(event.content);
+        resolve(typeof content.picture === 'string' && content.picture ? content.picture : null);
+      } catch {
+        resolve(null);
+      }
+    });
+  });
+}
+
+/**
+ * Read at most `limit` bytes from a fetch response.
+ * A chunked response declares no content-length, so the body itself is bounded
+ * rather than trusting the header.
+ */
+async function readBounded(resp, limit) {
+  const declared = Number(resp.headers.get('content-length') || 0);
+  if (declared && declared > limit) return null;
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of resp.body) {
+    total += chunk.length;
+    if (total > limit) return null;
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
+ * GET /api/assistant/owner-avatar
+ *
+ * Streams the owner's own profile picture back same-origin, so the browser can
+ * draw it into a canvas without tainting it. Owner-only.
+ */
+async function handleOwnerAvatar(req, res) {
+  if (!isOwner(req) && !req.localTrusted) {
+    return res.status(403).json({ success: false, error: 'Owner authentication required' });
+  }
+  try {
+    const ownerPubkey = getConfigFromFile('BRAINSTORM_OWNER_PUBKEY');
+    if (!ownerPubkey) {
+      return res.status(404).json({ success: false, error: 'No owner pubkey configured' });
+    }
+    // Provenance matters here: the URL comes from the owner's own kind 0, never
+    // from the request (D2).
+    const pictureUrl = await getOwnerKind0PictureUrl(ownerPubkey);
+    if (!pictureUrl) {
+      // Not an error: this is the branded-fallback path the editor offers (AC5).
+      return res.status(404).json({ success: false, error: 'The owner has no profile picture' });
+    }
+
+    let parsed;
+    try { parsed = new URL(pictureUrl); } catch {
+      return res.status(404).json({ success: false, error: 'The owner picture URL is not a URL' });
+    }
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      return res.status(404).json({ success: false, error: 'Only http(s) picture URLs can be fetched' });
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    let upstream;
+    try {
+      upstream = await fetch(parsed.toString(), {
+        signal: controller.signal,
+        redirect: 'follow',
+        headers: { accept: 'image/*' },
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!upstream.ok) {
+      return res.status(404).json({ success: false, error: `The owner picture host answered ${upstream.status}` });
+    }
+
+    const type = (upstream.headers.get('content-type') || '').split(';')[0].trim().toLowerCase();
+    if (!type.startsWith('image/')) {
+      return res.status(404).json({ success: false, error: `The owner picture is ${type || 'untyped'}, not an image` });
+    }
+
+    const body = await readBounded(upstream, MAX_SOURCE_BYTES);
+    if (!body) {
+      return res.status(404).json({ success: false, error: 'The owner picture is too large to composite' });
+    }
+
+    res.set('Content-Type', type);
+    res.set('Cache-Control', 'no-store');
+    return res.send(body);
+  } catch (err) {
+    return res.status(404).json({ success: false, error: `Could not retrieve the owner picture: ${err.message}` });
+  }
+}
+
+const uploadMiddleware = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_UPLOAD_BYTES, files: 1 },
+}).single('avatar');
+
+/**
+ * POST /api/assistant/avatar  (multipart, field `avatar`)
+ *
+ * Stores the composite the owner's browser produced. Owner-only: this writes
+ * into a directory the world can read.
+ */
+async function handleUploadAvatar(req, res) {
+  if (!isOwner(req) && !req.localTrusted) {
+    return res.status(403).json({ success: false, error: 'Owner authentication required' });
+  }
+  try {
+    const buffer = req.file && req.file.buffer;
+    if (!buffer) {
+      return res.status(400).json({ success: false, error: 'No avatar file was uploaded' });
+    }
+    const stored = storeCompositeAvatar(buffer);
+    return res.json({ success: true, ...stored });
+  } catch (err) {
+    return res.status(400).json({ success: false, error: err.message });
+  }
+}
+
+module.exports = {
+  storeCompositeAvatar,
+  handleOwnerAvatar,
+  handleUploadAvatar,
+  uploadMiddleware,
+  GENERATED_DIR,
+  PUBLIC_PREFIX,
+};

--- a/src/api/assistant/avatar.js
+++ b/src/api/assistant/avatar.js
@@ -38,6 +38,18 @@ const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0
 const MAX_SOURCE_BYTES = 5 * 1024 * 1024;   // what we will pull from a remote host
 const MAX_UPLOAD_BYTES = 2 * 1024 * 1024;   // what we will store
 const FETCH_TIMEOUT_MS = 5000;
+// Redirects are the one part of this fetch where a THIRD PARTY picks the
+// destination, so we follow at most one hop and validate where it lands exactly
+// as we validate the URL the owner published (ADR ta-avatar/0003 D2).
+const MAX_REDIRECTS = 1;
+
+// The composite source is drawn into a canvas, so raster formats are all we need.
+// SVG is excluded deliberately: it can carry script, and this response is served
+// from our own origin — echoing `image/svg+xml` back would turn this endpoint into
+// a same-origin script-execution vector for anyone who opened it directly.
+const ALLOWED_SOURCE_TYPES = new Set([
+  'image/png', 'image/jpeg', 'image/jpg', 'image/webp', 'image/gif', 'image/avif', 'image/bmp',
+]);
 
 function ensureDir(p) {
   try { fs.mkdirSync(p, { recursive: true }); } catch (_) { /* fall through to the caller's check */ }
@@ -125,6 +137,26 @@ function getOwnerKind0PictureUrl(pubkey) {
   });
 }
 
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+function isRedirect(status) { return REDIRECT_STATUSES.has(status); }
+
+/**
+ * Parse a candidate URL and accept it only if it is something we are willing to
+ * fetch. Used for the owner's published URL and, unchanged, for a redirect hop —
+ * a redirect must clear the same bar as the original, or following one would be a
+ * hole straight through the check.
+ *
+ * @param {string} candidate
+ * @param {URL} [relativeTo]  base for a relative Location header
+ * @returns {URL|null}
+ */
+function parseFetchableUrl(candidate, relativeTo) {
+  let parsed;
+  try { parsed = relativeTo ? new URL(candidate, relativeTo) : new URL(candidate); } catch { return null; }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null;
+  return parsed;
+}
+
 /**
  * Read at most `limit` bytes from a fetch response.
  * A chunked response declares no content-length, so the body itself is bounded
@@ -166,23 +198,33 @@ async function handleOwnerAvatar(req, res) {
       return res.status(404).json({ success: false, error: 'The owner has no profile picture' });
     }
 
-    let parsed;
-    try { parsed = new URL(pictureUrl); } catch {
-      return res.status(404).json({ success: false, error: 'The owner picture URL is not a URL' });
-    }
-    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
-      return res.status(404).json({ success: false, error: 'Only http(s) picture URLs can be fetched' });
+    let parsed = parseFetchableUrl(pictureUrl);
+    if (!parsed) {
+      return res.status(404).json({ success: false, error: 'The owner picture URL is not a fetchable http(s) URL' });
     }
 
+    // At most one redirect, and the hop is validated the same way the original
+    // URL is — otherwise the far-end host, not the owner, chooses what we fetch.
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     let upstream;
     try {
-      upstream = await fetch(parsed.toString(), {
-        signal: controller.signal,
-        redirect: 'follow',
-        headers: { accept: 'image/*' },
-      });
+      for (let hop = 0; ; hop += 1) {
+        upstream = await fetch(parsed.toString(), {
+          signal: controller.signal,
+          redirect: 'manual',
+          headers: { accept: 'image/*' },
+        });
+        if (!isRedirect(upstream.status)) break;
+        if (hop >= MAX_REDIRECTS) {
+          return res.status(404).json({ success: false, error: 'The owner picture host redirected too many times' });
+        }
+        const next = parseFetchableUrl(upstream.headers.get('location') || '', parsed);
+        if (!next) {
+          return res.status(404).json({ success: false, error: 'The owner picture host redirected somewhere unfetchable' });
+        }
+        parsed = next;
+      }
     } finally {
       clearTimeout(timer);
     }
@@ -191,8 +233,11 @@ async function handleOwnerAvatar(req, res) {
     }
 
     const type = (upstream.headers.get('content-type') || '').split(';')[0].trim().toLowerCase();
-    if (!type.startsWith('image/')) {
-      return res.status(404).json({ success: false, error: `The owner picture is ${type || 'untyped'}, not an image` });
+    if (!ALLOWED_SOURCE_TYPES.has(type)) {
+      return res.status(404).json({
+        success: false,
+        error: `The owner picture is ${type || 'untyped'}, which cannot be used as a composite source`,
+      });
     }
 
     const body = await readBounded(upstream, MAX_SOURCE_BYTES);

--- a/src/api/assistant/index.js
+++ b/src/api/assistant/index.js
@@ -537,4 +537,10 @@ async function handleProvisionAssistantKey(req, res) {
 // buildDefaultProfileContent is exported for tests: it is the sole producer of the
 // defaults the editor offers and a content-less publish signs, so asserting on it
 // directly is the only stack-free handle on that contract.
-module.exports = { handlePublishProfile, handleAssistantStatus, handleGetTAPubkey, handleProvisionAssistantKey, buildDefaultProfileContent };
+// getInstanceWebsite + isPubliclyReachable are exported so ./avatar.js can gate the
+// composite's publishable URL on the SAME rule as the branded default — one notion
+// of "could a stranger fetch this", not two (ADR ta-avatar/0003 D4).
+module.exports = {
+  handlePublishProfile, handleAssistantStatus, handleGetTAPubkey, handleProvisionAssistantKey,
+  buildDefaultProfileContent, getInstanceWebsite, isPubliclyReachable,
+};

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -530,6 +530,12 @@ async function register(app) {
     app.post('/api/assistant/provision-key', assistantApi.handleProvisionAssistantKey);
     app.get('/api/assistant/status', assistantApi.handleAssistantStatus);
     app.get('/api/assistant/pubkey', assistantApi.handleGetTAPubkey);
+    // The composite avatar (ta-avatar #3, ADR 0003). Both are owner-only: the
+    // first reveals the owner's picture URL, the second writes into a directory
+    // that is served publicly.
+    const assistantAvatarApi = require('./assistant/avatar');
+    app.get('/api/assistant/owner-avatar', assistantAvatarApi.handleOwnerAvatar);
+    app.post('/api/assistant/avatar', assistantAvatarApi.uploadMiddleware, assistantAvatarApi.handleUploadAvatar);
 
     // ── Owner pubkey (public) ──
     const ownerApi = require('./owner');

--- a/test/stamped-composite-avatar.test.js
+++ b/test/stamped-composite-avatar.test.js
@@ -1,0 +1,329 @@
+/**
+ * ta-avatar #3: The stamped composite avatar, published to nostr — server half.
+ *
+ * Story: engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
+ * ADR:   engineering-team/decisions/ta-avatar/0003-owner-composited-avatar-hosted-by-the-instance.md
+ * Browser half: tests/brainstorm/ta-composite-avatar.spec.js (AC1's preview + the
+ * composite geometry, which only a browser can settle).
+ *
+ * Classes here:
+ *   U — the store-and-name step, executed against a temp directory. This is where
+ *       ADR D3 lives (regenerating must NOT delete the previous composite) and it
+ *       is the one part of this story that is pure enough to prove by execution.
+ *   S — the guards a unit test cannot reach: owner gating, the parameterless
+ *       proxy, the fetch bounds, the static mount, route registration.
+ *   H — a deployed instance's behavior. See the note on why it SKIPs below.
+ *
+ * ── Why the H class skips instead of failing ─────────────────────────────
+ * These tests describe an instance that has this story deployed. The reachable
+ * instance during development is localhost:7778, which serves the SHARED checkout
+ * — a different tree from this worktree — so it can never reflect this code
+ * (ta-avatar #2's test plan documents the same constraint). Rather than parking
+ * permanent red, the H class probes for the route and SKIPs when it is absent,
+ * announcing loudly that live coverage did not run. The driving is done by U, S
+ * and the browser class; H is the post-deploy instrument.
+ *
+ * ── One testability ask ──────────────────────────────────────────────────
+ * The storage step must be exported and must accept a base directory, so it can
+ * be exercised in a temp dir. Without that, D3 — the decision this story most
+ * needs to get right — could only be checked by scanning source for the absence
+ * of an unlink, which proves nothing about behavior.
+ *
+ * These FAIL against current code: src/api/assistant/avatar.js does not exist.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+
+const REPO = path.resolve(__dirname, '..');
+const AVATAR_SRC = path.join(REPO, 'src/api/assistant/avatar.js');
+const API_INDEX = path.join(REPO, 'src/api/index.js');
+const CONTROL_PANEL = path.join(REPO, 'bin/control-panel.js');
+const HOST_BASE = process.env.BRAINSTORM_BASE_URL || 'http://localhost:7778';
+
+const tests = [];
+function test(name, fn) { tests.push([name, fn]); }
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion failed'); }
+function safeRead(p) { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+
+let hExecuted = 0;
+let hSkipped = 0;
+let featureLive = null;
+
+/** Does the reachable instance actually have this story deployed? */
+async function featureAvailable() {
+  if (featureLive !== null) return featureLive;
+  try {
+    const r = await fetch(`${HOST_BASE}/api/assistant/owner-avatar`, { signal: AbortSignal.timeout(8000) });
+    // 401/403 means the route exists and is gated — that is "deployed".
+    // 404 means the route is absent (an instance predating this story).
+    featureLive = r.status !== 404;
+  } catch { featureLive = false; }
+  return featureLive;
+}
+
+// ── fixtures ────────────────────────────────────────────────────────────
+const PNG_SIG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** A valid, distinct 1x1 PNG. `seed` changes the bytes so the hash differs. */
+function makePng(seed) {
+  const base = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+    'base64');
+  // Append a tEXt-ish trailer: still PNG-signed, byte-distinct per seed.
+  return Buffer.concat([base, Buffer.from(String(seed))]);
+}
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ta-composite-'));
+}
+const madeDirs = [];
+function freshDir() { const d = tempDir(); madeDirs.push(d); return d; }
+function cleanupDirs() {
+  for (const d of madeDirs) { try { fs.rmSync(d, { recursive: true, force: true }); } catch {} }
+}
+
+function loadStore() {
+  const mod = require(AVATAR_SRC);
+  return mod;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// U — the store-and-name step
+// ─────────────────────────────────────────────────────────────────────────
+
+test('U1: the avatar module exists and exports a storage step that takes a base directory', () => {
+  assert(fs.existsSync(AVATAR_SRC),
+    'src/api/assistant/avatar.js does not exist. ADR 0003 puts the proxy, the upload and the storage ' +
+    'step in their own module rather than growing src/api/assistant/index.js past ~540 lines.');
+  const mod = loadStore();
+  assert(typeof mod.storeCompositeAvatar === 'function',
+    'src/api/assistant/avatar.js must export storeCompositeAvatar(buffer, opts). A base directory in ' +
+    '`opts` is a testability-only ask — /var/lib/brainstorm does not exist on a dev host or on CI, and ' +
+    'without an override ADR D3 (never delete the previous composite) can only be checked by scanning ' +
+    `for the absence of an unlink, which proves nothing. Exports found: ${Object.keys(mod).join(', ')}`);
+});
+
+test('U2: storing a composite writes exactly one content-addressed PNG', () => {
+  const { storeCompositeAvatar } = loadStore();
+  const dir = freshDir();
+  const buf = makePng('alpha');
+  const out = storeCompositeAvatar(buf, { baseDir: dir });
+  assert(out && typeof out === 'object', 'storeCompositeAvatar must return a descriptor object.');
+  assert(typeof out.filename === 'string' && out.filename,
+    `the descriptor must name the file it wrote. Got ${JSON.stringify(out)}`);
+  assert(/^ta-avatar-[0-9a-f]{8}\.png$/.test(out.filename),
+    `ADR 0003: the filename is content-addressed — ta-avatar-<hash8>.png — which is what lets a ` +
+    `regenerate produce a NEW url instead of a stale cached one. Got ${JSON.stringify(out.filename)}.`);
+  const files = fs.readdirSync(dir);
+  assert(files.length === 1, `exactly one file should have been written; found ${JSON.stringify(files)}`);
+  const written = fs.readFileSync(path.join(dir, out.filename));
+  assert(written.subarray(0, 8).equals(PNG_SIG), 'the bytes on disk must be the PNG that was handed in.');
+  assert(written.equals(buf), 'the stored file must be byte-identical to the supplied buffer.');
+  assert(typeof out.path === 'string' && out.path.includes(out.filename),
+    `the descriptor must carry the public path for the file. Got ${JSON.stringify(out.path)}`);
+});
+
+test('U3: storing the same composite twice is idempotent — same name, still one file', () => {
+  const { storeCompositeAvatar } = loadStore();
+  const dir = freshDir();
+  const buf = makePng('alpha');
+  const a = storeCompositeAvatar(buf, { baseDir: dir });
+  const b = storeCompositeAvatar(buf, { baseDir: dir });
+  assert(a.filename === b.filename,
+    `content addressing means identical bytes get identical names. Got ${a.filename} then ${b.filename}.`);
+  assert(fs.readdirSync(dir).length === 1,
+    `re-storing identical bytes must not accumulate files; found ${JSON.stringify(fs.readdirSync(dir))}`);
+});
+
+test('U4: regenerating does NOT delete the previous composite (ADR D3 — AC3 vs AC4)', () => {
+  const { storeCompositeAvatar } = loadStore();
+  const dir = freshDir();
+  const first = storeCompositeAvatar(makePng('alpha'), { baseDir: dir });
+  const second = storeCompositeAvatar(makePng('beta'), { baseDir: dir });
+
+  assert(first.filename !== second.filename,
+    'different composites must get different names, or re-publishing could not point at the new one (AC4).');
+  assert(fs.existsSync(path.join(dir, second.filename)),
+    'the newly generated composite must be on disk (AC4).');
+  assert(fs.existsSync(path.join(dir, first.filename)),
+    'AC3 — "a published picture never silently dies". The previously generated composite is still the ' +
+    'one named by the CURRENTLY published kind 0, and it stays published until the owner re-publishes. ' +
+    'Deleting it on regenerate kills the avatar of the live profile in the window between generating ' +
+    'and publishing. ADR 0003 D3 keeps old composites for exactly this reason; they are tens of ' +
+    'kilobytes and regeneration is a deliberate manual act.');
+  const files = fs.readdirSync(dir).sort();
+  assert(files.length === 2, `both composites should remain; found ${JSON.stringify(files)}`);
+});
+
+test('U5: a buffer that is not a PNG is rejected on its BYTES, not its declared type', () => {
+  const { storeCompositeAvatar } = loadStore();
+  const dir = freshDir();
+  const notPng = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"></svg>', 'utf8');
+  let threw = false;
+  try { storeCompositeAvatar(notPng, { baseDir: dir }); } catch { threw = true; }
+  assert(threw,
+    'storeCompositeAvatar must reject a non-PNG buffer (checked by magic bytes — a declared mime type ' +
+    'is caller-supplied and cannot be trusted). Anything reaching this directory is served publicly.');
+  assert(fs.readdirSync(dir).length === 0,
+    `nothing may be written when the input is rejected; found ${JSON.stringify(fs.readdirSync(dir))}`);
+});
+
+test('U6: the stored name is derived from the content, so two different owners cannot collide by chance', () => {
+  const { storeCompositeAvatar } = loadStore();
+  const dir = freshDir();
+  const buf = makePng('gamma');
+  const out = storeCompositeAvatar(buf, { baseDir: dir });
+  const hash = crypto.createHash('sha256').update(buf).digest('hex').slice(0, 8);
+  assert(out.filename.includes(hash),
+    `the name should be the content hash (sha256, first 8 hex) so identical input is stable across ` +
+    `restarts and different input never overwrites. Expected a name containing ${hash}, got ` +
+    `${JSON.stringify(out.filename)}. (If you chose a different digest, say so in the ADR and update this.)`);
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// S — the guards a unit test cannot reach
+// ─────────────────────────────────────────────────────────────────────────
+
+test('S1: both new endpoints are owner-gated (AC6)', () => {
+  const src = safeRead(AVATAR_SRC);
+  assert(src, 'src/api/assistant/avatar.js missing — see U1.');
+  assert(/isOwner\s*\(/.test(src),
+    'AC6: the generate and store operations must be refused to anyone but the owner. Use the established ' +
+    'gate — isOwner(req) from src/middleware/auth.js, as src/api/strfry/commands/publishEvent.js:34-38 does.');
+  const gates = (src.match(/!\s*isOwner\s*\(\s*req\s*\)/g) || []).length;
+  assert(gates >= 2,
+    `both handlers need their own gate; found ${gates} owner check(s). The proxy leaks the owner's ` +
+    'avatar URL and the upload writes to a publicly-served directory — neither may be open.');
+  assert(/\b403\b/.test(src), 'an unauthorised caller must be refused with 403.');
+});
+
+test('S2: the proxy takes no URL from the request (ADR D2)', () => {
+  const src = safeRead(AVATAR_SRC);
+  assert(src, 'src/api/assistant/avatar.js missing — see U1.');
+  const proxy = (src.match(/function handleOwnerAvatar[\s\S]*?\n\}/) || [''])[0];
+  assert(proxy, 'src/api/assistant/avatar.js must define handleOwnerAvatar (ADR 0003 §Implementation notes).');
+  assert(!/req\.(query|body|params)\s*\.\s*(url|src|picture|image|href)/.test(proxy),
+    'ADR 0003 D2: the proxy must NOT accept a URL from the caller — that would make it a general-purpose ' +
+    'arbitrary-fetch primitive. It reads the picture URL from the owner\'s own kind 0, server-side, so its ' +
+    'reachable set is "whatever the owner published about themselves".');
+  assert(/kinds?\s*[:=]\s*\[?\s*0|getKind0|kind 0/i.test(proxy) || /kind0/i.test(src),
+    'the proxy must source the URL from the owner\'s kind 0 rather than from the request.');
+});
+
+test('S3: the proxy fetch is bounded — timeout, image-only, size cap', () => {
+  const src = safeRead(AVATAR_SRC);
+  assert(src, 'src/api/assistant/avatar.js missing — see U1.');
+  assert(/AbortSignal\.timeout|AbortController/.test(src),
+    'the outbound fetch needs a timeout (src/api/nip05.js:126-147 is the house pattern) — without one a ' +
+    'slow host holds a server socket open indefinitely.');
+  assert(/image\//.test(src),
+    "the response content-type must be allow-listed to image/* — this endpoint's bytes are handed to a " +
+    'canvas and then stored in a public directory.');
+  assert(/content-length|byteLength|maxBytes|MAX_[A-Z_]*BYTES|5\s*\*\s*1024/i.test(src),
+    'the download needs a size cap. Checking content-length alone is not enough — a chunked response ' +
+    'declares none, so the streamed body must be bounded too (ADR 0003 D2).');
+  assert(/https?:/.test(src),
+    'only http(s) URLs may be fetched; a file:// or other scheme from a kind 0 must be refused.');
+});
+
+test('S4: nothing in the storage path deletes a previously stored composite (ADR D3)', () => {
+  const src = safeRead(AVATAR_SRC);
+  assert(src, 'src/api/assistant/avatar.js missing — see U1.');
+  assert(!/unlinkSync|fs\.unlink|rmSync|fs\.rm\b|rimraf/.test(src),
+    'ADR 0003 D3: old composites are kept deliberately. A delete here would break AC3 for the profile ' +
+    'that is published right now. U4 proves the behavior; this sentinel catches a delete added later ' +
+    'for tidiness, which is exactly how this regression would return.');
+});
+
+test('S5: the generated directory is served, and only that directory', () => {
+  const src = safeRead(CONTROL_PANEL);
+  assert(src, 'bin/control-panel.js missing — regression.');
+  assert(/\/generated/.test(src) && /express\.static/.test(src),
+    'bin/control-panel.js must serve the generated composites — this is the first directory in the repo ' +
+    'that is both persisted and web-served (ADR 0003 §Consequences). Without the mount, every published ' +
+    'composite URL 404s.');
+  assert(/\/var\/lib\/brainstorm\/generated/.test(src),
+    'the mount must point at the persisted volume path (/var/lib/brainstorm is the tapestry-data volume, ' +
+    'docker-compose.yml:23) — a path inside the image would be wiped on every redeploy, breaking AC3.');
+});
+
+test('S6: both routes are registered', () => {
+  const src = safeRead(API_INDEX);
+  assert(/\/api\/assistant\/owner-avatar/.test(src),
+    'src/api/index.js must register GET /api/assistant/owner-avatar beside the other assistant routes (:528-532).');
+  assert(/\/api\/assistant\/avatar/.test(src),
+    'src/api/index.js must register POST /api/assistant/avatar.');
+});
+
+test('S7: the publishable URL reuses story 2\'s reachability rule rather than a second one (ADR D4)', () => {
+  const src = safeRead(AVATAR_SRC);
+  assert(src, 'src/api/assistant/avatar.js missing — see U1.');
+  assert(/isPubliclyReachable/.test(src),
+    'ADR 0003 D4: the absolute URL offered for publishing is gated on the SAME predicate story 2 uses ' +
+    '(isPubliclyReachable, src/api/assistant/index.js). Forking a second notion of "reachable" would mean ' +
+    'two places to fix when OPEN.md #148 is addressed.');
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// H — a deployed instance (skips when the instance predates this story)
+// ─────────────────────────────────────────────────────────────────────────
+
+test('H1: an unauthenticated caller is refused the proxy and the upload (AC6)', async () => {
+  if (!(await featureAvailable())) { hSkipped += 1; return 'SKIP'; }
+  hExecuted += 1;
+  const get = await fetch(`${HOST_BASE}/api/assistant/owner-avatar`, { signal: AbortSignal.timeout(15000) });
+  assert(get.status === 401 || get.status === 403,
+    `AC6: an anonymous caller must be refused the proxy; got HTTP ${get.status}.`);
+  const post = await fetch(`${HOST_BASE}/api/assistant/avatar`, { method: 'POST', signal: AbortSignal.timeout(15000) });
+  assert(post.status === 401 || post.status === 403,
+    `AC6: an anonymous caller must be refused the upload; got HTTP ${post.status}. This endpoint writes ` +
+    'into a publicly-served directory.');
+});
+
+test('H2: the generated directory is mounted and does not leak a directory listing', async () => {
+  if (!(await featureAvailable())) { hSkipped += 1; return 'SKIP'; }
+  hExecuted += 1;
+  const r = await fetch(`${HOST_BASE}/generated/`, { signal: AbortSignal.timeout(15000) });
+  const body = await r.text();
+  assert(!/<title>Index of|Directory listing for/i.test(body),
+    'the generated mount must not serve a directory index — express.static does not by default; this ' +
+    'guards a later `{ index: true }` or an autoindex proxy in front.');
+});
+
+async function run() {
+  console.log('\n=== stamped-composite-avatar (ta-avatar #3, server half) ===');
+  let pass = 0, fail = 0, skipped = 0;
+  const failures = [];
+  try {
+    for (const [name, fn] of tests) {
+      try {
+        const r = await fn();
+        if (r === 'SKIP') { console.log(`  SKIP  ${name}`); skipped++; }
+        else { console.log(`  PASS  ${name}`); pass++; }
+      } catch (err) {
+        console.log(`  FAIL  ${name}\n        ${err.message}`);
+        failures.push({ name, message: err.message });
+        fail++;
+      }
+    }
+  } finally {
+    cleanupDirs();
+  }
+  console.log(`stamped-composite-avatar: H-class ${hExecuted} executed / ${hSkipped} skipped`);
+  if (hSkipped > 0 && hExecuted === 0) {
+    console.log('stamped-composite-avatar: !! LIVE COVERAGE DID NOT RUN — the reachable instance does not ' +
+      'serve this story (expected during development: localhost:7778 serves the shared checkout). ' +
+      'Re-run against staging after deploy.');
+    if (process.env.TAPESTRY_REQUIRE_LIVE === '1') {
+      failures.push({ name: 'live coverage', message: 'TAPESTRY_REQUIRE_LIVE=1 but the whole H-class skipped.' });
+      fail++;
+    }
+  }
+  console.log(`\nstamped-composite-avatar: ${pass} passed, ${fail} failed, ${skipped} skipped`);
+  return { pass, fail, failures, skipped, hExecuted, hSkipped };
+}
+
+module.exports = { run };

--- a/test/test.js
+++ b/test/test.js
@@ -212,6 +212,10 @@ const inAppBadgedTaAvatar = require('./in-app-badged-ta-avatar.test.js');
 // stack-free; the H class asserts one invariant whose branch is chosen by whether the
 // instance under test has a publicly reachable address.
 const recognizablePublishedTaProfile = require('./recognizable-published-ta-profile.test.js');
+// epic: ta-avatar — Story 3 (the stamped composite). U/S are stack-free; the H class
+// SKIPs unless the reachable instance actually serves this story. AC1's preview and the
+// composite geometry are settled by tests/brainstorm/ta-composite-avatar.spec.js.
+const stampedCompositeAvatar = require('./stamped-composite-avatar.test.js');
 // epic: shared-concepts-adoption — Story 1 (b-coverage audit + guided disposition).
 const bCoverageAuditAndDisposition = require('./b-coverage-audit-and-disposition.test.js');
 // epic: shared-concepts-adoption — Story 2 (adoption-candidates queue).
@@ -535,6 +539,7 @@ async function main() {
   console.log('\nin-app-badged-ta-avatar suite:');
   const inAppBadgedTaAvatarResult = await inAppBadgedTaAvatar.run();
   const recognizablePublishedTaProfileResult = await recognizablePublishedTaProfile.run();
+  const stampedCompositeAvatarResult = await stampedCompositeAvatar.run();
 
   console.log('\ntapestry-key-put-await suite:');
   const tapestryKeyPutAwaitResult = await tapestryKeyPutAwait.run();
@@ -1016,6 +1021,9 @@ async function main() {
   console.log(`in-app-badged-ta-avatar B-class:                 browser only — tests/brainstorm/ta-badged-avatar.spec.js (npm run test:playwright)`);
   console.log(`recognizable-published-ta-profile suite:         ${recognizablePublishedTaProfileResult.fail === 0 ? 'PASS' : 'FAIL'} (${recognizablePublishedTaProfileResult.pass} passed, ${recognizablePublishedTaProfileResult.fail} failed${recognizablePublishedTaProfileResult.skipped ? `, ${recognizablePublishedTaProfileResult.skipped} skipped` : ''})`);
   console.log(`recognizable-published-ta-profile H-class:       ${recognizablePublishedTaProfileResult.hExecuted} executed / ${recognizablePublishedTaProfileResult.hSkipped} skipped`);
+  console.log(`stamped-composite-avatar suite:                  ${stampedCompositeAvatarResult.fail === 0 ? 'PASS' : 'FAIL'} (${stampedCompositeAvatarResult.pass} passed, ${stampedCompositeAvatarResult.fail} failed${stampedCompositeAvatarResult.skipped ? `, ${stampedCompositeAvatarResult.skipped} skipped` : ''})`);
+  console.log(`stamped-composite-avatar H-class:                ${stampedCompositeAvatarResult.hExecuted} executed / ${stampedCompositeAvatarResult.hSkipped} skipped`);
+  console.log(`stamped-composite-avatar B-class:                browser only — tests/brainstorm/ta-composite-avatar.spec.js (npm run test:playwright)`);
   console.log(`add-a-concept-to-a-tapestry suite:               ${addConceptToTapestryResult.fail === 0 ? 'PASS' : 'FAIL'} (${addConceptToTapestryResult.pass} passed, ${addConceptToTapestryResult.fail} failed)`);
   console.log(`take-a-concept-back-out suite:                   ${takeAConceptBackOutResult.fail === 0 ? 'PASS' : 'FAIL'} (${takeAConceptBackOutResult.pass} passed, ${takeAConceptBackOutResult.fail} failed)`);
   console.log(`brain-first-tapestry-authoring suite:            ${brainFirstTapestryAuthoringResult.fail === 0 ? 'PASS' : 'FAIL'} (${brainFirstTapestryAuthoringResult.pass} passed, ${brainFirstTapestryAuthoringResult.fail} failed, ${brainFirstTapestryAuthoringResult.skipped} skipped)`);
@@ -1196,6 +1204,8 @@ async function main() {
     inAppBadgedTaAvatarResult.fail === 0 &&
     // ta-avatar #2 — recognizable published TA profile defaults
     recognizablePublishedTaProfileResult.fail === 0 &&
+    // ta-avatar #3 — the stamped composite avatar (server half)
+    stampedCompositeAvatarResult.fail === 0 &&
     // tapestries #5 — add a concept to a tapestry (add-only, same-coordinate republish)
     addConceptToTapestryResult.fail === 0 &&
     // tapestries #6 — take a concept back out (remove-only, same-coordinate republish)
@@ -1256,7 +1266,7 @@ async function main() {
     captureAGoalAndSeeItResult, firmwareConceptElementsSetsResult, tapestryPerConceptDetailViewsResult, structuresTheBrainCanTrustResult,
     breakAGoalIntoPiecesResult, attachTheWorldResult, sessionsReadTheBrainResult, theProposalLoopResult,
     operationalDirectionResult, storeTheFourResult, returnTheFourResult, showTheFourResult,
-    inAppBadgedTaAvatarResult, recognizablePublishedTaProfileResult,
+    inAppBadgedTaAvatarResult, recognizablePublishedTaProfileResult, stampedCompositeAvatarResult,
     addConceptToTapestryResult, takeAConceptBackOutResult, brainFirstTapestryAuthoringResult,
     bCoverageAuditAndDispositionResult, adoptionCandidatesQueueResult, inverseQueuePublishCandidatesResult,
     publishTimeDefaultStampingResult, trustedDictionaryResult,

--- a/tests/brainstorm/ta-composite-avatar.spec.js
+++ b/tests/brainstorm/ta-composite-avatar.spec.js
@@ -1,0 +1,304 @@
+const { test, expect } = require('@playwright/test');
+const zlib = require('zlib');
+
+/**
+ * ta-avatar #3: The stamped composite avatar — browser half.
+ *
+ * Story: engineering-team/stories/ta-avatar/3-stamped-composite-avatar-on-nostr.md
+ * ADR:   engineering-team/decisions/ta-avatar/0003-owner-composited-avatar-hosted-by-the-instance.md
+ * Server half: test/stamped-composite-avatar.test.js (U/S/H).
+ *
+ * ── What only a browser can settle ───────────────────────────────────────
+ * AC1 is "a preview of their picture stamped with the brand mark on one corner
+ * appears before anything is published". Every load-bearing word there is about
+ * pixels: that the owner's picture is what got drawn, that the mark is ON it, and
+ * that it is in a CORNER. A source scan sees a canvas and a drawImage call and
+ * cannot tell any of that apart from a blank square — the goal-intent-fields #3
+ * kick-back ("green suite, invisible feature") is the standing precedent.
+ *
+ * So these tests SAMPLE THE RENDERED PIXELS. The mocked owner avatar is solid
+ * white; the badge is brand purple (#9546ed). If the composite happened, the
+ * middle of the preview is white and its bottom-right corner is purple. Neither
+ * is true of a blank canvas, a canvas that drew only the source, or a canvas that
+ * drew the badge in the wrong place.
+ *
+ *   B0 — the served bundle contains the code under test.        [prerequisite]
+ *   B1 — Generate produces a preview: owner's picture in the frame,
+ *        brand mark in the bottom-right corner.                 [AC1]
+ *   B2 — the composite is NOT published until the owner accepts. [AC1 "before"]
+ *   B3 — accepting puts the instance-hosted URL into the picture field. [AC2]
+ *   B4 — no owner picture: the branded fallback is offered, nothing crashes. [AC5]
+ *
+ * ── Prerequisites ────────────────────────────────────────────────────────
+ *   BRAINSTORM_SERVER_ACCESSIBLE=true, and BRAINSTORM_BASE_URL pointing at an
+ *   origin serving the BUILT ui. From an isolated worktree that is
+ *   `cd ui && npm run build && npx vite preview --port 4173` — every API call
+ *   below is route-mocked, so no stack and no live avatar host is touched.
+ *
+ * These FAIL against current code: the editor has no generate action, no preview,
+ * and no way to reach /api/assistant/owner-avatar.
+ */
+
+const OWNER = 'bb'.repeat(32);
+const TA = 'aa'.repeat(32);
+
+const BADGE_RGB = [0x95, 0x46, 0xed]; // #9546ed — the brand purple of ta-badge.svg
+const SOURCE_RGB = [255, 255, 255];   // the mocked owner avatar: solid white
+
+const HOSTED_PATH = '/generated/ta-avatar-deadbeef.png';
+const HOSTED_URL = `https://staging.example.test${HOSTED_PATH}`;
+const FALLBACK_PATH = '/ta-avatar.png'; // story 2's branded asset (AC5)
+
+/** A real, solid-colour PNG. Built here so the fixture colours are exact. */
+function solidPng(width, height, [r, g, b]) {
+  const chunk = (type, data) => {
+    const len = Buffer.alloc(4); len.writeUInt32BE(data.length);
+    const td = Buffer.concat([Buffer.from(type, 'latin1'), data]);
+    const crc = Buffer.alloc(4); crc.writeUInt32BE(zlib.crc32(td) >>> 0);
+    return Buffer.concat([len, td, crc]);
+  };
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0); ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; ihdr[9] = 2; ihdr[10] = 0; ihdr[11] = 0; ihdr[12] = 0; // 8-bit RGB
+  const row = Buffer.concat([Buffer.from([0]), Buffer.concat(Array.from({ length: width }, () => Buffer.from([r, g, b])))]);
+  const raw = Buffer.concat(Array.from({ length: height }, () => row));
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk('IHDR', ihdr), chunk('IDAT', zlib.deflateSync(raw)), chunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+test.describe('The stamped composite avatar (ta-avatar #3)', () => {
+  test.beforeEach(async ({ page }) => {
+    if (process.env.BRAINSTORM_SERVER_ACCESSIBLE !== 'true') {
+      test.skip('Brainstorm server not accessible (set BRAINSTORM_SERVER_ACCESSIBLE=true)');
+    }
+  });
+
+  /** `ownerAvatar: 'ok' | 'missing'` chooses AC1's path or AC5's. */
+  async function mock(page, { ownerAvatar = 'ok' } = {}) {
+    const json = (body, status = 200) => ({ status, contentType: 'application/json', body: JSON.stringify(body) });
+
+    // Catch-all FIRST: Playwright resolves overlapping routes in reverse
+    // registration order, so the specific handlers below win.
+    await page.route('**/api/**', (r) => r.fulfill(json({ success: true })));
+
+    await page.route('**/api/assistant/pubkey', (r) => r.fulfill(json({ success: true, pubkey: TA })));
+    await page.route('**/api/owner/pubkey', (r) => r.fulfill(json({ success: true, pubkey: OWNER })));
+    await page.route('**/api/relays', (r) => r.fulfill(json({ success: true, aRelays: {} })));
+    await page.route('**/api/profiles**', (r) => r.fulfill(json({ success: true, profiles: {} })));
+
+    // Signed in AS THE OWNER — the editor renders from user.pubkey.
+    await page.route('**/api/auth/status', (r) => r.fulfill(json({ authenticated: true, pubkey: OWNER })));
+    await page.route('**/api/auth/user-classification', (r) =>
+      r.fulfill(json({ classification: 'owner', pubkey: OWNER, assistantPubkey: TA })));
+
+    await page.route('**/api/assistant/status**', (r) => r.fulfill(json({
+      success: true, hasRelayKey: true, hasProfile: false, isOwner: true, assistantPubkey: TA,
+      defaults: {
+        name: "Owner's Tapestry Assistant", display_name: "Owner's Tapestry Assistant",
+        about: 'fixture', picture: '', banner: '', website: 'https://staging.example.test', lud16: '',
+      },
+    })));
+
+    // The proxy (ADR D2). 'missing' is AC5's trigger and must not read as an error.
+    await page.route('**/api/assistant/owner-avatar', (r) => (ownerAvatar === 'ok'
+      ? r.fulfill({ status: 200, contentType: 'image/png', body: solidPng(256, 256, SOURCE_RGB) })
+      : r.fulfill(json({ success: false, error: 'owner has no picture' }, 404))));
+
+    // The upload. Records that it was called so B2 can assert it was NOT.
+    await page.route('**/api/assistant/avatar', (r) => (r.request().method() === 'POST'
+      ? r.fulfill(json({ success: true, filename: 'ta-avatar-deadbeef.png', path: HOSTED_PATH, url: HOSTED_URL }))
+      : r.fulfill(json({ success: true }))));
+
+    // Story 2's branded asset, so AC5's fallback resolves to real bytes.
+    await page.route(`**${FALLBACK_PATH}`, (r) =>
+      r.fulfill({ status: 200, contentType: 'image/png', body: solidPng(64, 64, BADGE_RGB) }));
+  }
+
+  async function gotoEditor(page) {
+    await page.goto('/tapestry/settings/assistant');
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('.settings-group').first(),
+      'the Assistant Profile settings tab must render for a signed-in owner').toBeVisible({ timeout: 20000 });
+  }
+
+  /** The Generate control, by accessible name rather than a brittle selector. */
+  function generateButton(page) {
+    return page.getByRole('button', { name: /generate|badge|stamp/i }).first();
+  }
+
+  /**
+   * Sample the preview. Handles a <canvas> or an <img>: an img is drawn into an
+   * offscreen canvas first, so the assertion does not constrain which the
+   * implementation chooses. Returns {w,h,at(x,y)} in fractional coordinates.
+   */
+  async function samplePreview(page) {
+    return page.evaluate(() => {
+      const el = document.querySelector('.ta-composite-preview');
+      if (!el) return { error: 'no element with class .ta-composite-preview' };
+      const w = el.naturalWidth || el.width;
+      const h = el.naturalHeight || el.height;
+      if (!w || !h) return { error: `preview has no intrinsic size (${w}x${h})` };
+      const c = document.createElement('canvas');
+      c.width = w; c.height = h;
+      const ctx = c.getContext('2d');
+      ctx.drawImage(el, 0, 0, w, h);
+      let data;
+      try { data = ctx.getImageData(0, 0, w, h).data; }
+      catch (e) { return { error: `preview canvas is tainted: ${e.message}` }; }
+      const px = (fx, fy) => {
+        const x = Math.min(w - 1, Math.max(0, Math.round(fx * (w - 1))));
+        const y = Math.min(h - 1, Math.max(0, Math.round(fy * (h - 1))));
+        const i = (y * w + x) * 4;
+        return [data[i], data[i + 1], data[i + 2], data[i + 3]];
+      };
+      // Scan the bottom-right eighth for the closest match to the brand purple.
+      let best = null;
+      for (let y = Math.floor(h * 0.62); y < h; y += 1) {
+        for (let x = Math.floor(w * 0.62); x < w; x += 1) {
+          const i = (y * w + x) * 4;
+          const d = Math.abs(data[i] - 0x95) + Math.abs(data[i + 1] - 0x46) + Math.abs(data[i + 2] - 0xed);
+          if (best === null || d < best.d) best = { d, rgb: [data[i], data[i + 1], data[i + 2]] };
+        }
+      }
+      // And the same scan over the TOP-LEFT eighth, to prove the mark is in a corner
+      // rather than smeared over the whole image.
+      let bestTL = null;
+      for (let y = 0; y < Math.floor(h * 0.38); y += 1) {
+        for (let x = 0; x < Math.floor(w * 0.38); x += 1) {
+          const i = (y * w + x) * 4;
+          const d = Math.abs(data[i] - 0x95) + Math.abs(data[i + 1] - 0x46) + Math.abs(data[i + 2] - 0xed);
+          if (bestTL === null || d < bestTL.d) bestTL = { d, rgb: [data[i], data[i + 1], data[i + 2]] };
+        }
+      }
+      return { w, h, centre: px(0.5, 0.4), bottomRight: best, topLeft: bestTL };
+    });
+  }
+
+  /* ───────── B0 — is the code under test the code that is running? ───────── */
+  test('B0: the served bundle contains the composite UI', async ({ request, baseURL }) => {
+    const index = await request.get('/');
+    expect(index.ok(), `${baseURL} did not serve an app shell (HTTP ${index.status()}).`).toBe(true);
+    const assets = [...(await index.text()).matchAll(/(?:src|href)="([^"]+\.js)"/g)].map((m) => m[1]);
+    expect(assets.length, 'no built JS referenced from the app shell — is this a built UI?').toBeGreaterThan(0);
+    let found = false;
+    for (const a of assets) {
+      const res = await request.get(a);
+      if (res.ok() && (await res.text()).includes('ta-composite-preview')) { found = true; break; }
+    }
+    expect(found,
+      'the served bundle does not contain "ta-composite-preview", the class ADR 0003 gives the preview. ' +
+      'Either the bundle predates your edit — a source-only change is INVISIBLE to this class, so run ' +
+      '`cd ui && npm run build` — or the preview is not implemented, in which case B1 says so directly.')
+      .toBe(true);
+  });
+
+  /* ───────── B1 — AC1, decided on pixels ───────── */
+  test('B1: Generate previews the owner\'s picture with the brand mark stamped in the corner', async ({ page }) => {
+    await mock(page);
+    await gotoEditor(page);
+
+    const btn = generateButton(page);
+    await expect(btn, 'AC1: the editor must offer a way to generate the badged avatar').toBeVisible({ timeout: 15000 });
+    await btn.click();
+
+    await expect(page.locator('.ta-composite-preview'),
+      'AC1: a preview must appear before anything is published').toBeVisible({ timeout: 20000 });
+
+    const s = await samplePreview(page);
+    expect(s.error, `could not read the preview: ${s.error}`).toBeUndefined();
+
+    // The owner's picture is what got drawn.
+    const [r, g, b] = s.centre;
+    expect(Math.abs(r - 255) + Math.abs(g - 255) + Math.abs(b - 255),
+      `AC1: the preview must show the OWNER'S PICTURE. The mocked avatar is solid white, so the middle ` +
+      `of the composite should be white; sampled rgb(${r},${g},${b}). A blank or badge-only canvas fails here.`)
+      .toBeLessThan(60);
+
+    // The mark is ON it, in the bottom-right.
+    expect(s.bottomRight.d,
+      `AC1: the brand mark must be stamped on the composite. Scanned the bottom-right eighth for the ` +
+      `badge purple #9546ed and the closest pixel was rgb(${s.bottomRight.rgb.join(',')}). A preview that ` +
+      'drew only the owner\'s picture fails exactly here.').toBeLessThan(60);
+
+    // …and only there — a mark covering the whole frame is not "on one corner".
+    expect(s.topLeft.d,
+      `AC1 says the mark sits "on one corner". The top-left eighth should NOT be badge-coloured, but its ` +
+      `closest pixel was rgb(${s.topLeft.rgb.join(',')}). A full-bleed mark hides the owner's face, which ` +
+      'defeats the point of the composite.').toBeGreaterThan(60);
+  });
+
+  /* ───────── B2 — AC1's "before anything is published" ───────── */
+  test('B2: generating a preview does not publish or store anything on its own', async ({ page }) => {
+    await mock(page);
+    const posted = [];
+    page.on('request', (req) => {
+      if (req.method() === 'POST' && /\/api\/assistant\/(avatar|publish-profile)/.test(req.url())) {
+        posted.push(req.url());
+      }
+    });
+    await gotoEditor(page);
+    await generateButton(page).click();
+    await expect(page.locator('.ta-composite-preview')).toBeVisible({ timeout: 20000 });
+    await page.waitForTimeout(600);
+
+    expect(posted,
+      `AC1: the preview appears "before anything is published". Generating must not upload or publish ` +
+      `by itself — the owner accepts first. Observed POSTs: ${JSON.stringify(posted)}`).toEqual([]);
+  });
+
+  /* ───────── B3 — AC2's client half ───────── */
+  test('B3: accepting the composite puts the instance-hosted URL into the picture field', async ({ page }) => {
+    await mock(page);
+    await gotoEditor(page);
+    await generateButton(page).click();
+    await expect(page.locator('.ta-composite-preview')).toBeVisible({ timeout: 20000 });
+
+    const accept = page.getByRole('button', { name: /use|accept|apply|save/i }).first();
+    await expect(accept, 'AC2: the owner must be able to accept the generated composite').toBeVisible({ timeout: 15000 });
+    await accept.click();
+
+    // Scan every field rather than indexing one: `about` renders as a textarea,
+    // so the picture input's position is not what PROFILE_FIELDS' order suggests,
+    // and pinning an index here would break the moment a field is added.
+    await expect
+      .poll(async () => {
+        const values = await page.locator('input').evaluateAll((els) => els.map((e) => e.value));
+        return values.some((v) => typeof v === 'string' && v.includes(HOSTED_PATH));
+      }, {
+        timeout: 15000,
+        message:
+          `AC2: after accepting, the picture field must carry the URL the instance returned (${HOSTED_URL}). ` +
+          'The existing publish flow then signs it unchanged — this story supplies a value for a field ' +
+          'that already exists.',
+      })
+      .toBe(true);
+  });
+
+  /* ───────── B4 — AC5 ───────── */
+  test('B4: with no owner picture, the branded fallback is offered instead of an error', async ({ page }) => {
+    await mock(page, { ownerAvatar: 'missing' });
+    await gotoEditor(page);
+    await generateButton(page).click();
+    await page.waitForTimeout(1200);
+
+    const body = (await page.locator('.settings-group').first().innerText()).replace(/\s+/g, ' ');
+    expect(body,
+      `AC5: when the owner has no picture the flow must OFFER THE BRANDED FALLBACK, not fail. The editor ` +
+      `should say so and make story 2's image available. Panel read: "${body.slice(0, 300)}"`)
+      .toMatch(/fallback|branded|instead|no picture|default/i);
+
+    const usedFallback = await page.evaluate((p) => {
+      const hit = (s) => typeof s === 'string' && s.includes(p);
+      if ([...document.querySelectorAll('img')].some((i) => hit(i.getAttribute('src')))) return true;
+      return [...document.querySelectorAll('input')].some((i) => hit(i.value));
+    }, FALLBACK_PATH);
+    expect(usedFallback,
+      `AC5: story 2's ${FALLBACK_PATH} must be what the flow falls back to — it exists precisely to be ` +
+      'this fallback. Neither a preview nor the picture field referenced it.').toBe(true);
+
+    await expect(page.locator('.ta-composite-preview'),
+      'AC5: a missing owner picture is not an error state — the panel must still be usable.').toHaveCount(0);
+  });
+});

--- a/ui/src/components/AssistantProfileEditor.jsx
+++ b/ui/src/components/AssistantProfileEditor.jsx
@@ -1,5 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
+import { buildCompositeAvatar } from '../utils/compositeAvatar';
+
+// Story 2's branded image, served from the instance root. Offered when the owner
+// has no picture of their own to stamp (ta-avatar #3 AC5).
+const BRANDED_FALLBACK_SRC = '/ta-avatar.png';
 
 // NIP-05 is omitted on purpose — the server computes it deterministically
 // from the caller's name + the Assistant's pubkey, and writes the matching
@@ -47,6 +52,12 @@ export default function AssistantProfileEditor({ customerPubkey }) {
   const [publishResult, setPublishResult] = useState(null);
   const [provisioning, setProvisioning] = useState(false);
   const [provisionError, setProvisionError] = useState(null);
+  // The stamped composite (ta-avatar #3). `composite` holds the preview until the
+  // owner accepts it — generating publishes and stores nothing on its own.
+  const [composite, setComposite] = useState(null);
+  const [generating, setGenerating] = useState(false);
+  const [compositeNotice, setCompositeNotice] = useState(null);
+  const [offerFallback, setOfferFallback] = useState(false);
 
   const loadStatus = useCallback(async () => {
     if (!customerPubkey) return;
@@ -74,9 +85,69 @@ export default function AssistantProfileEditor({ customerPubkey }) {
     setPublishResult(null);
   }
 
+  /**
+   * Build the stamped avatar and show it. Deliberately stores nothing: the owner
+   * sees the composite first and accepts it (AC1 — "before anything is published").
+   */
+  async function generateComposite() {
+    setGenerating(true);
+    setCompositeNotice(null);
+    setOfferFallback(false);
+    setComposite(null);
+    try {
+      // Same-origin proxy, so the canvas is not tainted. It answers 404 when the
+      // owner has no picture — that is the fallback path, not an error.
+      const res = await fetch('/api/assistant/owner-avatar');
+      if (!res.ok) {
+        setOfferFallback(true);
+        setCompositeNotice(
+          'You have no profile picture to stamp yet, so there is nothing to composite. '
+          + 'You can use the branded Tapestry image instead, or set a picture on your own profile and try again.');
+        return;
+      }
+      const built = await buildCompositeAvatar(await res.blob());
+      setComposite(built);
+    } catch (err) {
+      setOfferFallback(true);
+      setCompositeNotice(`Could not build the composite (${err.message}). You can use the branded image instead.`);
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  /** Store the accepted composite and point the picture field at it (AC2). */
+  async function useComposite() {
+    if (!composite) return;
+    setGenerating(true);
+    setCompositeNotice(null);
+    try {
+      const body = new FormData();
+      body.append('avatar', composite.blob, 'ta-avatar.png');
+      const res = await fetch('/api/assistant/avatar', { method: 'POST', body });
+      const data = await res.json();
+      if (!data.success) throw new Error(data.error || 'Upload failed');
+      updateField('picture', data.url || data.path);
+      setCompositeNotice('Saved. Publish the profile to point your assistant at it.');
+      setComposite(null);
+    } catch (err) {
+      setCompositeNotice(`Could not save the composite: ${err.message}`);
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  function useBrandedFallback() {
+    updateField('picture', status?.defaults?.picture || BRANDED_FALLBACK_SRC);
+    setOfferFallback(false);
+    setCompositeNotice('Using the branded Tapestry image.');
+  }
+
   function resetToDefaults() {
     if (!status?.defaults) return;
     setForm(pickFields(status.defaults));
+    setComposite(null);
+    setOfferFallback(false);
+    setCompositeNotice(null);
     setPublishResult(null);
   }
 
@@ -199,6 +270,58 @@ export default function AssistantProfileEditor({ customerPubkey }) {
             ? <span style={{ color: '#22c55e' }}>✅ Yes</span>
             : <span style={{ color: '#f59e0b' }}>⚠️ Not yet</span>}
         </div>
+      </div>
+
+      {/* The stamped composite: your avatar, wearing the mark (ta-avatar #3). */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+          <button
+            className="settings-action-btn settings-action-btn-secondary"
+            onClick={generateComposite}
+            disabled={generating || publishing}
+          >
+            {generating ? 'Working…' : '🎨 Generate badged avatar'}
+          </button>
+          <span style={{ fontSize: '0.8rem', opacity: 0.75 }}>
+            Stamps your own profile picture with the Tapestry mark.
+          </span>
+        </div>
+
+        {composite && (
+          <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}>
+            <img
+              className="ta-composite-preview"
+              src={composite.dataUrl}
+              alt="Preview of the assistant avatar: your picture with the Tapestry mark"
+              width={96}
+              height={96}
+              style={{ borderRadius: '50%', border: '1px solid var(--border, #444)' }}
+            />
+            <button className="settings-action-btn" onClick={useComposite} disabled={generating}>
+              Use this avatar
+            </button>
+          </div>
+        )}
+
+        {offerFallback && (
+          <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}>
+            <img
+              className="ta-composite-fallback"
+              src={BRANDED_FALLBACK_SRC}
+              alt="The branded Tapestry Assistant image"
+              width={96}
+              height={96}
+              style={{ borderRadius: '50%', border: '1px solid var(--border, #444)' }}
+            />
+            <button className="settings-action-btn" onClick={useBrandedFallback} disabled={generating}>
+              Use the branded image instead
+            </button>
+          </div>
+        )}
+
+        {compositeNotice && (
+          <div style={{ fontSize: '0.8rem', opacity: 0.85 }}>{compositeNotice}</div>
+        )}
       </div>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>

--- a/ui/src/utils/compositeAvatar.js
+++ b/ui/src/utils/compositeAvatar.js
@@ -1,0 +1,82 @@
+/**
+ * Build the Tapestry Assistant's stamped avatar: the owner's picture with the
+ * brand mark on one corner (ta-avatar #3, ADR 0003).
+ *
+ * This runs in the owner's browser rather than on the server so the preview and
+ * the published artefact are literally the same pixels — the canvas that is shown
+ * is the canvas that gets uploaded — and so no native image library has to enter
+ * the Docker image.
+ *
+ * The source image arrives from /api/assistant/owner-avatar, which is same-origin,
+ * so the canvas is never tainted and toBlob() always succeeds.
+ */
+
+export const COMPOSITE_SIZE = 512;
+export const BADGE_SRC = '/ta-badge.svg';
+/** Badge diameter as a fraction of the canvas. Matches the in-app badge's weight. */
+const BADGE_FRACTION = 0.34;
+/** Inset from the bottom-right edge, as a fraction of the canvas. */
+const BADGE_INSET = 0.035;
+/** Ring behind the badge so it separates from a busy photo. */
+const RING_FRACTION = 0.03;
+const RING_COLOR = '#0d1117';
+
+function loadImage(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error(`could not load ${src}`));
+    img.src = src;
+  });
+}
+
+/** Cover-fit: fill the square, cropping the long edge, like every avatar UI. */
+function drawCover(ctx, img, size) {
+  const w = img.naturalWidth || img.width;
+  const h = img.naturalHeight || img.height;
+  if (!w || !h) throw new Error('the source image has no dimensions');
+  const scale = Math.max(size / w, size / h);
+  const dw = w * scale;
+  const dh = h * scale;
+  ctx.drawImage(img, (size - dw) / 2, (size - dh) / 2, dw, dh);
+}
+
+/**
+ * @param {Blob} sourceBlob  the owner's picture, as fetched from the proxy
+ * @returns {Promise<{ blob: Blob, dataUrl: string }>}
+ */
+export async function buildCompositeAvatar(sourceBlob) {
+  const objectUrl = URL.createObjectURL(sourceBlob);
+  try {
+    const [source, badge] = await Promise.all([loadImage(objectUrl), loadImage(BADGE_SRC)]);
+
+    const size = COMPOSITE_SIZE;
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d');
+
+    drawCover(ctx, source, size);
+
+    const badgeSize = size * BADGE_FRACTION;
+    const inset = size * BADGE_INSET;
+    const cx = size - inset - badgeSize / 2;
+    const cy = size - inset - badgeSize / 2;
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(cx, cy, badgeSize / 2 + size * RING_FRACTION, 0, Math.PI * 2);
+    ctx.fillStyle = RING_COLOR;
+    ctx.fill();
+    ctx.restore();
+
+    ctx.drawImage(badge, cx - badgeSize / 2, cy - badgeSize / 2, badgeSize, badgeSize);
+
+    const blob = await new Promise((resolve, reject) => {
+      canvas.toBlob((b) => (b ? resolve(b) : reject(new Error('the browser produced no image'))), 'image/png');
+    });
+    return { blob, dataUrl: canvas.toDataURL('image/png') };
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}


### PR DESCRIPTION
## Summary

The end state of the `ta-avatar` epic: not a badge our own UI paints at render time, but **the stamped image itself** — the owner's avatar with the brain-and-lightning mark baked into one picture — published as the assistant's nostr profile picture, so *every* client shows it.

Story 3 of 3. Story 1 (in-app badge) and story 2 (branded published defaults, which this story falls back to) are already on staging.

## Changes

- **`src/api/assistant/avatar.js`** (new) — an owner-gated proxy that streams the owner's picture back same-origin so the canvas is never tainted, plus `storeCompositeAvatar()`, which writes a content-addressed `ta-avatar-<hash8>.png`.
- **`bin/control-panel.js`** — a `/generated` static mount over the persisted `tapestry-data` volume, no directory index. **The repo's first directory that is both persisted and web-served.**
- **`ui/src/utils/compositeAvatar.js`** (new) + `AssistantProfileEditor` — cover-fit the owner's picture into 512×512, ring + badge bottom-right, `toBlob`. **The canvas is the preview**, so what the owner sees is byte-for-byte what gets uploaded.
- **`src/api/index.js`** — the two owner-only routes.

## The decisions worth knowing

**Regenerating never deletes the previous composite.** Two acceptance criteria pull against each other here: a regenerate must point re-publishing at a new image, but the *currently published* kind-0 still names the old URL until the owner re-publishes. Deleting on regenerate would kill the live profile's picture in that window. Content-hashed filenames give the new-URL behaviour without deletion; old composites are kept deliberately.

**The proxy takes no URL from the caller.** It reads the picture URL from the owner's own kind-0, server-side — an endpoint that accepted a URL would be a general-purpose arbitrary-fetch primitive.

**Two security fixes came out of review** (round 1 returned them; both fixed in `fe613e46`):
- Redirects are bounded to **one hop**, and each hop is re-validated by the same check applied to the original URL — so following a redirect can't reach a scheme the first check would have refused. Redirects are the one place a *third party* picks the destination.
- The source allow-list is **raster-only**; `image/svg+xml` is refused. SVG can carry script and the response is served from our own origin, which would have made the proxy a same-origin script-execution vector.

## Test plan

- [ ] After merge: `deploy-staging.yml` runs.
- [ ] Smoke test on staging.brainstorm.world.
- [ ] **Tier 3 — the live half, which has never executed:** `BRAINSTORM_BASE_URL=https://staging.brainstorm.world node -e "require('./test/stamped-composite-avatar.test.js').run()"` → the H-class should now **execute rather than skip**: anonymous callers refused on both endpoints, and `/generated/` serving no directory index.
- [ ] **Tier 3 — the new mount:** `/generated/` responds and does not leak a listing.
- [ ] Tier 5: stories 1 and 2 intact — the badge still renders, `/ta-avatar.png` still serves PNG bytes, and story 2's suite still passes 13/13 against staging.

Verified before shipping: server suite 13/13 (+2 H skipped locally by design), browser suite 5/5 including pixel assertions that the composite's centre is the owner's picture, its bottom-right carries the mark, and its top-left does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)