### PR TITLE
THROWAWAY: verify main-source-guard is enforced

### DIFF
--- a/.github/workflows/guard-main-source.yml
+++ b/.github/workflows/guard-main-source.yml
@@ -46,3 +46,4 @@ jobs:
               exit 1
               ;;
           esac
+# enforcement verification — throwaway, do not merge


### PR DESCRIPTION
Confirms the ruleset change actually blocks a merge from a disallowed branch. Closed immediately. Do not merge.