### PR TITLE
THROWAWAY: guard smoke — test/guard-smoke-denied

### DIFF
--- a/.github/workflows/guard-main-source.yml
+++ b/.github/workflows/guard-main-source.yml
@@ -46,3 +46,4 @@ jobs:
               exit 1
               ;;
           esac
+# smoke test (DENIED) — throwaway, do not merge


### PR DESCRIPTION
Throwaway PR to make `main-source-guard` report once so it becomes selectable in ruleset 15863292 (OPEN.md #155).

Expected: **should FAIL (denied source)**

Diff is a single comment line in the guard workflow. **Do not merge** — will be closed as soon as the check reports.

Refs #515